### PR TITLE
Split JLCoverTreePoint.h into definitions and declarations

### DIFF
--- a/src/shogun/lib/JLCoverTreePoint.cpp
+++ b/src/shogun/lib/JLCoverTreePoint.cpp
@@ -13,8 +13,6 @@
 
 
 namespace shogun { 
-/** Functions declared out of the class definition to respect JLCoverTree 
- *  structure */
 
 float distance(CJLCoverTreePoint p1, CJLCoverTreePoint p2, float64_t upper_bound)
 {

--- a/src/shogun/lib/JLCoverTreePoint.h
+++ b/src/shogun/lib/JLCoverTreePoint.h
@@ -132,10 +132,10 @@ class CJLCoverTreePoint
 
 }; /* class JLCoverTreePoint */
 
-float distance(CJLCoverTreePoint p1, CJLCoverTreePoint p2, float64_t upper_bound) ;
+float distance(CJLCoverTreePoint p1, CJLCoverTreePoint p2, float64_t upper_bound);
 
 /** Fills up a v_array of CJLCoverTreePoint objects */
-v_array< CJLCoverTreePoint > parse_points(CDistance* distance, EFeaturesContainer fc) ;
+v_array< CJLCoverTreePoint > parse_points(CDistance* distance, EFeaturesContainer fc);
 
 /** Print the information of the CoverTree point */
 void print(CJLCoverTreePoint &p);

--- a/src/shogun/multiclass/KNN.cpp
+++ b/src/shogun/multiclass/KNN.cpp
@@ -17,7 +17,6 @@
 #include <shogun/mathematics/Math.h>
 #include <shogun/lib/Signal.h>
 #include <shogun/lib/JLCoverTree.h>
-#include <shogun/lib/JLCoverTreePoint.h>
 #include <shogun/lib/Time.h>
 #include <shogun/base/Parameter.h>
 


### PR DESCRIPTION
i.e. JLCoverTreePoint.h ad JLCoverTreePoint.cpp 
