### PR TITLE
CMath::abs(complex64_t) changed to not to make use of std::abs()

### DIFF
--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -243,7 +243,9 @@ class CMath : public CSGObject
 		///return the absolute value of a complex number
 		static inline float64_t abs(complex64_t a)
 		{
-			return std::abs(a);
+			float64_t a_real=a.real();
+			float64_t a_imag=a.imag();
+			return (CMath::sqrt(a_real*a_real+a_imag*a_imag));
 		}
 		//@}
 

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -196,7 +196,7 @@ TEST(SGVectorTest,complex64_tests)
 	}
 	a.permute();
 	complex64_t sum=SGVector<complex64_t>::sum_abs(a.vector, 1);
-	EXPECT_NEAR(sum.real(), 15.62049935181330795331, 1E-15);
+	EXPECT_NEAR(sum.real(), 15.62049935181330878825, 1E-15);
 	EXPECT_NEAR(sum.imag(), 0.0, 1E-15);
 
 	SGVector<index_t> res=a.find(complex64_t(10.0, 12.0));

--- a/tests/unit/mathematics/Complex_unittest.cc
+++ b/tests/unit/mathematics/Complex_unittest.cc
@@ -17,7 +17,7 @@ TEST(CMath, complex_test)
 {
 	complex64_t a(5.0, 6.0), result;
 
-	EXPECT_NEAR(abs(a), 7.81024967590665397665, 1E-15);
+	EXPECT_NEAR(CMath::abs(a), 7.81024967590665439412, 1E-15);
 	result=CMath::log(a);
 	EXPECT_NEAR(result.real(), 2.05543693208665567695, 1E-15);
 	EXPECT_NEAR(result.imag(), 0.87605805059819341629, 1E-15);


### PR DESCRIPTION
- also, changed the reference values for two tests.
