### PR TITLE
Fix #1060 Use DynamicObjectArray in CFeatures for managing Preprocessors

### DIFF
--- a/src/shogun/features/Features.cpp
+++ b/src/shogun/features/Features.cpp
@@ -14,6 +14,7 @@
 #include <shogun/preprocessor/Preprocessor.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/base/Parameter.h>
+#include <shogun/lib/DynamicObjectArray.h>
 
 #include <string.h>
 
@@ -33,9 +34,7 @@ CFeatures::CFeatures(const CFeatures& orig)
 
 	preproc = orig.preproc;
 	num_preproc = orig.num_preproc;
-
-	preprocessed=SG_MALLOC(bool, orig.num_preproc);
-	memcpy(preprocessed, orig.preprocessed, sizeof(bool)*orig.num_preproc);
+	preprocessed = orig.preprocessed;
 }
 
 CFeatures::CFeatures(CFile* loader)
@@ -51,6 +50,8 @@ CFeatures::~CFeatures()
 {
 	clean_preprocessors();
 	SG_UNREF(m_subset_stack);
+	SG_UNREF(preproc);
+	SG_UNREF(preprocessed);
 }
 
 void CFeatures::init()
@@ -59,22 +60,22 @@ void CFeatures::init()
 	SG_ADD(&cache_size, "cache_size", "Size of cache in MB", MS_NOT_AVAILABLE);
 
 	/* TODO, use SGVector for arrays to be able to use SG_ADD macro */
-	m_parameters->add_vector((CSGObject***) &preproc, &num_preproc, "preproc",
-			"List of preprocessors");
-	m_parameters->add_vector(&preprocessed, &num_preproc, "preprocessed",
-			"Feature[i] is already preprocessed");
+	SG_ADD((CSGObject**) &preproc, "preproc", "Array of preprocessors.", 
+	       MS_NOT_AVAILABLE);
+	SG_ADD((CSGObject**) &preprocessed, "preprocessed", "Array of preprocessed.", 
+	       MS_NOT_AVAILABLE);
 
 	SG_ADD((CSGObject**)&m_subset_stack, "subset_stack", "Stack of subsets",
-			MS_NOT_AVAILABLE);
+	       MS_NOT_AVAILABLE);
 
 	m_subset_stack=new CSubsetStack();
 	SG_REF(m_subset_stack);
 
 	properties = FP_NONE;
 	cache_size = 0;
-	preproc = NULL;
+	preproc = new CDynamicObjectArray() ;
 	num_preproc = 0;
-	preprocessed = NULL;
+	preprocessed = new CDynamicArray<bool>();
 }
 
 /// set preprocessor
@@ -83,26 +84,12 @@ int32_t CFeatures::add_preprocessor(CPreprocessor* p)
 	SG_INFO("%d preprocs currently, new preproc list is\n", num_preproc)
 	ASSERT(p)
 
-	bool* preprocd=SG_MALLOC(bool, num_preproc+1);
-	CPreprocessor** pps=SG_MALLOC(CPreprocessor*, num_preproc+1);
-	for (int32_t i=0; i<num_preproc; i++)
-	{
-		pps[i]=preproc[i];
-		preprocd[i]=preprocessed[i];
-	}
-	SG_FREE(preproc);
-	SG_FREE(preprocessed);
-	preproc=pps;
-	preprocessed=preprocd;
-	preproc[num_preproc]=p;
-	preprocessed[num_preproc]=false;
-
+	preproc->push_back(p);
+	preprocessed->push_back(false);
 	num_preproc++;
 
 	for (int32_t i=0; i<num_preproc; i++)
-		SG_INFO("preproc[%d]=%s %ld\n",i, preproc[i]->get_name(), preproc[i]) 
-
-	SG_REF(p);
+	  SG_INFO("preproc[%d]=%s %ld\n",i, preproc->get_element(i)->get_name(), preproc->get_element(i));
 
 	return num_preproc;
 }
