### PR TITLE
Kernel normalizer references fix

### DIFF
--- a/src/shogun/kernel/CommUlongStringKernel.cpp
+++ b/src/shogun/kernel/CommUlongStringKernel.cpp
@@ -10,7 +10,7 @@
 
 #include <shogun/lib/common.h>
 #include <shogun/kernel/CommUlongStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/StringFeatures.h>
 #include <shogun/io/SGIO.h>
 

--- a/src/shogun/kernel/CommWordStringKernel.cpp
+++ b/src/shogun/kernel/CommWordStringKernel.cpp
@@ -14,7 +14,7 @@
 #include <shogun/base/Parameter.h>
 
 #include <shogun/kernel/CommWordStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/StringFeatures.h>
 
 using namespace shogun;

--- a/src/shogun/kernel/FixedDegreeStringKernel.cpp
+++ b/src/shogun/kernel/FixedDegreeStringKernel.cpp
@@ -10,7 +10,7 @@
 
 #include <shogun/lib/common.h>
 #include <shogun/kernel/FixedDegreeStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 #include <shogun/io/SGIO.h>

--- a/src/shogun/kernel/GaussianMatchStringKernel.cpp
+++ b/src/shogun/kernel/GaussianMatchStringKernel.cpp
@@ -11,7 +11,7 @@
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/GaussianMatchStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 

--- a/src/shogun/kernel/Kernel.cpp
+++ b/src/shogun/kernel/Kernel.cpp
@@ -22,7 +22,7 @@
 #include <shogun/base/Parallel.h>
 
 #include <shogun/kernel/Kernel.h>
-#include <shogun/kernel/IdentityKernelNormalizer.h>
+#include <shogun/kernel/normalize/IdentityKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/base/Parameter.h>
 

--- a/src/shogun/kernel/MatchWordStringKernel.cpp
+++ b/src/shogun/kernel/MatchWordStringKernel.cpp
@@ -12,7 +12,7 @@
 #include <shogun/mathematics/Math.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/MatchWordStringKernel.h>
-#include <shogun/kernel/AvgDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/AvgDiagKernelNormalizer.h>
 #include <shogun/features/StringFeatures.h>
 
 using namespace shogun;

--- a/src/shogun/kernel/OligoStringKernel.cpp
+++ b/src/shogun/kernel/OligoStringKernel.cpp
@@ -12,7 +12,7 @@
  *
  */
 #include <shogun/kernel/OligoStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/StringFeatures.h>
 
 #include <map>

--- a/src/shogun/kernel/PolyKernel.cpp
+++ b/src/shogun/kernel/PolyKernel.cpp
@@ -13,7 +13,7 @@
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/PolyKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/DotFeatures.h>
 
 using namespace shogun;

--- a/src/shogun/kernel/PolyMatchStringKernel.cpp
+++ b/src/shogun/kernel/PolyMatchStringKernel.cpp
@@ -11,7 +11,7 @@
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/PolyMatchStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 

--- a/src/shogun/kernel/PolyMatchWordStringKernel.cpp
+++ b/src/shogun/kernel/PolyMatchWordStringKernel.cpp
@@ -11,7 +11,7 @@
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/PolyMatchWordStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 

--- a/src/shogun/kernel/SNPStringKernel.cpp
+++ b/src/shogun/kernel/SNPStringKernel.cpp
@@ -11,7 +11,7 @@
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/SNPStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 

--- a/src/shogun/kernel/WeightedDegreePositionStringKernel.cpp
+++ b/src/shogun/kernel/WeightedDegreePositionStringKernel.cpp
@@ -16,7 +16,7 @@
 #include <shogun/base/Parallel.h>
 
 #include <shogun/kernel/WeightedDegreePositionStringKernel.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 

--- a/src/shogun/kernel/WeightedDegreeStringKernel.cpp
+++ b/src/shogun/kernel/WeightedDegreeStringKernel.cpp
@@ -17,7 +17,7 @@
 #include <shogun/base/Parallel.h>
 
 #include <shogun/kernel/WeightedDegreeStringKernel.h>
-#include <shogun/kernel/FirstElementKernelNormalizer.h>
+#include <shogun/kernel/normalize/FirstElementKernelNormalizer.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/StringFeatures.h>
 

--- a/src/shogun/multiclass/ScatterSVM.cpp
+++ b/src/shogun/multiclass/ScatterSVM.cpp
@@ -14,7 +14,7 @@
 
 #include <shogun/kernel/Kernel.h>
 #include <shogun/multiclass/ScatterSVM.h>
-#include <shogun/kernel/ScatterKernelNormalizer.h>
+#include <shogun/kernel/normalize/ScatterKernelNormalizer.h>
 #include <shogun/multiclass/MulticlassOneVsRestStrategy.h>
 #include <shogun/io/SGIO.h>
 

--- a/src/shogun/ui/GUIKernel.cpp
+++ b/src/shogun/ui/GUIKernel.cpp
@@ -47,15 +47,15 @@
 #include <shogun/kernel/OligoStringKernel.h>
 #include <shogun/kernel/DistanceKernel.h>
 #include <shogun/kernel/TensorProductPairKernel.h>
-#include <shogun/kernel/AvgDiagKernelNormalizer.h>
-#include <shogun/kernel/RidgeKernelNormalizer.h>
-#include <shogun/kernel/FirstElementKernelNormalizer.h>
-#include <shogun/kernel/IdentityKernelNormalizer.h>
-#include <shogun/kernel/SqrtDiagKernelNormalizer.h>
-#include <shogun/kernel/VarianceKernelNormalizer.h>
-#include <shogun/kernel/ScatterKernelNormalizer.h>
+#include <shogun/kernel/normalize/AvgDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/RidgeKernelNormalizer.h>
+#include <shogun/kernel/normalize/FirstElementKernelNormalizer.h>
+#include <shogun/kernel/normalize/IdentityKernelNormalizer.h>
+#include <shogun/kernel/normalize/SqrtDiagKernelNormalizer.h>
+#include <shogun/kernel/normalize/VarianceKernelNormalizer.h>
+#include <shogun/kernel/normalize/ScatterKernelNormalizer.h>
 #include <shogun/classifier/svm/SVM.h>
-#include <shogun/kernel/ZeroMeanCenterKernelNormalizer.h>
+#include <shogun/kernel/normalize/ZeroMeanCenterKernelNormalizer.h>
 #include <shogun/kernel/WaveletKernel.h>
 
 #include <string.h>


### PR DESCRIPTION
Several references to normalizers were broken in the kernels that had built-in normalization, and they are now fixed
