### PR TITLE
Mosek is using threads

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -3504,7 +3504,7 @@ EOF
 		fi
 
 		echocheck "Mosek support"
-		if cxx_check $MOSEK_LDADD
+		if cxx_check $MOSEK_LDADD -lpthread
 		then
 			echores "yes"
 			USE_MOSEK='#define USE_MOSEK 1'


### PR DESCRIPTION
the -lpthread libarary flag was missing for cxx_check.
Otherwise it should be amongst the POSTLINKFLAGS
