### PR TITLE
Small fix to avoid seg fault

### DIFF
--- a/src/shogun/machine/KernelMachine.cpp
+++ b/src/shogun/machine/KernelMachine.cpp
@@ -586,6 +586,9 @@ CLabels* CKernelMachine::apply_locked(SGVector<index_t> indices)
 
 void CKernelMachine::data_lock(CLabels* labs, CFeatures* features)
 {
+	if ( !kernel )
+		SG_ERROR("The kernel is not initialized\n");
+
 	/* init kernel with data */
 	kernel->init(features, features);
 

--- a/src/shogun/machine/KernelMachine.h
+++ b/src/shogun/machine/KernelMachine.h
@@ -50,15 +50,15 @@ class CKernelMachine : public CMachine
 		/** default constructor */
 		CKernelMachine();
 
-        /** Convenience constructor to initialize a trained kernel
-         * machine
-         *
-         * @param k kernel
-         * @param alphas vector of alpha weights
-         * @param svs indices of examples, i.e. i's for x_i
-         * @param b bias term
-         */
-        CKernelMachine(CKernel* k, SGVector<float64_t> alphas, SGVector<int32_t> svs, float64_t b);
+		/** Convenience constructor to initialize a trained kernel
+		 * machine
+		 *
+		 * @param k kernel
+		 * @param alphas vector of alpha weights
+		 * @param svs indices of examples, i.e. i's for x_i
+		 * @param b bias term
+		 */
+		CKernelMachine(CKernel* k, SGVector<float64_t> alphas, SGVector<int32_t> svs, float64_t b);
 
 		/** copy constructor
 		 * @param machine machine having parameters to copy


### PR DESCRIPTION
When cross validation was intended to be done with a KernelMachine but the Kernel member has not been initialized, there was a segmentation fault. The fix blocks the execution in this scenario.

This error has been pointed bout by Nicholas Pilkington in the mailing list.

There is a small indent fix as well :)
