### PR TITLE
Fix to test_ruby in configure.

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -533,7 +533,6 @@ test_ruby()
 	echocheck "Ruby"
 	if ruby -v >/dev/null 2>&1
 	then
-
 		RUBYVER=`ruby -v 2>&1 | head -n 1 | cut -f 2 -d ' '`
 		echores "${RUBYVER}"
 
@@ -541,14 +540,20 @@ cat >$TMPRUBY << EOF
 require('mkmf')
 puts CONFIG['prefix']+'/'+CONFIG['libdir'].sub('\$(exec_prefix)','')+'/ruby/'+CONFIG['MAJOR']+'.'+CONFIG['MINOR']+'/'+CONFIG['arch']
 EOF
-
-		INCLUDES_RUBY=-I`ruby $TMPRUBY`
-		LINKFLAGS_RUBY="-lruby`ruby -v | cut -f 2 -d ' ' | cut -f 1-2 -d '.'` -fPIC -shared"
-		EXT_IF_SWIG_RUBY_MODULAR='stop'
-		PRE_LIB_SWIG_RUBY_MODULAR=
-		EXT_LIB_SWIG_RUBY_MODULAR=.so
-		SWIGFLAGS_RUBY_MODULAR="-c++ -ruby"
-		_ruby=yes
+		echocheck "Ruby Developer Files"
+		if ruby $TMPRUBY >/dev/null 2>&1 
+			then
+			echores "yes"
+			INCLUDES_RUBY=-I`ruby $TMPRUBY`
+			LINKFLAGS_RUBY="-lruby`ruby -v | cut -f 2 -d ' ' | cut -f 1-2 -d '.'` -fPIC -shared"
+			EXT_IF_SWIG_RUBY_MODULAR='stop'
+			PRE_LIB_SWIG_RUBY_MODULAR=
+			EXT_LIB_SWIG_RUBY_MODULAR=.so
+			SWIGFLAGS_RUBY_MODULAR="-c++ -ruby"
+			_ruby=yes
+		else
+			echores "no"
+		fi
 	else
 		echores "not detected"
 	fi


### PR DESCRIPTION
Fixed test_ruby() in configure, previously would error if ruby was installed but not ruby-dev, was missing some conditional statements.
