### PR TITLE
adding classes to Evaluation swig interface and doing some DynArray cleanups

### DIFF
--- a/src/libshogun/evaluation/CrossValidation.cpp
+++ b/src/libshogun/evaluation/CrossValidation.cpp
@@ -115,13 +115,12 @@ float64_t CCrossValidation::evaluate_one_run()
 	for (index_t i=0; i<num_subsets; ++i)
 	{
 		/* set feature subset for training */
-		SGVector<index_t> inverse_subset_indices;
-		m_splitting_strategy->generate_subset_inverse(i, inverse_subset_indices);
+		SGVector<index_t> inverse_subset_indices=
+				m_splitting_strategy->generate_subset_inverse(i);
 		m_features->set_subset(new CSubset(inverse_subset_indices));
 
 		/* set label subset for training (copy data before) */
 		SGVector<index_t> inverse_subset_indices_copy(
-				new index_t[inverse_subset_indices.vlen],
 				inverse_subset_indices.vlen);
 		memcpy(inverse_subset_indices_copy.vector,
 				inverse_subset_indices.vector,
@@ -132,8 +131,8 @@ float64_t CCrossValidation::evaluate_one_run()
 		m_machine->train(m_features);
 
 		/* set feature subset for testing (subset method that stores pointer) */
-		SGVector<index_t> subset_indices;
-		m_splitting_strategy->generate_subset_indices(i, subset_indices);
+		SGVector<index_t> subset_indices=
+				m_splitting_strategy->generate_subset_indices(i);
 		m_features->set_subset(new CSubset(subset_indices));
 
 		/* apply machine to test features */

--- a/src/libshogun/evaluation/SplittingStrategy.cpp
+++ b/src/libshogun/evaluation/SplittingStrategy.cpp
@@ -23,44 +23,40 @@ CSplittingStrategy::CSplittingStrategy(CLabels* labels, int32_t num_subsets) :
 {
 	/* construct all arrays */
 	for (index_t i=0; i<num_subsets; ++i)
-		m_subset_indices.append_element(new DynArray<index_t> ());
+		m_subset_indices.append_element(new CDynamicArray<index_t> ());
 
 	SG_REF(m_labels);
 }
 
 CSplittingStrategy::~CSplittingStrategy()
 {
-	/* delete all created arrays */
-	for (index_t i=0; i<m_subset_indices.get_num_elements(); ++i)
-		delete m_subset_indices[i];
-
 	SG_UNREF(m_labels);
 }
 
-void CSplittingStrategy::generate_subset_indices(index_t subset_idx,
-		SGVector<index_t>& result)
+SGVector<index_t> CSplittingStrategy::generate_subset_indices(index_t subset_idx)
 {
 	/* construct SGVector copy from index vector */
-	DynArray<index_t>* to_copy=m_subset_indices.get_element_safe(subset_idx);
+	CDynamicArray<index_t>* to_copy=m_subset_indices.get_element_safe(
+			subset_idx);
 
 	index_t num_elements=to_copy->get_num_elements();
-
-	/* fill result vector */
-	result.vector=new index_t[num_elements];
-	result.vlen=num_elements;
+	SGVector<index_t> result(num_elements, true);
 
 	/* copy data */
 	memcpy(result.vector, to_copy->get_array(), sizeof(index_t)*num_elements);
+
+	SG_UNREF(to_copy);
+
+	return result;
 }
 
-void CSplittingStrategy::generate_subset_inverse(index_t subset_idx,
-		SGVector<index_t>& result)
+SGVector<index_t> CSplittingStrategy::generate_subset_inverse(index_t subset_idx)
 {
-	DynArray<index_t>* to_invert=m_subset_indices.get_element_safe(subset_idx);
+	CDynamicArray<index_t>* to_invert=m_subset_indices.get_element_safe(
+			subset_idx);
 
-	/* fill result vector */
-	result.vlen=m_labels->get_num_labels()-to_invert->get_num_elements();
-	result.vector=new index_t[result.vlen];
+	SGVector<index_t> result(
+			m_labels->get_num_labels()-to_invert->get_num_elements(), true);
 
 	index_t index=0;
 	for (index_t i=0; i<m_labels->get_num_labels(); ++i)
@@ -69,4 +65,8 @@ void CSplittingStrategy::generate_subset_inverse(index_t subset_idx,
 		if (to_invert->find_element(i)==-1)
 			result.vector[index++]=i;
 	}
+
+	SG_UNREF(to_invert);
+
+	return result;
 }

--- a/src/libshogun/evaluation/SplittingStrategy.h
+++ b/src/libshogun/evaluation/SplittingStrategy.h
@@ -12,7 +12,8 @@
 #define __SPLITTINGSTRATEGY_H_
 
 #include "base/SGObject.h"
-#include "base/DynArray.h"
+#include "lib/DynamicArray.h"
+#include "lib/DynamicObjectArray.h"
 
 namespace shogun
 {
@@ -50,22 +51,22 @@ public:
 	 * with the desired index
 	 *
 	 * @param subset_idx subset index of the to be generated vector indices
-	 * @param result newly created vector of subset indices of the specified
-	 * subset is written here
+	 * @return newly created vector of subset indices of the specified
+	 * subset is written here. do not forget to free_vector
 	 */
-	void generate_subset_indices(index_t subset_idx, SGVector<index_t>& result);
+	SGVector<index_t> generate_subset_indices(index_t subset_idx);
 
 	/** generates a newly created SGVector<index_t> with inverse indices of the
 	 * subset with the desired index. inverse here means all other indices.
 	 *
 	 * @param subset_idx subset index of the to be generated inverse indices
-	 * @return result newly created vector of the subset's inverse indices is
-	 * written here
+	 * @return newly created vector of the subset's inverse indices is
+	 * written here. do not forget to free_vector
 	 */
-	void generate_subset_inverse(index_t subset_idx, SGVector<index_t>& result);
+	SGVector<index_t> generate_subset_inverse(index_t subset_idx);
 
 	/** @return number of subsets */
-	index_t get_num_subsets() { return m_subset_indices.get_num_elements(); }
+	index_t get_num_subsets() const { return m_subset_indices.get_num_elements(); }
 
 	/** @return name of the SGSerializable */
 	inline virtual const char* get_name() const	{ return "SplittingStrategy"; }
@@ -73,13 +74,13 @@ public:
 protected:
 	/** Abstract method.
 	 * Has to fill the elements of the m_subset_indices variable with concrete
-	 * indices. Note that DynArray<index_t> instances for every subset are
+	 * indices. Note that CDynamicArray<index_t> instances for every subset are
 	 * created in the constructor of this class - they just have to be filled.
 	 */
 	virtual void build_subsets()=0;
 
 	CLabels* m_labels;
-	DynArray<DynArray<index_t>*> m_subset_indices;
+	CDynamicObjectArray<CDynamicArray<index_t> > m_subset_indices;
 };
 }
 

--- a/src/libshogun/evaluation/StratifiedCrossValidationSplitting.cpp
+++ b/src/libshogun/evaluation/StratifiedCrossValidationSplitting.cpp
@@ -34,9 +34,9 @@ void CStratifiedCrossValidationSplitting::build_subsets()
 		unique_labels.add(m_labels->get_label(i));
 
 	/* for every label, build set for indices */
-	DynArray<DynArray<index_t>*> label_indices;
+	CDynamicObjectArray<CDynamicArray<index_t> > label_indices;
 	for (index_t i=0; i<unique_labels.get_num_elements(); ++i)
-		label_indices.append_element(new DynArray<index_t> ());
+		label_indices.append_element(new CDynamicArray<index_t> ());
 
 	/* fill set with indices, for each label type ... */
 	for (index_t i=0; i<unique_labels.get_num_elements(); ++i)
@@ -45,35 +45,43 @@ void CStratifiedCrossValidationSplitting::build_subsets()
 		for (index_t j=0; j<m_labels->get_num_labels(); ++j)
 		{
 			if (m_labels->get_label(j)==unique_labels[i])
-				label_indices[i]->append_element(j);
+			{
+				CDynamicArray<index_t>* current=label_indices.get_element(i);
+				current->append_element(j);
+				SG_UNREF(current);
+			}
 		}
 	}
 
 	/* shuffle created label sets */
 	for (index_t i=0; i<label_indices.get_num_elements(); ++i)
