### PR TITLE
Rename HMSVMLabels to SequenceLabels.

### DIFF
--- a/examples/undocumented/libshogun/so_hmsvm_mosek.cpp
+++ b/examples/undocumented/libshogun/so_hmsvm_mosek.cpp
@@ -1,6 +1,6 @@
 #include <shogun/labels/StructuredLabels.h>
 #include <shogun/loss/HingeLoss.h>
-#include <shogun/structure/HMSVMLabels.h>
+#include <shogun/structure/SequenceLabels.h>
 #include <shogun/structure/HMSVMModel.h>
 #include <shogun/structure/PrimalMosekSOSVM.h>
 #include <shogun/structure/TwoStateModel.h>

--- a/examples/undocumented/libshogun/so_hmsvm_mosek_simple.cpp
+++ b/examples/undocumented/libshogun/so_hmsvm_mosek_simple.cpp
@@ -1,6 +1,6 @@
 #include <shogun/features/MatrixFeatures.h>
 #include <shogun/loss/HingeLoss.h>
-#include <shogun/structure/HMSVMLabels.h>
+#include <shogun/structure/SequenceLabels.h>
 #include <shogun/structure/HMSVMModel.h>
 #include <shogun/structure/PrimalMosekSOSVM.h>
 
@@ -13,7 +13,7 @@ int main(int argc, char ** argv)
 #ifdef USE_MOSEK
 
 	// Create structured labels
-	CHMSVMLabels* labels = new CHMSVMLabels(5, 2);
+	CSequenceLabels* labels = new CSequenceLabels(5, 2);
 
 	// Label sequences of with two states
 	int32_t lab1[] = {0, 0, 1, 1};

--- a/examples/undocumented/python_modular/structure_hmsvm_bmrm.py
+++ b/examples/undocumented/python_modular/structure_hmsvm_bmrm.py
@@ -11,7 +11,7 @@ parameter_list=[[data_dict]]
 def structure_hmsvm_bmrm (m_data_dict=data_dict):
 	from shogun.Features   import RealMatrixFeatures
 	from shogun.Loss       import HingeLoss
-	from shogun.Structure  import HMSVMLabels, HMSVMModel, Sequence, TwoStateModel, SMT_TWO_STATE
+	from shogun.Structure  import SequenceLabels, HMSVMModel, Sequence, TwoStateModel, SMT_TWO_STATE
 	from shogun.Evaluation import StructuredAccuracy
 	from shogun.Structure  import DualLibQPBMSOSVM
 
@@ -20,7 +20,7 @@ def structure_hmsvm_bmrm (m_data_dict=data_dict):
 	idxs = numpy.nonzero(labels_array == -1)
 	labels_array[idxs] = 0
 
-	labels = HMSVMLabels(labels_array, 250, 500, 2)
+	labels = SequenceLabels(labels_array, 250, 500, 2)
 	features = RealMatrixFeatures(m_data_dict['signal'].astype(float), 250, 500)
 
 	loss = HingeLoss()

--- a/examples/undocumented/python_modular/structure_hmsvm_mosek.py
+++ b/examples/undocumented/python_modular/structure_hmsvm_mosek.py
@@ -11,7 +11,7 @@ parameter_list=[[data_dict]]
 def structure_hmsvm_mosek (m_data_dict=data_dict):
 	from shogun.Features   import RealMatrixFeatures
 	from shogun.Loss       import HingeLoss
-	from shogun.Structure  import HMSVMLabels, HMSVMModel, Sequence, TwoStateModel, SMT_TWO_STATE
+	from shogun.Structure  import SequenceLabels, HMSVMModel, Sequence, TwoStateModel, SMT_TWO_STATE
 	from shogun.Evaluation import StructuredAccuracy
 
 	try:
@@ -25,7 +25,7 @@ def structure_hmsvm_mosek (m_data_dict=data_dict):
 	idxs = numpy.nonzero(labels_array == -1)
 	labels_array[idxs] = 0
 
