### PR TITLE
3032013 rf2

### DIFF
--- a/examples/undocumented/libshogun/preprocessor_randomfouriergauss.cpp
+++ b/examples/undocumented/libshogun/preprocessor_randomfouriergauss.cpp
@@ -10,10 +10,10 @@
  */
 #include <shogun/kernel/GaussianKernel.h>
 #include <shogun/kernel/LinearKernel.h>
-#include <shogun/preproc/RandomFourierGaussPreproc.h>
+#include <shogun/preprocessor/RandomFourierGaussPreproc.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/classifier/svm/LibSVM.h>
-#include <shogun/lib/Mathematics.h>
+#include <shogun/mathematics/Math.h>
 #include <shogun/lib/common.h>
 #include <shogun/base/init.h>
 
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <algorithm>
 #include <ctime>
+
+//g++ -Wall -O3 -o tester preprocessor_randomfouriergauss.cpp -I ~/installed_software/shogun_git_localmaster/include/  -L  ~/installed_software/shogun_git_localmaster/lib/ -l shogun
 
 using namespace shogun;
 
@@ -50,169 +52,105 @@ void gen_rand_data(float64_t* & feat, float64_t* & lab,const int32_t num,const i
 				feat[i*dims+j]=CMath::random(0.0,1.0)-dist;
 		}
 	}
-	CMath::display_vector(lab,num);
-	CMath::display_matrix(feat,dims, num);
+
 }
 
 int main()
 {
 
+
 	time_t a,b;
-	int32_t dims=6000;
+
+	// data generation parameters
+	int32_t dims=6;
 	float64_t dist=0.5;
 
-	int32_t randomfourier_featurespace_dim=500; // the typical application of the below preprocessor are cases with high input dimensionalities of some thousands
+	int32_t numtr=300;
 
-	int32_t numtr=3000;
-	int32_t numte=3000;
 
-	const int32_t feature_cache=0;
-	const int32_t kernel_cache=0;
-
+	// random fourier transformation parameters
+	int32_t randomfourier_featurespace_dim=900; // the typical application of the below preprocessor are cases with high input dimensionalities of some thousands
+	const float64_t rbf_width=60; // gaussian kernel width
 	// important trick for RFgauss to work: kernel width is set such that average inner kernel distance is close one
 	// the rfgauss approximation breaks down if average inner kernel distances (~~ kernel width to small compared to variance of data) are too large
 	// try rbf_width=0.1 to see how it fails! - you will see the problem in the large number of negative kernel entries (numnegratio) for the rfgauss linear kernel
 
-	const float64_t rbf_width=4000;
-	const float64_t svm_C=10;
-	const float64_t svm_eps=0.001;
+
+
+
+	const int32_t kernel_cache=0;
+
+
+
+
+	
 
 	init_shogun();
 
 
-	float64_t* feattr(NULL);
+	float64_t* feattr1(NULL);
 	float64_t* labtr(NULL);
 
 	a=time(NULL);
 	std::cout << "generating train data"<<std::endl;
-	gen_rand_data(feattr,labtr,numtr,dims,dist);
+	gen_rand_data(feattr1,labtr,numtr,dims,dist);
 	float64_t* feattr2=SG_MALLOC(float64_t, numtr*dims);
-	std::copy(feattr,feattr+numtr*dims,feattr2);
+	std::copy(feattr1,feattr1+numtr*dims,feattr2);
+	float64_t* feattr3=SG_MALLOC(float64_t, numtr*dims);
+	std::copy(feattr1,feattr1+numtr*dims,feattr3);
 	std::cout << "finished"<<std::endl;
 	b=time(NULL);
 	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	float64_t* featte(NULL);
-	float64_t* labte(NULL);
-
-	a=time(NULL);
-	std::cout << "generating test data"<<std::endl;
-	gen_rand_data(featte,labte,numte,dims,dist);
-	float64_t* featte2=SG_MALLOC(float64_t, numtr*dims);
-	std::copy(featte,featte+numtr*dims,featte2);
-	float64_t* featte3=SG_MALLOC(float64_t, numtr*dims);
-	std::copy(featte,featte+numtr*dims,featte3);
-	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	// create train labels
-	CLabels* labelstr=new CLabels();
-	labelstr->set_labels(labtr, numtr);
-	SG_REF(labelstr);
 
 	// create train features
-	a=time(NULL);
+
 	std::cout << "initializing shogun train feature"<<std::endl;
 
-	CDenseFeatures<float64_t>* featurestr1 = new CDenseFeatures<float64_t>(feature_cache);
+	CDenseFeatures<float64_t>* featurestr1 = new CDenseFeatures<float64_t>(feattr1, dims, numtr);
 	SG_REF(featurestr1);
 
-
-	featurestr1->set_feature_matrix(feattr, dims, numtr);
 	std::cout << "finished"<<std::endl;
-	//b=time(NULL);
-	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
+
 
 	// create gaussian kernel
-//	std::cout << "computing gaussian train kernel"<<std::endl;
+	std::cout << "computing gaussian train kernel"<<std::endl;
 
 	CGaussianKernel* kerneltr1 = new CGaussianKernel(kernel_cache, rbf_width);
 	SG_REF(kerneltr1);
 	kerneltr1->init(featurestr1, featurestr1);
 
-	// create svm via libsvm and train
-	CLibSVM* svm1 = new CLibSVM(svm_C, kerneltr1, labelstr);
-	SG_REF(svm1);
-	svm1->set_epsilon(svm_eps);
-
-	a=time(NULL);
-	std::cout << "training SVM over gaussian kernel"<<std::endl;
-	svm1->train();
-	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	printf("num_sv:%d b:%f\n", svm1->get_num_support_vectors(), svm1->get_bias());
-
-	a=time(NULL);
-	std::cout << "initializing shogun test feature"<<std::endl;
-
-	CDenseFeatures<float64_t>* featureste1 = new CDenseFeatures<float64_t>(feature_cache);
-	SG_REF(featureste1);
-
-
-	featureste1->set_feature_matrix(featte, dims, numte);
-	std::cout << "finished"<<std::endl;
-	//b=time(NULL);
-	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	//std::cout << "computing gaussian test kernel"<<std::endl;
-	CGaussianKernel* kernelte1 = new CGaussianKernel(kernel_cache, rbf_width);
-	SG_REF(kernelte1);
-	kernelte1->init(featurestr1, featureste1);
-	svm1->set_kernel(kernelte1);
 	
-	a=time(NULL);
-	std::cout << "scoring gaussian test kernel"<<std::endl;
-
-
-	std::vector<float64_t> scoreste1(numte);
-	float64_t err1=0;
-	for(int32_t i=0; i< numte ;++i)
-	{
-		scoreste1[i]=svm1->classify_example(i);
-		if(scoreste1[i]*labte[i]<0)
-		{
-			err1+=1.0/numte;
-		}
-	}
-
 	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-
 
  // ***************************************
 // now WITH the preprocessor
-	a=time(NULL);
+
 	std::cout << "initializing preprocessor"<<std::endl;
 
 	CRandomFourierGaussPreproc *rfgauss=new CRandomFourierGaussPreproc;
 	SG_REF(rfgauss);
 
-	rfgauss->get_io()->set_loglevel(MSG_DEBUG);
+	//rfgauss->get_io()->set_loglevel(MSG_DEBUG);
 
 	// ************************************************************
 	// set parameters of the preprocessor
 	// ******************************** !!!!!!!!!!!!!!!!! CMath::sqrt(rbf_width/2.0)
-	rfgauss->set_kernelwidth( CMath::sqrt(rbf_width/2.0) );
-	rfgauss->set_dim_input_space(dims);
-	rfgauss->set_dim_feature_space(randomfourier_featurespace_dim);
 
+
+	rfgauss->set_parameters(dims,randomfourier_featurespace_dim,CMath::sqrt(rbf_width/2.0));
+	//**********8
+	// initializing coefficients, do that one time and reuse coefficients for test feature transformation by: store coefficients using get_random_coefficients(...)  and set them for test features using set_random_coefficients(...)
+	//*****************
+	rfgauss->init_randomcoefficients_from_scratch();
 	std::cout << "finished"<<std::endl;
-	//b=time(NULL);
-	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
 
 	// create train features
 
-	a=time(NULL);
 	std::cout << "initializing shogun train feature again"<<std::endl;
 
-	CDenseFeatures<float64_t>* featurestr2 = new CDenseFeatures<float64_t>(feature_cache);
-	SG_REF(featurestr2);
-	featurestr2->set_feature_matrix(feattr2, dims, numtr);
+	CDenseFeatures<float64_t>* featurestr2pre = new CDenseFeatures<float64_t>(feattr2, dims, numtr);
+	SG_REF(featurestr2pre);
+
 
 	std::cout << "finished"<<std::endl;
 	//b=time(NULL);
@@ -221,18 +159,25 @@ int main()
 	// ************************************************************
 	// use preprocessor
 	// **************************************************************
-	// add preprocessor
-	featurestr2->add_preproc(rfgauss);
+
 	// apply preprocessor
 	a=time(NULL);
 	std::cout << "applying preprocessor to train feature"<<std::endl;
 
-	featurestr2->apply_preproc();
+	CDenseFeatures<float64_t>* featurestr2=rfgauss->apply_to_dotfeatures_sparse_or_dense_with_real(featurestr2pre);
+
 	std::cout << "finished"<<std::endl;
 	b=time(NULL);
 	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
 
+	// create linear kernel
+	std::cout << "computing linear train kernel over preprocessed features"<<std::endl;
 
+	CLinearKernel* kerneltr2 = new CLinearKernel();
+	SG_REF(kerneltr2);
+	kerneltr2->init(featurestr2, featurestr2);
+
+	std::cout << "finished"<<std::endl;
 	// save random coefficients and state data of preprocessor for use with a new preprocessor object (see lines following "// now the same with a new preprocessor to show the usage of set_randomcoefficients"
 	// Alternative: use built-in serialization to load and save state data from/to a file!!!
  
@@ -244,112 +189,55 @@ int main()
 				&randomcoeff_multiplicative2,
 				&dim_feature_space2, &dim_input_space2, &kernelwidth2);
 
