### PR TITLE
Issue #1103: removed CCombinedKernel::get_first_kernel()

### DIFF
--- a/src/shogun/classifier/mkl/MKL.cpp
+++ b/src/shogun/classifier/mkl/MKL.cpp
@@ -593,7 +593,7 @@ float64_t CMKL::compute_elasticnet_dual_objective()
 		// Compute Elastic-net dual
 		float64_t* nm = SG_MALLOC(float64_t, num_kernels);
 		float64_t del=0;
-		CKernel* kn = ((CCombinedKernel*)kernel)->get_first_kernel();
+		CKernel* kn = ((CCombinedKernel*)kernel)->get_kernel(0);
 
 		int32_t k=0;
 		while (kn)
@@ -1529,7 +1529,7 @@ float64_t CMKL::compute_mkl_dual_objective()
 
 	if (m_labels && kernel && kernel->get_kernel_type() == K_COMBINED)
 	{
-		CKernel* kn = ((CCombinedKernel*)kernel)->get_first_kernel();
+		CKernel* kn = ((CCombinedKernel*)kernel)->get_kernel(0);
 		while (kn)
 		{
 			float64_t sum=0;

--- a/src/shogun/classifier/svm/SVMLight.cpp
+++ b/src/shogun/classifier/svm/SVMLight.cpp
@@ -247,7 +247,7 @@ bool CSVMLight::train_machine(CFeatures* data)
 
 	if (kernel->get_kernel_type() == K_COMBINED)
 	{
-		CKernel* kn = ((CCombinedKernel*)kernel)->get_first_kernel();
+		CKernel* kn = ((CCombinedKernel*)kernel)->get_kernel(0);
 
 		while (kn)
 		{
@@ -436,7 +436,7 @@ void CSVMLight::svm_learn()
 		   )
 		{
 			CCombinedKernel* k      = (CCombinedKernel*) kernel;
-			CKernel* kn = k->get_first_kernel();
+			CKernel* kn = k->get_kernel(0);
 
 			while (kn)
 			{
@@ -760,7 +760,7 @@ int32_t CSVMLight::optimize_to_convergence(int32_t* docs, int32_t* label, int32_
 			 )
 		  {
 			  CCombinedKernel* k      = (CCombinedKernel*) kernel;
-			  CKernel* kn = k->get_first_kernel();
+			  CKernel* kn = k->get_kernel(0);
 
 			  while (kn)
 			  {
@@ -1536,7 +1536,7 @@ void CSVMLight::update_linear_component_mkl(
 			 (!((CCombinedKernel*)kernel)->get_append_subkernel_weights()))// for combined kernel
 	{
 		CCombinedKernel* k      = (CCombinedKernel*) kernel;
-		CKernel* kn = k->get_first_kernel() ;
+		CKernel* kn = k->get_kernel(0) ;
 		int32_t n = 0, i, j ;
 
 		while (kn!=NULL)

--- a/src/shogun/classifier/svm/SVMLightOneClass.cpp
+++ b/src/shogun/classifier/svm/SVMLightOneClass.cpp
@@ -119,7 +119,7 @@ bool CSVMLightOneClass::train_machine(CFeatures* data)
 
 	if (kernel->get_kernel_type() == K_COMBINED)
 	{
-		CKernel* kn = ((CCombinedKernel*)kernel)->get_first_kernel();
+		CKernel* kn = ((CCombinedKernel*)kernel)->get_kernel(0);
 
 		while (kn)
 		{

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -764,7 +764,7 @@ void CCombinedKernel::set_subkernel_weights(SGVector<float64_t> weights)
 
 void CCombinedKernel::set_optimization_type(EOptimizationType t)
 {
-	CKernel* k = get_first_kernel();
+	CKernel* k = get_kernel(0);
 
 	while(k)
 	{
@@ -779,7 +779,7 @@ void CCombinedKernel::set_optimization_type(EOptimizationType t)
 
 bool CCombinedKernel::precompute_subkernels()
 {
-	CKernel* k = get_first_kernel();
+	CKernel* k = get_kernel(0);
 
 	if (!k)
 		return false;

--- a/src/shogun/kernel/CombinedKernel.h
+++ b/src/shogun/kernel/CombinedKernel.h
@@ -107,15 +107,6 @@ class CCombinedKernel : public CKernel
 
 		/** get first kernel
 		 *
-		 * @return first kernel
-		 */
-		inline CKernel* get_first_kernel()
-		{
-			return (CKernel*) kernel_list->get_first_element();
-		}
-
-		/** get first kernel
-		 *
 		 * @param current
 		 * @return first kernel
 		 */
@@ -131,7 +122,7 @@ class CCombinedKernel : public CKernel
 		 */
 		inline CKernel* get_kernel(int32_t idx)
 		{
-			CKernel * k = get_first_kernel();
+		  CKernel * k = (CKernel*) kernel_list->get_first_element();
 			for (int32_t i=0; i<idx; i++)
 			{
 				SG_UNREF(k);

--- a/src/shogun/regression/svr/SVRLight.cpp
+++ b/src/shogun/regression/svr/SVRLight.cpp
@@ -191,7 +191,7 @@ void CSVRLight::svr_learn()
   if (kernel->get_kernel_type() == K_COMBINED)
   {
 	  CCombinedKernel* k      = (CCombinedKernel*) kernel;
-	  CKernel* kn = k->get_first_kernel();
+	  CKernel* kn = k->get_kernel(0);
 
 	  while (kn)
 	  {
@@ -509,7 +509,7 @@ void CSVRLight::update_linear_component_mkl(
 			 (!((CCombinedKernel*)kernel)->get_append_subkernel_weights()))// for combined kernel
 	{
 		CCombinedKernel* k      = (CCombinedKernel*) kernel;
-		CKernel* kn = k->get_first_kernel() ;
+		CKernel* kn = k->get_kernel(0) ;
 		int32_t n = 0, i, j ;
 
 		while (kn!=NULL)

--- a/src/shogun/statistics/LinearTimeMMD.cpp
+++ b/src/shogun/statistics/LinearTimeMMD.cpp
@@ -195,7 +195,7 @@ void CLinearTimeMMD::compute_statistic_and_variance(
 		if (multiple_kernels)
 		{
 			SG_DEBUG("using multiple kernels\n");
-			kernel=((CCombinedKernel*)m_kernel)->get_first_kernel();
+			kernel=((CCombinedKernel*)m_kernel)->get_kernel(0);
 		}
 
 		/* iterate through all kernels for this data */
@@ -327,7 +327,7 @@ void CLinearTimeMMD::compute_statistic_and_Q(
 	/* produce two kernel lists to iterate doubly nested */
 	CList* list_i=new CList();
 	CList* list_j=new CList();
-	CKernel* kernel=combined->get_first_kernel();
+	CKernel* kernel=combined->get_kernel(0);
 	while (kernel)
 	{
 		list_i->append_element(kernel);

--- a/src/shogun/statistics/MMDKernelSelection.cpp
+++ b/src/shogun/statistics/MMDKernelSelection.cpp
@@ -84,7 +84,7 @@ CKernel* CMMDKernelSelection::select_kernel()
 
 	/* find kernel with corresponding index */
 	CCombinedKernel* combined=(CCombinedKernel*)m_mmd->get_kernel();
-	CKernel* current=combined->get_first_kernel();
+	CKernel* current=combined->get_kernel(0);
 	for (index_t i=0; i<max_idx; ++i)
 	{
 		SG_UNREF(current);

--- a/src/shogun/statistics/MMDKernelSelectionMedian.cpp
+++ b/src/shogun/statistics/MMDKernelSelectionMedian.cpp
@@ -40,7 +40,7 @@ CMMDKernelSelectionMedian::CMMDKernelSelectionMedian(
 
 	/* assert that all subkernels are Gaussian kernels */
 	CCombinedKernel* combined=(CCombinedKernel*)kernel;
-	CKernel* subkernel=combined->get_first_kernel();
+	CKernel* subkernel=combined->get_kernel(0);
 	index_t i=0;
 	while (subkernel)
 	{
@@ -206,7 +206,7 @@ CKernel* CMMDKernelSelectionMedian::select_kernel()
 	/* now of all kernels, find the one which has its width closest
 	 * Cast is safe due to constructor of MMDKernelSelection class */
 	CCombinedKernel* combined=(CCombinedKernel*)m_mmd->get_kernel();
-	CKernel* current=combined->get_first_kernel();
+	CKernel* current=combined->get_kernel(0);
 	float64_t min_distance=CMath::MAX_REAL_NUMBER;
 	CKernel* min_kernel=NULL;
 	float64_t distance;

--- a/src/shogun/statistics/QuadraticTimeMMD.cpp
+++ b/src/shogun/statistics/QuadraticTimeMMD.cpp
@@ -234,7 +234,7 @@ SGVector<float64_t> CQuadraticTimeMMD::compute_statistic(
 		mmds=SGVector<float64_t>(combined->get_num_subkernels());
 
 		/* iterate through all kernels and compute statistic */
-		CKernel* current=combined->get_first_kernel();
+		CKernel* current=combined->get_kernel(0);
 
 		/* TODO this might be done in parallel */
 		for (index_t i=0; i<mmds.vlen; ++i)


### PR DESCRIPTION
Removed CCombinedKernel::get_first_kernel() by 
- Removing the function in CombinedKernel.h
- Replacing function calls of get_frist_kernel() in other files by get_kernel(0)

Did NOT remove get_last_kernel() because the following files will need this function:
- src/shogun/ui/GUIKernel.cpp:  
- src/shogun/ui/SGInterface.cpp:

and I'm not sure what to do for these function calls.
