### PR TITLE
Minor fix: Add -lpthread flag to build tests correctly

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -25,7 +25,7 @@ shogun-lib:
 	@$(MAKE) -C $(SHOGUNSRCTOP)/shogun
 
 shogun-unit-test: libgmock.a shogun-lib $(TESTOBJFILES)
-	@$(LINK) -o shogun-unit-test $(TESTOBJFILES) $(LINKFLAGS) -L$(SHOGUNSRCTOP)/shogun -lshogun libgmock.a $(LINKFLAGS_GMOCK)
+	@$(LINK) -o shogun-unit-test $(TESTOBJFILES) $(LINKFLAGS) -L$(SHOGUNSRCTOP)/shogun -lshogun -lpthread libgmock.a $(LINKFLAGS_GMOCK)
 
 build: shogun-unit-test
 	@$(LIBRARY_PATH)=$(SHOGUNSRCTOP)/shogun:$$$(LIBRARY_PATH) ./shogun-unit-test


### PR DESCRIPTION
The Makefile in ${GMOCK_DIR}/make includes this compile flag so it may make sense to have it there. Without the flag the build fails due to:

/usr/bin/ld: libgmock.a(gtest-all.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
/usr/bin/ld: note: 'pthread_key_delete@@GLIBC_2.2.5' is defined in DSO /usr/lib/libpthread.so.0 so try adding it to the linker command line

PS. The tests run fine here but there are some warnings, do you also get them? Most of them look like:

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: argmax_h(@0x7fff1f3f3230 32-byte object <30-6F 1D-74 88-7F 00-00 90-78 68-02 00-00 00-00 60-4E 68-02 00-00 00-00 0A-00 00-00 00-00 00-00>)
Stack trace:

GMOCK WARNING:
Uninteresting mock function call - returning default value.
    Function call: get_name()
          Returns: NULL
