### PR TITLE
kernel selection for linear time mmd for modular interfaces

### DIFF
--- a/examples/undocumented/libshogun/statistics_mmd_kernel_selection.cpp
+++ b/examples/undocumented/libshogun/statistics_mmd_kernel_selection.cpp
@@ -12,7 +12,7 @@
 #include <shogun/statistics/QuadraticTimeMMD.h>
 #include <shogun/statistics/MMDKernelSelectionCombOpt.h>
 #include <shogun/statistics/MMDKernelSelectionCombMaxL2.h>
-#include <shogun/statistics/MMDKernelSelectionOptSingle.h>
+#include <shogun/statistics/MMDKernelSelectionOpt.h>
 #include <shogun/statistics/MMDKernelSelectionMax.h>
 #include <shogun/statistics/MMDKernelSelectionMedian.h>
 #include <shogun/features/streaming/StreamingFeatures.h>
@@ -247,8 +247,8 @@ void test_kernel_choice_linear_time_mmd_opt_single()
 			streaming_q, m);
 
 	/* kernel selection instance with regularisation term */
-	CMMDKernelSelectionOptSingle* selection=
-			new CMMDKernelSelectionOptSingle(mmd, 10E-5);
+	CMMDKernelSelectionOpt* selection=
+			new CMMDKernelSelectionOpt(mmd, 10E-5);
 
 	/* start streaming features parser */
 	streaming_p->start_parser();

--- a/src/interfaces/modular/Features.i
+++ b/src/interfaces/modular/Features.i
@@ -423,8 +423,12 @@ namespace shogun
 #endif
 }
 
+/* these classes need the above typed CFeature definitions */
 %rename(MeanShiftDataGenerator) CMeanShiftDataGenerator;
 %include <shogun/features/streaming/generators/MeanShiftDataGenerator.h>
+
+%rename(GaussianBlobsDataGenerator) CGaussianBlobsDataGenerator;
+%include <shogun/features/streaming/generators/GaussianBlobsDataGenerator.h>
 
 /* Templated Class DenseSubsetFeatures */
 %include <shogun/features/DenseSubsetFeatures.h>

--- a/src/interfaces/modular/Features_includes.i
+++ b/src/interfaces/modular/Features_includes.i
@@ -43,6 +43,7 @@
 #include <shogun/features/ImplicitWeightedSpecFeatures.h>
 #include <shogun/features/DataGenerator.h>
 #include <shogun/features/streaming/generators/MeanShiftDataGenerator.h>
+#include <shogun/features/streaming/generators/GaussianBlobsDataGenerator.h>
 #include <shogun/features/LatentFeatures.h>
 #include <shogun/features/MatrixFeatures.h>
 %}

--- a/src/interfaces/modular/Statistics.i
+++ b/src/interfaces/modular/Statistics.i
@@ -4,7 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2012 Heiko Strathmann
+ * Written (W) 2012-2013 Heiko Strathmann
  */
  
 /* Remove C Prefix */
@@ -16,6 +16,14 @@
 %rename(KernelIndependenceTestStatistic) CKernelIndependenceTestStatistic;
 %rename(HSIC) CHSIC;
 %rename(KernelMeanMatching) CKernelMeanMatching;
+%rename(MMDKernelSelection) CMMDKernelSelection;
+%rename(MMDKernelSelectionComb) CMMDKernelSelectionComb;
+%rename(MMDKernelSelectionMedian) CMMDKernelSelectionMedian;
+%rename(MMDKernelSelectionMax) CMMDKernelSelectionMax;
+%rename(MMDKernelSelectionOpt) CMMDKernelSelectionOpt;
+%rename(MMDKernelSelectionCombOpt) CMMDKernelSelectionCombOpt;
+%rename(MMDKernelSelectionCombMaxL2) CMMDKernelSelectionCombMaxL2;
+
 
 /* Include Class Headers to make them visible from within the target language */
 %include <shogun/statistics/TestStatistic.h>
@@ -26,3 +34,10 @@
 %include <shogun/statistics/KernelIndependenceTestStatistic.h>
 %include <shogun/statistics/HSIC.h>
 %include <shogun/statistics/KernelMeanMatching.h>
