### PR TITLE
Added a wrapper for t-SNE method implemented in tapkee library and a basic unit test for it.

### DIFF
--- a/src/shogun/converter/TDistributedStochasticNeighborEmbedding.cpp
+++ b/src/shogun/converter/TDistributedStochasticNeighborEmbedding.cpp
@@ -1,0 +1,76 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Vladyslav S. Gorbatiuk
+ * Copyright (C) 2011-2013 Vladyslav S. Gorbatiuk
+ */
+
+#include <shogun/converter/TDistributedStochasticNeighborEmbedding.h>
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/tapkee/tapkee_shogun.hpp>
+#include <shogun/features/DenseFeatures.h>
+
+using namespace shogun;
+
+CTDistributedStochasticNeighborEmbedding::CTDistributedStochasticNeighborEmbedding() :
+		CEmbeddingConverter()
+{
+	// Default values
+	m_perplexity = 30.0;
+	m_theta = 0.5;
+	init();
+}
+
+void CTDistributedStochasticNeighborEmbedding::init()
+{
+	SG_ADD(&m_perplexity, "perplexity", "perplexity", MS_NOT_AVAILABLE);
+	SG_ADD(&m_theta, "theta", "learning rate", MS_NOT_AVAILABLE);
+}
+
+CTDistributedStochasticNeighborEmbedding::~CTDistributedStochasticNeighborEmbedding()
+{
+}
+
+const char* CTDistributedStochasticNeighborEmbedding::get_name() const
+{
+	return "TDistributedStochasticNeighborEmbedding";
+}
+
+void CTDistributedStochasticNeighborEmbedding::set_theta(const float64_t theta)
+{
+
+	m_theta = theta;
+}
+
+float64_t CTDistributedStochasticNeighborEmbedding::get_theta() const
+{
+	return m_theta;
+}
+
+void CTDistributedStochasticNeighborEmbedding::set_perplexity(const float64_t perplexity)
+{
+	m_perplexity = perplexity;
+}
+
+float64_t CTDistributedStochasticNeighborEmbedding::get_perplexity() const
+{
+	return m_perplexity;
+}
+
+CFeatures* CTDistributedStochasticNeighborEmbedding::apply(CFeatures* features)
+{
+	TAPKEE_PARAMETERS_FOR_SHOGUN parameters;
+	parameters.sne_theta = m_theta;
+	parameters.sne_perplexity = m_perplexity;
+	parameters.features = (CDotFeatures*)features;
+	
+	parameters.method = SHOGUN_TDISTRIBUTED_STOCHASTIC_NEIGHBOR_EMBEDDING;
+	parameters.target_dimension = m_target_dim;
+	CDenseFeatures<float64_t>* embedding = tapkee_embed(parameters);
+	return embedding;
+}
+
+#endif /* HAVE_EIGEN */

--- a/src/shogun/converter/TDistributedStochasticNeighborEmbedding.h
+++ b/src/shogun/converter/TDistributedStochasticNeighborEmbedding.h
@@ -1,0 +1,89 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Vladyslav S. Gorbatiuk
+ * Copyright (C) 2011-2013 Vladyslav S. Gorbatiuk
+ */
+
+#ifndef TDISTRIBUTEDSTOCHASTICNEIGHBOREMBEDDING_H_
+#define TDISTRIBUTEDSTOCHASTICNEIGHBOREMBEDDING_H_
+#include <shogun/lib/config.h>
+#ifdef HAVE_EIGEN3
+#include <shogun/converter/EmbeddingConverter.h>
+#include <shogun/features/Features.h>
+
+namespace shogun
+{
+
+/** @class class CTDistributedStochasticNeighborEmbedding used to embed 
+ * data using t-distributed stochastic neighbor embedding algorithm:
+ * http://jmlr.csail.mit.edu/papers/volume9/vandermaaten08a/vandermaaten08a.pdf.
+ *
+ * Uses implementation from the Tapkee library.
+ *
+ */
+class CTDistributedStochasticNeighborEmbedding : public CEmbeddingConverter
+{
+public:
+
+	/** constructor */
+	CTDistributedStochasticNeighborEmbedding();
+
+	/** destructor */
+	virtual ~CTDistributedStochasticNeighborEmbedding();
+
+	/** get name */
+	virtual const char* get_name() const;
+
+	/** apply preprocessor to features
+	 *
+	 * @param features features to embed
+	 */
+	virtual CFeatures* apply(CFeatures* features);
+
+	/** setter for the learning rate
+	 *
+	 * @param theta the learning rate
+	 */
+	void set_theta(const float64_t theta);
+
+	/** getter for the learning rate
+	 *
+	 * @return the learning rate theta
+	 */
+	float64_t get_theta() const;
+
+	/** setter for perplexity
+	 *
+	 * @param perplexity convergence parameter
+	 */
+	void set_perplexity(const float64_t perplexity);
+
+	/** getter for perplexity
+	 *
+	 * @return perplexity
+	 */
+	float64_t get_perplexity() const;
+
+private:
+
+	/** default init */
+	void init();
+
+private:
+
+	/** theta - learning rate */
+	float64_t m_theta;
+
+	/** perplexity */
+	float64_t m_perplexity;
+
+}; /* class CTDistributedStochasticNeighborEmbedding */
+
+} /* namespace shogun */
+
+#endif /* HAVE_EIGEN3 */
+#endif /* TDISTRIBUTEDSTOCHASTICNEIGHBOREMBEDDING_H_ */

