### PR TITLE
Fixed file seeking in getline()

### DIFF
--- a/src/libshogun/lib/AsciiFile.cpp
+++ b/src/libshogun/lib/AsciiFile.cpp
@@ -1036,7 +1036,7 @@ ssize_t CAsciiFile::getdelim(char **lineptr, size_t *n, char delimiter, FILE *st
 	int32_t threshold_size=100000;
 
 	while (1)
-o	{
+	{
 		// We need some limit in case file does not contain '\n'
 		if (*n > threshold_size)
 			return -1;


### PR DESCRIPTION
File pointer should seek back to the location after the last \n encountered (since fread is used for reading, and running getline in a while loop will read from the end of the fread block after each iteration, thus potentially skipping over some text). This patch adds the code for this.
