### PR TITLE
made DynamicObjectArray non-generic

### DIFF
--- a/examples/undocumented/libshogun/modelselection_apply_parameter_tree.cpp
+++ b/examples/undocumented/libshogun/modelselection_apply_parameter_tree.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -50,7 +50,7 @@ CModelSelectionParameters* create_param_tree()
 	return root;
 }
 
-void apply_parameter_tree(CDynamicObjectArray<CParameterCombination>* combinations)
+void apply_parameter_tree(CDynamicObjectArray* combinations)
 {
 	/* create some data */
 	float64_t* matrix=SG_MALLOC(float64_t, 6);
@@ -78,7 +78,8 @@ void apply_parameter_tree(CDynamicObjectArray<CParameterCombination>* combinatio
 	for (index_t i=0; i<combinations->get_num_elements(); ++i)
 	{
 		SG_SPRINT("applying:\n");
-		CParameterCombination* current_combination=combinations->get_element(i);
+		CParameterCombination* current_combination=(CParameterCombination*)
+				combinations->get_element(i);
 		current_combination->print_tree();
 		Parameter* current_parameters=svm->m_parameters;
 		current_combination->apply_to_modsel_parameter(current_parameters);
@@ -117,14 +118,15 @@ int main(int argc, char **argv)
 	SG_SPRINT("----------------------------------\n");
 
 	/* build combinations of parameter trees */
-	CDynamicObjectArray<CParameterCombination>* combinations=tree->get_combinations();
+	CDynamicObjectArray* combinations=tree->get_combinations();
 
 	apply_parameter_tree(combinations);
 
 	/* print and directly delete them all */
 	for (index_t i=0; i<combinations->get_num_elements(); ++i)
 	{
-		CParameterCombination* combination=combinations->get_element(i);
+		CParameterCombination* combination=(CParameterCombination*)
+				combinations->get_element(i);
 		SG_UNREF(combination);
 	}
 

--- a/examples/undocumented/libshogun/modelselection_model_selection_parameters_test.cpp
+++ b/examples/undocumented/libshogun/modelselection_model_selection_parameters_test.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -180,13 +180,14 @@ void test_get_combinations(CModelSelectionParameters* tree)
 	tree->print_tree();
 
 	/* build combinations of parameter trees */
-	CDynamicObjectArray<CParameterCombination>* combinations=tree->get_combinations();
+	CDynamicObjectArray* combinations=tree->get_combinations();
 
 	/* print and directly delete them all */
 	SG_SPRINT("----------------------------------\n");
 	for (index_t i=0; i<combinations->get_num_elements(); ++i)
 	{
-		CParameterCombination* combination=combinations->get_element(i);
+		CParameterCombination* combination=(CParameterCombination*)
+				combinations->get_element(i);
 		combination->print_tree();
 		SG_UNREF(combination);
 	}

--- a/examples/undocumented/libshogun/modelselection_parameter_combination_test.cpp
+++ b/examples/undocumented/libshogun/modelselection_parameter_combination_test.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -80,12 +80,11 @@ void test_leaf_sets_multiplication()
 	SGVector<float64_t> param_vector(6, true);
 	CMath::range_fill_vector(param_vector.vector, param_vector.vlen);
 
-	CDynamicObjectArray<CDynamicObjectArray<CParameterCombination> > sets;
+	CDynamicObjectArray sets;
 	CParameterCombination* new_root=new CParameterCombination();
 	SG_REF(new_root);
 
-	CDynamicObjectArray<CParameterCombination>* current=new CDynamicObjectArray<
-			CParameterCombination>();
+	CDynamicObjectArray* current=new CDynamicObjectArray();
 	sets.append_element(current);
 	Parameter* p=new Parameter();
 	p->add(&param_vector.vector[0], "0");
@@ -98,13 +97,14 @@ void test_leaf_sets_multiplication()
 	current->append_element(pc);
 
 	/* first case: one element */
-	CDynamicObjectArray<CParameterCombination>* result_simple=
+	CDynamicObjectArray* result_simple=
 			CParameterCombination::leaf_sets_multiplication(sets, new_root);
 
 	SG_SPRINT("one set\n");
 	for (index_t i=0; i<result_simple->get_num_elements(); ++i)
 	{
-		CParameterCombination* current=result_simple->get_element(i);
+		CParameterCombination* current=(CParameterCombination*)
+				result_simple->get_element(i);
 		current->print_tree();
 		SG_UNREF(current);
 	}
@@ -112,7 +112,7 @@ void test_leaf_sets_multiplication()
 
 	/* now more elements are created */
 
-	current=new CDynamicObjectArray<CParameterCombination>();
+	current=new CDynamicObjectArray();
 	sets.append_element(current);
 	p=new Parameter();
 	p->add(&param_vector.vector[2], "2");
@@ -124,7 +124,7 @@ void test_leaf_sets_multiplication()
 	pc=new CParameterCombination(p);
 	current->append_element(pc);
 
-	current=new CDynamicObjectArray<CParameterCombination>();
+	current=new CDynamicObjectArray();
 	sets.append_element(current);
 	p=new Parameter();
 	p->add(&param_vector.vector[4], "4");
@@ -137,13 +137,14 @@ void test_leaf_sets_multiplication()
 	current->append_element(pc);
 
 	/* second case: more element */
-	CDynamicObjectArray<CParameterCombination>* result_complex=
+	CDynamicObjectArray* result_complex=
 			CParameterCombination::leaf_sets_multiplication(sets, new_root);
 
 	SG_SPRINT("more sets\n");
 	for (index_t i=0; i<result_complex->get_num_elements(); ++i)
 	{
-		CParameterCombination* current=result_complex->get_element(i);
+		CParameterCombination* current=(CParameterCombination*)
+				result_complex->get_element(i);
 		current->print_tree();
 		SG_UNREF(current);
 	}

--- a/examples/undocumented/libshogun/modelselection_parameter_tree.cpp
+++ b/examples/undocumented/libshogun/modelselection_parameter_tree.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -114,13 +114,14 @@ int main(int argc, char **argv)
 	tree->print_tree();
 
 	/* build combinations of parameter trees */
-	CDynamicObjectArray<CParameterCombination>* combinations=tree->get_combinations();
+	CDynamicObjectArray* combinations=tree->get_combinations();
 
 	/* print and directly delete them all */
 	SG_SPRINT("----------------------------------\n");
 	for (index_t i=0; i<combinations->get_num_elements(); ++i)
 	{
-		CParameterCombination* combination=combinations->get_element(i);
+		CParameterCombination* combination=(CParameterCombination*)
+				combinations->get_element(i);
 		combination->print_tree();
 		SG_UNREF(combination);
 	}

--- a/examples/undocumented/python_modular/modelselection_parameter_tree_modular.py
+++ b/examples/undocumented/python_modular/modelselection_parameter_tree_modular.py
@@ -4,7 +4,7 @@
 # the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
-# Written (W) 2011 Heiko Strathmann
+# Written (W) 2011-2012 Heiko Strathmann
 # Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
 #
 
@@ -13,7 +13,6 @@ parameter_list=[[None]]
 def modelselection_parameter_tree_modular(dummy):
     from shogun.ModelSelection import ParameterCombination
     from shogun.ModelSelection import ModelSelectionParameters, R_EXP, R_LINEAR
-    from shogun.ModelSelection import DynamicParameterCombinationArray
     from shogun.Kernel import PowerKernel
     from shogun.Kernel import GaussianKernel
     from shogun.Kernel import DistantSegmentsKernel

--- a/src/interfaces/modular/ModelSelection.i
+++ b/src/interfaces/modular/ModelSelection.i
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
  
@@ -26,12 +26,5 @@ SERIALIZABLE_DUMMY(shogun::CrossValidationResult);
 %include <shogun/modelselection/ModelSelection.h>
 %include <shogun/modelselection/GridSearchModelSelection.h>
 %include <shogun/modelselection/ParameterCombination.h>
-
-/* Templated Class DynamicObjectArray */
 %include <shogun/lib/DynamicObjectArray.h>
-namespace shogun
-{
-    %template(DynamicParameterCombinationArray) CDynamicObjectArray<CParameterCombination>;
-}
-
 %include <shogun/modelselection/ModelSelectionParameters.h>

--- a/src/shogun/base/DynArray.h
+++ b/src/shogun/base/DynArray.h
@@ -18,7 +18,6 @@
 namespace shogun
 {
 template <class T> class CDynamicArray;
-template <class T> class CDynamicObjectArray;
 
 /** @brief Template Dynamic array class that creates an array that can
  * be used like a list or an array.
@@ -31,7 +30,7 @@ template <class T> class CDynamicObjectArray;
 template <class T> class DynArray
 {
 	template<class U> friend class CDynamicArray;
-	template<class U> friend class CDynamicObjectArray;
+	friend class CDynamicObjectArray;
 	friend class CCommUlongStringKernel;
 
 	public:

--- a/src/shogun/evaluation/CrossValidationSplitting.cpp
+++ b/src/shogun/evaluation/CrossValidationSplitting.cpp
@@ -47,7 +47,7 @@ void CCrossValidationSplitting::build_subsets()
 	for (index_t i=0; i<indices.vlen; ++i)
 	{
 		/* fill current subset */
-		CDynamicArray<index_t>* current=
+		CDynamicArray<index_t>* current=(CDynamicArray<index_t>*)
 				m_subset_indices->get_element(current_subset);
 
 		/* add element of current index */

--- a/src/shogun/evaluation/SplittingStrategy.cpp
+++ b/src/shogun/evaluation/SplittingStrategy.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -42,7 +42,7 @@ void CSplittingStrategy::reset_subsets()
 	if (m_subset_indices)
 		SG_UNREF(m_subset_indices);
 
-	m_subset_indices=new CDynamicObjectArray<CDynamicArray<index_t> >();
+	m_subset_indices=new CDynamicObjectArray();
 	SG_REF(m_subset_indices);
 
 	/* construct all arrays */
@@ -83,8 +83,8 @@ SGVector<index_t> CSplittingStrategy::generate_subset_indices(index_t subset_idx
 	}
 
 	/* construct SGVector copy from index vector */
-	CDynamicArray<index_t>* to_copy=m_subset_indices->get_element_safe(
-			subset_idx);
+	CDynamicArray<index_t>* to_copy=(CDynamicArray<index_t>*)
+			m_subset_indices->get_element_safe(subset_idx);
 
 	index_t num_elements=to_copy->get_num_elements();
 	SGVector<index_t> result(num_elements, true);
@@ -106,8 +106,8 @@ SGVector<index_t> CSplittingStrategy::generate_subset_inverse(index_t subset_idx
 				get_name(), get_name());
 	}
 
-	CDynamicArray<index_t>* to_invert=m_subset_indices->get_element_safe(
-			subset_idx);
+	CDynamicArray<index_t>* to_invert=(CDynamicArray<index_t>*)
+			m_subset_indices->get_element_safe(subset_idx);
 
 	SGVector<index_t> result(
 			m_labels->get_num_labels()-to_invert->get_num_elements(), true);

--- a/src/shogun/evaluation/SplittingStrategy.h
+++ b/src/shogun/evaluation/SplittingStrategy.h
@@ -100,7 +100,7 @@ protected:
 	CLabels* m_labels;
 
 	/** subset indices */
-	CDynamicObjectArray<CDynamicArray<index_t> >* m_subset_indices;
+	CDynamicObjectArray* m_subset_indices;
 
 	/** additional variable to store number of index subsets */
 	index_t m_num_subsets;

--- a/src/shogun/evaluation/StratifiedCrossValidationSplitting.cpp
+++ b/src/shogun/evaluation/StratifiedCrossValidationSplitting.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -63,7 +63,7 @@ void CStratifiedCrossValidationSplitting::build_subsets()
 	SGVector<float64_t> unique_labels=m_labels->get_unique_labels();
 
 	/* for every label, build set for indices */
-	CDynamicObjectArray<CDynamicArray<index_t> > label_indices;
+	CDynamicObjectArray label_indices;
 	for (index_t i=0; i<unique_labels.vlen; ++i)
 		label_indices.append_element(new CDynamicArray<index_t> ());
 
@@ -75,7 +75,8 @@ void CStratifiedCrossValidationSplitting::build_subsets()
 		{
 			if (m_labels->get_label(j)==unique_labels.vector[i])
 			{
-				CDynamicArray<index_t>* current=label_indices.get_element(i);
+				CDynamicArray<index_t>* current=(CDynamicArray<index_t>*)
+						label_indices.get_element(i);
 				current->append_element(j);
 				SG_UNREF(current);
 			}
@@ -85,7 +86,8 @@ void CStratifiedCrossValidationSplitting::build_subsets()
 	/* shuffle created label sets */
 	for (index_t i=0; i<label_indices.get_num_elements(); ++i)
 	{
-		CDynamicArray<index_t>* current=label_indices.get_element(i);
+		CDynamicArray<index_t>* current=(CDynamicArray<index_t>*)
+				label_indices.get_element(i);
 		current->shuffle();
 		SG_UNREF(current);
 	}
@@ -95,12 +97,13 @@ void CStratifiedCrossValidationSplitting::build_subsets()
 	for (index_t i=0; i<unique_labels.vlen; ++i)
 	{
 		/* current index set for current label */
-		CDynamicArray<index_t>* current=label_indices.get_element(i);
+		CDynamicArray<index_t>* current=(CDynamicArray<index_t>*)
+				label_indices.get_element(i);
 
 		for (index_t j=0; j<current->get_num_elements(); ++j)
 		{
-			CDynamicArray<index_t>* next=m_subset_indices->get_element(
-					target_set++);
+			CDynamicArray<index_t>* next=(CDynamicArray<index_t>*)
+					m_subset_indices->get_element(target_set++);
 			next->append_element(current->get_element(j));
 			target_set%=m_subset_indices->get_num_elements();
 			SG_UNREF(next);

--- a/src/shogun/lib/DynamicObjectArray.h
+++ b/src/shogun/lib/DynamicObjectArray.h
@@ -5,7 +5,7 @@
  * (at your option) any later version.
  *
  * Written (W) 1999-2009 Soeren Sonnenburg
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 1999-2009 Fraunhofer Institute FIRST and Max-Planck-Society
  */
 
@@ -18,18 +18,15 @@
 
 namespace shogun
 {
-/** @brief Template Dynamic array class that creates an array that can
- * be used like a list or an array.
+/** @brief Dynamic array class for CSGObject pointers that creates an array
+ * that can be used like a list or an array.
  *
  * It grows and shrinks dynamically, while elements can be accessed
- * via index.  It only stores CSGObject pointers, which ARE automagically
+ * via index. It only stores CSGObject pointers, which ARE automagically
  * SG_REF'd/deleted.
  *
- * Note that this array is generic, but only takes pointers to objects which
- * implement the CSGObject interface, so only put these in here.
- * T specifies the type of the pointers
  */
-template<class T>class CDynamicObjectArray :public CSGObject
+class CDynamicObjectArray : public CSGObject
 {
 	public:
 		/** constructor
@@ -39,10 +36,8 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		CDynamicObjectArray(int32_t p_resize_granularity=128)
 		: CSGObject()
 		{
-			CSGObject*** casted_array=(CSGObject***)&m_array.array;
-
-			m_parameters->add_vector(casted_array, &m_array.num_elements, "array",
-					"Memory for dynamic array.");
+			m_parameters->add_vector(&m_array.array, &m_array.num_elements,
+					"array", "Memory for dynamic array.");
 			m_parameters->add(&m_array.last_element_idx, "last_element_idx",
 					"Element with largest index.");
 			m_parameters->add(&m_array.resize_granularity, "resize_granularity",
@@ -75,11 +70,10 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param index index
 		 * @return array element at index
 		 */
-		inline T* get_element(int32_t index) const
+		inline CSGObject* get_element(int32_t index) const
 		{
-			T* element=m_array.get_element(index);
-			CSGObject* casted=cast_to_sgobject(element);
-			SG_REF(casted);
+			CSGObject* element=m_array.get_element(index);
+			SG_REF(element);
 			return element;
 		}
 
@@ -90,11 +84,10 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param index index
 		 * @return array element at index
 		 */
-		inline T* get_element_safe(int32_t index) const
+		inline CSGObject* get_element_safe(int32_t index) const
 		{
-			T* element=m_array.get_element_safe(index);
-			CSGObject* casted=(CSGObject*)element;
-			SG_REF(casted);
+			CSGObject* element=m_array.get_element_safe(index);
+			SG_REF(element);
 			return element;
 		}
 
@@ -104,15 +97,14 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param index index
 		 * @return if setting was successful
 		 */
-		inline bool set_element(T* element, int32_t index)
+		inline bool set_element(CSGObject* element, int32_t index)
 		{
-			CSGObject* casted=cast_to_sgobject(element);
 			CSGObject* old=(CSGObject*)m_array.get_element(index);
 
 			bool success=m_array.set_element(element, index);
 			if (success)
 			{
-				SG_REF(casted);
+				SG_REF(element);
 				SG_UNREF(old);
 			}
 
@@ -126,12 +118,11 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param index index
 		 * @return if setting was successful
 		 */
-		inline bool insert_element(T* element, int32_t index)
+		inline bool insert_element(CSGObject* element, int32_t index)
 		{
-			CSGObject* casted=cast_to_sgobject(element);
 			bool success=m_array.insert_element(element, index);
 			if (success)
-				SG_REF(casted);
+				SG_REF(element);
 
 			return success;
 		}
@@ -141,12 +132,11 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param element element to append
 		 * @return if setting was successful
 		 */
-		inline bool append_element(T* element)
+		inline bool append_element(CSGObject* element)
 		{
-			CSGObject* casted=cast_to_sgobject(element);
 			bool success=m_array.append_element(element);
 			if (success)
-				SG_REF(casted);
+				SG_REF(element);
 
 			return success;
 		}
@@ -156,10 +146,9 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 *
 		 * @param element element to append
 		 */
-		inline void push_back(T* element)
+		inline void push_back(CSGObject* element)
 		{
-			CSGObject* casted=cast_to_sgobject(element);
-			SG_REF(casted);
+			SG_REF(element);
 			m_array.push_back(element);
 		}
 
@@ -168,7 +157,7 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 */
 		inline void pop_back()
 		{
-			CSGObject* element=(CSGObject*)m_array.back();
+			CSGObject* element=m_array.back();
 			SG_UNREF(element);
 
 			m_array.pop_back();
@@ -179,11 +168,10 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 *
 		 * @return element at the end of array
 		 */
-		inline T* back() const
+		inline CSGObject* back() const
 		{
-			T* element=m_array.back();
-			CSGObject* casted=(CSGObject*)element;
-			SG_REF(casted);
+			CSGObject* element=m_array.back();
+			SG_REF(element);
 			return element;
 		}
 
@@ -193,7 +181,7 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param element element to search for
 		 * @return index of element or -1
 		 */
-		inline int32_t find_element(T* element) const
+		inline int32_t find_element(CSGObject* element) const
 		{
 			return m_array.find_element(element);
 		}
@@ -206,7 +194,7 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 */
 		inline bool delete_element(int32_t idx)
 		{
-			CSGObject* element=(CSGObject*)m_array.get_element(idx);
+			CSGObject* element=m_array.get_element(idx);
 			SG_UNREF(element);
 
 			return m_array.delete_element(idx);
@@ -224,7 +212,7 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		 * @param orig original array
 		 * @return new array
 		 */
-		inline CDynamicObjectArray<T>& operator=(CDynamicObjectArray<T>& orig)
+		inline CDynamicObjectArray& operator=(CDynamicObjectArray& orig)
 		{
 			/* SG_REF all new elements (implicitly) */
 			for (index_t i=0; i<orig.get_num_elements(); ++i)
@@ -239,7 +227,7 @@ template<class T>class CDynamicObjectArray :public CSGObject
 		}
 
 		/** @return underlying array of pointers */
-		inline T** get_array() const { return m_array.get_array(); }
+		inline CSGObject** get_array() const { return m_array.get_array(); }
 
 		/** shuffles the array */
 		inline void shuffle() { m_array.shuffle(); }
@@ -255,32 +243,13 @@ template<class T>class CDynamicObjectArray :public CSGObject
 			/* SG_UNREF all my elements */
 			for (index_t i=0; i<m_array.get_num_elements(); ++i)
 			{
-				CSGObject* element=(CSGObject*)m_array.get_element(i);
+				CSGObject* element=m_array.get_element(i);
 				SG_UNREF(element);
 			}
 		}
 
-		/** Dynamically casts the given element to a CSGObject, if non-NULL.
-		 * Used for all method that have some input elements that are to be put
-		 * into the array */
-		inline CSGObject* cast_to_sgobject(T* element) const
-		{
-			if (!element)
-				return NULL;
-
-			CSGObject* casted=dynamic_cast<CSGObject*>(element);
-
-			if (!casted)
-			{
-				SG_ERROR("Generic type of CDynamicObjectArray is not of type "
-						"CSGObject!\n");
-			}
-
-			return casted;
-		}
-
-    private:
-        DynArray<T*> m_array;
+	private:
+		DynArray<CSGObject*> m_array;
 
 };
 }

--- a/src/shogun/machine/MulticlassMachine.cpp
+++ b/src/shogun/machine/MulticlassMachine.cpp
@@ -17,7 +17,7 @@ using namespace shogun;
 
 CMulticlassMachine::CMulticlassMachine()
 : CMachine(), m_multiclass_strategy(ONE_VS_REST_STRATEGY),
-	m_machine(NULL), m_machines(new CDynamicObjectArray<CMachine>()),
+	m_machine(NULL), m_machines(new CDynamicObjectArray()),
 	m_rejection_strategy(NULL)
 {
 	register_parameters();
@@ -27,7 +27,7 @@ CMulticlassMachine::CMulticlassMachine(
 		EMulticlassStrategy strategy,
 		CMachine* machine, CLabels* labs)
 : CMachine(), m_multiclass_strategy(strategy),
-	m_machines(new CDynamicObjectArray<CMachine>()), m_rejection_strategy(NULL)
+	m_machines(new CDynamicObjectArray()), m_rejection_strategy(NULL)
 {
 	set_labels(labs);
 	SG_REF(machine);
@@ -204,7 +204,7 @@ CLabels* CMulticlassMachine::classify_one_vs_rest()
 
 		for (int32_t i=0; i<num_machines; i++)
 		{
-			CMachine *machine = m_machines->get_element(i);
+			CMachine *machine = (CMachine*)m_machines->get_element(i);
 			ASSERT(machine);
 			outputs[i]=machine->apply();
 			SG_UNREF(machine);
@@ -275,7 +275,7 @@ CLabels* CMulticlassMachine::classify_one_vs_one()
 
 		for (int32_t i=0; i<num_machines; i++)
 		{
-			CMachine *machine = m_machines->get_element(i);
+			CMachine *machine = (CMachine*)m_machines->get_element(i);
 			ASSERT(machine);
 			outputs[i]=machine->apply();
 			SG_UNREF(machine);

--- a/src/shogun/machine/MulticlassMachine.h
+++ b/src/shogun/machine/MulticlassMachine.h
@@ -71,7 +71,7 @@ class CMulticlassMachine : public CMachine
 		 */
 		inline CMachine* get_machine(int32_t num) const
 		{
-			return m_machines->get_element_safe(num);
+			return (CMachine*)m_machines->get_element_safe(num);
 		}
 
 		/** get number of machines
@@ -216,7 +216,7 @@ class CMulticlassMachine : public CMachine
 		CMachine* m_machine;
 
 		/** machines */
-		CDynamicObjectArray<CMachine> *m_machines;
+		CDynamicObjectArray *m_machines;
 
 		/** rejection strategy */
 		CRejectionStrategy* m_rejection_strategy;

--- a/src/shogun/modelselection/GridSearchModelSelection.cpp
+++ b/src/shogun/modelselection/GridSearchModelSelection.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -40,8 +40,8 @@ CParameterCombination* CGridSearchModelSelection::select_model(bool print_state)
 		SG_PRINT("Generating parameter combinations\n");
 
 	/* Retrieve all possible parameter combinations */
-	CDynamicObjectArray<CParameterCombination>* combinations=
-			m_model_parameters->get_combinations();
+	CDynamicObjectArray* combinations=
+			(CDynamicObjectArray*)m_model_parameters->get_combinations();
 
 	CrossValidationResult best_result;
 
@@ -57,7 +57,8 @@ CParameterCombination* CGridSearchModelSelection::select_model(bool print_state)
 	/* apply all combinations and search for best one */
 	for (index_t i=0; i<combinations->get_num_elements(); ++i)
 	{
-		CParameterCombination* current_combination=combinations->get_element(i);
+		CParameterCombination* current_combination=(CParameterCombination*)
+				combinations->get_element(i);
 
 		/* eventually print */
 		if (print_state)
@@ -83,12 +84,14 @@ CParameterCombination* CGridSearchModelSelection::select_model(bool print_state)
 				if (best_combination)
 					SG_UNREF(best_combination);
 
-				best_combination=combinations->get_element(i);
+				best_combination=(CParameterCombination*)
+						combinations->get_element(i);
 				best_result=result;
 			}
 			else
 			{
-				CParameterCombination* combination=combinations->get_element(i);
+				CParameterCombination* combination=(CParameterCombination*)
+						combinations->get_element(i);
 				SG_UNREF(combination);
 			}
 		}
@@ -99,12 +102,14 @@ CParameterCombination* CGridSearchModelSelection::select_model(bool print_state)
 				if (best_combination)
 					SG_UNREF(best_combination);
 
-				best_combination=combinations->get_element(i);
+				best_combination=(CParameterCombination*)
+						combinations->get_element(i);
 				best_result=result;
 			}
 			else
 			{
-				CParameterCombination* combination=combinations->get_element(i);
+				CParameterCombination* combination=(CParameterCombination*)
+						combinations->get_element(i);
 				SG_UNREF(combination);
 			}
 		}

--- a/src/shogun/modelselection/ModelSelectionParameters.cpp
+++ b/src/shogun/modelselection/ModelSelectionParameters.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -42,7 +42,7 @@ void CModelSelectionParameters::init()
 {
 	m_node_name=NULL;
 	m_sgobject=NULL;
-	m_child_nodes=new CDynamicObjectArray<CModelSelectionParameters>();
+	m_child_nodes=new CDynamicObjectArray();
 	SG_REF(m_child_nodes);
 	m_value_type=MSPT_NONE;
 
@@ -164,10 +164,9 @@ void CModelSelectionParameters::build_values(EMSParamType value_type, void* min,
 	}
 }
 
-CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combinations()
+CDynamicObjectArray* CModelSelectionParameters::get_combinations()
 {
-	CDynamicObjectArray<CParameterCombination>* result=new CDynamicObjectArray<
-			CParameterCombination>();
+	CDynamicObjectArray* result=new CDynamicObjectArray();
 
 	/* value case: node with values and no children.
 	 * build trees of Parameter instances which each contain one value
@@ -216,12 +215,13 @@ CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combi
 	if (m_child_nodes->get_num_elements())
 	{
 		/* split value and non-value child combinations */
-		CDynamicObjectArray<CModelSelectionParameters> value_children;
-		CDynamicObjectArray<CModelSelectionParameters> non_value_children;
+		CDynamicObjectArray value_children;
+		CDynamicObjectArray non_value_children;
 
 		for (index_t i=0; i<m_child_nodes->get_num_elements(); ++i)
 		{
-			CModelSelectionParameters* current=m_child_nodes->get_element(i);
+			CModelSelectionParameters* current=
+					(CModelSelectionParameters*)m_child_nodes->get_element(i);
 
 			/* split children with values and children with other */
 			if (current->m_values.vector)
@@ -233,12 +233,12 @@ CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combi
 		}
 
 		/* extract all tree sets of all value children */
-		CDynamicObjectArray<CDynamicObjectArray<CParameterCombination> > value_node_sets;
+		CDynamicObjectArray value_node_sets;
 		for (index_t i=0; i<value_children.get_num_elements(); ++i)
 		{
 			/* recursively get all combinations in a new array */
 			CModelSelectionParameters* value_child=
-					value_children.get_element(i);
+					(CModelSelectionParameters*)value_children.get_element(i);
 			value_node_sets.append_element(value_child->get_combinations());
 			SG_UNREF(value_child);
 		}
@@ -258,7 +258,7 @@ CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combi
 
 		SG_REF(new_root);
 
-		CDynamicObjectArray<CParameterCombination>* value_combinations=
+		CDynamicObjectArray* value_combinations=
 				CParameterCombination::leaf_sets_multiplication(value_node_sets,
 						new_root);
 
@@ -272,12 +272,12 @@ CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combi
 		else
 		{
 			/* extract all tree sets of non-value nodes */
-			CDynamicObjectArray<CDynamicObjectArray<CParameterCombination> >
-					non_value_combinations;
+			CDynamicObjectArray non_value_combinations;
 			for (index_t i=0; i<non_value_children.get_num_elements(); ++i)
 			{
 				/* recursively get all combinations in a new array */
 				CModelSelectionParameters* non_value_child=
+						(CModelSelectionParameters*)
 						non_value_children.get_element(i);
 				non_value_combinations.append_element(
 						non_value_child->get_combinations());
@@ -298,13 +298,15 @@ CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combi
 				for (index_t j=0;
 						j<non_value_combinations.get_num_elements(); ++j)
 				{
-					CDynamicObjectArray<CParameterCombination>* current_non_value_set=
+					CDynamicObjectArray* current_non_value_set=
+							(CDynamicObjectArray*)
 							non_value_combinations.get_element(j);
 
 					for (index_t k=0; k
 							<current_non_value_set->get_num_elements(); ++k)
 					{
 						CParameterCombination* current_non_value_tree=
+								(CParameterCombination*)
 								current_non_value_set->get_element(k);
 
 						/* append new root with rest of tree to current
@@ -324,18 +326,21 @@ CDynamicObjectArray<CParameterCombination>* CModelSelectionParameters::get_combi
 				for (index_t i=0; i<value_combinations->get_num_elements(); ++i)
 				{
 					CParameterCombination* current_value_tree=
+							(CParameterCombination*)
 							value_combinations->get_element(i);
 
 					for (index_t j=0; j
 							<non_value_combinations.get_num_elements(); ++j)
 					{
-						CDynamicObjectArray<CParameterCombination> * current_non_value_set=
+						CDynamicObjectArray* current_non_value_set=
+								(CDynamicObjectArray*)
 								non_value_combinations.get_element(j);
 
 						for (index_t k=0; k
 								<current_non_value_set->get_num_elements(); ++k)
 						{
 							CParameterCombination* current_non_value_tree=
+									(CParameterCombination*)
 									current_non_value_set->get_element(k);
 
 							/* copy the current trees and append non-value
@@ -401,7 +406,8 @@ void CModelSelectionParameters::print_tree(int prefix_num)
 		/* cast safe because only CModelSelectionParameters are added to list */
 		for (index_t i=0; i<m_child_nodes->get_num_elements(); ++i)
 		{
-			CModelSelectionParameters* child=m_child_nodes->get_element(i);
+			CModelSelectionParameters* child=
+					(CModelSelectionParameters*)m_child_nodes->get_element(i);
 			child->print_tree(prefix_num+1);
 			SG_UNREF(child);
 		}

--- a/src/shogun/modelselection/ModelSelectionParameters.h
+++ b/src/shogun/modelselection/ModelSelectionParameters.h
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -106,9 +106,8 @@ public:
 	 * that are implied by this tree is generated.
 	 *
 	 * @result result all trees of parameter combinations are put into here
-	 *
 	 */
-	CDynamicObjectArray<CParameterCombination>* get_combinations();
+	CDynamicObjectArray* get_combinations();
 
 	/** float64_t wrapper for build_values() */
 	void build_values(float64_t min, float64_t max, ERangeType type,
@@ -148,7 +147,7 @@ private:
 	CSGObject* m_sgobject;
 	const char* m_node_name;
 	SGVector<char> m_values; // dummy void type char
-	CDynamicObjectArray<CModelSelectionParameters>* m_child_nodes;
+	CDynamicObjectArray* m_child_nodes;
 	EMSParamType m_value_type;
 };
 

--- a/src/shogun/modelselection/ParameterCombination.cpp
+++ b/src/shogun/modelselection/ParameterCombination.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -29,7 +29,7 @@ CParameterCombination::CParameterCombination(Parameter* param)
 void CParameterCombination::init()
 {
 	m_param=NULL;
-	m_child_nodes=new CDynamicObjectArray<CParameterCombination> ();
+	m_child_nodes=new CDynamicObjectArray();
 	SG_REF(m_child_nodes);
 
 	m_parameters->add((CSGObject**)m_child_nodes, "child nodes",
@@ -99,7 +99,8 @@ void CParameterCombination::print_tree(int prefix_num) const
 
 	for (index_t i=0; i<m_child_nodes->get_num_elements(); ++i)
 	{
-		CParameterCombination* child=m_child_nodes->get_element(i);
+		CParameterCombination* child=(CParameterCombination*)
+				m_child_nodes->get_element(i);
 		child->print_tree(prefix_num+1);
 		SG_UNREF(child);
 	}
@@ -126,18 +127,16 @@ DynArray<Parameter*>* CParameterCombination::parameter_set_multiplication(
 	return result;
 }
 
-CDynamicObjectArray<CParameterCombination>* CParameterCombination::leaf_sets_multiplication(
-		const CDynamicObjectArray<CDynamicObjectArray<CParameterCombination> >& sets,
-		const CParameterCombination* new_root)
+CDynamicObjectArray* CParameterCombination::leaf_sets_multiplication(
+		const CDynamicObjectArray& sets, const CParameterCombination* new_root)
 {
-	CDynamicObjectArray<CParameterCombination>* result=new CDynamicObjectArray<
-			CParameterCombination>();
+	CDynamicObjectArray* result=new CDynamicObjectArray();
 
 	/* check marginal cases */
 	if (sets.get_num_elements()==1)
 	{
-		CDynamicObjectArray<CParameterCombination>* current_set=
-				sets.get_element(0);
+		CDynamicObjectArray* current_set=
+				(CDynamicObjectArray*)sets.get_element(0);
 
 		/* just use the only element into result array.
 		 * put root node before all combinations*/
@@ -148,7 +147,8 @@ CDynamicObjectArray<CParameterCombination>* CParameterCombination::leaf_sets_mul
 		for (index_t i=0; i<result->get_num_elements(); ++i)
 		{
 			/* put new root as root into the tree and replace tree */
-			CParameterCombination* current=result->get_element(i);
+			CParameterCombination* current=(CParameterCombination*)
+					result->get_element(i);
 			CParameterCombination* root=new_root->copy_tree();
 			root->append_child(current);
 			result->set_element(root, i);
@@ -164,14 +164,15 @@ CDynamicObjectArray<CParameterCombination>* CParameterCombination::leaf_sets_mul
 
 		for (index_t set_nr=0; set_nr<sets.get_num_elements(); ++set_nr)
 		{
-			CDynamicObjectArray<CParameterCombination>* current_set=
+			CDynamicObjectArray* current_set=(CDynamicObjectArray*)
 					sets.get_element(set_nr);
 			DynArray<Parameter*>* new_param_set=new DynArray<Parameter*> ();
 			param_sets.append_element(new_param_set);
 
 			for (index_t i=0; i<current_set->get_num_elements(); ++i)
 			{
-				CParameterCombination* current_node=current_set->get_element(i);
+				CParameterCombination* current_node=(CParameterCombination*)
+						current_set->get_element(i);
 
 				if (current_node->m_child_nodes->get_num_elements())
 				{
@@ -264,7 +265,8 @@ CParameterCombination* CParameterCombination::copy_tree() const
 	/* recursively copy all children */
 	for (index_t i=0; i<m_child_nodes->get_num_elements(); ++i)
 	{
-		CParameterCombination* child=m_child_nodes->get_element(i);
+		CParameterCombination* child=(CParameterCombination*)
+				m_child_nodes->get_element(i);
 		copy->m_child_nodes->append_element(child->copy_tree());
 		SG_UNREF(child);
 	}
@@ -288,7 +290,8 @@ void CParameterCombination::apply_to_modsel_parameter(
 		 * recursion level downwards) */
 		for (index_t i=0; i<m_child_nodes->get_num_elements(); ++i)
 		{
-			CParameterCombination* child=m_child_nodes->get_element(i);
+			CParameterCombination* child=(CParameterCombination*)
+					m_child_nodes->get_element(i);
 			child->apply_to_modsel_parameter(parameter);
 			SG_UNREF(child);
 		}
@@ -320,7 +323,8 @@ void CParameterCombination::apply_to_modsel_parameter(
 			 * their values */
 			for (index_t i=0; i<m_child_nodes->get_num_elements(); ++i)
 			{
-				CParameterCombination* child=m_child_nodes->get_element(i);
+				CParameterCombination* child=(CParameterCombination*)
+						m_child_nodes->get_element(i);
 				child->apply_to_modsel_parameter(
 						current_sgobject->m_model_selection_parameters);
 				SG_UNREF(child);

--- a/src/shogun/modelselection/ParameterCombination.h
+++ b/src/shogun/modelselection/ParameterCombination.h
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 
@@ -103,8 +103,8 @@ public:
 	 * trees
 	 * @result result set of tree combinations
 	 */
-	static CDynamicObjectArray<CParameterCombination>* leaf_sets_multiplication(
-			const CDynamicObjectArray<CDynamicObjectArray<CParameterCombination> >& sets,
+	static CDynamicObjectArray* leaf_sets_multiplication(
+			const CDynamicObjectArray& sets,
 			const CParameterCombination* new_root);
 
 	/** checks whether this node has children
@@ -138,7 +138,7 @@ private:
 
 private:
 	Parameter* m_param;
-	CDynamicObjectArray<CParameterCombination>* m_child_nodes;
+	CDynamicObjectArray* m_child_nodes;
 };
 }
 


### PR DESCRIPTION
Because generic objects containing a CSGObject cannot be serialized. This is now possible.
Type safety (which CSGObject subclass) is lost and all get_element() calls have to be casted.

All tests run fine, but I will let this open till you guys read it.
