### PR TITLE
multi-class probabilistic outputs for SVM

### DIFF
--- a/examples/undocumented/libshogun/classifier_multiclasslinearmachine_prob.cpp
+++ b/examples/undocumented/libshogun/classifier_multiclasslinearmachine_prob.cpp
@@ -1,0 +1,147 @@
+#include <shogun/io/AsciiFile.h>
+#include <shogun/labels/MulticlassLabels.h>
+#include <shogun/io/SGIO.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/multiclass/MulticlassOneVsOneStrategy.h>
+#include <shogun/multiclass/MulticlassOneVsRestStrategy.h>
+#include <shogun/machine/LinearMulticlassMachine.h>
+#include <shogun/classifier/svm/LibLinear.h>
+#include <shogun/base/init.h>
+
+#define  EPSILON  1e-5
+
+using namespace shogun;
+
+/* file data */
+const char fname_feats[]="../data/fm_train_real.dat";
+const char fname_labels[]="../data/label_train_multiclass.dat";
+
+void test()
+{
+	/* dense features from matrix */
+	CAsciiFile* feature_file = new CAsciiFile(fname_feats);
+	SGMatrix<float64_t> mat=SGMatrix<float64_t>();
+	mat.load(feature_file);
+	SG_UNREF(feature_file);
+
+	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(mat);
+	SG_REF(features);
+
+	/* labels from vector */
+	CAsciiFile* label_file = new CAsciiFile(fname_labels);
+	SGVector<float64_t> label_vec;
+	label_vec.load(label_file);
+	SG_UNREF(label_file);
+
+	CMulticlassLabels* labels=new CMulticlassLabels(label_vec);
+	SG_REF(labels);
+
+	// Create liblinear svm classifier with L2-regularized L2-loss
+	CLibLinear* svm = new CLibLinear(L2R_L2LOSS_SVC);
+	SG_REF(svm);
+
+	// Add some configuration to the svm
+	svm->set_epsilon(EPSILON);
+	svm->set_bias_enabled(true);
+
+	// Create a multiclass svm classifier that consists of several of the previous one
+	CLinearMulticlassMachine* mc_svm_ova = new CLinearMulticlassMachine(
+			new CMulticlassOneVsRestStrategy(), (CDotFeatures*) features, svm, labels);
+	SG_REF(mc_svm_ova);
+
+	// Train the multiclass machine using the data passed in the constructor
+	mc_svm_ova->train();
+
+	// Classify the training examples and show the results
+    SG_SPRINT("-- OVA: Use direct SVM outputs --\n");
+	CMulticlassLabels* output_ova = CMulticlassLabels::obtain_from_generic(mc_svm_ova->apply());
+
+	SGVector< int32_t > out_labels = output_ova->get_int_labels();
+	SGVector<int32_t>::display_vector(out_labels.vector, out_labels.vlen);
+
+    for (int32_t i=0; i<output_ova->get_num_labels(); i++)
+    {
+        SG_SPRINT("out_values[%d] = ", i);
+        SGVector<float64_t> out_values = output_ova->get_multiclass_confidences(i);
+	    SGVector<float64_t>::display_vector(out_values.vector, out_values.vlen);
+        SG_SPRINT("\n");
+    }
+
+    SG_SPRINT("-- OVA: Use probabilistic SVM outputs --\n");
+    mc_svm_ova->set_prob_support();
+	CMulticlassLabels* output_p_ova = CMulticlassLabels::obtain_from_generic(mc_svm_ova->apply());
+
+	out_labels = output_p_ova->get_int_labels();
+	SGVector<int32_t>::display_vector(out_labels.vector, out_labels.vlen);
+
+    for (int32_t i=0; i<output_p_ova->get_num_labels(); i++)
+    {
+        SG_SPRINT("out_values[%d] = ", i);
+        SGVector<float64_t> out_values = output_p_ova->get_multiclass_confidences(i);
+	    SGVector<float64_t>::display_vector(out_values.vector, out_values.vlen);
+        SG_SPRINT("\n");
+    }
+
+	// Create a multiclass svm classifier that consists of several of the previous one
+	CLinearMulticlassMachine* mc_svm_ovo = new CLinearMulticlassMachine(
+			new CMulticlassOneVsOneStrategy(), (CDotFeatures*) features, svm, labels);
+	SG_REF(mc_svm_ovo);
+
+	// Train the multiclass machine using the data passed in the constructor
+	mc_svm_ovo->train();
+
+	// Classify the training examples and show the results
+    SG_SPRINT("-- OVO: Use direct SVM outputs --\n");
+	CMulticlassLabels* output_ovo = CMulticlassLabels::obtain_from_generic(mc_svm_ovo->apply());
+
+	out_labels = output_ovo->get_int_labels();
+	SGVector<int32_t>::display_vector(out_labels.vector, out_labels.vlen);
+
+    for (int32_t i=0; i<output_ovo->get_num_labels(); i++)
+    {
+        SG_SPRINT("out_values[%d] = ", i);
+        SGVector<float64_t> out_values = output_ovo->get_multiclass_confidences(i);
+	    SGVector<float64_t>::display_vector(out_values.vector, out_values.vlen);
+        SG_SPRINT("\n");
+    }
+
+    SG_SPRINT("-- OVO: Use probabilistic SVM outputs --\n");
+    mc_svm_ovo->set_prob_support();
+	CMulticlassLabels* output_p_ovo = CMulticlassLabels::obtain_from_generic(mc_svm_ovo->apply());
+
+	out_labels = output_p_ovo->get_int_labels();
+	SGVector<int32_t>::display_vector(out_labels.vector, out_labels.vlen);
+
+    for (int32_t i=0; i<output_p_ovo->get_num_labels(); i++)
+    {
+        SG_SPRINT("out_values[%d] = ", i);
+        SGVector<float64_t> out_values = output_p_ovo->get_multiclass_confidences(i);
+	    SGVector<float64_t>::display_vector(out_values.vector, out_values.vlen);
+        SG_SPRINT("\n");
+    }
+
+	//Free resources
+	SG_UNREF(mc_svm_ova);
+	SG_UNREF(mc_svm_ovo);
+	SG_UNREF(svm);
+	SG_UNREF(output_ova);
+	SG_UNREF(output_ovo);
+	SG_UNREF(output_p_ova);
+	SG_UNREF(output_p_ovo);
+	SG_UNREF(features);
+	SG_UNREF(labels);
+}
+
+int main(int argc, char** argv)
+{
+	init_shogun_with_defaults();
+
+	//sg_io->set_loglevel(MSG_DEBUG);
+
+	test();
+
+	exit_shogun();
+
+	return 0;
+}
+

