### PR TITLE
QDA for python_modular's testsuite 

### DIFF
--- a/examples/undocumented/python_modular/classifier_qda_modular.py
+++ b/examples/undocumented/python_modular/classifier_qda_modular.py
@@ -1,0 +1,29 @@
+from tools.load import LoadMatrix
+lm = LoadMatrix()
+
+traindat = lm.load_numbers('../data/fm_train_real.dat')
+testdat = lm.load_numbers('../data/fm_test_real.dat')
+label_traindat = lm.load_labels('../data/label_train_multiclass.dat')
+
+parameter_list = [[traindat, testdat, label_traindat, 1e-4, False], \
+		  [traindat, testdat, label_traindat, 1e-4, True]]
+
+def classifier_qda_modular (fm_train_real=traindat, fm_test_real=testdat, label_train_twoclass=label_traindat, tolerance=1e-4, store_covs=False):
+	from shogun.Features import RealFeatures, Labels
+	from shogun.Classifier import QDA
+
+	feats_train = RealFeatures(fm_train_real)
+	feats_test  = RealFeatures(fm_test_real)
+
+	labels = Labels(label_train_twoclass)
+
+	qda = QDA(feats_train, labels, tolerance, store_covs)
+	qda.train()
+
+	qda.apply(feats_test).get_labels()
+	qda.set_features(feats_test)
+	return qda, qda.apply().get_labels()
+
+if __name__=='__main__':
+	print('QDA')
+	classifier_qda_modular(*parameter_list[0])


### PR DESCRIPTION
I am starting to play around with the testsuite to understand how it works. Here, I have added an example for QDA for the python_modular interface.

Some doubts regarding the testsuite:
- Locally, in testsuite/python_modular I had to execute 

python generate.py classifier_qda_modular.py

in order for the tester to recognize it. I have noticed no modification in any file though, is there something to left to do to include this test file in the testsuite of the main repository?
- Is it a good practice to include similar examples to this one for the other iinterfaces (e.g. octave_modular)?

Thank you!
