### PR TITLE
CList to CDynamicObjectArray in ProductKernel

### DIFF
--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -107,12 +107,16 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 	for (index_t k_idx=0; k_idx<get_num_kernels() && result; k_idx++)
 	{
 		k = get_kernel(k_idx);
+
+		if (!k)
+			SG_ERROR("Kernel at position %d is NULL\n", k_idx);	
 		
 		// skip over features - the custom kernel does not need any
 		if (k->get_kernel_type() != K_CUSTOM)
 		{
 			lf = ((CCombinedFeatures*) l)->get_feature_obj(f_idx);
 			rf = ((CCombinedFeatures*) r)->get_feature_obj(f_idx);
+			f_idx++;
 			if (!lf || !rf)
 			{
 				SG_UNREF(lf);
@@ -125,7 +129,9 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			result=k->init(lf,rf);
 			SG_UNREF(lf);
 			SG_UNREF(rf);
-			f_idx++;
+			
+			if (!result)
+				break;
 		}
 		else
 		{
@@ -145,7 +151,10 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 	{
 		SG_INFO("CombinedKernel: Initialising the following kernel failed\n")
 		if (k)
+		{
 			k->list_kernel();
+			SG_UNREF(k);
+		}
 		else
 			SG_INFO("<NULL>\n")
 		return false;

--- a/tests/unit/kernel/ProductKernel_unittest.cc
+++ b/tests/unit/kernel/ProductKernel_unittest.cc
@@ -1,0 +1,37 @@
+#include <shogun/kernel/ProductKernel.h>
+#include <shogun/kernel/GaussianKernel.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(ProductKernelTest,test_array_operations)
+{
+	CProductKernel* product = new CProductKernel();
+	CGaussianKernel* gaus_1 = new CGaussianKernel();
+	product->append_kernel(gaus_1);
+	
+	CGaussianKernel* gaus_2 = new CGaussianKernel();
+	product->append_kernel(gaus_2);
+	
+	CGaussianKernel* gaus_3 = new CGaussianKernel();
+	product->insert_kernel(gaus_3,1);
+
+	CGaussianKernel* gaus_4 = new CGaussianKernel();
+	product->insert_kernel(gaus_4,0);
+
+	EXPECT_EQ(product->get_num_subkernels(),4);
+
+	product->delete_kernel(2);
+
+	CKernel* k_1 = product->get_kernel(0);
+	EXPECT_EQ(k_1, gaus_4);
+	CKernel* k_2 = product->get_kernel(1);
+	EXPECT_EQ(k_2, gaus_1);
+	CKernel* k_3 = product->get_kernel(2);
+	EXPECT_EQ(k_3, gaus_2);
+
+	SG_UNREF(k_1);
+	SG_UNREF(k_2);
+	SG_UNREF(k_3);
+	SG_UNREF(product);
+}


### PR DESCRIPTION
What the title says. Plus made a change in CCombinedKernel to have it display, in case of failure, the kernel that was failed to be initialized, as it was intended before.
