### PR TITLE
Fixed insertion in CombinedKernel/CombinedFeatures

### DIFF
--- a/src/shogun/features/CombinedFeatures.cpp
+++ b/src/shogun/features/CombinedFeatures.cpp
@@ -147,7 +147,20 @@ bool CCombinedFeatures::insert_feature_obj(CFeatures* obj, int32_t idx)
 
 bool CCombinedFeatures::append_feature_obj(CFeatures* obj)
 {
-	return insert_feature_obj(obj, get_num_feature_obj());
+	ASSERT(obj)
+	int32_t n=obj->get_num_vectors();
+
+	if (get_num_vectors()>0 && n!=get_num_vectors())
+	{
+		SG_ERROR("Number of feature vectors does not match (expected %d, "
+				"obj has %d)\n", get_num_vectors(), n);
+	}
+
+	num_vec=n;
+
+	int num_feature_obj = get_num_feature_obj();
+	feature_array->push_back(obj);
+	return num_feature_obj+1 == feature_array->get_num_elements();
 }
 
 bool CCombinedFeatures::delete_feature_obj(int32_t idx)

--- a/src/shogun/features/CombinedFeatures.h
+++ b/src/shogun/features/CombinedFeatures.h
@@ -114,6 +114,7 @@ class CCombinedFeatures : public CFeatures
 		CFeatures* get_last_feature_obj();
 
 		/** insert feature object at index idx
+		 *  Important, idx must be < num_feature_obj
 		 *
 		 * @param obj feature object to insert
 		 * @param idx the index where to insert the feature object
@@ -122,7 +123,6 @@ class CCombinedFeatures : public CFeatures
 		bool insert_feature_obj(CFeatures* obj, int32_t idx);
 
 		/** append feature object to the end of this CombinedFeatures object array
-		 *  convience method for insert_feature_obj(obj, get_num_feature_obj())
 		 *
 		 * @param obj feature object to append
 		 * @return if appending was successful

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -107,13 +107,12 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 	for (index_t k_idx=0; k_idx<get_num_kernels() && result; k_idx++)
 	{
 		k = get_kernel(k_idx);
-		lf = ((CCombinedFeatures*) l)->get_feature_obj(f_idx);
-		rf = ((CCombinedFeatures*) r)->get_feature_obj(f_idx);
-		f_idx++;
-
+		
 		// skip over features - the custom kernel does not need any
 		if (k->get_kernel_type() != K_CUSTOM)
 		{
+			lf = ((CCombinedFeatures*) l)->get_feature_obj(f_idx);
+			rf = ((CCombinedFeatures*) r)->get_feature_obj(f_idx);
 			if (!lf || !rf)
 			{
 				SG_UNREF(lf);
@@ -123,7 +122,10 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			}
 
 			SG_DEBUG("Initializing 0x%p - \"%s\"\n", this, k->get_name())
-			result=k->init(lf,rf);		
+			result=k->init(lf,rf);
+			SG_UNREF(lf);
+			SG_UNREF(rf);
+			f_idx++;
 		}
 		else
 		{
@@ -137,8 +139,6 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 		}
 
 		SG_UNREF(k);
-		SG_UNREF(lf);
-		SG_UNREF(rf);	
 	}
 
 	if (!result)
@@ -945,7 +945,7 @@ CList* CCombinedKernel::combine_kernels(CList* kernel_list)
 		{
 			CCombinedKernel* comb_kernel = 
 					dynamic_cast<CCombinedKernel* >(kernel_array.get_element(index));
-			comb_kernel->insert_kernel(c_kernel, 0);
+			comb_kernel->append_kernel(c_kernel);
 			SG_UNREF(comb_kernel);
 		}
 		++kernel_index;

--- a/src/shogun/kernel/CombinedKernel.h
+++ b/src/shogun/kernel/CombinedKernel.h
@@ -134,7 +134,8 @@ class CCombinedKernel : public CKernel
 			return get_kernel(get_num_kernels()-1);
 		}
 
-		/** insert kernel
+		/** insert kernel at position idx
+		 *	 idx must be < num_kernels
 		 *
 		 * @param k kernel
 		 * @param idx the index of the position where the kernel should be added
@@ -152,14 +153,21 @@ class CCombinedKernel : public CKernel
 		}
 
 		/** append kernel to the end of the array
-		 *  convient method for insert_kernel(k, get_num_kernels())
 		 *
 		 * @param k kernel
 		 * @return if appending was successful
 		 */
 		inline bool append_kernel(CKernel* k)
 		{
-			return insert_kernel(k, get_num_kernels());
+			ASSERT(k)
+			adjust_num_lhs_rhs_initialized(k);
+
+			if (!(k->has_property(KP_LINADD)))
+				unset_property(KP_LINADD);
+
+			int n = get_num_kernels();
+			kernel_array->push_back(k);
+			return n+1==get_num_kernels();
 		}
 
 