-		label_indices[i]->shuffle();
+	{
+		CDynamicArray<index_t>* current=label_indices.get_element(i);
+		current->shuffle();
+		SG_UNREF(current);
+	}
 
 	/* distribute labels to subsets for all label types */
 	index_t target_set=0;
 	for (index_t i=0; i<unique_labels.get_num_elements(); ++i)
 	{
 		/* current index set for current label */
-		DynArray<index_t>* current=label_indices[i];
+		CDynamicArray<index_t>* current=label_indices.get_element(i);
 
 		for (index_t j=0; j<current->get_num_elements(); ++j)
 		{
-			m_subset_indices[target_set++]->append_element(
-					current->get_element(j));
+			CDynamicArray<index_t>* next=m_subset_indices.get_element(
+					target_set++);
+			next->append_element(current->get_element(j));
 			target_set%=m_subset_indices.get_num_elements();
+			SG_UNREF(next);
 		}
+
+		SG_UNREF(current);
 	}
 
 	/* finally shuffle to avoid that subsets with low indices have more
 	 * elements, which happens if the number of class labels is not equal to
 	 * the number of subsets */
 	m_subset_indices.shuffle();
-
-	/* delete created sets */
-	for (index_t i=0; i<label_indices.get_num_elements(); ++i)
-		delete label_indices[i];
 }

