### PR TITLE
* doc fixes and less warnings

### DIFF
--- a/src/shogun/features/MatrixFeatures.cpp
+++ b/src/shogun/features/MatrixFeatures.cpp
@@ -30,11 +30,11 @@ template< class ST > CMatrixFeatures< ST >::CMatrixFeatures(
 }
 
 template< class ST > CMatrixFeatures< ST >::CMatrixFeatures(
-		SGMatrixList< ST > feats, int32_t num_vecs, int32_t num_feats)
+		SGMatrixList< ST > feats, int32_t num_feats)
 : CFeatures(0)
 {
 	init();
-	set_features(feats, num_vecs, num_feats);
+	set_features(feats, num_feats);
 }
 
 template< class ST > CMatrixFeatures< ST >::CMatrixFeatures(
@@ -45,7 +45,7 @@ template< class ST > CMatrixFeatures< ST >::CMatrixFeatures(
 			"must be equal to feat_length times num_vecs\n");
 	init();
 	SGMatrixList< ST > feats_list = SGMatrixList< ST >::split(feats, num_vecs);
-	set_features(feats_list, num_vecs, feats.num_rows);
+	set_features(feats_list, feats.num_rows);
 }
 
 /* TODO */
@@ -144,10 +144,10 @@ template< class ST > void CMatrixFeatures< ST >::set_feature_vector(
 }
 
 template< class ST > void CMatrixFeatures< ST >::set_features(
-		SGMatrixList< ST > features, int32_t num_vecs, int32_t num_feats)
+		SGMatrixList< ST > features, int32_t num_feats)
 {
 	m_features     = features;
-	m_num_vectors  = num_vecs;
+	m_num_vectors  = features.num_matrices;
 	m_num_features = num_feats;
 }
 

--- a/src/shogun/features/MatrixFeatures.h
+++ b/src/shogun/features/MatrixFeatures.h
@@ -35,26 +35,27 @@ template< class ST > class CMatrixFeatures : public CFeatures
 		/** standard constructor
 		 *
 		 * @param num_vecs number of vectors
-		 * @param num_feat number of features per vector
+		 * @param num_feats number of features per vector
 		 */
 		CMatrixFeatures(int32_t num_vecs, int32_t num_feats = 0);
 
 		/** constructor
 		 *
-		 * @param features list of feature matrices
+		 * @param feats list of feature matrices
+		 * @param num_feats number of features per vector
 		 */
-		CMatrixFeatures(SGMatrixList< ST > feats, int32_t num, int32_t num_feats = 0);
+		CMatrixFeatures(SGMatrixList< ST > feats, int32_t num_feats = 0);
 
 		/**
-		 * constructor using the data of all the features concatenated in a
-		 * matrix. All the features are assumed to have the same length. The number
-		 * of colums of feats must be equal to feat_length times num_vecs. The number
-		 * of features per vector is equal to the number of rows of feats.
+		 * constructor using the data of all the features concatenated
+		 * in a matrix. All the features are assumed to have the same
+		 * length. The number of colums of feats must be equal to
+		 * feat_length times num_vecs. The number of features per vector
+		 * is equal to the number of rows of feats.
 		 *
 		 * @param feats concatenation of the features
 		 * @param feat_length length of each feature
 		 * @param num_vecs number of feature vectors
-		 * @param num_feat number of features per vector
 		 */
 		CMatrixFeatures(SGMatrix< ST > feats, int32_t feat_length, int32_t num_vecs);
 
@@ -125,9 +126,9 @@ template< class ST > class CMatrixFeatures : public CFeatures
 		/** set features
 		 *
 		 * @param features to set
-		 * @param num_vecs number of vectors
+		 * @param num_feats number of features per vector
 		 */
-		void set_features(SGMatrixList< ST > features, int32_t num_vecs, int32_t num_feats);
+		void set_features(SGMatrixList< ST > features, int32_t num_feats);
 
 		/** @return object name */
 		virtual const char* get_name() const { return "MatrixFeatures"; }