-	// create linear kernel
-	//std::cout << "computing linear train kernel over preprocessed features"<<std::endl;
 
-	CLinearKernel* kerneltr2 = new CLinearKernel();
-	SG_REF(kerneltr2);
-	kerneltr2->init(featurestr2, featurestr2);
-
-	// create svm via libsvm and train
-	CLibSVM* svm2 = new CLibSVM(svm_C, kerneltr2, labelstr);
-	SG_REF(svm2);
-	svm2->set_epsilon(svm_eps);
-	a=time(NULL);
-	std::cout << "training SVM over linear kernel over preprocessed features"<<std::endl;
-
-	svm2->train();
-	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	printf("num_sv:%d b:%f\n", svm2->get_num_support_vectors(), svm2->get_bias());
-	a=time(NULL);
-	std::cout << "initializing shogun test feature again"<<std::endl;
-
-	CDenseFeatures<float64_t>* featureste2 = new CDenseFeatures<float64_t>(feature_cache);
-	SG_REF(featureste2);
-	featureste2->set_feature_matrix(featte2, dims, numte);
-	std::cout << "finished"<<std::endl;
-	//b=time(NULL);
-	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
 
 
 	// ************************************************************
-	// use preprocessor
+	// use preprocessor with setting of rf coefficients (usually one would use that when computing testing features)
 	// **************************************************************
+
+	CDenseFeatures<float64_t>* featurestr3pre = new CDenseFeatures<float64_t>(feattr3, dims, numtr);
+	SG_REF(featurestr3pre);
+
+
 	CRandomFourierGaussPreproc *rfgauss2=new CRandomFourierGaussPreproc;
 	SG_REF(rfgauss2);
 
-	rfgauss2->get_io()->set_loglevel(MSG_DEBUG);
+	//rfgauss2->get_io()->set_loglevel(MSG_DEBUG);
 
-	// add preprocessor
-	featureste2->add_preproc(rfgauss);
+	rfgauss2->set_parameters(dims,randomfourier_featurespace_dim,CMath::sqrt(rbf_width/2.0));
+	rfgauss2->set_randomcoefficients(randomcoeff_additive2,
+				randomcoeff_multiplicative2,
+				dim_feature_space2, dim_input_space2, kernelwidth2);
+
+
 	// apply preprocessor
 	a=time(NULL);
 	std::cout << "applying same preprocessor to test feature"<<std::endl;
 
-	featureste2->apply_preproc();
+
+	CDenseFeatures<float64_t>* featurestr3=rfgauss->apply_to_dotfeatures_sparse_or_dense_with_real(featurestr3pre);
+
 	std::cout << "finished"<<std::endl;
 	b=time(NULL);
 	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
 
 	//std::cout << "computing linear test kernel over preprocessed features"<<std::endl;
 
-	CLinearKernel* kernelte2 = new CLinearKernel();
-	SG_REF(kernelte2);
-	kernelte2->init(featurestr2, featureste2);
+	CLinearKernel* kerneltr3 = new CLinearKernel();
+	SG_REF(kerneltr3);
+	kerneltr3->init(featurestr3, featurestr3);
 	//std::cout << "finished"<<std::endl;
 	//b=time(NULL);
 	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
 
-	svm2->set_kernel(kernelte2);
-	a=time(NULL);
-	std::cout << "scoring linear test kernel over preprocessed features"<<std::endl;
-
-	std::vector<float64_t> scoreste2(numte);
-
-	float64_t err2=0;
-	for(int32_t i=0; i< numte ;++i)
-	{
-		scoreste2[i]=svm2->classify_example(i);
-		if(scoreste2[i]*labte[i]<0)
-		{
-			err2+=1.0/numte;
-		}
-	}
-	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	std::cout << "pausing 12 seconds"<<std::endl;
-	sleep(12);
-	// ************************************************************
-	// compare results
-	// **************************************************************
-	int32_t num_labeldiffs=0;
-	float64_t avg_scorediff=0;
-	for(int32_t i=0; i< numte ;++i)
-	{
-		if( (int32_t)CMath::sign(scoreste1[i]) != (int32_t)CMath::sign(scoreste2[i]))
-		{
-			++num_labeldiffs;
-		}
-		avg_scorediff+=CMath::abs(scoreste1[i]-scoreste2[i])/numte;
-		std::cout<< "at sample i"<< i <<" label 1= " << CMath::sign(scoreste1[i]) <<" label 2= " << CMath::sign(scoreste2[i])<< " scorediff " << scoreste1[i] << " - " <<scoreste2[i] <<" = " << CMath::abs(scoreste1[i]-scoreste2[i])<<std::endl;
-	}
-	std::cout << "usedwidth for rbf kernel"<<	kerneltr1->get_width() << " " <<	kernelte1->get_width()<<std::endl;
-
-std::cout<< "number of different labels between gaussian kernel and rfgauss "<< num_labeldiffs<< " out of "<< numte << " labels "<<std::endl;
-std::cout<< "average test sample SVM output score difference between gaussian kernel and rfgauss "<< avg_scorediff<<std::endl;
-std::cout<< "classification errors gaussian kernel and rfgauss  "<< err1 << " " <<err2<<std::endl;
-
+	
 a=time(NULL);
 std::cout << "computing effective kernel widths (means of inner distances)"<<std::endl;
 
