### PR TITLE
Updated install docs w/ current interfaces names, homebrew suggestion

### DIFF
--- a/doc/pages/Installation.mainpage
+++ b/doc/pages/Installation.mainpage
@@ -113,11 +113,11 @@ sudo make install
 
 where \b interface is one of the following
 
-\li python or python-modular -- for python (see http://www.python.org)
+\li python_static or python_modular -- for python (see http://www.python.org)
 
-\li octave or octave_modular -- for octave (see http://www.octave.org)
+\li octave_static or octave_modular -- for octave (see http://www.octave.org)
 
-\li r or r_modular -- for r (see http://www.r-project.org).
+\li r_static or r_modular -- for r (see http://www.r-project.org).
 
 \li java_modular -- for java (see http://www.java.com).
 
@@ -127,7 +127,9 @@ where \b interface is one of the following
 
 \li csharp_modular -- for csharp (see http://www.csharp-station.com/).
 
-\li matlab -- for matlab (see http://www.mathworks.com)
+\li matlab_static -- for matlab (see http://www.mathworks.com)
+
+\li libshogun_static -- for for regular shogun library
 
 (you don't need to compile libshogunui in case you compile a modular interface)
 

--- a/src/INSTALL
+++ b/src/INSTALL
@@ -209,7 +209,7 @@ A workaround is to uncomment this in math.h:
 Also make sure you don't mix python versions (i.e. python2.5 and python2.6) on build/runtime.
 You can specify the python version as a argument to configure, e.g.: --python=python2.7
 
-./configure --interface=python
+./configure --interface=python_static
 make
 
 to test if it is working try:
@@ -218,7 +218,7 @@ PYTHONPATH=`pwd` python ../examples/documented/python/graphical/svm_classificati
 
 object oriented python/swig interface:
 ======================================
-Follow the above instructions for python. Then use fink/darwinports to install swig.
+Follow the above instructions for python. Then use homebrew/fink/darwinports to install swig.
 
 ./configure --interfaces=python-modular
 make


### PR DESCRIPTION
Updated install docs w/ current interfaces names, homebrew suggestion for OSX

The installation document seen on the shogun homepage has out-of-date interface names. I noticed these names because I was trying out various ways to compile from source on OS X,  as I'm planning on writing a homebrew formula to make installation easier.

I also added homebrew to the section on installing swig via fink/darwinports.
