### PR TITLE
HKM: fix warning and pass vector by reference

### DIFF
--- a/src/shogun/preprocessor/HomogeneousKernelMap.cpp
+++ b/src/shogun/preprocessor/HomogeneousKernelMap.cpp
@@ -182,10 +182,7 @@ SGMatrix<float64_t> CHomogeneousKernelMap::apply_to_feature_matrix (CFeatures* f
 /// apply preproc on single feature vector
 SGVector<float64_t> CHomogeneousKernelMap::apply_to_feature_vector(SGVector<float64_t> vector)
 {
-	uint64_t featureDimension = 2*m_order+1;
-	uint64_t m_target_dim = vector.vlen * featureDimension;
 	SGVector<float64_t> result = apply_to_vector(vector);
-
 	return result;
 }
 
@@ -298,7 +295,7 @@ CHomogeneousKernelMap::get_smooth_spectrum (float64_t omega) const
   return kappa_hat;
 }
 
-SGVector<float64_t> CHomogeneousKernelMap::apply_to_vector(SGVector<float64_t> in_v) const
+SGVector<float64_t> CHomogeneousKernelMap::apply_to_vector(const SGVector<float64_t>& in_v) const
 {
 	/* assert for in vector */
 	ASSERT (in_v.vlen > 0);

--- a/src/shogun/preprocessor/HomogeneousKernelMap.h
+++ b/src/shogun/preprocessor/HomogeneousKernelMap.h
@@ -144,7 +144,7 @@ namespace shogun
 			inline float64_t get_smooth_spectrum (float64_t omega) const;
 			inline float64_t sinc (float64_t x) const;
 			inline float64_t get_spectrum (float64_t omega) const;
-			SGVector<float64_t> apply_to_vector(SGVector<float64_t> in_v) const;
+			SGVector<float64_t> apply_to_vector(const SGVector<float64_t>& in_v) const;
 
 		private:
 			HomogeneousKernelType m_kernel;


### PR DESCRIPTION
No need for copying the vector on the stack it's enough to
pass a const reference to it as we are only reading from it.
