### PR TITLE
Fixed dot product precision

### DIFF
--- a/src/shogun/mathematics/Math.cpp
+++ b/src/shogun/mathematics/Math.cpp
@@ -581,16 +581,16 @@ float64_t CMath::dot(const float64_t* v1, const float64_t* v2, int32_t n)
 	return r;
 }
 
-float32_t CMath::dot(
+float64_t CMath::dot(
 		const float32_t* v1, const float32_t* v2, int32_t n)
 {
 	float64_t r=0;
 #ifdef HAVE_LAPACK
 	int32_t skip=1;
-	r = cblas_sdot(n, v1, skip, v2, skip);
+	r = cblas_ddot(n, v1, skip, v2, skip);
 #else
 	for (int32_t i=0; i<n; i++)
-		r+=v1[i]*v2[i];
+		r+=((float64_t)v1[i])*v2[i];
 #endif
 	return r;
 }

--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -685,7 +685,7 @@ class CMath : public CSGObject
 		static float64_t dot(const float64_t* v1, const float64_t* v2, int32_t n);
 
 		/// compute dot product between v1 and v2 (blas optimized)
-		static float32_t dot(
+		static float64_t dot(
 			const float32_t* v1, const float32_t* v2, int32_t n);
 
 		/// compute dot product between v1 and v2 (for 64bit unsigned ints)


### PR DESCRIPTION
The dot product of two float32_t\* vectors was computed in single precision, which caused precision issues for features vectors of float32_t
