### PR TITLE
CSet and CMap improvements

### DIFF
--- a/src/shogun/lib/Map.h
+++ b/src/shogun/lib/Map.h
@@ -57,7 +57,7 @@ IGNORE_IN_CLASSLIST template<class K, class T> class CMap: public CSGObject
 {
 public:
 	/** Custom constructor */
-	CMap(int32_t size=1, int32_t reserved=1, bool tracable=true)
+	CMap(int32_t size=41, int32_t reserved=128, bool tracable=true)
 	{	
 		hash_size=size;
 		free_index=0;

--- a/src/shogun/lib/Set.h
+++ b/src/shogun/lib/Set.h
@@ -50,7 +50,7 @@ template<class T> class CSet: public CSGObject
 {
 public:
 	/** Custom constructor */
-	CSet(int32_t size=1, int32_t reserved=1, bool tracable=true)
+	CSet(int32_t size=41, int32_t reserved=128, bool tracable=true)
 	{	
 		hash_size=size;
 		free_index=0;


### PR DESCRIPTION
wiking: 0x000000010023294d in shogun::CMap<int, int>::hash (this=0x7fff5fbfdfa0, key=<value temporarily unavailable, due to optimizations>) at Map.h:249

...

gsomix: wiking, I'll fix it. please, use custom constructor