--- a/src/shogun/lib/tapkee/tapkee_shogun.cpp
+++ b/src/shogun/lib/tapkee/tapkee_shogun.cpp
@@ -143,6 +143,10 @@ CDenseFeatures<float64_t>* shogun::tapkee_embed(const shogun::TAPKEE_PARAMETERS_
 			method = tapkee::FactorAnalysis;
 			N = parameters.features->get_num_vectors();
 			break;
+		case SHOGUN_TDISTRIBUTED_STOCHASTIC_NEIGHBOR_EMBEDDING:
+			method = tapkee::tDistributedStochasticNeighborEmbedding;
+			N = parameters.features->get_num_vectors();
+			break;
 	}
 	
 	std::vector<int32_t> indices(N);
@@ -163,7 +167,9 @@ CDenseFeatures<float64_t>* shogun::tapkee_embed(const shogun::TAPKEE_PARAMETERS_
 		 tapkee::keywords::spe_tolerance = parameters.spe_tolerance,
 		 tapkee::keywords::spe_global_strategy = parameters.spe_global_strategy,
 		 tapkee::keywords::max_iteration = parameters.max_iteration,
-		 tapkee::keywords::fa_epsilon = parameters.fa_epsilon
+		 tapkee::keywords::fa_epsilon = parameters.fa_epsilon,
+		 tapkee::keywords::sne_perplexity = parameters.sne_perplexity,
+		 tapkee::keywords::sne_theta = parameters.sne_theta
 		 );
 
 	tapkee::TapkeeOutput output = tapkee::embed(indices.begin(),indices.end(),

--- a/src/shogun/lib/tapkee/tapkee_shogun.hpp
+++ b/src/shogun/lib/tapkee/tapkee_shogun.hpp
@@ -39,6 +39,7 @@ enum TAPKEE_METHODS_FOR_SHOGUN
 	SHOGUN_LANDMARK_ISOMAP,
 	SHOGUN_STOCHASTIC_PROXIMITY_EMBEDDING,
 	SHOGUN_FACTOR_ANALYSIS,
+	SHOGUN_TDISTRIBUTED_STOCHASTIC_NEIGHBOR_EMBEDDING,
 };
 
 struct TAPKEE_PARAMETERS_FOR_SHOGUN
@@ -50,8 +51,9 @@ struct TAPKEE_PARAMETERS_FOR_SHOGUN
 		eigenshift(1e-9), landmark_ratio(0.5),
 		gaussian_kernel_width(1.0), spe_tolerance(1e-5),
 		spe_global_strategy(false), max_iteration(100),
-		fa_epsilon(1e-5),
-		kernel(NULL), distance(NULL), features(NULL)
+		fa_epsilon(1e-5), sne_theta(0.5),
+		sne_perplexity(30.0), kernel(NULL),
+		distance(NULL), features(NULL)
 	{
 	}
 	TAPKEE_METHODS_FOR_SHOGUN method;
@@ -66,6 +68,8 @@ struct TAPKEE_PARAMETERS_FOR_SHOGUN
 	bool spe_global_strategy;
 	uint32_t max_iteration;
 	float64_t fa_epsilon;
+	float64_t sne_theta;
+	float64_t sne_perplexity;
 	CKernel* kernel;
 	CDistance* distance;
 	CDotFeatures* features;

--- a/tests/unit/converter/TDistributedStochasticNeighborEmbedding_unittest.cc
+++ b/tests/unit/converter/TDistributedStochasticNeighborEmbedding_unittest.cc
@@ -1,0 +1,39 @@
+#include <shogun/converter/TDistributedStochasticNeighborEmbedding.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/features/DataGenerator.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+#ifdef HAVE_EIGEN3
+
+/* Basic test for t-SNE, that just checks that it works anyhow */
+TEST(TDistributedStochasticNeighborEmbeddingTest,basic)
+{
+	const index_t n_samples = 15;
+	const index_t n_dimensions = 3;
+	const index_t n_target_dimensions = 2;
+	CDenseFeatures<float64_t>* high_dimensional_features = 
+		new CDenseFeatures<float64_t>(CDataGenerator::generate_gaussians(n_samples, 1, n_dimensions)); 
+
+	CTDistributedStochasticNeighborEmbedding* embedder =
+		new CTDistributedStochasticNeighborEmbedding();
+
+	embedder->set_target_dim(n_target_dimensions);
+	EXPECT_EQ(n_target_dimensions, embedder->get_target_dim());
+
+	/* Set perplexity so that it is in range 
+	 * 0<=perplexity<=(n_samples - 1)/3.
+	 */
+	embedder->set_perplexity(n_samples / 5.0);
+
+	CDenseFeatures<float64_t>* low_dimensional_features = 
+		embedder->embed(high_dimensional_features);
+
+	EXPECT_EQ(n_target_dimensions,low_dimensional_features->get_dim_feature_space());
+	EXPECT_EQ(high_dimensional_features->get_num_vectors(),low_dimensional_features->get_num_vectors());
+
+	SG_UNREF(embedder);
+}
+
+#endif


### PR DESCRIPTION
Added a wrapper (CTDistributedStochasticNeighborEmbedding class) for t-SNE dimensionality reduction method, implemented in tapkee (according to https://github.com/shogun-toolbox/shogun/issues/946).

Also added a basic unit test for it, that embeds the test data from 3D to 2D using implemented wrapper, and checks that resulting data is actually in 2D, and that number of features stay the same.
