### PR TITLE
Update gitignore with automatically created file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ configure.log
 /src/interfaces/java_modular/org/*
 /src/interfaces/java_modular/shogun/*
 /src/interfaces/python_modular/*.py
+/src/interfaces/python_modular/abstract_types_extension.i
 /src/interfaces/r_modular/*.R
 /src/interfaces/r_modular/*.RData
 /src/interfaces/perl_modular/*.pm


### PR DESCRIPTION
Add interfaces/python_modular/abstract_type_extension.i to gitignore.
