### PR TITLE
,long evening

### DIFF
--- a/src/shogun/modelselection/ModelSelectionParameters.cpp
+++ b/src/shogun/modelselection/ModelSelectionParameters.cpp
@@ -59,10 +59,6 @@ CModelSelectionParameters::~CModelSelectionParameters()
 {
 	SG_UNREF(m_child_nodes);
 	SG_UNREF(m_sgobject);
-<<<<<<< HEAD
-=======
-
->>>>>>> kernelmachine
 	delete_values();
 }
 
@@ -128,17 +124,10 @@ void CModelSelectionParameters::build_values(EMSParamType value_type, void* min,
 
 	/* possibly delete old range values */
 	delete_values();
-<<<<<<< HEAD
 
 	/* save new type */
 	m_value_type=value_type;
 
-=======
-
-	/* save new type */
-	m_value_type=value_type;
-
->>>>>>> kernelmachine
 	if (value_type==MSPT_FLOAT64)
 	{
 		SGVector<float64_t> values=create_range_array<float64_t>(


### PR DESCRIPTION
-made model selection parameter able to hold multiple numeric types (currently float and int)
-applied changes to all examples (interfaces remain the same)
-added copy_subset for string_features, so kernel machines on string features may now store their model and therefore may be used for cross-validation and therefor for model selection
-an example will follow, i got this "ALPHABET does not contain all symbols in histogram" error again (but this time with only UPPERCASE letters, happens model selection, will check this tomorrow

good night :)