-	labels = HMSVMLabels(labels_array, 250, 500, 2)
+	labels = SequenceLabels(labels_array, 250, 500, 2)
 	features = RealMatrixFeatures(m_data_dict['signal'].astype(float), 250, 500)
 
 	loss = HingeLoss()

--- a/src/interfaces/modular/Structure.i
+++ b/src/interfaces/modular/Structure.i
@@ -30,7 +30,7 @@
 %rename(MulticlassSOLabels) CMulticlassSOLabels;
 %rename(RealNumber) CRealNumber;
 %rename(HMSVMModel) CHMSVMModel;
-%rename(HMSVMLabels) CHMSVMLabels;
+%rename(SequenceLabels) CSequenceLabels;
 %rename(Sequence) CSequence;
 %rename(StateModel) CStateModel;
 %rename(TwoStateModel) CTwoStateModel;
@@ -59,7 +59,7 @@
 %include <shogun/structure/MulticlassModel.h>
 %include <shogun/structure/MulticlassSOLabels.h>
 %include <shogun/structure/HMSVMModel.h>
-%include <shogun/structure/HMSVMLabels.h>
+%include <shogun/structure/SequenceLabels.h>
 %include <shogun/structure/StateModelTypes.h>
 %include <shogun/structure/StateModel.h>
 %include <shogun/structure/TwoStateModel.h>

--- a/src/interfaces/modular/Structure_includes.i
+++ b/src/interfaces/modular/Structure_includes.i
@@ -16,7 +16,7 @@
  #include <shogun/structure/MulticlassModel.h>
  #include <shogun/structure/MulticlassSOLabels.h>
  #include <shogun/structure/HMSVMModel.h>
- #include <shogun/structure/HMSVMLabels.h>
+ #include <shogun/structure/SequenceLabels.h>
  #include <shogun/structure/StateModelTypes.h>
  #include <shogun/structure/StateModel.h>
  #include <shogun/structure/TwoStateModel.h>

--- a/src/shogun/evaluation/StructuredAccuracy.cpp
+++ b/src/shogun/evaluation/StructuredAccuracy.cpp
@@ -4,12 +4,12 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2012 Fernando José Iglesias García
- * Copyright (C) 2012 Fernando José Iglesias García
+ * Written (W) 2012-2013 Fernando José Iglesias García
+ * Copyright (C) 2012-2013 Fernando José Iglesias García
  */
 
 #include <shogun/evaluation/StructuredAccuracy.h>
-#include <shogun/structure/HMSVMLabels.h>
+#include <shogun/structure/SequenceLabels.h>
 #include <shogun/structure/MulticlassSOLabels.h>
 
 using namespace shogun;

