### PR TITLE
Remove apply() implementation from LinearLatentMachine

### DIFF
--- a/src/shogun/machine/LinearLatentMachine.cpp
+++ b/src/shogun/machine/LinearLatentMachine.cpp
@@ -42,10 +42,6 @@ CLinearLatentMachine::~CLinearLatentMachine()
 	SG_UNREF(m_model);
 }
 
-CLatentLabels* CLinearLatentMachine::apply()
-{
-}
-
 CLatentLabels* CLinearLatentMachine::apply(CFeatures* data)
 {
 	if (m_model == NULL)


### PR DESCRIPTION
As it has been defined as a pure virtual function no need 
to have an implmentation of it.