@@ -112,8 +99,7 @@ CPreprocessor* CFeatures::get_preprocessor(int32_t num) const
 {
 	if (num<num_preproc)
 	{
-		SG_REF(preproc[num]);
-		return preproc[num];
+	  return static_cast<CPreprocessor*>(preproc->get_element(num));
 	}
 	else
 		return NULL;
@@ -126,7 +112,7 @@ int32_t CFeatures::get_num_preprocessed() const
 
 	for (int32_t i=0; i<num_preproc; i++)
 	{
-		if (preprocessed[i])
+	  if ((*preprocessed)[i])
 			num++;
 	}
 
@@ -142,43 +128,19 @@ void CFeatures::clean_preprocessors()
 /// del current preprocessor
 CPreprocessor* CFeatures::del_preprocessor(int32_t num)
 {
-	CPreprocessor** pps=NULL;
-	bool* preprocd=NULL;
 	CPreprocessor* removed_preproc=NULL;
 
 	if (num_preproc>0 && num<num_preproc)
 	{
-		removed_preproc=preproc[num];
+	  removed_preproc = static_cast<CPreprocessor*>(preproc->get_element(num));
 
-		if (num_preproc>1)
-		{
-			pps= SG_MALLOC(CPreprocessor*, num_preproc-1);
-			preprocd= SG_MALLOC(bool, num_preproc-1);
-
-			if (pps && preprocd)
-			{
-				int32_t j=0;
-				for (int32_t i=0; i<num_preproc; i++)
-				{
-					if (i!=num)
-					{
-						pps[j]=preproc[i];
-						preprocd[j]=preprocessed[i];
-						j++;
-					}
-				}
-			}
-		}
-
-		SG_FREE(preproc);
-		preproc=pps;
-		SG_FREE(preprocessed);
-		preprocessed=preprocd;
+		preproc->delete_element(num);
+		preprocessed->delete_element(num);
 
 		num_preproc--;
 
 		for (int32_t i=0; i<num_preproc; i++)
-			SG_INFO("preproc[%d]=%s\n",i, preproc[i]->get_name()) 
+		  SG_INFO("preproc[%d]=%s\n",i, preproc->get_element(i)->get_name()) 
 	}
 
 	SG_UNREF(removed_preproc);
@@ -187,12 +149,12 @@ CPreprocessor* CFeatures::del_preprocessor(int32_t num)
 
 void CFeatures::set_preprocessed(int32_t num)
 {
-	preprocessed[num]=true;
+  (*preprocessed)[num]=true;
 }
 
 bool CFeatures::is_preprocessed(int32_t num) const
 {
-	return preprocessed[num];
+  return (*preprocessed)[num];
 }
 
 int32_t CFeatures::get_num_preprocessors() const

--- a/src/shogun/features/Features.h
+++ b/src/shogun/features/Features.h
@@ -20,6 +20,8 @@
 #include <shogun/features/FeatureTypes.h>
 #include <shogun/features/SubsetStack.h>
 #include <shogun/lib/List.h>
+#include <shogun/lib/DynamicObjectArray.h>
+#include <shogun/lib/DynamicArray.h>
 
 namespace shogun
 {
@@ -297,13 +299,13 @@ class CFeatures : public CSGObject
 		int32_t cache_size;
 
 		/** list of preprocessors */
-		CPreprocessor** preproc;
+		CDynamicObjectArray *preproc;
 
 		/** number of preprocs in list */
 		int32_t num_preproc;
 
 		/** i'th entry is true if features were already preprocessed with preproc i */
-		bool* preprocessed;
+		CDynamicArray<bool> *preprocessed;
 
 	protected:
 		/** subset used for index transformations */


### PR DESCRIPTION
As previous try to pull-request:
- Used CDynamicObjectArray \* for Features.preproc
- Used DynamicArray\* for Features.preprocessed
- Tested the feature\* files in the examples folder