--- a/src/shogun/structure/HMSVMLabels.h
+++ b/src/shogun/structure/HMSVMLabels.h
@@ -25,6 +25,7 @@ class CHMSVMLabels;
  * (SO) learning to Hidden Markov Support Vector Machines (HM-SVM). */
 struct CSequence : public CStructuredData
 {
+	/** data type */
 	STRUCTURED_DATA_TYPE(SDT_SEQUENCE);
 
 	/** constructor

--- a/src/shogun/structure/HMSVMModel.h
+++ b/src/shogun/structure/HMSVMModel.h
@@ -22,7 +22,9 @@ namespace shogun
 enum EStateModelType;
 
 /**
- * @brief Class CHMSVMModel TODO DOC
+ * @brief Class CHMSVMModel that represents the application specific model
+ * and contains the application dependent logic to solve Hidden Markov Support
+ * Vector Machines (HM-SVM) type of problems within a generic SO framework.
  */
 class CHMSVMModel : public CStructuredModel
 {
@@ -34,6 +36,7 @@ class CHMSVMModel : public CStructuredModel
 		 *
 		 * @param features the feature vectors, must be of type MatrixFeatures
 		 * @param labels HMSVM labels
+		 * @param smt internal state representation
 		 * @param num_obs number of observations
 		 */
 		CHMSVMModel(CFeatures* features, CStructuredLabels* labels, EStateModelType smt, int32_t num_obs);

--- a/src/shogun/structure/MulticlassModel.h
+++ b/src/shogun/structure/MulticlassModel.h
@@ -16,7 +16,11 @@
 namespace shogun
 {
 
-/** @brief TODO */
+/**
+ * @brief Class CMulticlassModel that represents the application specific model
+ * and contains the application dependent logic to solve multiclass
+ * classification within a generic SO framework.
+ */
 class CMulticlassModel : public CStructuredModel
 {
 

--- a/src/shogun/structure/StateModel.h
+++ b/src/shogun/structure/StateModel.h
@@ -20,7 +20,10 @@
 namespace shogun
 {
 
-/** TODO DOC */
+/**
+ * @brief class CStateModel base, abstract class for the internal state
+ * representation used in the CHMSVMModel.
+ */
 class CStateModel : public CSGObject
 {
 	public:
@@ -65,11 +68,10 @@ class CStateModel : public CSGObject
 		 * This vector is suitable to iterate through when constructing the
 		 * emission matrix used in Viterbi decoding
 		 *
+		 * @param emission_weights emission parameters outputted
 		 * @param w the weight vector
 		 * @param num_feats number of features
 		 * @param num_obs number of emission scores per feature and state
-		 *
-		 * @return a vector with the emission parameters
 		 */
 		virtual void reshape_emission_params(SGVector< float64_t >& emission_weights,
 			SGVector< float64_t > w, int32_t num_feats, int32_t num_obs) = 0;
@@ -79,12 +81,11 @@ class CStateModel : public CSGObject
 		 * adding zero elements for the states whose parameters are not learnt.
 		 * This matrix is suitable to iterate during Viterbi decoding
 		 *
+		 * @param transmission_weights transmission parameters outputted
 		 * @param w the weight vector
-		 *
-		 * @return a matrix with the transmission parameters
 		 */
 		virtual void reshape_transmission_params(
-				SGMatrix< float64_t >& transmission_matrix,
+				SGMatrix< float64_t >& transmission_weights,
 				SGVector< float64_t > w) = 0;
 
 		/** translates label sequence to state sequence
@@ -109,7 +110,7 @@ class CStateModel : public CSGObject
 		 * weight vector)
 		 *
 		 * @param psi output vector
-		 * @param transition_weights counts of the state transitions for a state
+		 * @param transmission_weights counts of the state transitions for a state
 		 * sequence
 		 * @param emission_weights counts of the emission scores for a state
 		 * sequence and a feature vector
@@ -117,7 +118,7 @@ class CStateModel : public CSGObject
 		 * @param num_obs number of emission scores per feature and state
 		 */
 		virtual void weights_to_vector(SGVector< float64_t >& psi,
-				SGMatrix< float64_t > transiton_weights,
+				SGMatrix< float64_t > transmission_weights,
 				SGVector< float64_t > emission_weights,
 				int32_t num_feats, int32_t num_obs) const = 0;
 

--- a/src/shogun/structure/TwoStateModel.cpp
+++ b/src/shogun/structure/TwoStateModel.cpp
@@ -143,9 +143,9 @@ void CTwoStateModel::reshape_emission_params(SGVector< float64_t >& emission_wei
 }
 
 void CTwoStateModel::reshape_transmission_params(
-		SGMatrix< float64_t >& transmission_matrix, SGVector< float64_t > w)
+		SGMatrix< float64_t >& transmission_weights, SGVector< float64_t > w)
 {
-	transmission_matrix.set_const(-CMath::INFTY);
+	transmission_weights.set_const(-CMath::INFTY);
 
 	// Legend for state indices:
 	// 0 -> start state
@@ -154,20 +154,20 @@ void CTwoStateModel::reshape_transmission_params(
 	// 3 -> positive state (label == 1)
 
 	// From start
-	transmission_matrix(0,2) = 0;    // to negative
-	transmission_matrix(0,3) = 0;    // to positive
+	transmission_weights(0,2) = 0;    // to negative
+	transmission_weights(0,3) = 0;    // to positive
 	// From negative
-	transmission_matrix(2,1) = 0;    // to stop
-	transmission_matrix(2,2) = w[0]; // to negative
-	transmission_matrix(2,3) = w[1]; // to positive
+	transmission_weights(2,1) = 0;    // to stop
+	transmission_weights(2,2) = w[0]; // to negative
+	transmission_weights(2,3) = w[1]; // to positive
 	// From positive
-	transmission_matrix(3,1) = 0;    // to stop
-	transmission_matrix(3,2) = w[3]; // to positive
-	transmission_matrix(3,3) = w[2]; // to negative
+	transmission_weights(3,1) = 0;    // to stop
+	transmission_weights(3,2) = w[3]; // to positive
+	transmission_weights(3,3) = w[2]; // to negative
 }
 
 void CTwoStateModel::weights_to_vector(SGVector< float64_t >& psi,
-		SGMatrix< float64_t > transition_weights,
+		SGMatrix< float64_t > transmission_weights,
 		SGVector< float64_t > emission_weights,
 		int32_t num_feats, int32_t num_obs) const
 {
@@ -176,10 +176,10 @@ void CTwoStateModel::weights_to_vector(SGVector< float64_t >& psi,
 	// 1 -> stop state
 	// 2 -> negative state
 	// 3 -> positive state
-	psi[0] = transition_weights(2,2);
-	psi[1] = transition_weights(2,3);
-	psi[2] = transition_weights(3,3);
-	psi[3] = transition_weights(3,2);
+	psi[0] = transmission_weights(2,2);
+	psi[1] = transmission_weights(2,3);
+	psi[2] = transmission_weights(3,3);
+	psi[3] = transmission_weights(3,2);
 
 	// start and stop states have no emission scores
 	index_t obs_idx, psi_idx = m_num_transmission_params;

--- a/src/shogun/structure/TwoStateModel.h
+++ b/src/shogun/structure/TwoStateModel.h
@@ -17,7 +17,10 @@
 namespace shogun
 {
 
-/** TODO DOC */
+/**
+ * @brief class CTwoStateModel class for the internal two-state representation
+ * used in the CHMSVMModel.
+ */
 class CTwoStateModel : public CStateModel
 {
 	public:
@@ -56,11 +59,10 @@ class CTwoStateModel : public CStateModel
 		 * This vector is suitable to iterate through when constructing the
 		 * emission matrix used in Viterbi decoding
 		 *
+		 * @param emission_weights emission parameters outputted
 		 * @param w the weight vector
 		 * @param num_feats number of features
 		 * @param num_obs number of emission scores per feature and state
-		 *
-		 * @return a vector with the emission parameters
 		 */
 		virtual void reshape_emission_params(SGVector< float64_t >& emission_weights,
 				SGVector< float64_t > w, int32_t num_feats, int32_t num_obs);
@@ -70,12 +72,11 @@ class CTwoStateModel : public CStateModel
 		 * adding zero elements for the states whose parameters are not learnt.
 		 * This matrix is suitable to iterate during Viterbi decoding
 		 *
+		 * @param transmission_weights transmission parameters outputted
 		 * @param w the weight vector
-		 *
-		 * @return a matrix with the transmission parameters
 		 */
 		virtual void reshape_transmission_params(
-				SGMatrix< float64_t >& transmission_matrix,
+				SGMatrix< float64_t >& transmission_weights,
 				SGVector< float64_t > w);
 
 		/** translates label sequence to state sequence
@@ -100,7 +101,7 @@ class CTwoStateModel : public CStateModel
 		 * weight vector)
 		 *
 		 * @param psi output vector
-		 * @param transition_weights counts of the state transitions for a state
+		 * @param transmission_weights counts of the state transitions for a state
 		 * sequence
 		 * @param emission_weights counts of the emission scores for a state
 		 * sequence and a feature vector
@@ -108,7 +109,7 @@ class CTwoStateModel : public CStateModel
 		 * @param num_obs number of emission scores per feature and state
 		 */
 		virtual void weights_to_vector(SGVector< float64_t >& psi,
-				SGMatrix< float64_t > transiton_weights,
+				SGMatrix< float64_t > transmission_weights,
 				SGVector< float64_t > emission_weights,
 				int32_t num_feats, int32_t num_obs) const;
 


### PR DESCRIPTION
There were a couple of warnings in my code I didn't manage to solve. These are:

/home/buildslave/nightly_all/build/src/shogun/structure/StateModel.h:150: warning: explicit link request to 'INFTY' could not be resolved
/home/buildslave/nightly_all/build/src/shogun/structure/StateModel.h:167: warning: explicit link request to 'INFTY' could not be resolved

(note that the lines showed above may have changed as a result of the changes introduced in this commit)

Please, let me know if you know how to fix them.
