### PR TITLE
Use CBLAS optimized vector multiplication inside SGVector::vec1_plus_scalar_times_vec2

### DIFF
--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -292,6 +292,32 @@ void SGVector<floatmax_t>::display_vector(const floatmax_t* vector, int32_t n,
 }
 
 template <class T>
+void SGVector<T>::vec1_plus_scalar_times_vec2(float64_t* vec1,
+		const float64_t scalar, const float64_t* vec2, int32_t n)
+{
+#ifdef HAVE_LAPACK
+	int32_t skip=1;
+	cblas_daxpy(n, scalar, vec2, skip, vec1, skip);
+#else
+	for (int32_t i=0; i<n; i++)
+		vec1[i]+=scalar*vec2[i];
+#endif
+}
+
+template <class T>
+void SGVector<T>::vec1_plus_scalar_times_vec2(float32_t* vec1,
+		const float32_t scalar, const float32_t* vec2, int32_t n)
+{
+#ifdef HAVE_LAPACK
+	int32_t skip=1;
+	cblas_saxpy(n, scalar, vec2, skip, vec1, skip);
+#else
+	for (int32_t i=0; i<n; i++)
+		vec1[i]+=scalar*vec2[i];
+#endif
+}
+
+template <class T>
 float64_t SGVector<T>::dot(const float64_t* v1, const float64_t* v2, int32_t n)
 {
 	float64_t r=0;

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -186,13 +186,21 @@ template<class T> class SGVector : public SGReferencedData
 		/// || x ||_q
 		static T qnorm(T* x, int32_t len, float64_t q);
 
-		/// x=x+alpha*y
-		static inline void vec1_plus_scalar_times_vec2(T* vec1,
-				T scalar, const T* vec2, int32_t n)
-		{
-			for (int32_t i=0; i<n; i++)
-				vec1[i]+=scalar*vec2[i];
-		}
+//		/// x=x+alpha*y
+//		static inline void vec1_plus_scalar_times_vec2(T* vec1,
+//				T scalar, const T* vec2, int32_t n)
+//		{
+//			for (int32_t i=0; i<n; i++)
+//				vec1[i]+=scalar*vec2[i];
+//		}
+
+		/// x=x+alpha*y (blas optimized)
+		static void vec1_plus_scalar_times_vec2(float64_t* vec1,
+				const float64_t scalar, const float64_t* vec2, int32_t n);
+
+		/// x=x+alpha*y (blas optimized)
+		static void vec1_plus_scalar_times_vec2(float32_t* vec1,
+				const float32_t scalar, const float32_t* vec2, int32_t n);
 
 		/// compute dot product between v1 and v2 (blas optimized)
 		static inline float64_t dot(const bool* v1, const bool* v2, int32_t n)


### PR DESCRIPTION
The function SGVector::vec1_plus_scalar_times_vec2 maps nicely onto
cblas_saxpy and cblas_daxpy, which are significantly faster.
The generic template for vec1_plus_scalar_times_vec2 is commented out, but it is not used anyway. Other (unoptimized) instantiations are trivial to write based on the commented out version, should they be needed in the future.
