### PR TITLE
Unit tests for CMath::qsort(): Trying to sort empty lists with qsort(*T) and qsort(**T)

### DIFF
--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -930,7 +930,7 @@ class CMath : public CSGObject
 		template <class T>
 			static void qsort(T** vector, index_t length)
 			{
-				if (length==1)
+				if (length<=1)
 					return;
 
 				if (length==2)
@@ -1416,6 +1416,11 @@ void* CMath::parallel_qsort_index(void* p)
 		int32_t sort_limit=ps->sort_limit;
 		int32_t num_threads=ps->num_threads;
 
+		if (size<2)
+		{
+			return NULL;
+		}
+
 		if (size==2)
 		{
 			if (output[0] > output [1])
@@ -1512,7 +1517,7 @@ void* CMath::parallel_qsort_index(void* p)
 	template <class T1,class T2>
 void CMath::qsort_index(T1* output, T2* index, uint32_t size)
 {
-	if (size==1)
+	if (size<=1)
 		return;
 
 	if (size==2)
@@ -1556,6 +1561,9 @@ void CMath::qsort_index(T1* output, T2* index, uint32_t size)
 	template <class T1,class T2>
 void CMath::qsort_backward_index(T1* output, T2* index, int32_t size)
 {
+	if (size<=1)
+		return;
+
 	if (size==2)
 	{
 		if (output[0] < output [1])

--- a/tests/unit/mathematics/Math_unittest.cc
+++ b/tests/unit/mathematics/Math_unittest.cc
@@ -1,0 +1,75 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Thoralf Klein
+ */
+
+#include <shogun/lib/common.h>
+#include <shogun/mathematics/Math.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(CMath, qsort_test)
+{
+	// testing qsort on list of zero elements
+	CMath::qsort((int32_t *)NULL, 0);
+
+	// testing qsort on list of one element
+	int32_t * v1 = SG_CALLOC(int32_t, 1);
+	CMath::qsort(v1, 1);
+	SG_FREE(v1);
+}
+
+TEST(CMath, qsort_ptr_test)
+{
+	// testing qsort on list of zero pointers
+	CMath::qsort((int32_t **)NULL, 0);
+
+	// testing qsort on list of one pointer
+	int32_t ** v1 = SG_CALLOC(int32_t *, 1);
+	CMath::qsort(v1, 1);
+	SG_FREE(v1);
+}
+
+TEST(CMath, qsort_index_test)
+{
+	// testing qsort_index on list of zero elements
+	CMath::qsort_index((int32_t *)NULL, (int32_t *)NULL, 0);
+
+	// testing qsort_index on list of one element
+	int32_t * v1 = SG_CALLOC(int32_t, 1);
+	int32_t * i1 = SG_CALLOC(int32_t, 1);
+	CMath::qsort_index(v1, i1, 1);
+	SG_FREE(v1);
+	SG_FREE(i1);
+}
+
+TEST(CMath, qsort_backward_index_test)
+{
+	// testing qsort_backward_index on list of zero elements
+	CMath::qsort_backward_index((int32_t *)NULL, (int32_t *)NULL, 0);
+
+	// testing qsort_backward_index on list of one element
+	int32_t * v1 = SG_CALLOC(int32_t, 1);
+	int32_t * i1 = SG_CALLOC(int32_t, 1);
+	CMath::qsort_backward_index(v1, i1, 1);
+	SG_FREE(v1);
+	SG_FREE(i1);
+}
+
+TEST(CMath, parallel_qsort_index_test)
+{
+	// testing parallel_qsort_index on list of zero elements
+	CMath::parallel_qsort_index((int32_t *)NULL, (int32_t *)NULL, 0, 8);
+
+	// testing parallel_qsort_index on list of one element
+	int32_t * v1 = SG_CALLOC(int32_t, 1);
+	int32_t * i1 = SG_CALLOC(int32_t, 1);
+	CMath::parallel_qsort_index(v1, i1, 1, 8);
+	SG_FREE(v1);
+	SG_FREE(i1);
+}


### PR DESCRIPTION
A bunch of tests:
- for the fixed bug of qsort(*T)
- for the fixed bug of qsort(**T)
- for the fixed bug of qsort_index()
- for the fixed bug of qsort_backward_index()

Fixed qsort(), qsort_index(), parallel_qsort_index(), qsort_backward_index() and parallel_qsort_index().
