### PR TITLE
Use the supplied pkg-config script to detect eigen

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -3385,17 +3385,12 @@ check_eigen3()
 {
 	if test "$_eigen3" = yes || test "$_eigen3" = auto
 	then
-		cat > $TMPCXX << EOF
-#include <eigen3/Eigen/Dense>
-int main(int argc, char **argv)
-{
-	return 0;
-}
-EOF
 		echocheck "Eigen3 support"
-		if cxx_check
+		if pkg-config --exists eigen3
 		then
 			echores "yes"
+			EIGEN3_CFLAGS=`pkg-config --cflags eigen3`
+			INCLUDES="$INCLUDES $EIGEN3_CFLAGS"
 			HAVE_EIGEN3='#define HAVE_EIGEN3 1'
 			DEFINES="$DEFINES -DHAVE_EIGEN3"
 		else

--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -38,7 +38,7 @@
 
 #ifdef HAVE_EIGEN3
 #define EIGEN_RUNTIME_NO_MALLOC
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #endif
 
 /// workaround for log2 being a define on cygwin


### PR DESCRIPTION
Use pkg-config to detect eigen3, as it supplies pkg-config 
script and include eigen headers as they
are ment to be included (see documentation of eigen).
