### PR TITLE
Fix StreamingFeatures

### DIFF
--- a/src/shogun/features/streaming/StreamingDotFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingDotFeatures.cpp
@@ -13,14 +13,6 @@ using namespace shogun;
 
 CStreamingDotFeatures::CStreamingDotFeatures() : CStreamingFeatures()
 {
-	init();
-	set_property(FP_STREAMING_DOT);
-}
-
-CStreamingDotFeatures::CStreamingDotFeatures(CStreamingFile* file, bool is_labelled,
-		int32_t size) : CStreamingFeatures()
-{
-	init(file, is_labelled, size);
 	set_property(FP_STREAMING_DOT);
 }
 
@@ -102,12 +94,4 @@ void CStreamingDotFeatures::free_feature_iterator(void* iterator)
 {
 	SG_NOTIMPLEMENTED;
 	return;
-}
-
-void CStreamingDotFeatures::init()
-{
-}
-
-void CStreamingDotFeatures::init(CStreamingFile *file, bool is_labelled, int32_t size)
-{
 }

--- a/src/shogun/features/streaming/StreamingDotFeatures.h
+++ b/src/shogun/features/streaming/StreamingDotFeatures.h
@@ -180,13 +180,6 @@ public:
 	 */
 	virtual void free_feature_iterator(void* iterator);
 
-private:
-	virtual void init();
-
-	virtual void init(CStreamingFile *file, bool is_labelled, int32_t size);
-
-
-
 protected:
 
 	/// feature weighting in combined dot features

--- a/src/shogun/features/streaming/StreamingFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingFeatures.cpp
@@ -25,11 +25,6 @@ CStreamingFeatures::~CStreamingFeatures()
 	SG_DEBUG("leaving CStreamingFeatures::~CStreamingFeatures()\n");
 }
 
-CStreamingFeatures::CStreamingFeatures(CStreamingFile* file,
-		bool is_labelled, int32_t size) : CFeatures()
-{
-}
-
 void CStreamingFeatures::set_read_functions()
 {
 	set_vector_reader();

--- a/src/shogun/features/streaming/StreamingFeatures.h
+++ b/src/shogun/features/streaming/StreamingFeatures.h
@@ -79,15 +79,6 @@ public:
 	CStreamingFeatures();
 
 	/**
-	 * Constructor with input information passed.
-	 *
-	 * @param file CStreamingFile to take input from.
-	 * @param is_labelled Whether examples are labelled or not.
-	 * @param size Number of examples to be held in the parser's "ring".
-	 */
-	CStreamingFeatures(CStreamingFile* file, bool is_labelled, int32_t size);
-
-	/**
 	 * Destructor
 	 */
 	virtual ~CStreamingFeatures();

--- a/src/shogun/features/streaming/StreamingSparseFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingSparseFeatures.cpp
@@ -380,6 +380,7 @@ void CStreamingSparseFeatures<T>::init(CStreamingFile* file,
 	init();
 	has_labels = is_labelled;
 	working_file = file;
+	SG_REF(working_file);
 	parser.init(file, is_labelled, size);
 }
 

--- a/src/shogun/features/streaming/StreamingSparseFeatures.h
+++ b/src/shogun/features/streaming/StreamingSparseFeatures.h
@@ -70,7 +70,7 @@ public:
 	 *
 	 * Ends the parsing thread. (Waits for pthread_join to complete)
 	 */
-	~CStreamingSparseFeatures();
+	virtual ~CStreamingSparseFeatures();
 
 	/**
 	 * Sets the read function (in case the examples are
@@ -371,9 +371,6 @@ private:
 protected:
 	/// The parser object, which reads from input and returns parsed example objects.
 	CInputParser< SGSparseVectorEntry<T> > parser;
-
-	/// The StreamingFile object to read from.
-	CStreamingFile* working_file;
 
 	/// The current example's feature vector as an SGVector<T>
 	SGSparseVector<T> current_sgvector;


### PR DESCRIPTION
- StreamingDotFeatures, StreamingFeatures:
  Remove empty functions and constructors
- StreamingSparseFeatures:
  removing working_file variable that shadows the same variable in
  StreamingFeatures,
  increase the reference of the working_file in ctor,
  define the dtor virtual
