### PR TITLE
fix java modular build by renaming methods

### DIFF
--- a/examples/undocumented/libshogun/evaluation_cross_validation_mkl_weight_storage.cpp
+++ b/examples/undocumented/libshogun/evaluation_cross_validation_mkl_weight_storage.cpp
@@ -109,9 +109,9 @@ void test_mkl_cross_validation()
 
 	/* print mean and variance of each kernel weight. These could for example
 	 * been used to compute confidence intervals */
-	CStatistics::mean(weights, false).display_vector("mean per kernel");
-	CStatistics::variance(weights, false).display_vector("variance per kernel");
-	CStatistics::std_deviation(weights, false).display_vector("std-dev per kernel");
+	CStatistics::matrix_mean(weights, false).display_vector("mean per kernel");
+	CStatistics::matrix_variance(weights, false).display_vector("variance per kernel");
+	CStatistics::matrix_std_deviation(weights, false).display_vector("std-dev per kernel");
 
 	SG_UNREF(result);
 
@@ -125,9 +125,9 @@ void test_mkl_cross_validation()
 
 	/* print mean and variance of each kernel weight. These could for example
 	 * been used to compute confidence intervals */
-	CStatistics::mean(weights, false).display_vector("mean per kernel");
-	CStatistics::variance(weights, false).display_vector("variance per kernel");
-	CStatistics::std_deviation(weights, false).display_vector("std-dev per kernel");
+	CStatistics::matrix_mean(weights, false).display_vector("mean per kernel");
+	CStatistics::matrix_variance(weights, false).display_vector("variance per kernel");
+	CStatistics::matrix_std_deviation(weights, false).display_vector("std-dev per kernel");
 
 	/* clean up */
 	SG_UNREF(result);

--- a/examples/undocumented/python_modular/evaluation_cross_validation_mkl_weight_storage.py
+++ b/examples/undocumented/python_modular/evaluation_cross_validation_mkl_weight_storage.py
@@ -79,13 +79,13 @@ def evaluation_cross_validation_classification(traindat=traindat, label_traindat
     print weights
     
     print "mean per kernel"
-    print Statistics.mean(weights, False)
+    print Statistics.matrix_mean(weights, False)
     
     print "variance per kernel"
-    print Statistics.variance(weights, False)
+    print Statistics.matrix_variance(weights, False)
     
     print "std-dev per kernel"
-    print Statistics.std_deviation(weights, False)
+    print Statistics.matrix_std_deviation(weights, False)
     
 
 if __name__=='__main__':

--- a/src/shogun/mathematics/Statistics.cpp
+++ b/src/shogun/mathematics/Statistics.cpp
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2011 Heiko Strathmann
+ * Written (W) 2011-2012 Heiko Strathmann
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  *
  * ALGLIB Copyright 1984, 1987, 1995, 2000 by Stephen L. Moshier under GPL2+
@@ -49,7 +49,7 @@ float64_t CStatistics::variance(SGVector<float64_t> values)
 	return sum_squared_diff/(values.vlen-1);
 }
 
-SGVector<float64_t> CStatistics::mean(SGMatrix<float64_t> values,
+SGVector<float64_t> CStatistics::matrix_mean(SGMatrix<float64_t> values,
 		bool col_wise)
 {
 	ASSERT(values.num_rows>0);
@@ -86,7 +86,7 @@ SGVector<float64_t> CStatistics::mean(SGMatrix<float64_t> values,
 	return result;
 }
 
-SGVector<float64_t> CStatistics::variance(SGMatrix<float64_t> values,
+SGVector<float64_t> CStatistics::matrix_variance(SGMatrix<float64_t> values,
 		bool col_wise)
 {
 	ASSERT(values.num_rows>0);
@@ -94,7 +94,7 @@ SGVector<float64_t> CStatistics::variance(SGMatrix<float64_t> values,
 	ASSERT(values.matrix);
 
 	/* first compute mean */
-	SGVector<float64_t> mean=CStatistics::mean(values, col_wise);
+	SGVector<float64_t> mean=CStatistics::matrix_mean(values, col_wise);
 
 	SGVector<float64_t> result;
 
@@ -131,10 +131,10 @@ float64_t CStatistics::std_deviation(SGVector<float64_t> values)
 	return CMath::sqrt(variance(values));
 }
 
-SGVector<float64_t> CStatistics::std_deviation(SGMatrix<float64_t> values,
-			bool col_wise)
+SGVector<float64_t> CStatistics::matrix_std_deviation(
+		SGMatrix<float64_t> values, bool col_wise)
 {
-	SGVector<float64_t> var=CStatistics::variance(values, col_wise);
+	SGVector<float64_t> var=CStatistics::matrix_variance(values, col_wise);
 	for (index_t i=0; i<var.vlen; ++i)
 		var[i]=CMath::sqrt(var[i]);
 

--- a/src/shogun/mathematics/Statistics.h
+++ b/src/shogun/mathematics/Statistics.h
@@ -70,7 +70,7 @@ public:
 	 * otherwise
 	 * @return mean of given values
 	 */
-	static SGVector<float64_t> mean(SGMatrix<float64_t> values,
+	static SGVector<float64_t> matrix_mean(SGMatrix<float64_t> values,
 			bool col_wise=true);
 
 	/** Calculates unbiased empirical variance estimator of given values. Given
@@ -85,7 +85,7 @@ public:
 	 * otherwise
 	 * @return variance of given values
 	 */
-	static SGVector<float64_t> variance(SGMatrix<float64_t> values,
+	static SGVector<float64_t> matrix_variance(SGMatrix<float64_t> values,
 			bool col_wise=true);
 
 	/** Calculates unbiased empirical standard deviation estimator of given
@@ -100,8 +100,8 @@ public:
 	 * otherwise
 	 * @return variance of given values
 	 */
-	static SGVector<float64_t> std_deviation(SGMatrix<float64_t> values,
-			bool col_wise=true);
+	static SGVector<float64_t> matrix_std_deviation(
+			SGMatrix<float64_t> values, bool col_wise=true);
 
 #ifdef HAVE_LAPACK
 	/** Computes the empirical estimate of the covariance matrix of the given


### PR DESCRIPTION
java does not distinguish types and therefore cannot handle overloaded methods with SGVector/SGMatrix
