### PR TITLE
Small hack to fix double-free in StreamingSparseFeatures

### DIFF
--- a/src/shogun/features/streaming/StreamingSparseFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingSparseFeatures.cpp
@@ -31,6 +31,11 @@ CStreamingSparseFeatures<T>::CStreamingSparseFeatures(CStreamingFile* file,
 template <class T>
 CStreamingSparseFeatures<T>::~CStreamingSparseFeatures()
 {
+	/* needed to prevent double free memory errors */
+	/* this might result in a small memory leak... */
+	current_sgvector.features=NULL;
+	current_sgvector.num_feat_entries=0;
+
 	parser.end_parser();
 }
 


### PR DESCRIPTION
Although it does not fix the whole problem, this small fix prevents a possible double free (and potentially leaks one single features vector).