--- a/tests/unit/features/CombinedFeatures_unittest.cc
+++ b/tests/unit/features/CombinedFeatures_unittest.cc
@@ -14,6 +14,53 @@
 
 using namespace shogun;
 
+TEST(CombinedFeaturesTest,test_array_operations)
+{
+	index_t n_1=3;
+	index_t dim=2;
+
+	SGMatrix<float64_t> data_1(dim,n_1);
+	SGMatrix<float64_t> data_2(dim,n_1);
+	SGMatrix<float64_t> data_3(dim,n_1);
+	for (index_t i=0; i < dim*n_1; i++)
+	{
+		data_1[i] = i;
+		data_2[i] = -i;
+		data_3[i] = 2*i;
+	}
+	
+	CCombinedFeatures* comb_feat = new CCombinedFeatures();
+	CDenseFeatures<float64_t>* feat_1 = new CDenseFeatures<float64_t>(data_1);
+	CDenseFeatures<float64_t>* feat_2 = new CDenseFeatures<float64_t>(data_2);
+	CDenseFeatures<float64_t>* feat_3 = new CDenseFeatures<float64_t>(data_3);
+
+	if (comb_feat->append_feature_obj(feat_1))
+		EXPECT_EQ(comb_feat->get_num_feature_obj(),1);
+
+	if (comb_feat->append_feature_obj(feat_2))
+		EXPECT_EQ(comb_feat->get_num_feature_obj(),2);
+
+	if (comb_feat->insert_feature_obj(feat_3, 1))
+		EXPECT_EQ(comb_feat->get_num_feature_obj(),3);
+
+	comb_feat->delete_feature_obj(0);
+	EXPECT_EQ(comb_feat->get_num_feature_obj(),2);
+	
+	CDenseFeatures<float64_t>* f_1 = (CDenseFeatures<float64_t>*) comb_feat->get_feature_obj(0);
+	SGMatrix<float64_t> m_1 = f_1->get_feature_matrix();
+	CDenseFeatures<float64_t>* f_2 = (CDenseFeatures<float64_t>*) comb_feat->get_feature_obj(1);
+	SGMatrix<float64_t> m_2 = f_2->get_feature_matrix();
+	for (index_t i=0; i < dim*n_1; i++)
+	{
+		EXPECT_EQ(m_1[i], data_3[i]);
+		EXPECT_EQ(m_2[i], data_2[i]);
+	}
+	SG_UNREF(f_1);
+	SG_UNREF(f_2);
+
+	SG_UNREF(comb_feat);
+}
+
 TEST(CombinedFeaturesTest,create_merged_copy)
 {
 	/* create two matrices, feature objects for them, call create_merged_copy,

--- a/tests/unit/kernel/CombinedKernel_unittest.cc
+++ b/tests/unit/kernel/CombinedKernel_unittest.cc
@@ -5,6 +5,38 @@
 
 using namespace shogun;
 
+TEST(CombinedKernelTest,test_array_operations)
+{
+	CCombinedKernel* combined = new CCombinedKernel();
+	CGaussianKernel* gaus_1 = new CGaussianKernel();
+	combined->append_kernel(gaus_1);
+	
+	CGaussianKernel* gaus_2 = new CGaussianKernel();
+	combined->append_kernel(gaus_2);
+	
+	CGaussianKernel* gaus_3 = new CGaussianKernel();
+	combined->insert_kernel(gaus_3,1);
+
+	CGaussianKernel* gaus_4 = new CGaussianKernel();
+	combined->insert_kernel(gaus_4,0);
+
+	EXPECT_EQ(combined->get_num_kernels(),4);
+
+	combined->delete_kernel(2);
+
+	CKernel* k_1 = combined->get_kernel(0);
+	EXPECT_EQ(k_1, gaus_4);
+	CKernel* k_2 = combined->get_kernel(1);
+	EXPECT_EQ(k_2, gaus_1);
+	CKernel* k_3 = combined->get_kernel(2);
+	EXPECT_EQ(k_3, gaus_2);
+
+	SG_UNREF(k_1);
+	SG_UNREF(k_2);
+	SG_UNREF(k_3);
+	SG_UNREF(combined);
+}
+
 TEST(CombinedKernelTest,weights)
 {
 	CCombinedKernel* combined = new CCombinedKernel();


### PR DESCRIPTION
Since I didn't find the Combined*::insert() methods used somewhere and because append() is used instead, I decided to use array.push_back() in append and comment the function insert that it requires the index to be less than the number of objects.
Also added a couple of unit tests.
Plus, fixed bug that whenever a CCustomKernel was used in CCombinedKernel, the index of the features in a loop
shouldn't be incremented.
