### PR TITLE
Add new make option for valgrind

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -35,6 +35,11 @@ build: shogun-unit-test
 valgrind: shogun-unit-test
 	@$(LIBRARY_PATH)=$(SHOGUNSRCTOP)/shogun:$$$(LIBRARY_PATH) valgrind $(VALGRINDOPTS) ./shogun-unit-test
 
+valgrind-per-module:
+	@$(LIBRARY_PATH)=$(SHOGUNSRCTOP)/shogun:$$$(LIBRARY_PATH) ./shogun-unit-test --gtest_list_tests \
+	 | grep -E '^[a-zA-Z0-9]*\.' \
+	 | xargs -I{} valgrind $(VALGRINDOPTS) ./shogun-unit-test --gtest_filter={}\*
+
 %$(EXT_OBJ_TEST): %$(EXT_SRC_TEST)
 	$(COMP_CPP) -I$(SHOGUNSRCTOP) $(COMPFLAGS_CPP) $(COMPFLAGS_GTEST_CPP) $(COMPFLAGS_GMOCK_CPP) $(DEFINES) -c $(INCLUDES) -o $@ $<
 


### PR DESCRIPTION
'make valgrind-per-module' command runs valgrind on each unit testing module separately. (for Heiko with love ;)
