### PR TITLE
Fix GPR examples

### DIFF
--- a/examples/undocumented/libshogun/regression_gaussian_process_ard.cpp
+++ b/examples/undocumented/libshogun/regression_gaussian_process_ard.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <shogun/lib/config.h>
-#ifdef HAVE_EIGEN3
+#if defined(HAVE_EIGEN3) && defined(HAVE_NLOPT)
 #include <shogun/base/init.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>

--- a/examples/undocumented/libshogun/regression_gaussian_process_fitc.cpp
+++ b/examples/undocumented/libshogun/regression_gaussian_process_fitc.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <shogun/lib/config.h>
-#ifdef HAVE_EIGEN3
+#if defined(HAVE_EIGEN3) && defined(HAVE_NLOPT)
 #include <shogun/base/init.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>
@@ -95,7 +95,6 @@ int main(int argc, char **argv)
 {
 	init_shogun_with_defaults();
 
-#ifdef HAVE_EIGEN3
 	/* create some data and labels */
 	SGMatrix<float64_t> matrix =
 			SGMatrix<float64_t>(dim_vectors, num_vectors);
@@ -216,9 +215,6 @@ int main(int argc, char **argv)
 	SG_UNREF(best_combination);
 	SG_UNREF(result);
 
-#else
-	SG_SPRINT("shogun needs to be compiled with eigen3 for this example to work\n");
-#endif // HAVE_EIGEN3
 	exit_shogun();
 	return 0;
 }

--- a/examples/undocumented/libshogun/regression_gaussian_process_gaussian.cpp
+++ b/examples/undocumented/libshogun/regression_gaussian_process_gaussian.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <shogun/lib/config.h>
-#ifdef HAVE_EIGEN3
+#if defined(HAVE_EIGEN3) && defined(HAVE_NLOPT)
 #include <shogun/base/init.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>

--- a/examples/undocumented/libshogun/regression_gaussian_process_laplace.cpp
+++ b/examples/undocumented/libshogun/regression_gaussian_process_laplace.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <shogun/lib/config.h>
-#ifdef HAVE_EIGEN3
+#if defined(HAVE_EIGEN3) && defined(HAVE_NLOPT)
 #include <shogun/base/init.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>

--- a/examples/undocumented/libshogun/regression_gaussian_process_product.cpp
+++ b/examples/undocumented/libshogun/regression_gaussian_process_product.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <shogun/lib/config.h>
-#ifdef HAVE_EIGEN3
+#if defined(HAVE_EIGEN3) && defined(HAVE_NLOPT)
 #include <shogun/base/init.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>
@@ -173,7 +173,6 @@ int main(int argc, char **argv)
 {
 	init_shogun_with_defaults();
 
-#ifdef HAVE_NLOPT
 	/* create some data and labels */
 	SGMatrix<float64_t> matrix =
 		 SGMatrix<float64_t>(dim_vectors, num_vectors);
@@ -298,7 +297,6 @@ int main(int argc, char **argv)
 	SG_UNREF(grad_search);
 	SG_UNREF(best_combination);
 	SG_UNREF(result);
-#endif // HAVE_NLOPT
 
 	exit_shogun();
 

--- a/examples/undocumented/libshogun/regression_gaussian_process_sum.cpp
+++ b/examples/undocumented/libshogun/regression_gaussian_process_sum.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <shogun/lib/config.h>
-#ifdef HAVE_EIGEN3
+#if defined(HAVE_EIGEN3) && defined(HAVE_NLOPT)
 #include <shogun/base/init.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>
@@ -173,7 +173,6 @@ int main(int argc, char **argv)
 {
 	init_shogun_with_defaults();
 
-#ifdef HAVE_NLOPT
 	/* create some data and labels */
 	SGMatrix<float64_t> matrix =
 		 SGMatrix<float64_t>(dim_vectors, num_vectors);
@@ -298,16 +297,15 @@ int main(int argc, char **argv)
 	SG_UNREF(grad_search);
 	SG_UNREF(best_combination);
 	SG_UNREF(result);
-#endif // HAVE_NLOPT
 
 	exit_shogun();
 
 	return 0;
 
 }
-#else // HAVE_EIGEN3
+#else // HAVE_EIGEN3 && HAVE_NLOPT
 int main(int argc, char **argv)
 {
 	return 0;
 }
-#endif // HAVE_EIGEN3
+#endif // HAVE_EIGEN3 && HAVE_NLOPT


### PR DESCRIPTION
Gaussian Process Regression examples will not work without NLOPT
Fixing by checking HAVE_NLOPT macro