--- a/src/libshogun/features/Subset.cpp
+++ b/src/libshogun/features/Subset.cpp
@@ -29,14 +29,12 @@ CSubset::~CSubset() {
 }
 
 CSubset* CSubset::duplicate() {
-	SGVector<index_t> idx_copy(new index_t[m_subset_idx.vlen],
-			m_subset_idx.vlen);
+	SGVector<index_t> idx_copy(m_subset_idx.vlen);
 
 	memcpy(idx_copy.vector, m_subset_idx.vector,
 			sizeof(index_t)*m_subset_idx.vlen);
 
 	CSubset* copy_subset=new CSubset(idx_copy);
-	SG_REF(copy_subset);
 
 	return copy_subset;
 }

--- a/src/libshogun/lib/DynamicArray.h
+++ b/src/libshogun/lib/DynamicArray.h
@@ -247,6 +247,9 @@ template <class T> class CDynamicArray :public CSGObject
 			return *this;
 		}
 
+		/** shuffles the array */
+		inline void shuffle() { m_array.shuffle(); }
+
 		/** @return object name */
 		inline virtual const char* get_name() const
 		{

--- a/src/libshogun/lib/DynamicObjectArray.h
+++ b/src/libshogun/lib/DynamicObjectArray.h
@@ -251,6 +251,7 @@ template<class T>class CDynamicObjectArray :public CSGObject
 			return *this;
 		}
 
+		/** shuffles the array */
 		inline void shuffle() { m_array.shuffle(); }
 
 		/** @return object name */

--- a/src/libshogun/modelselection/ModelSelectionParameters.h
+++ b/src/libshogun/modelselection/ModelSelectionParameters.h
@@ -130,7 +130,7 @@ protected:
 	 *
 	 * @return true if it has children
 	 */
-	bool has_children()
+	bool has_children() const
 	{
 		return m_child_nodes->get_num_elements()>0;
 	}

--- a/src/modular/Evaluation.i
+++ b/src/modular/Evaluation.i
@@ -50,6 +50,9 @@
 %rename(RecallMeasure) CRecallMeasure;
 %rename(PrecisionMeasure) CPrecisionMeasure;
 %rename(SpecificityMeasure) CSpecificityMeasure;
+%rename(CrossValidation) CCrossValidation;
+%rename(SplittingStrategy) CSplittingStrategy;
+%rename(StratifiedCrossValidationSplitting) CStratifiedCrossValidationSplitting;
 
 /* Include Class Headers to make them visible from within the target language */
 %include <shogun/evaluation/Evaluation.h>
@@ -59,3 +62,6 @@
 %include <shogun/evaluation/MeanSquaredError.h>
 %include <shogun/evaluation/ROCEvaluation.h>
 %include <shogun/evaluation/PRCEvaluation.h>
+%include <shogun/evaluation/CrossValidation.h>
+%include <shogun/evaluation/SplittingStrategy.h>
+%include <shogun/evaluation/StratifiedCrossValidationSplitting.h>

--- a/src/modular/Evaluation_includes.i
+++ b/src/modular/Evaluation_includes.i
@@ -7,5 +7,8 @@
  #include <shogun/evaluation/MeanSquaredError.h>
  #include <shogun/evaluation/ROCEvaluation.h>
  #include <shogun/evaluation/PRCEvaluation.h>
+ #include <shogun/evaluation/CrossValidation.h>
+ #include <shogun/evaluation/SplittingStrategy.h>
+ #include <shogun/evaluation/StratifiedCrossValidationSplitting.h>
 %}
 


### PR DESCRIPTION
commit 116d110c03a9a4c394ecfbf52f11bb4eaac0d31e
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 21:40:53 2011 +0200

```
-removed wrong SG_REF
-usage of SGVector constructor to create array
```

commit 477f42508a5f3f78cf8f4f3f3d4013745e58193c
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 21:31:03 2011 +0200

```
added classes
```

commit b0399426af55d015a25104ce148b8f13beec6850
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 21:30:34 2011 +0200

```
applied interface changes due to SGVector changes
```

commit 614b7fb3a93834cbde3977432941dc775609b5d5
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 21:30:12 2011 +0200

```
-generell cleanup
-usage of CDynamicObjectArray and CDynamicArray instead of DynArray
-SGVector cleanup
```

commit 2dc5f3625ee1dcd864bf45fa4dbd0928fd6dd996
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 21:29:06 2011 +0200

```
added shuffle() method
```

commit c6acd061a3ec4f5fc595e9d12d6f3c3740fa14d9
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 21:28:57 2011 +0200

```
added comment
```

commit da48e781312037a8660eb01d5f4d4f47f9ff3d1b
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 17:06:38 2011 +0200

```
Revert "made get_evaluation_direction() const"

This reverts commit da627efed746f371a9d33bf2799670a072523f40.
```

commit 321aeefe86b4f9808055c29cc2889b171b2e9eee
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 17:02:49 2011 +0200

```
made get_evaluation_direction() const
```

commit c89a51a6269df4f37b6ce01671457da24a7b0b8e
Author: Heiko Strathmann heiko.strathmann@gmail.com
Date:   Thu Jul 14 16:50:36 2011 +0200

```
made has_children() method const
```
