### PR TITLE
Replaced size_t with uint32_t in hash func typedef.

### DIFF
--- a/src/shogun/classifier/vw/vw_common.h
+++ b/src/shogun/classifier/vw/vw_common.h
@@ -28,7 +28,7 @@
 namespace shogun
 {
 
-typedef size_t (*hash_func_t)(substring, uint32_t);
+typedef uint32_t (*hash_func_t)(substring, uint32_t);
 
 const int32_t quadratic_constant = 27942141;
 const int32_t constant_hash = 11650396;


### PR DESCRIPTION
Hopefully this fixed the compile issue. The hash function is declared with uint32_t in Hash.h and was typedef'd as size_t in vw_common.h