--- a/src/shogun/lib/SGMatrixList.cpp
+++ b/src/shogun/lib/SGMatrixList.cpp
@@ -78,7 +78,7 @@ void SGMatrixList<T>::cleanup_matrices()
 		{
 			// Explicit call to the destructor required
 			// due to the use of in-place constructors
-			matrix_list[i].~SGMatrix();
+			matrix_list[i].~SGMatrix<T>();
 		}
 	}
 }

--- a/src/shogun/machine/Machine.cpp
+++ b/src/shogun/machine/Machine.cpp
@@ -39,6 +39,7 @@ CMachine::CMachine() : CSGObject(), m_max_train_time(0), m_labels(NULL),
 	);
 
 	m_parameter_map->finalize_map();
+    m_prob_output_supported = false;
 }
 
 CMachine::~CMachine()
@@ -117,6 +118,11 @@ ESolverType CMachine::get_solver_type()
 void CMachine::set_store_model_features(bool store_model)
 {
 	m_store_model_features = store_model;
+}
+
+void CMachine::set_prob_support()
+{
+    m_prob_output_supported = true;
 }
 
 void CMachine::data_lock(CLabels* labs, CFeatures* features)

--- a/src/shogun/machine/Machine.h
+++ b/src/shogun/machine/Machine.h
@@ -304,6 +304,9 @@ class CMachine : public CSGObject
 
 		virtual const char* get_name() const { return "Machine"; }
 
+		/** set support of probabilistic outputs */
+		void set_prob_support();
+
 	protected:
 		/** train machine
 		 *
@@ -353,6 +356,12 @@ class CMachine : public CSGObject
 		/** returns whether machine require labels for training */
 		virtual bool train_require_labels() const { return true; }
 
