### PR TITLE
Fixed: Segfault when sorting empty lists using CMath::qsort()

### DIFF
--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -615,7 +615,7 @@ class CMath : public CSGObject
 		template <class T>
 			static void qsort(T* output, int32_t size)
 			{
-				if (size==1)
+				if (size<=1)
 					return;
 
 				if (size==2)


### PR DESCRIPTION
The patch fixes the pre-condition in qsort.  Sorting an empty list is a no-op, so simply return if size is <= 1.
