### PR TITLE
Fix libshogun.dylib compilation on OS X

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -3928,7 +3928,7 @@ set_opts()
 		LIBRARY_PATH="DYLD_LIBRARY_PATH"
 		EXT_LIB=dylib
 		SONAMEOPT="-install_name "
-		SHAREDOPTS="-dynamiclib"
+		SHAREDOPTS="-dynamiclib -current_version ${LIBSHOGUNVER} -compatibility_version ${LIBSHOGUNSO}"
 		LIBSHOGUN_TARGET="libshogun.${LIBSHOGUNVER}.dylib"
 		LIBSHOGUN_SONAME="libshogun.${LIBSHOGUNSO}.dylib"
 		LIBSHOGUN_DYNAMIC="libshogun.dylib"


### PR DESCRIPTION
Set current version and compatibility version for libshogun.
i think we should start using proper versioning for dynamic library.
Currently i don't really see that we follow the major.minor version
scheme. We always change the major number...
