### PR TITLE
fixed doxygen error in Statistics.h

### DIFF
--- a/src/shogun/mathematics/Statistics.h
+++ b/src/shogun/mathematics/Statistics.h
@@ -500,6 +500,8 @@ public:
 	 * @param mean the mean vector
 	 * @param cov the covariance matrix
 	 * @param N number of samples
+	 * @param precision_matrix if true, use precision matrix instead
+	 * of covariance matrix for sampling
 	 * @return the sample matrix of size \f$N\times dim\f$
 	 */
 	static SGMatrix<float64_t> sample_from_gaussian(SGVector<float64_t> mean, 


### PR DESCRIPTION
fixed doxygen error for sample_from_gaussian method for dense matrices in CStatistics.