+%include <shogun/statistics/MMDKernelSelection.h>
+%include <shogun/statistics/MMDKernelSelectionComb.h>
+%include <shogun/statistics/MMDKernelSelectionMedian.h>
+%include <shogun/statistics/MMDKernelSelectionMax.h>
+%include <shogun/statistics/MMDKernelSelectionOpt.h>
+%include <shogun/statistics/MMDKernelSelectionCombOpt.h>
+%include <shogun/statistics/MMDKernelSelectionCombMaxL2.h>

--- a/src/interfaces/modular/Statistics_includes.i
+++ b/src/interfaces/modular/Statistics_includes.i
@@ -7,5 +7,12 @@
  #include <shogun/statistics/KernelIndependenceTestStatistic.h>
  #include <shogun/statistics/HSIC.h>
  #include <shogun/statistics/KernelMeanMatching.h>
+ #include <shogun/statistics/MMDKernelSelection.h>
+ #include <shogun/statistics/MMDKernelSelectionComb.h>
+ #include <shogun/statistics/MMDKernelSelectionMedian.h>
+ #include <shogun/statistics/MMDKernelSelectionMax.h>
+ #include <shogun/statistics/MMDKernelSelectionOpt.h>
+ #include <shogun/statistics/MMDKernelSelectionCombOpt.h>
+ #include <shogun/statistics/MMDKernelSelectionCombMaxL2.h>
 %}
 

--- a/src/shogun/features/streaming/generators/GaussianBlobsDataGenerator.cpp
+++ b/src/shogun/features/streaming/generators/GaussianBlobsDataGenerator.cpp
@@ -18,11 +18,11 @@ CGaussianBlobsDataGenerator::CGaussianBlobsDataGenerator() :
 }
 
 CGaussianBlobsDataGenerator::CGaussianBlobsDataGenerator(index_t sqrt_num_blobs,
-		float64_t distance, float64_t epsilon, float64_t angle) :
+		float64_t distance, float64_t stretch, float64_t angle) :
 		CStreamingDenseFeatures<float64_t>()
 {
 	init();
-	set_blobs_model(sqrt_num_blobs, distance, epsilon, angle);
+	set_blobs_model(sqrt_num_blobs, distance, stretch, angle);
 }
 
 CGaussianBlobsDataGenerator::~CGaussianBlobsDataGenerator()
@@ -30,11 +30,11 @@ CGaussianBlobsDataGenerator::~CGaussianBlobsDataGenerator()
 }
 
 void CGaussianBlobsDataGenerator::set_blobs_model(index_t sqrt_num_blobs,
-		float64_t distance, float64_t epsilon, float64_t angle)
+		float64_t distance, float64_t stretch, float64_t angle)
 {
 	m_sqrt_num_blobs=sqrt_num_blobs;
 	m_distance=distance;
-	m_epsilon=epsilon;
+	m_stretch=stretch;
 	m_angle=angle;
 
 	/* precompute cholesky decomposition, start with rotation matrix */
@@ -46,7 +46,7 @@ void CGaussianBlobsDataGenerator::set_blobs_model(index_t sqrt_num_blobs,
 
 	/* diagonal eigenvalue matrix */
 	SGMatrix<float64_t> L(2, 2);
-	L(0, 0)=CMath::sqrt(epsilon);
+	L(0, 0)=CMath::sqrt(stretch);
 	L(1, 0)=0;
 	L(0, 1)=0;
 	L(1, 1)=1;
@@ -60,7 +60,7 @@ void CGaussianBlobsDataGenerator::init()
 	SG_SWARNING("%s::init(): register parameters!\n", get_name());
 	m_sqrt_num_blobs=1;
 	m_distance=0;
-	m_epsilon=1;
+	m_stretch=1;
 	m_angle=0;
 	m_cholesky=SGMatrix<float64_t>(2, 2);
 	m_cholesky(0, 0)=1;

--- a/src/shogun/features/streaming/generators/GaussianBlobsDataGenerator.h
+++ b/src/shogun/features/streaming/generators/GaussianBlobsDataGenerator.h
@@ -24,7 +24,7 @@ public:
 	/** Constructor
 	 */
 	CGaussianBlobsDataGenerator(index_t sqrt_num_blobs, float64_t distance,
-			float64_t epsilon, float64_t angle);
+			float64_t stretch, float64_t angle);
 
 	/** Destructor */
 	virtual ~CGaussianBlobsDataGenerator();
@@ -40,7 +40,7 @@ public:
 	 *
 	 */
 	void set_blobs_model(index_t sqrt_num_blobs, float64_t distance,
-			float64_t epsilon, float64_t angle);
+			float64_t stretch, float64_t angle);
 
 	/** get the next example from stream */
 	bool get_next_example();
