### PR TITLE
Cleanup doc pages: fix issue tracker url, typos, line length

### DIFF
--- a/doc/pages/DeveloperTutorial.mainpage
+++ b/doc/pages/DeveloperTutorial.mainpage
@@ -108,7 +108,8 @@ CSimpleKernel<float64_t> (for strings it would be CStringKernel, for sparse
 features CSparseKernel).
 
 Essentially we only need to overload the CKernel::compute() function with our
-own implementation of compute. All the rest gets empty defaults. An example for our compute() function could be
+own implementation of compute. All the rest gets empty defaults. An example for
+our compute() function could be
 
 
 \verbatim
@@ -117,7 +118,7 @@ virtual float64_t compute(int32_t idx_a, int32_t idx_b)
     int32_t alen, blen;
     bool afree, bfree;
 
-    float64_t* avec= 
+    float64_t* avec=
         ((CSimpleFeatures<float64_t>*) lhs)->get_feature_vector(idx_a, alen, afree);
     float64_t* bvec=
         ((CSimpleFeatures<float64_t>*) rhs)->get_feature_vector(idx_b, blen, bfree);
@@ -183,11 +184,11 @@ and finally tell swig to wrap all functions found in the header
 \endverbatim
 
 In case you got your object working we will happily integrate it into shogun
