### PR TITLE
Fix Mac Compilation Error Before Mountain Lion

### DIFF
--- a/src/shogun/io/SGIO.h
+++ b/src/shogun/io/SGIO.h
@@ -56,6 +56,7 @@ enum EMessageType
 
 #define NUM_LOG_LEVELS 10
 #define FBUFSIZE 4096
+#define __MAC_10_8 1080
 
 #ifdef DARWIN
 #include <Availability.h>


### PR DESCRIPTION
shogun wasn't compiling on OS 10.7.4 for me because I didn't have __MAC_10_8 defined in my Availability.h

See this issue: https://github.com/shogun-toolbox/shogun/issues/784
