### PR TITLE
Changing include paths in AsciiFile.h to <shogun/lib/..> from <lib/..>

### DIFF
--- a/src/libshogun/lib/AsciiFile.h
+++ b/src/libshogun/lib/AsciiFile.h
@@ -10,11 +10,11 @@
 #ifndef __ASCII_FILE_H__
 #define __ASCII_FILE_H__
 
-#include <lib/config.h>
-#include <base/DynArray.h>
-#include <lib/common.h>
-#include <lib/File.h>
-#include <lib/io.h>
+#include <shogun/lib/config.h>
+#include <shogun/base/DynArray.h>
+#include <shogun/lib/common.h>
+#include <shogun/lib/File.h>
+#include <shogun/lib/io.h>
 
 namespace shogun
 {


### PR DESCRIPTION
I don't know if this is necessary, but the current code fails if <pre>#include &lt;shogun/lib/AsciiFile.h&gt;</pre> is done without the include path being explicitly specified with g++ -I.
