### PR TITLE
Added VW example and fixed a write-mode argument in IOBuffer.

### DIFF
--- a/examples/undocumented/libshogun/streaming_vowpalwabbit.cpp
+++ b/examples/undocumented/libshogun/streaming_vowpalwabbit.cpp
@@ -1,0 +1,46 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2011 Shashwat Lal Das
+ * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
+ *
+ * This example demonstrates use of the Vowpal Wabbit learning algorithm.
+ */
+
+#include <shogun/lib/common.h>
+
+#include <shogun/io/StreamingVwFile.h>
+#include <shogun/features/StreamingVwFeatures.h>
+#include <shogun/classifier/vw/VowpalWabbit.h>
+
+using namespace shogun;
+
+int main()
+{
+	init_shogun_with_defaults();
+
+	char* train_file_name = "../data/train_sparsereal.light";
+	CStreamingVwFile* train_file = new CStreamingVwFile(train_file_name);
+	train_file->set_parser_type(T_SVMLIGHT); // Treat the file as SVMLight format
+	SG_REF(train_file);
+
+	CStreamingVwFeatures* train_features = new CStreamingVwFeatures(train_file, true, 1024);
+	SG_REF(train_features);
+
+	CVowpalWabbit* vw = new CVowpalWabbit(train_features);
+	vw->set_regressor_out("./vw_regressor_text.dat"); // Save regressor to this file
+	vw->set_adaptive(false);			  // Use adaptive learning
+	vw->train_machine();
+
+	SG_SPRINT("Weights have been output in text form to vw_regressor_text.dat.\n");
+	train_file->close();
+
+	SG_UNREF(train_features);
+	SG_UNREF(train_file);
+	SG_UNREF(vw);
+
+	exit_shogun();
+}

--- a/src/shogun/io/IOBuffer.cpp
+++ b/src/shogun/io/IOBuffer.cpp
@@ -49,13 +49,14 @@ void CIOBuffer::use_file(int fd)
 int CIOBuffer::open_file(const char* name, char flag)
 {
 	int ret=1;
-	switch(flag){
+	switch(flag)
+	{
 	case 'r':
 		working_file = open(name, O_RDONLY|O_LARGEFILE);
 		break;
 
 	case 'w':
-		working_file = open(name, O_WRONLY|O_LARGEFILE);
+		working_file = open(name, O_CREAT|O_TRUNC|O_WRONLY, 0666);
 		break;
 
 	default:


### PR DESCRIPTION
This has a minimal VW example and also updates the open() in IOBuffer for write-mode files.
