### PR TITLE
Remove unused include of shogun/lib/Set.h

### DIFF
--- a/src/shogun/evaluation/CrossValidationSplitting.cpp
+++ b/src/shogun/evaluation/CrossValidationSplitting.cpp
@@ -10,7 +10,6 @@
 
 #include <shogun/evaluation/CrossValidationSplitting.h>
 #include <shogun/features/Labels.h>
-#include <shogun/lib/Set.h>
 
 using namespace shogun;
 

--- a/src/shogun/evaluation/StratifiedCrossValidationSplitting.cpp
+++ b/src/shogun/evaluation/StratifiedCrossValidationSplitting.cpp
@@ -10,7 +10,6 @@
 
 #include <shogun/evaluation/StratifiedCrossValidationSplitting.h>
 #include <shogun/features/Labels.h>
-#include <shogun/lib/Set.h>
 
 using namespace shogun;
 


### PR DESCRIPTION
StratifiedCrossValidationSplitting.cpp and CrossValidationSplitting.cpp had include lines for shogun/lib/Set.h
but CSet was not used within the implementations, thus i think it's safe to remove these includes instead of replacing them with CMap.
