### PR TITLE
compile fix

### DIFF
--- a/src/shogun/kernel/MultitaskKernelMaskPairNormalizer.h
+++ b/src/shogun/kernel/MultitaskKernelMaskPairNormalizer.h
@@ -14,6 +14,7 @@
 #include <shogun/kernel/KernelNormalizer.h>
 #include <shogun/kernel/Kernel.h>
 
+#include <string>
 
 namespace shogun
 {


### PR DESCRIPTION
(string include was recently removed out of Kernel.h)
