### PR TITLE
Fix unit tests for SGVector::max_abs and MOCASSVM

### DIFF
--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -95,12 +95,12 @@ TEST(SGVectorTest,misc)
 	
 	/* test, min, max, sum */
 	int arg_max = 0, arg_max_abs = 0;
-	float64_t min = 1025, max = -1025, sum = 0.0, max_abs = - 1, sum_abs = 0.0;
+	float64_t min = 1025, max = -1025, sum = 0.0, max_abs = -1, sum_abs = 0.0;
 	for (int32_t i = 0; i < a.vlen; ++i)
 	{
 		sum += a[i];
 		sum_abs += CMath::abs(a[i]);
-		if (CMath::abs(a[i]) > max)
+		if (CMath::abs(a[i]) > max_abs)
 		{
 			max_abs = CMath::abs(a[i]);
 			arg_max_abs=i;

--- a/tests/unit/multiclass/MulticlassOCAS_unittest.cc
+++ b/tests/unit/multiclass/MulticlassOCAS_unittest.cc
@@ -38,6 +38,7 @@ TEST(MulticlassOCASTest,train)
   CMulticlassLabels* ground_truth = new CMulticlassLabels(labels);
   CMulticlassOCAS* mocas = new CMulticlassOCAS(C, train_feats, ground_truth);
   mocas->train();
+  mocas->parallel->set_num_threads(1);
 
   CLabels* pred = mocas->apply(test_feats);
   for (int i = 0; i < set_size; ++i)


### PR DESCRIPTION
there was a bug when calculating max_abs in an 
SGVector and MulticlassOCAS has been set to use only
1 thread
