### PR TITLE
Added EigenSparseUtil class for ease of coverting SGSparseMatrix to Eigen3 SparseMatrix

### DIFF
--- a/src/shogun/mathematics/Statistics.cpp
+++ b/src/shogun/mathematics/Statistics.cpp
@@ -26,6 +26,7 @@
 
 #ifdef HAVE_EIGEN3
 #include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/eigen3.cpp>
 using namespace Eigen;
 #endif //HAVE_EIGEN3
 
@@ -1987,41 +1988,10 @@ float64_t CStatistics::log_det(SGMatrix<float64_t> m)
 
 float64_t CStatistics::log_det(const SGSparseMatrix<float64_t> m)
 {
-	// convert from SGSparseMatrix<T> to SparseMatrix<T>
-	index_t num_rows = m.num_vectors;
-	index_t num_cols = m.num_features;
-
-#ifdef EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
-	typedef shogun::EigenTriplet<float64_t> SparseTriplet;
-#else // EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
-	typedef Eigen::Triplet<float64_t> SparseTriplet;
-#endif // EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
-
-	// create a triplet list
-	std::vector<SparseTriplet> tripletList;
-
-	// fill the triplet list
-	for( index_t i = 0; i < num_rows; ++i )
-	{
-		for( index_t k = 0; k < m[i].num_feat_entries; ++k )
-		{
-			index_t &index_i = i;
-			index_t &index_j = m[i].features[k].feat_index;
-			float64_t &val = m[i].features[k].entry;
-			tripletList.push_back(SparseTriplet(index_i, index_j, val));
-		}
-	}
-#ifdef EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
-	// initialize the sparse matrix
-	DynamicSparseMatrix<float64_t> dM(num_rows, num_cols);
-	dM.reserve(tripletList.size());
-
-	for( std::vector<SparseTriplet>::iterator it = tripletList.begin(); it != tripletList.end(); ++it )
-			dM.coeffRef(it->row(), it->col()) += it->value();
-	SparseMatrix<float64_t> M(dM);
-
-	// access the lower triangular factor after cholesky decomposition
+	const SparseMatrix<float64_t> &M=EigenSparseUtil<float64_t>::toEigenSparse(m);
 	typedef SparseMatrix<float64_t> MatrixType;
+#ifdef EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
+	// access the lower triangular factor after cholesky decomposition
 	class EigenSimplicialLLT: public SimplicialCholesky<MatrixType, Eigen::Lower>
 	{
 	public:
@@ -2032,28 +2002,26 @@ float64_t CStatistics::log_det(const SGSparseMatrix<float64_t> m)
 		~EigenSimplicialLLT()
 		{
 		}
-		inline const MatrixType matrixL() { return SimplicialCholesky<MatrixType>::m_matrix; }
+		inline const MatrixType matrixL() 
+		{ 
+			return SimplicialCholesky<MatrixType>::m_matrix; 
+		}
 	};
 
 	EigenSimplicialLLT llt;
 #else // EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
-	// initialize the sparse matrix
-	SparseMatrix<float64_t> M(num_rows, num_cols);
-	M.setFromTriplets(tripletList.begin(), tripletList.end());
-
-	SimplicialLLT<SparseMatrix<float64_t> > llt;
+	SimplicialLLT<MatrixType> llt;
 #endif // EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
 
 	// factorize using cholesky with amd permutation 
 	llt.compute(M);
-	// get the lower triangular matrix
-	SparseMatrix<float64_t> L =  llt.matrixL();
+	MatrixType L=llt.matrixL();
 	
 	// calculate the log-determinant
-	float64_t retval = 0.0;
-	for( index_t i = 0; i < M.rows(); ++i )
-		retval += log(L.coeff(i,i));
-	retval *= 2;
+	float64_t retval=0.0;
+	for( index_t i=0; i<M.rows(); ++i )
+		retval+=log(L.coeff(i,i));
+	retval*=2;
 
 	return retval;
 }

--- a/src/shogun/mathematics/Statistics.h
+++ b/src/shogun/mathematics/Statistics.h
@@ -552,24 +552,6 @@ protected:
 	static inline bool greater_equal(float64_t a, float64_t b) { return a>=b; }
 };
 
-#ifdef HAVE_EIGEN3
-	/** EigenTriplet definition for Eigen3 backword compatibility */
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-	template <typename T> struct EigenTriplet
-	{
-		EigenTriplet(index_t colIndex, index_t rowIndex, T valueT) :
-		ecol(colIndex), erow(rowIndex), evalue(valueT)
-		{
-		}
-		index_t col() const { return ecol; };
-		index_t row() const { return erow; };
-		T value() const { return evalue; };
-		index_t ecol;
-		index_t erow;
-		T evalue;
-	};
-#endif /* DOXYGEN_SHOULD_SKIP_THIS */
-#endif //HAVE_EIGEN3
 }
 
 #endif /* __STATISTICS_H_ */

