### PR TITLE
ignore temporary files created by csharp and octave interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ configure.log
 
 # particular modular ones
 /src/interfaces/csharp_modular/*.cs
+/src/interfaces/csharp_modular/abstract_types_extension.i
+/src/interfaces/csharp_modular/modshogun.dll
 /src/interfaces/java_modular/*.java
 /src/interfaces/java_modular/*.jar
 /src/interfaces/java_modular/*.class
@@ -95,6 +97,7 @@ configure.log
 /src/interfaces/r_modular/*.R
 /src/interfaces/r_modular/*.RData
 /src/interfaces/perl_modular/*.pm
+/src/interfaces/octave_modular/abstract_types_extension.i
 /.duped_py_pl.pb
 
 # /examples/


### PR DESCRIPTION
ignore three temporary files generated by swig