--- a/src/shogun/structure/HMSVMModel.cpp
+++ b/src/shogun/structure/HMSVMModel.cpp
@@ -27,7 +27,7 @@ CHMSVMModel::CHMSVMModel(CFeatures* features, CStructuredLabels* labels, EStateM
 
 	m_num_obs = num_obs;
 	// Shorthand for the number of free states
-	int32_t free_states = ((CHMSVMLabels*) m_labels)->get_num_states();
+	int32_t free_states = ((CSequenceLabels*) m_labels)->get_num_states();
 	// Shorthand for the number of features of the feature vector
 	int32_t D = ((CMatrixFeatures< float64_t >*) m_features)->get_num_features();
 	m_num_aux = free_states*D*(num_obs-1);
@@ -55,7 +55,7 @@ CHMSVMModel::~CHMSVMModel()
 int32_t CHMSVMModel::get_dim() const
 {
 	// Shorthand for the number of states
-	int32_t S = ((CHMSVMLabels*) m_labels)->get_num_states();
+	int32_t S = ((CSequenceLabels*) m_labels)->get_num_states();
 	// Shorthand for the number of features of the feature vector
 	int32_t D = ((CMatrixFeatures< float64_t >*) m_features)->get_num_features();
 
@@ -281,7 +281,7 @@ void CHMSVMModel::init_opt(
 		SGMatrix< float64_t > & C)
 {
 	// Shorthand for the number of free states
-	int32_t S = ((CHMSVMLabels*) m_labels)->get_num_states();
+	int32_t S = ((CSequenceLabels*) m_labels)->get_num_states();
 	// Shorthand for the number of features of the feature vector
 	int32_t D = ((CMatrixFeatures< float64_t >*) m_features)->get_num_features();
 
@@ -357,7 +357,7 @@ void CHMSVMModel::init_opt(
 bool CHMSVMModel::check_training_setup() const
 {
 	// Shorthand for the labels in the correct type
-	CHMSVMLabels* hmsvm_labels = (CHMSVMLabels*) m_labels;
+	CSequenceLabels* hmsvm_labels = (CSequenceLabels*) m_labels;
 	// Frequency of each state
 	SGVector< int32_t > state_freq( hmsvm_labels->get_num_states() );
 	state_freq.zero();

--- a/src/shogun/structure/HMSVMModel.h
+++ b/src/shogun/structure/HMSVMModel.h
@@ -12,7 +12,7 @@
 #define _HMSVM_MODEL__H__
 
 #include <shogun/structure/StructuredModel.h>
-#include <shogun/structure/HMSVMLabels.h>
+#include <shogun/structure/SequenceLabels.h>
 #include <shogun/structure/StateModelTypes.h>
 #include <shogun/structure/StateModel.h>
 
@@ -35,7 +35,7 @@ class CHMSVMModel : public CStructuredModel
 		/** constructor
 		 *
 		 * @param features the feature vectors, must be of type MatrixFeatures
-		 * @param labels HMSVM labels
+		 * @param labels sequence labels
 		 * @param smt internal state representation
 		 * @param num_obs number of observations
 		 */

--- a/src/shogun/structure/SequenceLabels.cpp
+++ b/src/shogun/structure/SequenceLabels.cpp
@@ -8,22 +8,22 @@
  * Copyright (C) 2012 Fernando José Iglesias García
  */
 
-#include <shogun/structure/HMSVMLabels.h>
+#include <shogun/structure/SequenceLabels.h>
 
 using namespace shogun;
 
-CHMSVMLabels::CHMSVMLabels()
+CSequenceLabels::CSequenceLabels()
 : CStructuredLabels()
 {
 }
 
-CHMSVMLabels::CHMSVMLabels(int32_t num_labels, int32_t num_states)
+CSequenceLabels::CSequenceLabels(int32_t num_labels, int32_t num_states)
 : CStructuredLabels(num_labels), m_num_states(num_states)
 {
 	init();
 }
 
-CHMSVMLabels::CHMSVMLabels(SGVector< int32_t > labels, int32_t label_length,
+CSequenceLabels::CSequenceLabels(SGVector< int32_t > labels, int32_t label_length,
 		int32_t num_labels, int32_t num_states)
 : CStructuredLabels(num_labels), m_num_states(num_states)
 {
@@ -39,16 +39,16 @@ CHMSVMLabels::CHMSVMLabels(SGVector< int32_t > labels, int32_t label_length,
 	}
 }
 
-CHMSVMLabels::~CHMSVMLabels()
+CSequenceLabels::~CSequenceLabels()
 {
 }
 
-void CHMSVMLabels::add_label(SGVector< int32_t > label)
+void CSequenceLabels::add_label(SGVector< int32_t > label)
 {
 	CStructuredLabels::add_label( new CSequence(label) );
 }
 
-void CHMSVMLabels::init()
+void CSequenceLabels::init()
 {
 	SG_ADD(&m_num_states, "m_num_states", "Number of states", MS_NOT_AVAILABLE);
 }

--- a/src/shogun/structure/SequenceLabels.h
+++ b/src/shogun/structure/SequenceLabels.h
@@ -4,12 +4,12 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * Written (W) 2012 Fernando José Iglesias García
- * Copyright (C) 2012 Fernando José Iglesias García
+ * Written (W) 2012-2013 Fernando José Iglesias García
+ * Copyright (C) 2012-2013 Fernando José Iglesias García
  */
 
-#ifndef _HMSVM_LABELS__H__
-#define _HMSVM_LABELS__H__
+#ifndef _SEQUENCE_LABELS__H__
+#define _SEQUENCE_LABELS__H__
 
 #include <shogun/labels/StructuredLabels.h>
 #include <shogun/lib/SGVector.h>
@@ -19,7 +19,7 @@
 namespace shogun
 {
 
-class CHMSVMLabels;
+class CSequenceLabels;
 
 /** @brief Class CSequence to be used in the application of Structured Output
  * (SO) learning to Hidden Markov Support Vector Machines (HM-SVM). */
@@ -65,22 +65,22 @@ protected:
 
 };
 
-/** @brief Class CHMSVMLabels to be used in the application of Structured Output
+/** @brief Class CSequenceLabels used e.g. in the application of Structured Output
  * (SO) learning to Hidden Markov Support Vector Machines (HM-SVM). Each of the
  * labels is represented by a sequence of integers. Each label is of type
  * CSequence and all of them are stored in a CDynamicObjectArray. */
-class CHMSVMLabels : public CStructuredLabels
+class CSequenceLabels : public CStructuredLabels
 {
 	public:
 		/** default constructor */
-		CHMSVMLabels();
+		CSequenceLabels();
 
 		/** standard constructor
 		 *
 		 * @param num_labels number of labels
 		 * @param num_states number of states
 		 */
-		CHMSVMLabels(int32_t num_labels, int32_t num_states);
+		CSequenceLabels(int32_t num_labels, int32_t num_states);
 
 		/**
 		 * constructor using the data of all the labels concatenated. All the
@@ -92,13 +92,13 @@ class CHMSVMLabels : public CStructuredLabels
 		 * @param num_labels number of labels
 		 * @param num_states number of states
 		 */
-		CHMSVMLabels(SGVector< int32_t > labels, int32_t label_length, int32_t num_labels, int32_t num_states);
+		CSequenceLabels(SGVector< int32_t > labels, int32_t label_length, int32_t num_labels, int32_t num_states);
 
 		/** destructor */
-		virtual ~CHMSVMLabels();
+		virtual ~CSequenceLabels();
 
 		/** @return object name */
-		virtual const char* get_name() const { return "HMSVMLabels"; }
+		virtual const char* get_name() const { return "SequenceLabels"; }
 
 		/**
 		 * add a new label to the vector of labels, effectively
@@ -128,8 +128,8 @@ class CHMSVMLabels : public CStructuredLabels
 		 */
 		int32_t m_num_states;
 
-}; /* CHMSVMLabels */
+}; /* CSequenceLabels */
 
 } /* namespace shogun */
 
-#endif /* _HMSVM_LABELS__H__ */
+#endif /* _SEQUENCE_LABELS__H__ */

--- a/src/shogun/structure/StateModel.h
+++ b/src/shogun/structure/StateModel.h
@@ -15,7 +15,7 @@
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/mathematics/Math.h>
-#include <shogun/structure/HMSVMLabels.h>
+#include <shogun/structure/SequenceLabels.h>
 #include <shogun/structure/StateModelTypes.h>
 
 namespace shogun

--- a/src/shogun/structure/TwoStateModel.cpp
+++ b/src/shogun/structure/TwoStateModel.cpp
@@ -239,7 +239,7 @@ CHMSVMModel* CTwoStateModel::simulate_two_state_data()
 	// num_blocks[1] blocks of positive labels each of length between
 	// block_len[0] and block_len[1]
 
-	CHMSVMLabels* labels = new CHMSVMLabels(num_exm, num_states);
+	CSequenceLabels* labels = new CSequenceLabels(num_exm, num_states);
 	SGVector< int32_t > ll(num_exm*exm_len);
 	ll.zero();
 	int32_t rnb, rl, rp;


### PR DESCRIPTION
Because these labels can be used in other StructuredModels apart
from the HMSVMModel.

I have also used this small refactoring to familiarize with the git flow model.