-int32_t m, n;
-float64_t * kertr1;
-kerneltr1->get_kernel_matrix ( &kertr1, &m, &n);
+int32_t m= kerneltr1->get_num_vec_lhs(), n= kerneltr1->get_num_vec_rhs();
+
+SGMatrix<float64_t> kertr1= kerneltr1->get_kernel_matrix ();
 
 std::cout << "kernel size "<< m << " "<< n <<std::endl;
 
@@ -362,9 +250,11 @@ for(int i=0; i<m ;++i)
 	}
 }
 
-float64_t * kertr2;
-kerneltr2->get_kernel_matrix (&kertr2,&m, &n);
+SGMatrix<float64_t> kertr2= kerneltr2->get_kernel_matrix ();
+SGMatrix<float64_t> kertr3= kerneltr3->get_kernel_matrix ();
 
+float64_t diffs12=0;
+float64_t diffs23=0;
 
 float64_t avgdist2=0;
 float64_t numnegratio=0;
@@ -380,99 +270,27 @@ for(int i=0; i<m ;++i)
 		{
 		avgdist2+= -CMath::log(std::max(kertr2[i+l*m],1e-10))*2.0/m/(m+1.0);
 		}
+
+		diffs12+=fabs(kertr1[i+l*m]-kertr2[i+l*m])/kertr1[i+l*m]*2.0/m/(m+1.0);
+		diffs23+=fabs(kertr2[i+l*m]-kertr3[i+l*m])*2.0/m/(m+1.0);
 	}
 }
+
+
+
+
+
+
+std::cout << " absolute differences between rf approximation with inited coefficients and saved and set coefficients ( get_randomcoefficients(...)+set_randomcoefficients(...) " << diffs23  <<std::endl;
+
 std::cout << "finished"<<std::endl;
 b=time(NULL);
 std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-std::cout << "effective kernel width for gaussian kernel and RFgauss "<< avgdist1 << " " <<avgdist2/(1.0-numnegratio) << std::endl<< " numnegratio (negative entries in RFgauss approx kernel)"<< numnegratio<<std::endl;
+std::cout <<std::endl<< "effective kernel widths for gaussian kernel versus RFgauss approximation "<< avgdist1 << " " <<avgdist2/(1.0-numnegratio) << std::endl<< " ratio of negative entries in RFgauss approx kernel (that are bad results) "<< numnegratio<<std::endl;
 
 
 
-
-
- // **********************************************
-// now the same with a new preprocessor to show the usage of set_randomcoefficients
-// ********************************************8
-
-	CDenseFeatures<float64_t>* featureste3 = new CDenseFeatures<float64_t>(feature_cache);
-	SG_REF(featureste3);
-	featureste3->set_feature_matrix(featte3, dims, numte);
-	std::cout << "finished"<<std::endl;
-	//b=time(NULL);
-	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-
-	// ************************************************************
-	// use preprocessor
-	// **************************************************************
-	rfgauss2->set_randomcoefficients(
-		randomcoeff_additive2,
-		randomcoeff_multiplicative2,
-		dim_feature_space2, dim_input_space2, kernelwidth2);
-
-	// add preprocessor
-	featureste3->add_preproc(rfgauss2);
-	// apply preprocessor
-	a=time(NULL);
-	std::cout << "applying same preprocessor to test feature"<<std::endl;
-
-	featureste3->apply_preproc();
-	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	//std::cout << "computing linear test kernel over preprocessed features"<<std::endl;
-
-	CLinearKernel* kernelte3 = new CLinearKernel();
-	SG_REF(kernelte3);
-	kernelte2->init(featurestr2, featureste3);
-	//std::cout << "finished"<<std::endl;
-	//b=time(NULL);
-	//std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	svm2->set_kernel(kernelte3);
-	a=time(NULL);
-	std::cout << "scoring linear test kernel over preprocessed features"<<std::endl;
-
-	std::vector<float64_t> scoreste3(numte);
-
-	float64_t err3=0;
-	for(int32_t i=0; i< numte ;++i)
-	{
-		scoreste3[i]=svm2->classify_example(i);
-		if(scoreste3[i]*labte[i]<0)
-		{
-			err3+=1.0/numte;
-		}
-	}
-	std::cout << "finished"<<std::endl;
-	b=time(NULL);
-	std::cout<< "elapsed time in seconds "<<b-a <<std::endl;
-
-	std::cout << "pausing 12 seconds"<<std::endl;
-	sleep(12);
-	// ************************************************************
-	// compare results
-	// **************************************************************
-	num_labeldiffs=0;
-	avg_scorediff=0;
-	for(int32_t i=0; i< numte ;++i)
-	{
-		if( (int32_t)CMath::sign(scoreste1[i]) != (int32_t)CMath::sign(scoreste3[i]))
-		{
-			++num_labeldiffs;
-		}
-		avg_scorediff+=CMath::abs(scoreste1[i]-scoreste3[i])/numte;
-		std::cout<< "at sample i"<< i <<" label 1= " << CMath::sign(scoreste1[i]) <<" label 2= " << CMath::sign(scoreste3[i])<< " scorediff " << scoreste1[i] << " - " <<scoreste3[i] <<" = " << CMath::abs(scoreste1[i]-scoreste3[i])<<std::endl;
-	}
-
-std::cout<< "number of different labels between gaussian kernel and rfgauss "<< num_labeldiffs<< " out of "<< numte << " labels "<<std::endl;
-std::cout<< "average test sample SVM output score difference between gaussian kernel and rfgauss "<< avg_scorediff<<std::endl;
-std::cout<< "classification errors gaussian kernel and rfgauss  "<< err1 << " " <<err3<<std::endl;
-
-
-
+std::cout <<std::endl<<std::endl<< " RELATIVE DIFFERENCES between true gaussian kernel and rf approximation " << diffs12  <<std::endl<<std::endl<<std::endl;
 
 
 
@@ -498,23 +316,21 @@ std::cout<< "classification errors gaussian kernel and rfgauss  "<< err1 << " " 
 	SG_FREE(randomcoeff_multiplicative2);
 
 	SG_FREE(labtr);
-	SG_FREE(labte);
-	SG_FREE(kertr1);
-	SG_FREE(kertr2);
 
-	SG_UNREF(labelstr);
-	SG_UNREF(kerneltr1);
-	SG_UNREF(kerneltr2);
-	SG_UNREF(kernelte1);
-	SG_UNREF(kernelte2);
-	SG_UNREF(kernelte3);
+	//SG_FREE(kertr1);
+	//SG_FREE(kertr2);
+	//SG_FREE(kertr3);
+
+
+	//SG_UNREF(kerneltr1);
+	//SG_UNREF(kerneltr2);
+	//SG_UNREF(kerneltr3);
+
 	SG_UNREF(featurestr1);
 	SG_UNREF(featurestr2);