@@ -55,7 +55,7 @@ private:
 protected:
 	index_t m_sqrt_num_blobs;
 	float64_t m_distance;
-	float64_t m_epsilon;
+	float64_t m_stretch;
 	float64_t m_angle;
 	SGMatrix<float64_t> m_cholesky;
 };

--- a/src/shogun/statistics/MMDKernelSelectionOpt.cpp
+++ b/src/shogun/statistics/MMDKernelSelectionOpt.cpp
@@ -7,19 +7,19 @@
  * Written (W) 2012-2013 Heiko Strathmann
  */
 
-#include <shogun/statistics/MMDKernelSelectionOptSingle.h>
+#include <shogun/statistics/MMDKernelSelectionOpt.h>
 #include <shogun/statistics/LinearTimeMMD.h>
 #include <shogun/kernel/CombinedKernel.h>
 
 using namespace shogun;
 
-CMMDKernelSelectionOptSingle::CMMDKernelSelectionOptSingle() :
+CMMDKernelSelectionOpt::CMMDKernelSelectionOpt() :
 		CMMDKernelSelection()
 {
 	init();
 }
 
-CMMDKernelSelectionOptSingle::CMMDKernelSelectionOptSingle(
+CMMDKernelSelectionOpt::CMMDKernelSelectionOpt(
 		CKernelTwoSampleTestStatistic* mmd, float64_t lambda) :
 		CMMDKernelSelection(mmd)
 {
@@ -33,11 +33,11 @@ CMMDKernelSelectionOptSingle::CMMDKernelSelectionOptSingle(
 	m_lambda=lambda;
 }
 
-CMMDKernelSelectionOptSingle::~CMMDKernelSelectionOptSingle()
+CMMDKernelSelectionOpt::~CMMDKernelSelectionOpt()
 {
 }
 
-SGVector<float64_t> CMMDKernelSelectionOptSingle::compute_measures()
+SGVector<float64_t> CMMDKernelSelectionOpt::compute_measures()
 {
 	/* comnpute mmd on all subkernels using the same data. Note that underlying
 	 * kernel was asserted to be a combined one */
@@ -54,7 +54,7 @@ SGVector<float64_t> CMMDKernelSelectionOptSingle::compute_measures()
 	return measures;
 }
 
-void CMMDKernelSelectionOptSingle::init()
+void CMMDKernelSelectionOpt::init()
 {
 	/* set to a sensible standard value that proved to be useful in
 	 * experiments, see NIPS paper */

--- a/src/shogun/statistics/MMDKernelSelectionOpt.h
+++ b/src/shogun/statistics/MMDKernelSelectionOpt.h
@@ -17,12 +17,12 @@ namespace shogun
 
 class CLinearTimeMMD;
 
-class CMMDKernelSelectionOptSingle: public CMMDKernelSelection
+class CMMDKernelSelectionOpt: public CMMDKernelSelection
 {
 public:
 
 	/** Default constructor */
-	CMMDKernelSelectionOptSingle();
+	CMMDKernelSelectionOpt();
 
 	/** Constructor that initialises the underlying MMD instance. Currently,
 	 * only the linear time MMD is developed
@@ -30,11 +30,11 @@ public:
 	 * @param mmd MMD instance to use
 	 * @param lamda ridge that is added to standard deviation
 	 */
-	CMMDKernelSelectionOptSingle(CKernelTwoSampleTestStatistic* mmd,
+	CMMDKernelSelectionOpt(CKernelTwoSampleTestStatistic* mmd,
 			float64_t lambda=10E-5);
 
 	/** Destructor */
-	virtual ~CMMDKernelSelectionOptSingle();
+	virtual ~CMMDKernelSelectionOpt();
 
 	/** Overwrites superclass method and ensures that all statistics are
 	 * computed on the same data. Since linear time MMD is a streaming
@@ -46,7 +46,7 @@ public:
 	virtual SGVector<float64_t> compute_measures();
 
 	/** @return name of the SGSerializable */
-	const char* get_name() const { return "MMDKernelSelectionOptSingle"; }
+	const char* get_name() const { return "MMDKernelSelectionOpt"; }
 
 private:
 	/** Initializer */


### PR DESCRIPTION
Towards having a nice example under python_modular
Includes minor overall changes on the classes
