### PR TITLE
minor fixes for the for the homogeneous kernel mapping implementation

### DIFF
--- a/src/shogun/preprocessor/HomogeneousKernelMap.cpp
+++ b/src/shogun/preprocessor/HomogeneousKernelMap.cpp
@@ -171,6 +171,9 @@ SGMatrix<float64_t> CHomogeneousKernelMap::apply_to_feature_matrix (CFeatures* f
 		apply_to_vector (v, col);
 	}
 	
+	/* set the new generated feature matrix */
+	simple_features->set_feature_matrix (result);
+	
 	return result;
 }
 


### PR DESCRIPTION
There's just 2 minor fixes in these commits:
- removing the null pointer check as asked by sonny
- setting the new matrix created matrix for the supplied SimpleFeatures instance. this way
  feats_train.add_preprocessor(preprocessor)
  feats_train.apply_preprocessor()

will work as supposed to...
