### PR TITLE
Mountain Lion changed API of scandir

### DIFF
--- a/src/shogun/io/SGIO.h
+++ b/src/shogun/io/SGIO.h
@@ -59,10 +59,10 @@ enum EMessageType
 
 #ifdef DARWIN
 #include <Availability.h>
-#ifdef __MAC_10_8
-#define CONST_DIRENT_T const struct dirent
-#else
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_8
 #define CONST_DIRENT_T struct dirent
+#else
+#define CONST_DIRENT_T const struct dirent
 #endif // Mountain Lion or earlier
 #else //DARWIN
 #define CONST_DIRENT_T const struct dirent


### PR DESCRIPTION
The API of scandir has been changed in OSX 10.8 in a way
that it's the same as in other linux distros. Without this
fix shogun will not compile on OSX 10.8