+		/** @return wether the outputs are probabilities. */
+		virtual bool is_prob_support() const
+		{
+			return m_prob_output_supported;
+		}
+
 	protected:
 		/** maximum training time */
 		float64_t m_max_train_time;
@@ -368,6 +377,9 @@ class CMachine : public CSGObject
 
 		/** whether data is locked */
 		bool m_data_locked;
+
+        /** whether output is probabilistic */
+        bool m_prob_output_supported;
 };
 }
 #endif // _MACHINE_H__

--- a/src/shogun/multiclass/MulticlassOneVsOneStrategy.h
+++ b/src/shogun/multiclass/MulticlassOneVsOneStrategy.h
@@ -57,6 +57,13 @@ public:
 		return "MulticlassOneVsOneStrategy";
 	};
 
+    /** estimate the posterior probabilities of class label given classifier outputs
+	 * @param outputs a vector of output from each machine (in that order), replace with probabilities
+	 * @param n_outputs number of outputs
+     * @return new outputs
+     */
+    virtual SGVector<float64_t> rescale_output(SGVector<float64_t> outputs);
+
 protected:
 	int32_t m_num_machines;     ///< number of machines
 	int32_t m_train_pair_idx_1; ///< 1st index of current submachine being trained

--- a/src/shogun/multiclass/MulticlassOneVsRestStrategy.cpp
+++ b/src/shogun/multiclass/MulticlassOneVsRestStrategy.cpp
@@ -61,3 +61,11 @@ SGVector<index_t> CMulticlassOneVsRestStrategy::decide_label_multiple_output(SGV
 	return result;
 }
 
+SGVector<float64_t> CMulticlassOneVsRestStrategy::rescale_output(SGVector<float64_t> outputs)
+{
+    SGVector<float64_t> posterior(outputs);
+    float64_t norm = SGVector<float64_t>::sum(outputs);
+    for (int32_t i=0; i<outputs.vlen; i++) 
+        posterior[i] /= norm;
+    return posterior;
+}

--- a/src/shogun/multiclass/MulticlassOneVsRestStrategy.h
+++ b/src/shogun/multiclass/MulticlassOneVsRestStrategy.h
@@ -72,6 +72,13 @@ public:
 		return "MulticlassOneVsRestStrategy";
 	};
 
+    /** estimate the posterior probabilities of class label given classifier outputs
+	 * @param outputs a vector of output from each machine (in that order), replace with probabilities
+	 * @param n_outputs number of outputs
+     * @return new outputs
+     */
+    virtual SGVector<float64_t> rescale_output(SGVector<float64_t> outputs);
+
 };
 
 } // namespace shogun

--- a/src/shogun/multiclass/MulticlassStrategy.h
+++ b/src/shogun/multiclass/MulticlassStrategy.h
@@ -97,6 +97,16 @@ public:
 	 */
 	virtual int32_t get_num_machines()=0;
 
+    /** estimate the posterior probabilities of class label given classifier outputs
+	 * @param outputs a vector of output from each machine (in that order), replace with probabilities
+	 * @param n_outputs number of outputs
+     * @return new outputs
+     */
+    virtual SGVector<float64_t> rescale_output(SGVector<float64_t> outputs)
+    {
+		SG_NOTIMPLEMENTED
+    }
+
 protected:
 
 	CRejectionStrategy* m_rejection_strategy; ///< rejection strategy


### PR DESCRIPTION
Implemented 2 heuristics for multi-class probabilistic outputs described in [1], specifically, Eq.(6) and Eq.(14).

I added a member variable m_prob_output_supported in CMachine, which indicates that if the output values are probabilities. When the trained machine applying to features, e.g. CMulticlassMachine::apply_multiclass(), if probabilities are desired, it calls CBinaryLabels::scores_to_probabilities(), i.e. Platt's rescaling for binary classifiers. The heuristics can be found in CMulticlassStrategy. 

[1] Jonathan Milgram et al. "One Against One" or "One Against All": Which One is Better for Handwriting Recognition with SVMs? http://hal.archives-ouvertes.fr/docs/00/10/39/55/PDF/cr102875872670.pdf
