### PR TITLE
implemented serialization support for CPolyFeatures

### DIFF
--- a/src/libshogun/features/PolyFeatures.cpp
+++ b/src/libshogun/features/PolyFeatures.cpp
@@ -6,13 +6,15 @@ CPolyFeatures::CPolyFeatures(void) :CDotFeatures()
 {
 	SG_UNSTABLE("CPolyFeatures::CPolyFeatures(void)", "\n");
 
-	m_feat = NULL;
-	m_degree = 0;
-	m_normalize = false;
-	m_input_dimensions = 0;
-	m_multi_index = NULL;
-	m_multinomial_coefficients = NULL;
-	m_normalization_values = NULL;
+	m_feat=NULL;
+	m_degree=0;
+	m_normalize=false;
+	m_input_dimensions=0;
+	m_multi_index=NULL;
+	m_multinomial_coefficients=NULL;
+	m_normalization_values=NULL;
+
+	register_parameters();
 }
 
 CPolyFeatures::CPolyFeatures(CSimpleFeatures<float64_t>* feat, int32_t degree, bool normalize)
@@ -32,6 +34,8 @@ CPolyFeatures::CPolyFeatures(CSimpleFeatures<float64_t>* feat, int32_t degree, b
 	store_multinomial_coefficients();
 	if (m_normalize)
 		store_normalization_values();
+
+	register_parameters();
 }
 
 CPolyFeatures::~CPolyFeatures()
@@ -314,4 +318,33 @@ int32_t CPolyFeatures::bico(int32_t n, int32_t k)
 CFeatures* CPolyFeatures::duplicate() const
 {
 	return new CPolyFeatures(*this);
+}
+
+void CPolyFeatures::register_parameters()
+{
+	m_parameters->add((CSGObject**) &m_feat, "features",
+				"Features in original space.");
+		m_parameters->add(&m_degree, "degree", "Degree of the polynomial kernel.");
+		m_parameters->add(&m_normalize, "normalize", "Normalize?");
+		m_parameters->add(&m_input_dimensions, "input_dimensions",
+				"Dimensions of the input space.");
+		m_parameters->add(&m_output_dimensions, "output_dimensions",
+				"Dimensions of the feature space of the polynomial kernel.");
+
+		multi_index_length=m_output_dimensions*m_degree;
+		m_parameters->add_vector(
+				&m_multi_index,
+				&multi_index_length,
+				"multi_index",
+				"Flattened matrix of all multi indices that sum do the degree of the polynomial kernel.");
+
+		multinomial_coefficients_length=m_output_dimensions;
+		m_parameters->add_vector(&m_multinomial_coefficients,
+				&multinomial_coefficients_length, "multinomial_coefficients",
+				"Multinomial coefficients for all multi-indices.");
+
+		normalization_values_length=get_num_vectors();
+		m_parameters->add_vector(&m_normalization_values,
+				&normalization_values_length, "normalization_values",
+				"Norm of each training example.");
 }

--- a/src/libshogun/features/PolyFeatures.h
+++ b/src/libshogun/features/PolyFeatures.h
@@ -265,6 +265,13 @@ class CPolyFeatures : public CDotFeatures
 		float64_t* m_multinomial_coefficients; 
 		/**store norm of each training example */
 		float32_t* m_normalization_values; 
+	private:
+		index_t multi_index_length;
+		index_t multinomial_coefficients_length;
+		index_t normalization_values_length;
+
+		/** Register all parameters */
+		void register_parameters();
 
 };
 }


### PR DESCRIPTION
As far as I have understood the serialization process, the only thing that is needed to add serialization support to a class is registering its attributes as parameters. Then CSGObject then does the rest.

In this case, the length of some matrices are depended on the initialisation, so, in contrast to Kernel.cpp, the parameters are registered after they are intitialized.

Since the length of the matrices is not originally stored in the class, I created new member variables for them. Using stack variables for the add-method does not work. Is this way ok, or should I do this differently?

I se- and deserialized an instance. It worked.
