### PR TITLE
SVMLight: Fixing type conversion when printing number of support vectors...

### DIFF
--- a/src/shogun/classifier/svm/SVMLight.cpp
+++ b/src/shogun/classifier/svm/SVMLight.cpp
@@ -520,7 +520,7 @@ void CSVMLight::svm_learn()
 					 learn_parm->epsilon_a))
 				upsupvecnum++;
 		}
-		SG_INFO("Number of SV: %ld (including %ld at upper bound)\n",
+		SG_INFO("Number of SV: %d (including %d at upper bound)\n",
 				model->sv_num-1,upsupvecnum);
 	}
 

--- a/src/shogun/regression/svr/SVRLight.cpp
+++ b/src/shogun/regression/svr/SVRLight.cpp
@@ -308,7 +308,7 @@ void CSVRLight::svr_learn()
 					 learn_parm->epsilon_a))
 				upsupvecnum++;
 		}
-		SG_INFO("Number of SV: %ld (including %ld at upper bound)\n",
+		SG_INFO("Number of SV: %d (including %d at upper bound)\n",
 				model->sv_num-1,upsupvecnum);
 	}
 


### PR DESCRIPTION
... (%d instead of %ld, because variable is of type int32_t).