-provided you follow a number of basic coding conventions detailed in \subpage devel (see
-FORMATTING for formatting instructions, MACROS on how to use and name macros,
-TYPES on which types to use, FUNCTIONS on how functions should look like and
-NAMING CONVENTIONS for the naming scheme. Note that in case you change the API
-in a way that breaks ABI compatibility you need to increase the major number of
-the libshogun soname (see \subpage soname ).
+provided you follow a number of basic coding conventions detailed in \subpage
+devel (see FORMATTING for formatting instructions, MACROS on how to use and name
+macros, TYPES on which types to use, FUNCTIONS on how functions should look like
+and NAMING CONVENTIONS for the naming scheme. Note that in case you change the
+API in a way that breaks ABI compatibility you need to increase the major number
+of the libshogun soname (see \subpage soname ).
 
 */

--- a/doc/pages/Documentation.mainpage
+++ b/doc/pages/Documentation.mainpage
@@ -25,7 +25,7 @@
   Perceptrons and features algorithms to train hidden markov models. The input
   feature-objects can be dense, sparse or strings and of type
   int/short/double/char and can be converted into different feature types.
-  Chains of preprocessors (e.g.  substracting the mean) can be attached to each
+  Chains of preprocessors (e.g.  subtracting the mean) can be attached to each
   feature object allowing for on-the-fly pre-processing.
 
   SHOGUN is implemented in C++ and interfaces to Matlab(tm), R, Octave and

--- a/doc/pages/EierlegendeWollmilchSauInterface.mainpage
+++ b/doc/pages/EierlegendeWollmilchSauInterface.mainpage
@@ -2,9 +2,9 @@
 
 As mentioned before SHOGUN interfaces to several programming languages and
 toolkits such as Matlab(tm), R, Python, Octave. The special
-Eierlegendewollmilchsau (elwms) interface does everything in one file. It is
-a chimera of all the \subpage staticinterfaces, thus all the examples and documentation
-form \subpage staticinterfaces still apply.
+Eierlegendewollmilchsau (elwms) interface does everything in one file. It is a
+chimera of all the \subpage staticinterfaces, thus all the examples and
+documentation form \subpage staticinterfaces still apply.
 
 One of the key strengths of this interface is that it provides the
 \verbatim
@@ -13,7 +13,8 @@ elwms('run_r', 'A', A, ..., 'rfile', '...')
 elwms('run_octave', 'A', A, ..., octavecode, '...')
 \endverbatim
 
-interoperability commands that enable running of code in foreign languages. For example 
+interoperability commands that enable running of code in foreign languages. For
+example
 
 \verbinclude octave_matplotlib.m
 

--- a/doc/pages/ExamplesLibshogun.mainpage
+++ b/doc/pages/ExamplesLibshogun.mainpage
@@ -2,28 +2,29 @@
 
 This page lists ready to run shogun examples for the C++ libshogun interface.
 
-\li \subpage libshogun_base_examples 
-\li \subpage libshogun_basic_examples 
-\li \subpage libshogun_classifier_examples 
-\li \subpage libshogun_clustering_examples 
-\li \subpage libshogun_converter_examples 
-\li \subpage libshogun_features_examples 
-\li \subpage libshogun_kernel_examples 
-\li \subpage libshogun_library_examples 
-\li \subpage libshogun_mathematics_examples 
-\li \subpage libshogun_modelselection_examples 
-\li \subpage libshogun_parameter_examples 
-\li \subpage libshogun_preprocessor_examples 
-\li \subpage libshogun_serialization_examples 
-\li \subpage libshogun_splitting_examples 
-\li \subpage libshogun_streaming_examples 
+\li \subpage libshogun_base_examples
+\li \subpage libshogun_basic_examples
+\li \subpage libshogun_classifier_examples
+\li \subpage libshogun_clustering_examples
+\li \subpage libshogun_converter_examples
+\li \subpage libshogun_features_examples
+\li \subpage libshogun_kernel_examples
+\li \subpage libshogun_library_examples
+\li \subpage libshogun_mathematics_examples
+\li \subpage libshogun_modelselection_examples
+\li \subpage libshogun_parameter_examples
+\li \subpage libshogun_preprocessor_examples
+\li \subpage libshogun_serialization_examples
+\li \subpage libshogun_splitting_examples
+\li \subpage libshogun_streaming_examples
 
 To run the examples you will need to manually compile them via
 \verbatim
 g++ name_of_example.cpp -lshogun
 \endverbatim
 
-in case you installed libshogun to a nonstandard directory you will need to specify the appropriate library and include paths, e.g.
+in case you installed libshogun to a nonstandard directory you will need to
+specify the appropriate library and include paths, e.g.
 \verbatim
 g++ -I/path/to/libshogun/includes name_of_example.cpp -L/path/to/libshogun/sofile -lshogun
 \endverbatim
@@ -32,11 +33,12 @@ Then the examples are standard binary executables and can be started via
 \verbatim
 ./name_of_example
 \endverbatim
-respectively if the libraries are in nonstandard locations (such that they cannot be found by the dynamic linker)
+respectively if the libraries are in nonstandard locations (such that they
+cannot be found by the dynamic linker)
 \verbatim
 LD_LIBRARY_PATH=path/to/libshogun ./name_of_example
 \endverbatim
-		
+
 \section libshogun_base_examples Base
 
 

--- a/doc/pages/ExamplesStaticOctave.mainpage
+++ b/doc/pages/ExamplesStaticOctave.mainpage
@@ -1,18 +1,19 @@
 /*! \page octave_static_examples Examples for Static Matlab(tm) and Octave Interface
 
-This page lists ready to run shogun examples for the Static Matlab(tm) and Octave interface.
+This page lists ready to run shogun examples for the Static Matlab(tm) and
+Octave interface.
 
-\li \subpage octave_static_classifier_examples 
-\li \subpage octave_static_clustering_examples 
-\li \subpage octave_static_distance_examples 
-\li \subpage octave_static_distribution_examples 
-\li \subpage octave_static_features_examples 
-\li \subpage octave_static_kernel_examples 
-\li \subpage octave_static_misc_examples 
-\li \subpage octave_static_mkl_examples 
-\li \subpage octave_static_preproc_examples 
-\li \subpage octave_static_regression_examples 
-\li \subpage octave_static_structure_examples 
+\li \subpage octave_static_classifier_examples
+\li \subpage octave_static_clustering_examples
+\li \subpage octave_static_distance_examples
+\li \subpage octave_static_distribution_examples
+\li \subpage octave_static_features_examples
+\li \subpage octave_static_kernel_examples
+\li \subpage octave_static_misc_examples
+\li \subpage octave_static_mkl_examples
+\li \subpage octave_static_preproc_examples
+\li \subpage octave_static_regression_examples
+\li \subpage octave_static_structure_examples
 
 To run the examples issue
 \verbatim
@@ -24,8 +25,9 @@ or start up matlab or octave and then type
 name_of_example
 \endverbatim
 
-Note that you have to make sure that the sg.oct or sg.mexglx (name varies with architecture)
-has to be in the matlab/octave path. This can be achieved using the addpath command:
+Note that you have to make sure that the sg.oct or sg.mexglx (name varies with
+architecture) has to be in the matlab/octave path. This can be achieved using
+the addpath command:
 \verbatim
 addpath /path/to/octave
 \endverbatim
@@ -34,13 +36,15 @@ respectively
 addpath /path/to/matlab
 \endverbatim
 
-Finally note that for non-root installations you will have to make sure that libshogun and libshogun ui can be found by the dynamic linker, e.g. you will need to set:
+Finally note that for non-root installations you will have to make sure that
+libshogun and libshogun ui can be found by the dynamic linker, e.g. you will
+need to set:
 
 \verbatim
 LD_LIBRARY_PATH=path/to/libshogun:path/to/libshogunui
 \endverbatim
 before starting matlab.
-		
+
 \section octave_static_classifier_examples Classifier
 
 

--- a/doc/pages/FAQ.mainpage
+++ b/doc/pages/FAQ.mainpage
@@ -2,16 +2,16 @@
 \page faq Frequently Asked Questions
 
 \li Q: I am puzzled, shogun interfaces to so many languages but which language
-and shogun interface should I use?
-A: That depends a lot on your taste. I personally consider the modular
-interfaces (python_modular, octave_modular) to be "best". Here best means very
-flexible and easily extensible. However, in case you just want to train a single
-SVM with a single or multiple kernels all of the static interfaces are
-sufficient. And well, of course you should be using \b python http://www.python.org :-)
+and shogun interface should I use? A: That depends a lot on your taste. I
+personally consider the modular interfaces (python_modular, octave_modular) to
+be "best". Here best means very flexible and easily extensible. However, in case
+you just want to train a single SVM with a single or multiple kernels all of the
+static interfaces are sufficient. And well, of course you should be using \b
+python http://www.python.org :-)
 
-\li Q: I've found a bug, where should I report it?
-A: Either report it in our bug tracker http://trac.tuebingen.mpg.de/shogun or
-ask on the mailinglist.
+\li Q: I've found a bug, where should I report it? A: Either report it in our
+bug tracker https://github.com/shogun-toolbox/shogun/issues or ask on the
+mailinglist.
 
 \li Q:Do I need CPLEX to use multiple kernel learning?
 A: No, as of version 0.7.0 you won't need cplex if you want to learn the weights
@@ -21,11 +21,11 @@ multiple kernel learning (MKL) the GNU Linear Programming Kit (GLPK) version at
 least 4.29 or CPLEX is required. For general p-norm MKL with p>1 it will work
 nonetheless.
 
-\li Q: Is it multiple kernel learning when I use many kernels?
-A: No, a plain combination of features/kernels will remain a plain
-concatenation. Only in case you learn the kernel weights you really do MKL. In
-the static interfaces you can issue \verbatim [W]=sg('get_subkernel_weights') \endverbatim
-and check whether all weights W are still 1.0.
+\li Q: Is it multiple kernel learning when I use many kernels? A: No, a plain
+combination of features/kernels will remain a plain concatenation. Only in case
+you learn the kernel weights you really do MKL. In the static interfaces you can
+issue \verbatim [W]=sg('get_subkernel_weights') \endverbatim and check whether
+all weights W are still 1.0.
 
 \li Q:Does shogun compile under windows?
 A: Yes! With cygwin 1.7.1 the cmdline, python, python_modular and octave
@@ -42,12 +42,12 @@ to install (etc.). A plain ./configure;make;make install will fail since
 repeated slashes (e.g., '//usr/local') in cygwin are problematic but in posix
 systems simply ignored.
 
-\li Q:How does shogun do its memory management?
-A: As does python, we use reference counting internally, i.e. objects holding a
-reference to another object should increase the reference count of the object
-they are referencing and decrease the counter when they finished using the
-object. It should be noted that loops (e.g., object A holding a reference to object B
-and vice versa) are not detecting and may thus create memory leaks. However,
-this scenario can so far be easily avoided - just don't create a combined
-kernel that contains itself as a subkernel ;-)
+\li Q:How does shogun do its memory management? A: As does python, we use
+reference counting internally, i.e. objects holding a reference to another
+object should increase the reference count of the object they are referencing
+and decrease the counter when they finished using the object. It should be noted
+that loops (e.g., object A holding a reference to object B and vice versa) are
+not detecting and may thus create memory leaks. However, this scenario can so
+far be easily avoided - just don't create a combined kernel that contains itself
+as a subkernel ;-)
 */

--- a/doc/pages/Installation.mainpage
+++ b/doc/pages/Installation.mainpage
@@ -139,7 +139,7 @@ will autodetect and configure for the available interfaces.
 
 Call
 \verbatim./configure --help \endverbatim
-to see the list of additional options detailled below.
+to see the list of additional options detailed below.
 \verbinclude Configure.generated
 
 If this does not work for you, consult the INSTALL file for platform specific

--- a/doc/pages/Methods.mainpage
+++ b/doc/pages/Methods.mainpage
@@ -8,11 +8,11 @@
   ML related Algorithms/Classes/Methods implemented within shogun.
 
   \section featrep_sec Feature Representations
-  Shogun supports a wide range of feature representations. Among them are the so called
-  simple features (cf., CSimpleFeatures) that are standard 2-d Matrices, strings
-  (cf., CStringFeatures) that however in contrast to other meanings of string are
-  just a list of vectors of arbitrary length and sparse features (cf.,
-  CSparseFeatures) to efficiently represent sparse matrices.
+  Shogun supports a wide range of feature representations. Among them are the so
+  called simple features (cf., CSimpleFeatures) that are standard 2-d Matrices,
+  strings (cf., CStringFeatures) that however in contrast to other meanings of
+  string are just a list of vectors of arbitrary length and sparse features
+  (cf., CSparseFeatures) to efficiently represent sparse matrices.
 
   Each of these feature objects
 
@@ -37,9 +37,9 @@
   Many other feature types available. Some of them are based on the three basic
   feature types above, like CTOPFeatures (TOP Kernel features from CHMM),
   CFKFeatures (Fisher Kernel features from CHMM) and CRealFileFeatures (vectors
-  fetched from a binary file). It should be noted that all 
-  feature objects are derived from CFeatures 
-  More complex 
+  fetched from a binary file). It should be noted that all
+  feature objects are derived from CFeatures
+  More complex
   \li CAttributeFeatures - Features of attribute value pairs.
   \li CCombinedDotFeatures -  Features that allow stacking of dot features.
   \li CCombinedFeatures - Features that allow stacking of arbitrary features.
@@ -49,7 +49,8 @@
   \li CImplicitWeightedSpecFeatures - DotFeatures that implicitly implement weighted spectrum kernel features.
   \li CWDFeatures - DotFeatures that implicitly implement weighted degree kernel features.
 
-  In addition, labels are represented in CLabels and the alphabet of a string in CAlphabet.
+  In addition, labels are represented in CLabels and the alphabet of a string in
+  CAlphabet.
 
 
 
@@ -112,7 +113,7 @@
   \subsection other_regress Others
   \li CKRR - Kernel Ridge Regression
 
-  
+
 
   \section distrib_sec Distributions
   \li CHMM - Hidden Markov Models
@@ -142,7 +143,7 @@
   \li CAUCKernel - To maximize AUC in SVM training (takes a kernel as input)
   \li CChi2Kernel - Chi^2 Kernel
   \li CCombinedKernel - Combined kernel to work with multiple kernels
-  \li CCommUlongStringKernel - Spectrum Kernel with spectrums of up to 64bit 
+  \li CCommUlongStringKernel - Spectrum Kernel with spectrums of up to 64bit
   \li CCommWordStringKernel - Spectrum kernel with spectrum of up to 16 bit
   \li CConstKernel - A ``kernel'' returning a constant
   \li CCustomKernel - A user supplied custom kernel

--- a/doc/pages/ModularTutorial.mainpage
+++ b/doc/pages/ModularTutorial.mainpage
@@ -1,18 +1,18 @@
 /*!
 \page modular_tutorial Tutorial for Modular Interfaces
 
-SHOGUN's "modular" interfaces to Python, Octave, Java, Lua, Ruby and C#
-give intuitive and easy access to the shogun's functionality.
-Compared to the static interfaces (\subpage staticinterfaces), 
-the modular ones are much more flexible and allow for nearly unlimited extensibility. 
+SHOGUN's "modular" interfaces to Python, Octave, Java, Lua, Ruby and C# give
+intuitive and easy access to the shogun's functionality. Compared to the static
+interfaces (\subpage staticinterfaces), the modular ones are much more flexible
+and allow for nearly unlimited extensibility.
 
 If this is your first time using shogun, you've found the right place to start!
 
 
-In this tutorial, we demonstrate how to use shogun to create a simple
-Gaussian kernel based Support Vector Machine (SVM) classifier, but first
-things first. Let's fire up python, octave, java, lua, ruby or C#, and load the modular
-shogun environment.
+In this tutorial, we demonstrate how to use shogun to create a simple Gaussian
+kernel based Support Vector Machine (SVM) classifier, but first things first.
+Let's fire up python, octave, java, lua, ruby or C#, and load the modular shogun
+environment.
 
 \section start_shogun_modular Starting SHOGUN
 
@@ -21,8 +21,8 @@ To load all of shogun's modules under octave start octave and issue
 init_shogun
 \endverbatim
 
-Under python we have to specify what we'd like to import. 
-For this example, we will need features and labels to represent our input data, 
+Under python we have to specify what we'd like to import.
+For this example, we will need features and labels to represent our input data,
 a classifier, a kernel to compare the similarity of features and
 some evaluation procedures.
 
@@ -70,8 +70,8 @@ as kernel, classifier, distance and so on.
 require('shogun')
 \endverbatim
 
-we also have to specify what we'd like to load. 
-For this example, we will need features and labels to represent our input data, 
+we also have to specify what we'd like to load.
+For this example, we will need features and labels to represent our input data,
 a classifier, a kernel to compare the similarity of features
 
 \verbatim
@@ -89,9 +89,9 @@ Features.init_shogun_with_defaults();
 
 \section docu_shogun_modular Getting Help
 
-If you would like to get an overview of the classes in shogun or 
+If you would like to get an overview of the classes in shogun or
 if you are looking for the documentation of a particular class,
-use the "Classes" tab above and browse through the class list. 
+use the "Classes" tab above and browse through the class list.
 All classes are rather well documented (if documentation is not good enough in a
 particular class, please notify us). Note that all classes in the
 classes list (classes tab above) are all prefixed with a 'C' - that
@@ -99,7 +99,7 @@ really is the only difference to using them from within the python or
 octave modular interfaces (where the C prefix is missing).
 
 Alternatively, under python the same documentation is available via
-python help strings, so you may issue 
+python help strings, so you may issue
 
 \verbatim
 help(<classname>)
@@ -180,7 +180,7 @@ function concatenate(...)
 		for row,rowdata in ipairs(t) do
 			for col,coldata in ipairs(rowdata) do
 				table.insert(result[row], coldata)
-			end		
+			end
 		end
 	end
 	return result
@@ -192,7 +192,7 @@ function rand_matrix(rows, cols, dist)
 		matrix[i] = {}
 		for j = 1, cols do
 			matrix[i][j] = math.random() + dist
-		end	
+		end
 	end
 	return matrix
 end
@@ -299,13 +299,15 @@ for (int i = 0; i < num; i ++) {
 	testlab[i + num] = 1;
 }
 
-The rest of this tutorial below will now work the same (identical syntax) for python,
-octave (when using a trailing semicolon for each command, which is optional in python),
-lua(we use colon to get the method of an object), ruby and C#
+The rest of this tutorial below will now work the same (identical syntax) for
+python, octave (when using a trailing semicolon for each command, which is
+optional in python), lua(we use colon to get the method of an object), ruby and
+C#
 
-For java, we use DoubleMatrix to represent most of the types. If shogun C++ class need a 
-int Vector/Matrix, we convert the DoubleMatrix into int Vector/Matrix and when returned 
-from the function, we convert the int Vector/Matrix into DoubleMatrix again.
+For java, we use DoubleMatrix to represent most of the types. If shogun C++
+class need a int Vector/Matrix, we convert the DoubleMatrix into int
+Vector/Matrix and when returned from the function, we convert the int
+Vector/Matrix into DoubleMatrix again.
 
 \section svm_tutorial_modular Creating an SVM classifier
 
@@ -333,19 +335,20 @@ and can now compute the kernel matrix
 km = kernel.get_kernel_matrix();
 \endverbatim
 
-To train an SVM, we need labeled examples, which is a vector of ones
-and minus ones, such as the one we have previously stored in the variable train_labels.
-We now create a shogun label object from it (the same goes for our test labels, which we'll
-use later):
+To train an SVM, we need labeled examples, which is a vector of ones and minus
+ones, such as the one we have previously stored in the variable train_labels. We
+now create a shogun label object from it (the same goes for our test labels,
+which we'll use later):
 
 \verbatim
 labels = Labels(train_labels);
 labels_test = Labels(test_labels);
 \endverbatim
 
-Given the labels object and the kernel all that is left to do is to specify a cost parameter C
-(used to control generalization performance) and we can construct an SVM object. To start the
-training, we simply invoke the train method of the SVM object. Quiet easy, isn't it?
+Given the labels object and the kernel all that is left to do is to specify a
+cost parameter C (used to control generalization performance) and we can
+construct an SVM object. To start the training, we simply invoke the train
+method of the SVM object. Quiet easy, isn't it?
 
 \verbatim
 C = 1.0;
@@ -353,12 +356,13 @@ svm = LibSVM(C, kernel, labels);
 svm.train();
 \endverbatim
 
-To apply the SVM to unseen test data, we simply need to pass a feature object to the 
-SVM's apply method, which returns a shogun Label object (note that we could alternatively
-initialize the kernel object with the train and test data manually and then call apply
-without arguments, which is done in some of the other example scripts).
-If we would like to analyze the outputs directly in python/octave, we can obtain the vector 
-of outputs in native python/octave representation via get_labels(). 
+To apply the SVM to unseen test data, we simply need to pass a feature object to
+the SVM's apply method, which returns a shogun Label object (note that we could
+alternatively initialize the kernel object with the train and test data manually
+and then call apply without arguments, which is done in some of the other
+example scripts). If we would like to analyze the outputs directly in
+python/octave, we can obtain the vector of outputs in native python/octave
+representation via get_labels().
 
 \verbatim
 output = svm.apply(feats_test);
@@ -366,10 +370,11 @@ output_vector = output.get_labels();
 \endverbatim
 
 
-Given the output and the test labels, we can now assess the prediction performance. For this, 
-we create an instance of the class PerformanceMeasures, which provides a convenient
-way of obtaining various performance measures, such as accuracy (acc), area under
-the receiver operator characteristic curve (auROC), F-score and others:
+Given the output and the test labels, we can now assess the prediction
+performance. For this, we create an instance of the class PerformanceMeasures,
+which provides a convenient way of obtaining various performance measures, such
+as accuracy (acc), area under the receiver operator characteristic curve
+(auROC), F-score and others:
 
 \verbatim
 pm = PerformanceMeasures(labels_test, output);
@@ -378,7 +383,8 @@ roc = pm.get_auROC();
 fms = pm.get_fmeasure();
 \endverbatim
 
-That's really it. For any of the advanced topics please have a look one of the \b many self-explanatory examples in
+That's really it. For any of the advanced topics please have a look one of the
+\b many self-explanatory examples in
 
 \li examples/octave-modular also available online \subpage octave_modular_examples "here"
 \li examples/python-modular also available online \subpage python_modular_examples "here"

--- a/doc/pages/StaticInterfaces.mainpage
+++ b/doc/pages/StaticInterfaces.mainpage
@@ -5,10 +5,10 @@ toolkits such as Matlab(tm), R, Python, Octave. The following sections shall
 give you an overview over the static interface commands of SHOGUN. For the
 static interfaces we tried to preserve the syntax of the commands in a
 consistent manner through all the different languages. However as in some cases
-this was not possible and we document the subtle differences of syntax and semantic
-in the respective toolkit. Instead of reading through all this, we suggest to have a look at
-the large number of examples available in the \b examples / interface directory.
-For example examples/R or examples/python etc.
+this was not possible and we document the subtle differences of syntax and
+semantic in the respective toolkit. Instead of reading through all this, we
+suggest to have a look at the large number of examples available in the \b
+examples / interface directory. For example examples/R or examples/python etc.
 
 <b>Overview of Static Interfaces & Testing the Installation</b>
 \li \ref staticoctaveinterf_sec
@@ -25,7 +25,7 @@ For example examples/R or examples/python etc.
 \li \ref staticifexample_sec
 
 <b>Command Reference</b>
-\li \ref staticifcmdref_sec 
+\li \ref staticifcmdref_sec
 
 \section staticifoverview_sec Overview of Static Interfaces & Testing the Installation
 
@@ -35,8 +35,8 @@ Since octave is nowadays up to par with matlab a single documentation for both
 interfaces is sufficient and will be based on octave (matlab can be used
 synonymously).
 
-To start SHOGUN in octave, start octave and check if it is correctly installed by
-by typing ( let ">" be the octave prompt )
+To start SHOGUN in octave, start octave and check if it is correctly installed
+by by typing ( let ">" be the octave prompt )
 
 \verbatim
   sg('help')
@@ -46,8 +46,8 @@ inside of octave. This should show you some help text.
 
 \subsection staticpythoninterf_sec Static Python Interface
 
-To start SHOGUN in python, start python and check if it is correctly installed by
-by typing ( let ">" be the python prompt )
+To start SHOGUN in python, start python and check if it is correctly installed
+by by typing ( let ">" be the python prompt )
 
 \verbatim
   from sg import sg
@@ -106,14 +106,16 @@ Transfer the features to shogun
 
 Features can be char/byte/word/int/real valued matrices, real values sparse
 matrices, or strings (lists or cell arrays of strings). When dealing with
-strings an alphabet name has to be specified (DNA, RAW, ...).
-Use 'TRAIN' to tell SHOGUN that this is the data you want to train your classifier and TEST for the test data.
+strings an alphabet name has to be specified (DNA, RAW, ...). Use 'TRAIN' to
+tell SHOGUN that this is the data you want to train your classifier and TEST for
+the test data.
 
 In contrast to \b set_features, \b add_features will create a combined feature
 object and append the features to it. This is useful when dealing with a set of
 different features (real valued and strings) and multiple kernels.
 
-In case a single string was set using \b set_features, it can be "multiplexed" by sliding a window over it using
+In case a single string was set using \b set_features, it can be "multiplexed"
+by sliding a window over it using
 \arg \b from_position_list \verbatim sg('from_position_list', 'TRAIN|TEST', winsize, shift[, skip]) \endverbatim
 or
 \arg \b obtain_from_sliding_window \verbatim sg('obtain_from_sliding_window', winsize, skip) \endverbatim
@@ -124,8 +126,8 @@ Deletes the features which we assigned before in the actual SHOGUN session.
 Obtain the Features from shogun
 \arg \b get_features \verbatim [features]=sg('get_features', 'TRAIN|TEST') \endverbatim
 
-One proceeds similar when assigning labels to the training data and obtaining labels from shogun:
-The commands
+One proceeds similar when assigning labels to the training data and obtaining
+labels from shogun: The commands
 
 \arg \b set_labels \verbatim sg('set_labels', 'TRAIN', trainlab) \endverbatim
 \arg \b get_labels \verbatim [labels]=sg('get_labels', 'TRAIN|TEST') \endverbatim
@@ -137,13 +139,17 @@ interface).
 
 \subsection staticifkernel_sec Kernel & Distances
 
-Kernel and DistanceMatrix specific commands, used to create, obtain and setting the kernel matrix.
+Kernel and DistanceMatrix specific commands, used to create, obtain and setting
+the kernel matrix.
 
 Creating a kernel in shogun
 \arg \b set_kernel \verbatim sg('set_kernel', 'KERNELNAME', 'FEATURETYPE', CACHESIZE, PARAMETERS) \endverbatim
 \arg \b add_kernel \verbatim sg('add_kernel', WEIGHT, 'KERNELNAME', 'FEATURETYPE', CACHESIZE, PARAMETERS) \endverbatim
 
-Here KERNELNAME is the name of the kernel one wishes to use, FEATURETYPE the type of features (e.g. REAL for standard realvalued feature vectors), CACHESIZE the size of the kernel cache in megabytes and PARAMETERS kernel specific additional parameters.
+Here KERNELNAME is the name of the kernel one wishes to use, FEATURETYPE the
+type of features (e.g. REAL for standard realvalued feature vectors), CACHESIZE
+the size of the kernel cache in megabytes and PARAMETERS kernel specific
+additional parameters.
 
 \subsubsection staticifsuppkernels_sec Supported Kernels
 
@@ -211,10 +217,14 @@ value of 0.1 and a coefficient of 0.1. Available types for the gaussian kernel: 
 \li Match Kernel
 \li Custom Kernel
 
-Assign a user defined custom kernel, fo which only the upper triangle may be given (DIAG) or the FULL matrix (FULL), or the full matrix which is then internally stored as a upper triangle (FULL2DIAG).
+Assign a user defined custom kernel, fo which only the upper triangle may be
+given (DIAG) or the FULL matrix (FULL), or the full matrix which is then
+internally stored as a upper triangle (FULL2DIAG).
 \arg \b set_custom_kernel \verbatim sg('set_custom_kernel', kernelmatrix, 'DIAG|FULL|FULL2DIAG') \endverbatim
 
-The purpose of the get_kernel_matrix and get_distance_matrix commands is to return a kernel or distance matrix representing the kernel/distance matrix for the actual problem. 
+The purpose of the get_kernel_matrix and get_distance_matrix commands is to
+return a kernel or distance matrix representing the kernel/distance matrix for
+the actual problem.
 
 \arg \b get_distance_matrix \verbatim [D]=sg('get_distance_matrix', 'TRAIN|TEST') \endverbatim
 \arg \b get_kernel_matrix \verbatim [K]=sg('get_kernel_matrix', 'TRAIN|TEST') \endverbatim

--- a/doc/pages/StaticTutorial.mainpage
+++ b/doc/pages/StaticTutorial.mainpage
@@ -1,13 +1,14 @@
 /*!
 \page static_tutorial Tutorial for Static Interfaces
 
-SHOGUN provides "static" interfaces to  Matlab(tm), R, Python, Octave and provides a command
-line stand-a-lone executable. The idea behind the static interfaces is to
-provide a simple environment just enough to do simple experiments. For example,
-it will allow you to train and evaluate a classifier but not go beyond that. In
-case you are looking for basically unlimited extensibility (multiple methods
-like classifiers potentially sharing data and interacting) you might want to
-look at the \subpage modular_tutorial "Modular Interfaces" instead.
+SHOGUN provides "static" interfaces to Matlab(tm), R, Python, Octave and
+provides a command line stand-a-lone executable. The idea behind the static
+interfaces is to provide a simple environment just enough to do simple
+experiments. For example, it will allow you to train and evaluate a classifier
+but not go beyond that. In case you are looking for basically unlimited
+extensibility (multiple methods like classifiers potentially sharing data and
+interacting) you might want to look at the \subpage modular_tutorial "Modular
+Interfaces" instead.
 
 In this tutorial we demonstrate how to use shogun to create a simple
 gaussian kernel based support vector machine classifier but first
@@ -27,7 +28,8 @@ For R issue (from within R)
   library(sg)
 \endverbatim
 
-For octave and matlab just make sure sg is in the path (use addpath). For the cmdline interface just start the shogun executable
+For octave and matlab just make sure sg is in the path (use addpath). For the
+cmdline interface just start the shogun executable
 
 Now in all languages
 
@@ -48,7 +50,7 @@ in the cmdline interface will show the help screen. If not consult
 
 The rest of this tutorial assumes that the cmdline shogun executable
 is used (but hints on how things work using other interfaces). The
-basic syntax is 
+basic syntax is
 \verbatim
   <command> <option1> <option2> ...
 \endverbatim
@@ -58,13 +60,16 @@ here options are separated by spaces. For example
 set_kernel GAUSSIAN REAL 10 1.2
 \endverbatim
 
-will create a gaussian kernel that operates on real-valued features uses a kernel cache of size 10 MB and kernel width of 1.2. In analogy the other the cmdline for the other interfaces (python,r,...) would look like
+will create a gaussian kernel that operates on real-valued features uses a
+kernel cache of size 10 MB and kernel width of 1.2. In analogy the other the
+cmdline for the other interfaces (python,r,...) would look like
 
 \verbatim
 sg('set_kernel', 'GAUSSIAN', 'REAL', 10, 1.2)
 \endverbatim
 
-Note that there is little difference to the other interfaces, basically only strings are marked as such and arguments comma separated.
+Note that there is little difference to the other interfaces, basically only
+strings are marked as such and arguments comma separated.
 
 We now use two random gaussians as inputs as train data:
 \verbatim
@@ -77,7 +82,8 @@ sg('set_features', 'TRAIN', [ randn(2, 100)-1, randn(2,100)+1 ])
 \endverbatim
 would work).
 
-For training a supervised method like an SVM we need a labeling of the training data, which we set via
+For training a supervised method like an SVM we need a labeling of the training
+data, which we set via
 \verbatim
 set_labels TRAIN ../data/label_train_twoclass.dat
 \endverbatim
@@ -88,7 +94,9 @@ sg('set_labels', 'TRAIN', sign(randn(1, 100)))
 \endverbatim
 would work)
 
-Now we create an SVM and set the SVM-C parameter to some hopefully sane value (which in real applications needs tuning; like the kernel parameters (here kernel width)).
+Now we create an SVM and set the SVM-C parameter to some hopefully sane value
+(which in real applications needs tuning; like the kernel parameters (here
+kernel width)).
 \verbatim
 new_classifier LIBSVM
 c 1
@@ -131,7 +139,7 @@ Finally, the complete example looks like this
 \verbinclude classifier_libsvm.sg
 
 and can be found together with many other \subpage examples "examples"
-in examples/cmdline/classifier_libsvm.sg . 
+in examples/cmdline/classifier_libsvm.sg .
 
 For users of other interfaces we show the translated example for completeness:
 


### PR DESCRIPTION
Here is a trivial patch for a broken link and some cosmetic issues in the docs. I updated the issue tracker url to github, fixed a few typos in the text, wrapped text lines, and stripped trailing whitespace.
