### PR TITLE
Fix doxygen comments in structure

### DIFF
--- a/src/shogun/structure/libbmrm.h
+++ b/src/shogun/structure/libbmrm.h
@@ -112,7 +112,7 @@ inline uint32_t find_free_idx(bool *map, uint32_t size)
 
 /** Standard BMRM Solver for Structured Output Learning
  *
- * @param model			Pointer to user data passed to risk function
+ * @param model			Pointer to user defined CStructuredModel
  * @param W				Weight vector
  * @param TolRel		Relative tolerance
  * @param TolAbs		Absolute tolerance

--- a/src/shogun/structure/libp3bm.h
+++ b/src/shogun/structure/libp3bm.h
@@ -22,11 +22,11 @@ namespace shogun
 	/** Proximal Point P-BMRM (multiple cutting plane models) Solver for
 	 * 	Structured Output Learning
 	 *
-	 * @param model			Pointer to user data passed to risk function
+	 * @param model			Pointer to user defined CStructuredModel
 	 * @param W				Weight vector
 	 * @param TolRel		Relative tolerance
 	 * @param TolAbs		Absolute tolerance
-	 * @param lambda		Regularization constant
+	 * @param _lambda		Regularization constant
 	 * @param _BufSize		Size of the CP buffer (i.e. maximal number of iterations)
 	 * @param cleanICP		Flag that enables/disables inactive cutting plane removal
 	 * 						feature

--- a/src/shogun/structure/libppbm.h
+++ b/src/shogun/structure/libppbm.h
@@ -21,11 +21,11 @@ namespace shogun
 {
 	/** Proximal Point BMRM Solver for Structured Output Learning
 	 *
-	 * @param data			Pointer to user data passed to risk function
+	 * @param model			Pointer to user defined CStructuredModel
 	 * @param W				Weight vector
 	 * @param TolRel		Relative tolerance
 	 * @param TolAbs		Absolute tolerance
-	 * @param lambda		Regularization constant
+	 * @param _lambda		Regularization constant
 	 * @param _BufSize		Size of the CP buffer (i.e. maximal number of iterations)
 	 * @param cleanICP		Flag that enables/disables inactive cutting plane removal
 	 * 						feature
@@ -34,7 +34,6 @@ namespace shogun
 	 * @param K				Parameter K
 	 * @param Tmax			Parameter Tmax
 	 * @param verbose		Flag that enables/disables screen output
-	 * @param risk_function	Pointer to risk function
 	 * @return Structure with BMRM algorithm result
 	 */
 	bmrm_return_value_T svm_ppbm_solver(


### PR DESCRIPTION
Some of the doxygen has not been removed or
changed in my previous commit. This fixes the warnings of those.
