### PR TITLE
Fix GMOCK_LDADD flag

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -523,7 +523,7 @@ int main(int argc, char** argv)
 }
 EOF
 
-	GMOCK_LDADD="-lgmock -lgtest"
+	GMOCK_LDADD="-lgmock -lgtest -lpthread -D_THREAD_SAFE"
 	if test "$_gmock" = yes || test "$_gmock" = auto
 	then
 		if $GMOCK --version > /dev/null 2>&1


### PR DESCRIPTION
gmock and gtest uses threads and -lpthread flag was
missing when trying to detect gmock and gtest presence manually
