### PR TITLE
Drop static SGVector::resize().

### DIFF
--- a/src/shogun/lib/Compressor.cpp
+++ b/src/shogun/lib/Compressor.cpp
@@ -204,7 +204,7 @@ void CCompressor::compress(uint8_t* uncompressed, uint64_t uncompressed_size,
 	}
 
 	if (compressed)
-		SGVector<uint8_t>::resize(compressed, initial_buffer_size, compressed_size);
+		compressed = SG_REALLOC(uint8_t, compressed, initial_buffer_size, compressed_size);
 }
 
 void CCompressor::decompress(uint8_t* compressed, uint64_t compressed_size,

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -568,15 +568,6 @@ void SGVector<T>::permute_vector(SGVector<T> vec)
 	}
 }
 
-template <class T>
-void SGVector<T>::resize(T* &data, int64_t old_size, int64_t new_size)
-{
-	if (old_size==new_size)
-		return;
-
-	data = SG_REALLOC(T, data, old_size, new_size);
-}
-
 template <>
 bool SGVector<bool>::twonorm(const bool* x, int32_t len)
 {

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -224,11 +224,6 @@ template<class T> class SGVector : public SGReferencedData
 		/** create a random permutation in place */
 		void permute();
 
-		/** resize array from old_size to new_size (keeping as much array
-		 * content as possible intact)
-		 */
-		static void resize(T* &data, int64_t old_size, int64_t new_size);
-
 		/// || x ||_2
 		static T twonorm(const T* x, int32_t len);
 

--- a/src/shogun/multiclass/LaRank.cpp
+++ b/src/shogun/multiclass/LaRank.cpp
@@ -457,8 +457,8 @@ void LaRankOutput::update (int32_t x_id, float64_t lambda, float64_t gp)
 	else
 	{
 		larank_kcache_swap_ri (kernel, l, x_id);
-		SGVector<float32_t>::resize(g, l, l+1);
-		SGVector<float32_t>::resize(beta, l, l+1);
+		g = SG_REALLOC(float32_t, g, l, l+1);
+		beta = SG_REALLOC(float32_t, beta, l, l+1);
 		g[l]=gp;
 		beta[l]=lambda;
 		l++;
@@ -504,8 +504,8 @@ int32_t LaRankOutput::cleanup ()
 			g[r]=g[r + 1];
 		}
 	}
-	SGVector<float32_t>::resize(beta, l, new_l+1);
-	SGVector<float32_t>::resize(g, l, new_l+1);
+	beta = SG_REALLOC(float32_t, beta, l, new_l+1);
+	g = SG_REALLOC(float32_t, g, l, new_l+1);
 	beta[new_l]=0;
 	g[new_l]=0;
 	l = new_l;


### PR DESCRIPTION
This method can be misleading since it should not be used for SGVectors,
use SGVector::resize_vector() instead.

For example I think that this should be reasonable:
SGVector<int32_t> vi(5);
SGVector<int32_t>::resize(vi.vector,vi.vlen, 10);
However, it is a bug since resize() doesn't modify the member vlen.
Then, I think we are better without this method.
