### PR TITLE
CrossValidation::evaluate() return type and accessor methods

### DIFF
--- a/src/shogun/evaluation/CrossValidation.cpp
+++ b/src/shogun/evaluation/CrossValidation.cpp
@@ -65,7 +65,7 @@ void CCrossValidation::init()
 			MS_NOT_AVAILABLE);
 }
 
-CEvaluationResult* CCrossValidation::evaluate()
+CCrossValidationResult* CCrossValidation::evaluate()
 {
 	SG_DEBUG("entering %s::evaluate()\n", get_name());
 

--- a/src/shogun/evaluation/CrossValidation.h
+++ b/src/shogun/evaluation/CrossValidation.h
@@ -67,6 +67,26 @@ class CCrossValidationResult : public CEvaluationResult
 				SG_SPRINT("%f\n", mean);
 		}
 
+		float64_t get_mean()
+		{
+			return mean;
+		}
+
+		float64_t get_conf_int_low()
+		{
+			return conf_int_low;
+		}
+
+		float64_t get_conf_int_up()
+		{
+			return conf_int_up;
+		}
+
+		float64_t get_conf_int_alpha()
+		{
+			return conf_int_alpha;
+		}
+
 	public:
 		/** mean */
 		float64_t mean;
@@ -144,7 +164,7 @@ public:
 	/** setter for the number of runs to use for evaluation */
 	void set_conf_int_alpha(float64_t m_conf_int_alpha);
 
-	virtual CEvaluationResult* evaluate();
+	virtual CCrossValidationResult* evaluate();
 
 	void add_cross_validation_output(
 			CCrossValidationOutput* cross_validation_output);


### PR DESCRIPTION
changing return type for CrossValidation::evaluate() from EvaluationResult\* to CCrossValidationResult*
adding accessor methods for CrossValidationResult