--- a/src/shogun/mathematics/eigen3.cpp
+++ b/src/shogun/mathematics/eigen3.cpp
@@ -1,0 +1,68 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/common.h>
+#include <shogun/lib/SGSparseMatrix.h>
+#include <shogun/mathematics/eigen3.h>
+
+using namespace shogun;
+using namespace Eigen;
+
+template<typename T>
+SparseMatrix<T> EigenSparseUtil<T>::toEigenSparse(SGSparseMatrix<T> sg_matrix)
+{
+	REQUIRE(sg_matrix.num_vectors>0,
+		"EigenSparseUtil::toEigenSparse(): \
+		Number of rows must be positive!\n");
+	REQUIRE(sg_matrix.num_features>0,
+		"EigenSparseUtil::toEigenSparse(): \
+		Number of cols must be positive!\n");
+	REQUIRE(sg_matrix.sparse_matrix,
+		"EigenSparseUtil::toEigenSparse(): \
+		sg_matrix is not initialized!\n");
+	
+	index_t num_rows=sg_matrix.num_vectors;
+	index_t num_cols=sg_matrix.num_features;
+
+  typedef Eigen::Triplet<T> SparseTriplet;
+
+	std::vector<SparseTriplet> tripletList;
+	for( index_t i=0; i<num_rows; ++i )
+	{
+		for( index_t k=0; k<sg_matrix[i].num_feat_entries; ++k )
+		{
+			index_t &index_i=i;
+			index_t &index_j=sg_matrix[i].features[k].feat_index;
+			T &val=sg_matrix[i].features[k].entry;
+			tripletList.push_back(SparseTriplet(index_i, index_j, val));
+		}
+	}
+
+#ifdef EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
+	DynamicSparseMatrix<T> dM(num_rows, num_cols);
+	dM.reserve(tripletList.size());
+
+	for( typename std::vector<SparseTriplet>::iterator it=tripletList.begin(); 
+		it!=tripletList.end(); ++it )
+	{
+		dM.coeffRef(it->row(), it->col())+=it->value();
+	}
+
+	SparseMatrix<T> M(dM);
+#else // EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
+	SparseMatrix<T> M(num_rows, num_cols);
+	M.setFromTriplets(tripletList.begin(), tripletList.end());
+#endif // EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
+
+	return M;
+}
+
+#endif //HAVE_EIGEN3

--- a/src/shogun/mathematics/eigen3.h
+++ b/src/shogun/mathematics/eigen3.h
@@ -21,7 +21,49 @@
 	#else
 		#define EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
 		#include <unsupported/Eigen/SparseExtra>
-	#endif
-#endif
+
+		#ifndef DOXYGEN_SHOULD_SKIP_THIS
+		// Triplet definition for Eigen3 backword compatibility
+		namespace Eigen {
+		template <typename T> struct Triplet
+		{
+			Triplet(index_t colIndex, index_t rowIndex, T valueT) :
+			ecol(colIndex), erow(rowIndex), evalue(valueT)
+			{
+			}
+			index_t col() const { return ecol; };
+			index_t row() const { return erow; };
+			T value() const { return evalue; };
+			index_t ecol;
+			index_t erow;
+			T evalue;
+		};
+		}
+		#endif //DOXYGEN_SHOULD_SKIP_THIS
+
+	#endif	//EIGEN_VERSION_AT_LEAST(3,0,93)
+
+namespace shogun
+{
+template<class T> class SGSparseMatrix;
+
+/** @brief This class contains some utilities for Eigen3 Sparse Matrix
+ * integration with shogun. Currently it provides a method for 
+ * converting SGSparseMatrix to Eigen3 SparseMatrix.
+ */
+template<typename T> class EigenSparseUtil
+{
+	public:
+	/** Converts a SGSparseMatrix to Eigen3 SparseMatrix
+	 * 
+	 * @param sg_matrix the SGSparseMatrix
+	 * @return Eigen3 SparseMatrix representation of sg_matrix
+	 */
+	static Eigen::SparseMatrix<T> toEigenSparse(SGSparseMatrix<T> sg_matrix);
+};
+
+}
+
+#endif	//HAVE_EIGEN3
 
 #endif


### PR DESCRIPTION
- Added a template class EigenSparseUtil in shogun/mathematics/eigen3.h, defined in shogun/mathematics/eigen3.cpp inside shogun namespace. 
- Also, defined Triplet struct for eigen<3.0.93 within Eigen namespace in shogun/mathematics/eigen3.h, so that we can avoid writing version specific code each time we use it. 
- Rewritten the log_det method for sparse matrices in CStatistics using EigenSparseUtil::toEigenSparse(..) to make it work with the new addition. Tested with both eigen<3.0.93 and eigen>3.0.93, unit tests working.
