### PR TITLE
Changed typo in regression_gaussian_process_modular.py 

### DIFF
--- a/examples/undocumented/python_modular/regression_gaussian_process_modular.py
+++ b/examples/undocumented/python_modular/regression_gaussian_process_modular.py
@@ -52,7 +52,7 @@ def regression_gaussian_process_modular (n=100,n_test=100, \
 	# inference
 	gp.set_return_type(GaussianProcessRegression.GP_RETURN_MEANS)
 	mean = gp.apply_regression(feats_test)
-	gp.set_return_type(GaussianProcessRegression.GP_RETURN_MEANS)
+	gp.set_return_type(GaussianProcessRegression.GP_RETURN_COV)
 	covariance = gp.apply_regression(feats_test)
 	
 	# plot results


### PR DESCRIPTION
First attempt to pull request in github. :)

Changed a typo in regression_gaussian_process_modular.py from GP_RETURN_MEAN to GP_RETURN_COV

The covariance returned has negative numbers and I have not found the reason. It might be a problem in the GP regression algorithm and a unit test might be required. 