-	SG_UNREF(featureste1);
-	SG_UNREF(featureste2);
-	SG_UNREF(featureste3);
-	SG_UNREF(svm1);
-	SG_UNREF(svm2);
+	SG_UNREF(featurestr3);
+
+
 	SG_UNREF(rfgauss);
 	SG_UNREF(rfgauss2);
 	exit_shogun();

--- a/examples/undocumented/python_modular/preprocessor_randomfouriergausspreproc_modular.py
+++ b/examples/undocumented/python_modular/preprocessor_randomfouriergausspreproc_modular.py
@@ -5,30 +5,46 @@ lm=LoadMatrix()
 traindat = lm.load_numbers('../data/fm_train_real.dat')
 testdat = lm.load_numbers('../data/fm_test_real.dat')
 
-parameter_list = [[traindat,testdat,1.5,10],[traindat,testdat,1.5,10]]
+parameter_list = [[traindat,testdat,1000,10],[traindat,testdat,1000,10]]
 
-def preprocessor_randomfouriergausspreproc_modular (fm_train_real=traindat,fm_test_real=testdat,width=1.4,size_cache=10):
-	from shogun.Kernel import Chi2Kernel
+def preprocessor_randomfouriergausspreproc_modular (fm_train_real=traindat,fm_test_real=testdat,kernelwidth=1,size_cache=10):
+	from shogun.Kernel import GaussianKernel
+	from shogun.Kernel import LinearKernel
 	from shogun.Features import RealFeatures
 	from shogun.Preprocessor import RandomFourierGaussPreproc
 
 	feats_train=RealFeatures(fm_train_real)
 	feats_test=RealFeatures(fm_test_real)
 
+	inputdim=feats_train.get_num_features()
+	outputdim=inputdim*100 # take outputdim = inputdim*30 is an arbitrary choice, use more dimensions for a better approximation
 	preproc=RandomFourierGaussPreproc()
-	preproc.init(feats_train)
-	feats_train.add_preprocessor(preproc)
-	feats_train.apply_preprocessor()
-	feats_test.add_preprocessor(preproc)
-	feats_test.apply_preprocessor()
+	preproc.set_parameters(inputdim,outputdim,kernelwidth)
+	preproc.init_randomcoefficients_from_scratch() # do not repeat this when computing testfeatures!!, instead get the coefficients from training run via get_randomcoefficients(...) and plug them in for the testing run  
 
-	kernel=Chi2Kernel(feats_train, feats_train, width, size_cache)
+	rfgauss_train=preproc.apply_to_dotfeatures_sparse_or_dense_with_real(feats_train)
+	#rfgauss_test=preproc.apply_to_dotfeatures_sparse_or_dense_with_real(feats_test)
 
-	km_train=kernel.get_kernel_matrix()
-	kernel.init(feats_train, feats_test)
-	km_test=kernel.get_kernel_matrix()
 
-	return km_train,km_test,kernel
+	#compute RFGAUSS approx for training kernel
+	kernel_rfgauss_train_vs_train=LinearKernel(rfgauss_train, rfgauss_train)
+	km_train_rfgauss=kernel_rfgauss_train_vs_train.get_kernel_matrix()
+
+	#compute exact gaussian kernel for testing kernel
+	kernel_exact_train_vs_train=GaussianKernel(feats_train, feats_train, kernelwidth, size_cache)
+	km_train_exact=kernel_exact_train_vs_train.get_kernel_matrix()
+
+
+	#compute relative difference
+	diffs=abs(km_train_rfgauss/km_train_exact-1)
+	v1=reduce(lambda x, y: x+y / float(92),diffs, 0)
+
+	print "inputdim", inputdim, " outputdim", outputdim, " kernelwidth", kernelwidth
+	print "mean relative difference between exact kernel and random fourier approximation"
+	print sum(v1)/float(92)
+
+	
+	return kernel_rfgauss_train_vs_train,kernel_exact_train_vs_train
 
 if __name__=='__main__':
 	print('RandomFourierGaussPreproc')

--- a/src/shogun/preprocessor/RandomFourierGaussPreproc.cpp
+++ b/src/shogun/preprocessor/RandomFourierGaussPreproc.cpp
@@ -17,60 +17,46 @@ using namespace shogun;
 void CRandomFourierGaussPreproc::copy(const CRandomFourierGaussPreproc & feats) {
 
 	dim_input_space = feats.dim_input_space;
-	cur_dim_input_space = feats.cur_dim_input_space;
-
 	dim_feature_space = feats.dim_feature_space;
-	cur_dim_feature_space=feats.cur_dim_feature_space;
-
 	kernelwidth=feats.kernelwidth;
-	cur_kernelwidth=feats.cur_kernelwidth;
 
-	if(cur_dim_feature_space>0)
+
+	if(feats.randomcoeff_additive==NULL)
 	{
-		if(feats.randomcoeff_additive==NULL)
-		{
-			throw ShogunException(
-							"void CRandomFourierGaussPreproc::copy(...): feats.randomcoeff_additive==NULL && cur_dim_feature_space>0 \n");
-		}
-
-		randomcoeff_additive = SG_MALLOC(float64_t, cur_dim_feature_space);
-		std::copy(feats.randomcoeff_additive,feats.randomcoeff_additive+cur_dim_feature_space,randomcoeff_additive);
+		SG_FREE(randomcoeff_additive);
+		randomcoeff_additive=NULL;
 	}
 	else
 	{
-		randomcoeff_additive = NULL;
+		randomcoeff_additive = SG_MALLOC(float64_t, dim_feature_space);
+		std::copy(feats.randomcoeff_additive,feats.randomcoeff_additive+dim_feature_space,randomcoeff_additive);
 	}
 
-	if((cur_dim_feature_space>0)&&(cur_dim_input_space>0))
+	if(feats.randomcoeff_multiplicative==NULL)
 	{
-		if(feats.randomcoeff_multiplicative==NULL)
-		{
-			throw ShogunException(
-							"void CRandomFourierGaussPreproc::copy(...): feats.randomcoeff_multiplicative==NULL && cur_dim_feature_space>0 &&(cur_dim_input_space>0)  \n");
-		}
-
-		randomcoeff_multiplicative=SG_MALLOC(float64_t, cur_dim_feature_space*cur_dim_input_space);
-		std::copy(feats.randomcoeff_multiplicative,feats.randomcoeff_multiplicative+cur_dim_feature_space*cur_dim_input_space,randomcoeff_multiplicative);
+		SG_FREE(randomcoeff_multiplicative);
+		randomcoeff_multiplicative=NULL;
 	}
 	else
 	{
-		randomcoeff_multiplicative = NULL;
+		randomcoeff_multiplicative=SG_MALLOC(float64_t, dim_feature_space*dim_input_space);
+		std::copy(feats.randomcoeff_multiplicative,feats.randomcoeff_multiplicative+dim_feature_space*dim_input_space,randomcoeff_multiplicative);
 	}
+
 
 }
 
 CRandomFourierGaussPreproc::CRandomFourierGaussPreproc() :
