### PR TITLE
LD_LIBRARY_PATH is overwritten in check-examples

### DIFF
--- a/src/Makefile.template
+++ b/src/Makefile.template
@@ -330,7 +330,7 @@ check-examples-libshogun:
 		LIB_PATH="$(DESTDIR)$(LIBDIR)" \
 		INC_PATH="$(DESTDIR)$(INCDIR)" \
 		LIBS="$(LINKFLAGS) -lshogun" \
-		$(LIBRARY_PATH)=$(DESTDIR)$(LIBDIR) \
+		$(LIBRARY_PATH)=$(DESTDIR)$(LIBDIR):$$$(LIBRARY_PATH) \
 		INCLUDES="$(INCLUDES)" \
 		MAKE="$(MAKE)" ./check.sh
 


### PR DESCRIPTION
If u have an LD_LIBRARY_PATH set in the shell when you try to run 'make check-examples-libshogun' the
LD_LIBRARY_PATH will be overwritten by the location of the libshogun.so
instead of just prepending that path to the already set LD_LIBRARY_PATHs
