### PR TITLE
fix SO modular compile segfault.

### DIFF
--- a/src/interfaces/modular/Structure.i
+++ b/src/interfaces/modular/Structure.i
@@ -30,6 +30,7 @@
 #endif /* USE_MOSEK */
 
 /* Include Class Headers to make them visible from within the target language */
+%include <shogun/lib/StructuredDataTypes.h>
 %include <shogun/structure/PlifBase.h>
 %include <shogun/structure/Plif.h>
 %include <shogun/structure/PlifArray.h>

--- a/src/interfaces/modular/Structure_includes.i
+++ b/src/interfaces/modular/Structure_includes.i
@@ -1,4 +1,5 @@
 %{
+ #include <shogun/lib/StructuredDataTypes.h>
  #include <shogun/structure/PlifBase.h>
  #include <shogun/structure/Plif.h>
  #include <shogun/structure/PlifArray.h>


### PR DESCRIPTION
SWIG is seg-faulting in my local box (SWIG 2.0.7 on Arch Linux). After some struggling, I fixed the problem by adding the header files.

Though this fixed the problem, I still have some wondering about SWIG preprocessor. It seems it doesn't process 2nd level header fine include. I.e. when I include a header file A.h in SWIG, and A.h includes yet another B.h, it seems that SWIG doesn't process B.h by default. We have to manually include B.h. AND it seems to make things correct, we even need to make sure we manually include B.h _BEFORE_ A.h is included in SWIG. I have encountered similar strange problems related to this before, but this is the first time to get SWIG segfault yet.

I'm wondering is this a feature or a bug of SWIG?