-	CDensePreprocessor<float64_t> () {
-	dim_feature_space = 1000;
+	CPreprocessor() {
+	dim_feature_space = 0;
 	dim_input_space = 0;
-	cur_dim_input_space = 0;
-	cur_dim_feature_space=0;
+	kernelwidth=0;
 
 	randomcoeff_multiplicative=NULL;
 	randomcoeff_additive=NULL;
 
-	kernelwidth=1;
-	cur_kernelwidth=kernelwidth;
+
+
 
 	//m_parameter is inherited from CSGObject,
 	//serialization initialization
@@ -78,25 +64,20 @@ CRandomFourierGaussPreproc::CRandomFourierGaussPreproc() :
 	{
 		SG_ADD(&dim_input_space, "dim_input_space",
 		    "Dimensionality of the input space.", MS_NOT_AVAILABLE);
-		SG_ADD(&cur_dim_input_space, "cur_dim_input_space",
-		    "Dimensionality of the input space.", MS_NOT_AVAILABLE);
 		SG_ADD(&dim_feature_space, "dim_feature_space",
-		    "Dimensionality of the feature space.", MS_NOT_AVAILABLE);
-		SG_ADD(&cur_dim_feature_space, "cur_dim_feature_space",
 		    "Dimensionality of the feature space.", MS_NOT_AVAILABLE);
 
 		SG_ADD(&kernelwidth, "kernelwidth", "Kernel width.", MS_AVAILABLE);
-		SG_ADD(&cur_kernelwidth, "cur_kernelwidth", "Kernel width.", MS_AVAILABLE);
 
-		m_parameters->add_vector(&randomcoeff_additive,&cur_dim_feature_space,"randomcoeff_additive");
-		m_parameters->add_matrix(&randomcoeff_multiplicative,&cur_dim_feature_space,&cur_dim_input_space,"randomcoeff_multiplicative");
+		m_parameters->add_vector(&randomcoeff_additive,&dim_feature_space,"randomcoeff_additive");
+		m_parameters->add_matrix(&randomcoeff_multiplicative,&dim_feature_space,&dim_input_space,"randomcoeff_multiplicative");
 	}
 
 }
 
 CRandomFourierGaussPreproc::CRandomFourierGaussPreproc(
 		const CRandomFourierGaussPreproc & feats) :
-	CDensePreprocessor<float64_t> () {
+	CPreprocessor () {
 
 	randomcoeff_multiplicative=NULL;
 	randomcoeff_additive=NULL;
@@ -107,18 +88,14 @@ CRandomFourierGaussPreproc::CRandomFourierGaussPreproc(
 	{
 		SG_ADD(&dim_input_space, "dim_input_space",
 		    "Dimensionality of the input space.", MS_NOT_AVAILABLE);
-		SG_ADD(&cur_dim_input_space, "cur_dim_input_space",
-		    "Dimensionality of the input space.", MS_NOT_AVAILABLE);
 		SG_ADD(&dim_feature_space, "dim_feature_space",
-		    "Dimensionality of the feature space.", MS_NOT_AVAILABLE);
-		SG_ADD(&cur_dim_feature_space, "cur_dim_feature_space",
 		    "Dimensionality of the feature space.", MS_NOT_AVAILABLE);
 
 		SG_ADD(&kernelwidth, "kernelwidth", "Kernel width.", MS_AVAILABLE);
-		SG_ADD(&cur_kernelwidth, "cur_kernelwidth", "Kernel width.", MS_AVAILABLE);
+		SG_ADD(&kernelwidth, "cur_kernelwidth", "Kernel width.", MS_AVAILABLE);
 
-		m_parameters->add_vector(&randomcoeff_additive,&cur_dim_feature_space,"randomcoeff_additive");
-		m_parameters->add_matrix(&randomcoeff_multiplicative,&cur_dim_feature_space,&cur_dim_input_space,"randomcoeff_multiplicative");
+		m_parameters->add_vector(&randomcoeff_additive,&dim_feature_space,"randomcoeff_additive");
+		m_parameters->add_matrix(&randomcoeff_multiplicative,&dim_feature_space,&dim_input_space,"randomcoeff_multiplicative");
 	}
 
 	copy(feats);
@@ -143,70 +120,59 @@ int32_t CRandomFourierGaussPreproc::get_dim_feature_space() const {
 	return ((int32_t) dim_feature_space);
 }
 
-void CRandomFourierGaussPreproc::set_dim_feature_space(const int32_t dim) {
-	if (dim <= 0) {
-		throw ShogunException(
-				"void CRandomFourierGaussPreproc::set_dim_feature_space(const int32 dim): dim<=0 is not allowed");
-	}
-
-	dim_feature_space = dim;
-
-}
 
 int32_t CRandomFourierGaussPreproc::get_dim_input_space() const {
 	return ((int32_t) dim_input_space);
 }
 
-void CRandomFourierGaussPreproc::set_kernelwidth(const float64_t kernelwidth2 ) {
-	if (kernelwidth2 <= 0) {
-		throw ShogunException(
-				"void CRandomFourierGaussPreproc::set_kernelwidth(const float64_t kernelwidth2 ): kernelwidth2 <= 0 is not allowed");
-	}
-	kernelwidth=kernelwidth2;
-}
 
 float64_t CRandomFourierGaussPreproc::get_kernelwidth( ) const {
 	return (kernelwidth);
 }
 
-void CRandomFourierGaussPreproc::set_dim_input_space(const int32_t dim) {
-	if (dim <= 0) {
-		throw ShogunException(
-				"void CRandomFourierGaussPreproc::set_dim_input_space(const int32 dim): dim<=0 is not allowed");
-	}
 
-	dim_input_space = dim;
-
-}
 
 bool CRandomFourierGaussPreproc::test_rfinited() const {
 
-	if ((dim_feature_space ==  cur_dim_feature_space)
-			&& (dim_input_space > 0) && (dim_feature_space > 0)) {
-		if ((dim_input_space == cur_dim_input_space)&&(CMath::abs(kernelwidth-cur_kernelwidth)<1e-5)) {
+	if (dim_input_space<=0)
+	{
+		return false;
+	} 
+	if (dim_feature_space<=0)
+	{
+		return false;
+	} 
+	if (kernelwidth<=0)
+	{
+		return false;
+	} 
 
-			// already inited
-			return true;
-		} else {
-			return false;
-		}
-	}
+	if(!randomcoeff_additive)
+	{
+		return false;
+	} 
 
-	return false;
+	if(!randomcoeff_multiplicative)
+	{
+		return false;
+	} 
+
+	return true;
+
 }
 
-bool CRandomFourierGaussPreproc::init_randomcoefficients() {
+bool CRandomFourierGaussPreproc::init_randomcoefficients_from_scratch() {
 	if (dim_feature_space <= 0) {
-		throw ShogunException(
-				"bool CRandomFourierGaussPreproc::init_randomcoefficients(): dim_feature_space<=0 is not allowed\n");
+		SG_ERROR(
+				"bool CRandomFourierGaussPreproc::init_randomcoefficients_from_scratch(): dim_feature_space<=0 is not allowed\n");
 	}
 	if (dim_input_space <= 0) {
-		throw ShogunException(
-				"bool CRandomFourierGaussPreproc::init_randomcoefficients(): dim_input_space<=0 is not allowed\n");
+		SG_ERROR(
+				"bool CRandomFourierGaussPreproc::init_randomcoefficients_from_scratch(): dim_input_space<=0 is not allowed\n");
 	}
-
-	if (test_rfinited()) {
-		return false;
+	if (kernelwidth <= 0) {
+		SG_ERROR(
+				"bool CRandomFourierGaussPreproc::init_randomcoefficients_from_scratch(): kernelwidth<=0 is not allowed\n");
 	}
 
 
@@ -220,20 +186,17 @@ bool CRandomFourierGaussPreproc::init_randomcoefficients() {
 	SG_FREE(randomcoeff_additive);
 	randomcoeff_additive=NULL;
 
+	randomcoeff_additive=SG_MALLOC(float64_t, dim_feature_space);
+	randomcoeff_multiplicative=SG_MALLOC(float64_t, dim_feature_space*dim_input_space);
 
-	cur_dim_feature_space=dim_feature_space;
-	randomcoeff_additive=SG_MALLOC(float64_t, cur_dim_feature_space);
-	cur_dim_input_space = dim_input_space;
-	randomcoeff_multiplicative=SG_MALLOC(float64_t, cur_dim_feature_space*cur_dim_input_space);
 
-	cur_kernelwidth=kernelwidth;
 
-	for (int32_t  i = 0; i < cur_dim_feature_space; ++i) {
+	for (int32_t  i = 0; i < dim_feature_space; ++i) {
 		randomcoeff_additive[i] = CMath::random((float64_t) 0.0, 2 * pi);
 	}
 
-	for (int32_t  i = 0; i < cur_dim_feature_space; ++i) {
-		for (int32_t k = 0; k < cur_dim_input_space; ++k) {
+	for (int32_t  i = 0; i < dim_feature_space; ++i) {
+		for (int32_t k = 0; k < dim_input_space; ++k) {
 			float64_t x1,x2;
 			float64_t s = 2;
 			while ((s >= 1) ) {
@@ -244,7 +207,7 @@ bool CRandomFourierGaussPreproc::init_randomcoefficients() {
 			}
 
 			// =  x1/CMath::sqrt(val)* CMath::sqrt(-2*CMath::log(val));
-			randomcoeff_multiplicative[i*cur_dim_input_space+k] =  x1*CMath::sqrt(-2*CMath::log(s)/s )/kernelwidth;
+			randomcoeff_multiplicative[i*dim_input_space+k] =  x1*CMath::sqrt(-2*CMath::log(s)/s )/kernelwidth;
 		}
 	}
 
@@ -270,16 +233,16 @@ void CRandomFourierGaussPreproc::get_randomcoefficients(
 		return;
 	}
 
-	*dim_feature_space2 = cur_dim_feature_space;
-	*dim_input_space2 = cur_dim_input_space;
-	*kernelwidth2=cur_kernelwidth;
+	*dim_feature_space2 = dim_feature_space;
+	*dim_input_space2 = dim_input_space;
+	*kernelwidth2=kernelwidth;
 
-	*randomcoeff_additive2 = SG_MALLOC(float64_t, cur_dim_feature_space);
-	*randomcoeff_multiplicative2 = SG_MALLOC(float64_t, cur_dim_feature_space*cur_dim_input_space);
+	*randomcoeff_additive2 = SG_MALLOC(float64_t, dim_feature_space);
+	*randomcoeff_multiplicative2 = SG_MALLOC(float64_t, dim_feature_space*dim_input_space);
 
-	std::copy(randomcoeff_additive, randomcoeff_additive+cur_dim_feature_space,
+	std::copy(randomcoeff_additive, randomcoeff_additive+dim_feature_space,
 			*randomcoeff_additive2);
-	std::copy(randomcoeff_multiplicative, randomcoeff_multiplicative+cur_dim_feature_space*cur_dim_input_space,
+	std::copy(randomcoeff_multiplicative, randomcoeff_multiplicative+dim_feature_space*dim_input_space,
 			*randomcoeff_multiplicative2);
 
 
@@ -298,115 +261,129 @@ void CRandomFourierGaussPreproc::set_randomcoefficients(
 	SG_FREE(randomcoeff_additive);
 	randomcoeff_additive=NULL;
 
-	cur_dim_feature_space=dim_feature_space;
-	cur_dim_input_space = dim_input_space;
-	cur_kernelwidth=kernelwidth;
 
 	if( (dim_feature_space>0) && (dim_input_space>0) )
 	{
-	randomcoeff_additive=SG_MALLOC(float64_t, cur_dim_feature_space);
-	randomcoeff_multiplicative=SG_MALLOC(float64_t, cur_dim_feature_space*cur_dim_input_space);
+	randomcoeff_additive=SG_MALLOC(float64_t, dim_feature_space);
+	randomcoeff_multiplicative=SG_MALLOC(float64_t, dim_feature_space*dim_input_space);
 
 	std::copy(randomcoeff_additive2, randomcoeff_additive2
 			+ dim_feature_space, randomcoeff_additive);
 	std::copy(randomcoeff_multiplicative2, randomcoeff_multiplicative2
-			+ cur_dim_feature_space*cur_dim_input_space, randomcoeff_multiplicative);
+			+ dim_feature_space*dim_input_space, randomcoeff_multiplicative);
 	}
 
 }
 
-bool CRandomFourierGaussPreproc::init(CFeatures *f) {
-	if (f->get_feature_class() != get_feature_class()) {
-		throw ShogunException(
-				"CRandomFourierGaussPreproc::init (CFeatures *f) requires CDenseFeatures<float64_t> as features\n");
-	}
-	if (f->get_feature_type() != get_feature_type()) {
-		throw ShogunException(
-				"CRandomFourierGaussPreproc::init (CFeatures *f) requires CDenseFeatures<float64_t> as features\n");
-	}
-	if (dim_feature_space <= 0) {
-		throw ShogunException(
-				"CRandomFourierGaussPreproc::init (CFeatures *f): dim_feature_space<=0 is not allowed, use void set_dim_feature_space(const int32 dim) before!\n");
-	}
+bool CRandomFourierGaussPreproc::set_parameters(const int32_t dim_input_space2, const int32_t dim_feature_space2, const float64_t kernelwidth2) {
 
-	SG_INFO("calling CRandomFourierGaussPreproc::init(...)\n")
-	int32_t num_features =
-			((CDenseFeatures<float64_t>*) f)->get_num_features();
+	dim_input_space=dim_input_space2;
+	dim_feature_space=dim_feature_space2;
+	kernelwidth=kernelwidth2;
 
-	if (!test_rfinited()) {
-		dim_input_space = num_features;
-		init_randomcoefficients();
-		ASSERT( test_rfinited())
-		return true;
-	} else {
-		dim_input_space = num_features;
-		// does not reinit if dimension is the same to avoid overriding a previous call of set_randomcoefficients(...)
-		bool inited = init_randomcoefficients();
-		return inited;
-	}
 
+	return true;
 }
 
+/*
 SGVector<float64_t> CRandomFourierGaussPreproc::apply_to_feature_vector(SGVector<float64_t> vector)
 {
 	if (!test_rfinited()) {
-		throw ShogunException(
-				"float64_t * CRandomFourierGaussPreproc::apply_to_feature_vector(...): test_rfinited()==false: you need to call before CRandomFourierGaussPreproc::init (CFeatures *f) OR 	1. set_dim_feature_space(const int32 dim), 2. set_dim_input_space(const int32 dim), 3. init_randomcoefficients() or set_randomcoefficients(...) \n");
+		SG_ERROR(
+				"float64_t * CRandomFourierGaussPreproc::apply_to_feature_vector(...): test_rfinited()==false: you need to call before CRandomFourierGaussPreproc::init (...)  \n");
 	}
 
-	float64_t val = CMath::sqrt(2.0 / cur_dim_feature_space);
-	float64_t *res = SG_MALLOC(float64_t, cur_dim_feature_space);
+	int32_t num_features =	vector.size();
+	if (num_features!=dim_input_space)
+	{
+		SG_ERROR(
+						"float64_t * CRandomFourierGaussPreproc::apply_to_feature_vector(...): num_features!=dim_input_space is not allowed\n");
+	}
 
-	for (int32_t od = 0; od < cur_dim_feature_space; ++od) {
+
+	float64_t val = CMath::sqrt(2.0 / dim_feature_space);
+	float64_t *res = SG_MALLOC(float64_t, dim_feature_space);
+
+	for (int32_t od = 0; od < dim_feature_space; ++od) {
 		res[od] = val * cos(randomcoeff_additive[od] + SGVector<float64_t>::dot(vector.vector,
-				randomcoeff_multiplicative+od*cur_dim_input_space, cur_dim_input_space));
+				randomcoeff_multiplicative+od*dim_input_space, dim_input_space));
 	}
 
-	return SGVector<float64_t>(res,cur_dim_feature_space);
+	return SGVector<float64_t>(res,dim_feature_space);
 }
+*/
 
-SGMatrix<float64_t> CRandomFourierGaussPreproc::apply_to_feature_matrix(CFeatures* features)
+
+bool CRandomFourierGaussPreproc::check_applicability_to_feature(CFeatures* features)
 {
-	init(features);
-
-	// version for case dim_feature_space < dim_input space with direct transformation on feature matrix ??
-
-	int32_t num_vectors = 0;
-	int32_t num_features = 0;
-	float64_t* m = ((CDenseFeatures<float64_t>*) features)->get_feature_matrix(
-			num_features, num_vectors);
-	SG_INFO("get Feature matrix: %ix%i\n", num_vectors, num_features)
-
-	if (num_features!=cur_dim_input_space)
+	if(!(
+		(features->get_feature_class()==C_SPARSE)
+		||(features->get_feature_class()==C_DENSE)
+		||(features->get_feature_class()==C_BINNED_DOT)
+		||(features->get_feature_class()==C_COMBINED_DOT)
+	))
 	{
-		throw ShogunException(
-						"float64_t * CRandomFourierGaussPreproc::apply_to_feature_matrix(CFeatures *f): num_features!=cur_dim_input_space is not allowed\n");
+		SG_ERROR("CRandomFourierGaussPreproc::check_applicability_to_feature(...):features->get_feature_class()!=C_SPARSE, C_DENSE, C_COMBINED_DOT or C_BINNING.Don't know how to apply a cosine on other features!\n");
+		return false;
+	}
+	 
+	if(!(
+  		(features->get_feature_type()==F_SHORTREAL)
+		||(features->get_feature_type()==F_DREAL)
+		||(features->get_feature_type()==F_LONGREAL)
+		||(features->get_feature_type()==F_INT)
+		||(features->get_feature_type()==F_UINT)
+		||(features->get_feature_type()==F_LONG)
+		||(features->get_feature_type()==F_ULONG)
+	))
+	{
+		SG_ERROR("CRandomFourierGaussPreproc::check_applicability_to_feature(...):features->get_feature_type() is not real or integer! It is likely unusual to apply a cosine on these features\n");
+		return false;
 	}
 
-	if (m)
-	{
-		SGMatrix<float64_t> res(cur_dim_feature_space,num_vectors);
-
-		float64_t val = CMath::sqrt(2.0 / cur_dim_feature_space);
-
-		for (int32_t vec = 0; vec < num_vectors; vec++)
-		{
-			for (int32_t od = 0; od < cur_dim_feature_space; ++od)
-			{
-				res.matrix[od + vec * cur_dim_feature_space] = val * cos(
-						randomcoeff_additive[od]
-								+ SGVector<float64_t>::dot(m+vec * num_features,
-										randomcoeff_multiplicative+od*cur_dim_input_space,
-										cur_dim_input_space));
-			}
-		}
-		((CDenseFeatures<float64_t>*) features)->set_feature_matrix(res);
-
-		return res;
-	}
-	else
-		return SGMatrix<float64_t>();
+	return true;
 }
+
+CDenseFeatures<float64_t>* CRandomFourierGaussPreproc::apply_to_dotfeatures_sparse_or_dense_with_real(CDotFeatures* features)
+{
+
+	if(false==check_applicability_to_feature( features))
+	{
+		SG_ERROR("CRandomFourierGaussPreproc::check_applicability_to_feature(...):feature_class must be of type C_SPARSE, C_DENSE or C_BINNING, feature_type must be integer or real\n");
+	}
+
+
+
+	int32_t num_features = features->get_dim_feature_space();
+	if (num_features!=dim_input_space)
+	{
+		SG_ERROR("class CRandomFourierGaussPreproc: num_features!=dim_input_space is not allowed\n");
+	}
+
+	int32_t num_samples=features->get_num_vectors();
+	SGMatrix<float64_t> outmatrix(dim_feature_space,num_samples);
+
+	float64_t val = CMath::sqrt(2.0 / dim_feature_space);
+	for (int32_t vecind = 0; vecind < num_samples; vecind++)
+	{
+		for (int32_t od = 0; od < dim_feature_space; ++od)
+		{
+			float64_t tmpval=randomcoeff_additive[od]+features->dense_dot (vecind, randomcoeff_multiplicative+od*dim_input_space, dim_input_space);
+			outmatrix.matrix[od+dim_feature_space*vecind]=val*cos(tmpval);
+		}
+	}
+
+	CDenseFeatures<float64_t> * result = new CDenseFeatures<float64_t>(outmatrix);
+
+	return(result);
+
+}
+
+bool CRandomFourierGaussPreproc::init(CFeatures *features)
+{
+return true;
+}
+
 
 void CRandomFourierGaussPreproc::cleanup()
 {

--- a/src/shogun/preprocessor/RandomFourierGaussPreproc.h
+++ b/src/shogun/preprocessor/RandomFourierGaussPreproc.h
@@ -19,6 +19,8 @@
 #include <shogun/mathematics/Math.h>
 #include <shogun/preprocessor/DensePreprocessor.h>
 
+
+
 namespace shogun {
 /** @brief Preprocessor CRandomFourierGaussPreproc
  * implements Random Fourier Features for the Gauss kernel a la Ali Rahimi and Ben Recht Nips2007
@@ -46,7 +48,7 @@ namespace shogun {
  * 2c) set_dim_input_space(const int32_t dim);
  * 2d) init_randomcoefficients() or apply_to_feature_matrix(...)
  */
-class CRandomFourierGaussPreproc: public CDensePreprocessor<float64_t> {
+class CRandomFourierGaussPreproc: public CPreprocessor {
 public:
 	/** default constructor */
 	CRandomFourierGaussPreproc();
@@ -59,20 +61,34 @@ public:
 	 */
 	~CRandomFourierGaussPreproc();
 
-	/** default processing routine, inherited from base class
-	 * @param features the features to be processed, must be of type CDenseFeatures<float64_t>
+
+	/** default processing routine, 
+	 * @param features the features to be processed, must be of type 
+	 
+	 * (features->get_feature_class()==C_SPARSE)
+         * ||(features->get_feature_class()==C_DENSE)
+	 * ||(features->get_feature_class()==C_BINNED_DOT)
+	 * ||(features->get_feature_class()==C_COMBINED_DOT)
+	 *
+	 *   (features->get_feature_type()==F_SHORTREAL)
+	 * ||(features->get_feature_type()==F_DREAL)
+	 * ||(features->get_feature_type()==F_LONGREAL)
+	 * ||(features->get_feature_type()==F_INT)
+	 * ||(features->get_feature_type()==F_UINT)
+	 * ||(features->get_feature_type()==F_LONG)
+	 * ||(features->get_feature_type()==F_ULONG)
+	 *
+	 * uses dense dot
+	 *
+	 * USAGE WARNING: during testing you must use the same random coefficients as have been used during training, use get_randomcoefficients and set_randomcoefficients for securing that!
+	 * always required is to call set_parameters() before usage
+	 * a call to init_randomcoefficients_from_scratch(); resets coefficients (or sets them for the first time, set_parameters() does NOT set them)!
+	 * 
 	 * @return the processed feature matrix from the CDenseFeatures<float64_t> class
 	 * in case (2) (see description above) this routine requires only steps 2a) and 2b), the rest is determined automatically
 	 */
-	virtual SGMatrix<float64_t> apply_to_feature_matrix(CFeatures* features); // ref count fo the feature matrix???
+	CDenseFeatures<float64_t>* apply_to_dotfeatures_sparse_or_dense_with_real(CDotFeatures* features);
 
-
-	/** alternative processing routine, inherited from base class
-	 * @param vector the feature vector to be processed
-	 * @return processed feature vector
-	 * in order to work this routine requires the steps described above under cases (1) or two (2) before calling this routine
-	 */
-	virtual SGVector<float64_t> apply_to_feature_vector(SGVector<float64_t> vector);
 
 	/** inherited from base class
 	 * @return C_DENSE
@@ -84,25 +100,21 @@ public:
 	 */
 	virtual EFeatureClass get_feature_class();
 
+
 	/** initializer routine
-	 * calls set_dim_input_space(const int32_t dim); with the proper value
-	 * calls init_randomcoefficients(); this call does NOT override a previous call to void set_randomcoefficients(...) IF and ONLY IF
-	 * the dimensions of input AND feature space are equal to the values from the previous call to void set_randomcoefficients(...)
-	 * @param f the features to be processed, must be of type CDenseFeatures<float64_t>
-	 * @return true if new random coefficients were generated, false if old ones from a call to set_randomcoefficients(...) are kept
+	 * sets parameters
+	 * @param dim_input_space2 the dimensionality of the input features, given by the features you want to use
+	 * @param dim_feature_space2 the dimensionality of the output features, a higher values gives a better approximation of the gaussian kernel, typically dim_feature_space2 >> dim_input_space2
+	 * @param kernelwidth2 the gaussian kernel width, too small values result in bad approximations up to negative eigenvalues
+	 * @return true always
 	 */
-	virtual bool init(CFeatures *f);
+        virtual bool set_parameters(const int32_t dim_input_space2, const int32_t dim_feature_space2, const float64_t kernelwidth2);
 
-	/**  setter for kernel width
-	 * @param width kernel width to be set
-	 */
-	void set_kernelwidth(const float64_t width);
 
-	/**  getter for kernel width
-	 * @return kernel width
-	 * throws exception if kernelwidth <=0
+	/** computes new random coefficients 
+	 * @return true always
 	 */
-	float64_t get_kernelwidth( ) const;
+	bool init_randomcoefficients_from_scratch();
 
 	/**  getter for the random coefficients
 	 * necessary for creating random fourier features compatible to the current ones
@@ -123,31 +135,7 @@ public:
 			float64_t * randomcoeff_multiplicative2,
 			const int32_t dim_feature_space2, const int32_t dim_input_space2, const float64_t kernelwidth2);
 
-	/** a setter
-	 * @param dim the value of protected member dim_input_space
-	 * throws a shogun exception if dim<=0
-	 */
-	void set_dim_input_space(const int32_t dim);
 
-	/** a setter
-	 * @param dim the value of protected member dim_feature_space
-	 * throws a shogun exception if dim<=0
-	 *
-	 */
-	void set_dim_feature_space(const int32_t dim);
-
-	/** computes new random coefficients IF test_rfinited() evaluates to false
-	 * test_rfinited() evaluates to TRUE if void set_randomcoefficients(...) hase been called and the values set by set_dim_input_space(...) , set_dim_feature_space(...) and set_kernelwidth(...) are consistent to the call of void set_randomcoefficients(...)
-	 *
-	 * throws shogun exception if dim_feature_space <= 0 or dim_input_space <= 0
-	 *
-	 * @return returns true if test_rfinited() evaluates to false and new coefficients are computed
-	 * returns false if test_rfinited() evaluates to true and old random coefficients are kept which were set by a previous call to void set_randomcoefficients(...)
-	 *
-	 * this function is useful if you want to use apply_to_feature_vector but cannot call before it init(CFeatures *f)
-	 *
-	 */
-	bool init_randomcoefficients();
 
 
 	/** a getter
@@ -160,6 +148,12 @@ public:
 	 */
 	int32_t get_dim_feature_space() const;
 
+	/**  getter for kernel width
+	 * @return kernel width
+	 * throws exception if kernelwidth <=0
+	 */
+	float64_t get_kernelwidth( ) const;
+
 	/** inherited from base class
 	 * does nothing
 	 */
@@ -171,7 +165,17 @@ public:
 	/// return a type of preprocessor
 	virtual EPreprocessorType get_type() const { return P_RANDOMFOURIERGAUSS; }
 
+	virtual bool init (CFeatures *features); // does nothing
+
 protected:
+
+
+
+
+	/**
+	* checks whether this feature can be used woth RF preprocessor
+	*/
+	virtual bool check_applicability_to_feature(CFeatures* features);
 
 	/**
 	 * helper for copy constructor and assignment operator=
@@ -184,20 +188,11 @@ protected:
 	 */
 	float64_t kernelwidth;
 
-	/** dimension of input features
-	 * width of gaussian kernel in the form of exp(-x^2 / (2.0 kernelwidth^2) ) NOTE the 2.0 and the power ^2 !
-	 */
-	float64_t cur_kernelwidth;
 
 	/** desired dimension of input features as set by void set_dim_input_space(const int32_t dim)
 	 *
 	 */
 	int32_t dim_input_space;
-
-	/** actual dimension of input features as set by bool init_randomcoefficients() or void set_randomcoefficients
-	 *
-	 */
-	int32_t cur_dim_input_space;
 
 
 	/** desired dimension of output features  as set by void set_dim_feature_space(const int32_t dim)
@@ -205,10 +200,7 @@ protected:
 	 */
 	int32_t dim_feature_space;
 
-	/** actual dimension of output features as set by bool init_randomcoefficients() or void set_randomcoefficients
-	 *
-	 */
-	int32_t cur_dim_feature_space;
+
 
 	/**
 	 * tests whether rf features have already been initialized
@@ -221,11 +213,15 @@ protected:
 	 */
 	float64_t* randomcoeff_additive;
 
+	//CDenseFeatures<float64_t> randomcoeff_additive2; 
+
 	/**
 	 * random coefficient
 	 * length = cur_dim_feature_space* cur_dim_input_space
 	 */
 	float64_t* randomcoeff_multiplicative;
+
+	//CDenseFeatures<float64_t> randomcoeff_multiplicative2;
 };
 }
 #endif


### PR DESCRIPTION
1) random fourier preprocessor works with many kind of dotfeatures derived classes
2) python modular example is updated and makes sense now
3) refurbished libshogun example ... it only computes the kernel in three ways and compares it against the original gaussian

not done yet: integration for CStreamingDotFeatures ... that comes later this week
