### PR TITLE
added more unit-tests serialization for ptype and ctype (SGVector, SGMatrix)

### DIFF
--- a/tests/unit/io/Serialization_unittest.cc
+++ b/tests/unit/io/Serialization_unittest.cc
@@ -11,11 +11,13 @@
 #include <shogun/base/Parameter.h>
 #include <shogun/io/SerializableAsciiFile.h>
 #include <shogun/io/SerializableJsonFile.h>
+#include <shogun/io/SerializableXmlFile.h>
+#include <shogun/io/SerializableHdf5File.h>
 #include <gtest/gtest.h>
 
 using namespace shogun;
 
-TEST(Serialization, Ascii_scaler_equal_BOOL)
+TEST(Serialization, Ascii_scalar_equal_BOOL)
 {
 	bool a=true;
 	bool b=false;
@@ -44,7 +46,7 @@ TEST(Serialization, Ascii_scaler_equal_BOOL)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_CHAR)
+TEST(Serialization, Ascii_scalar_equal_CHAR)
 {
 	char a='a';
 	char b='b';
@@ -73,7 +75,7 @@ TEST(Serialization, Ascii_scaler_equal_CHAR)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_INT8)
+TEST(Serialization, Ascii_scalar_equal_INT8)
 {
 	int8_t a=1;
 	int8_t b=2;
@@ -102,7 +104,7 @@ TEST(Serialization, Ascii_scaler_equal_INT8)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_UINT8)
+TEST(Serialization, Ascii_scalar_equal_UINT8)
 {
 	uint8_t a=1;
 	uint8_t b=2;
@@ -131,7 +133,7 @@ TEST(Serialization, Ascii_scaler_equal_UINT8)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_INT16)
+TEST(Serialization, Ascii_scalar_equal_INT16)
 {
 	int16_t a=1;
 	int16_t b=2;
@@ -160,7 +162,7 @@ TEST(Serialization, Ascii_scaler_equal_INT16)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_UINT16)
+TEST(Serialization, Ascii_scalar_equal_UINT16)
 {
 	uint16_t a=1;
 	uint16_t b=2;
@@ -189,7 +191,7 @@ TEST(Serialization, Ascii_scaler_equal_UINT16)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_INT32)
+TEST(Serialization, Ascii_scalar_equal_INT32)
 {
 	int32_t a=1;
 	int32_t b=2;
@@ -218,7 +220,7 @@ TEST(Serialization, Ascii_scaler_equal_INT32)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_UINT32)
+TEST(Serialization, Ascii_scalar_equal_UINT32)
 {
 	uint32_t a=1;
 	uint32_t b=2;
@@ -247,7 +249,7 @@ TEST(Serialization, Ascii_scaler_equal_UINT32)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_INT64)
+TEST(Serialization, Ascii_scalar_equal_INT64)
 {
 	int64_t a=1;
 	int64_t b=2;
@@ -276,7 +278,7 @@ TEST(Serialization, Ascii_scaler_equal_INT64)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_UINT64)
+TEST(Serialization, Ascii_scalar_equal_UINT64)
 {
 	uint64_t a=1;
 	uint64_t b=2;
@@ -305,7 +307,7 @@ TEST(Serialization, Ascii_scaler_equal_UINT64)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_FLOAT32)
+TEST(Serialization, Ascii_scalar_equal_FLOAT32)
 {
 	float32_t a=1.71265;
 	float32_t b=0.0;
@@ -335,7 +337,7 @@ TEST(Serialization, Ascii_scaler_equal_FLOAT32)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_FLOAT64)
+TEST(Serialization, Ascii_scalar_equal_FLOAT64)
 {
 	float64_t a=1.7126587125;
 	float64_t b=0.0;
@@ -365,7 +367,7 @@ TEST(Serialization, Ascii_scaler_equal_FLOAT64)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_FLOATMAX)
+TEST(Serialization, Ascii_scalar_equal_FLOATMAX)
 {
 	floatmax_t a=1.7126587125;
 	floatmax_t b=0.0;
@@ -395,7 +397,7 @@ TEST(Serialization, Ascii_scaler_equal_FLOATMAX)
 	delete param2;
 }
 
-TEST(Serialization, Ascii_scaler_equal_COMPLEX64)
+TEST(Serialization, Ascii_scalar_equal_COMPLEX64)
 {
 	complex64_t a(1.7126587125, 2.7126587125);
 	complex64_t b(0.0, 0.0);
@@ -425,8 +427,140 @@ TEST(Serialization, Ascii_scaler_equal_COMPLEX64)
 	delete param2;
 }
 
+TEST(Serialization, Ascii_vector_equal_FLOAT64)
+{
+	SGVector<float64_t> a(2);
+	SGVector<float64_t> b(2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGVECTOR, ST_NONE, PT_FLOAT64, &a.vlen);
+	TParameter* param1=new TParameter(&type, &a.vector, "param", "");
+	TParameter* param2=new TParameter(&type, &b.vector, "param", "");
+
+	const char* filename="float64_sgvec_param.txt";
+	// save parameter to an ascii file
+	CSerializableAsciiFile *file=new CSerializableAsciiFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from an ascii file
+	file=new CSerializableAsciiFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Ascii_vector_equal_COMPLEX64)
+{
+	SGVector<complex64_t> a(2);
+	SGVector<complex64_t> b(2);
+
+	a.set_const(complex64_t(1.14263158, 2.83645548));
+	b.zero();
+
+	TSGDataType type(CT_SGVECTOR, ST_NONE, PT_COMPLEX64, &a.vlen);
+	TParameter* param1=new TParameter(&type, &a.vector, "param", "");
+	TParameter* param2=new TParameter(&type, &b.vector, "param", "");
+
+	const char* filename="complex64_sgvec_param.txt";
+	// save parameter to an ascii file
+	CSerializableAsciiFile *file=new CSerializableAsciiFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from an ascii file
+	file=new CSerializableAsciiFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Ascii_matrix_equal_FLOAT64)
+{
+	SGMatrix<float64_t> a(2, 2);
+	SGMatrix<float64_t> b(2, 2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGMATRIX, ST_NONE, PT_FLOAT64, &a.num_rows, &a.num_cols);
+	TParameter* param1=new TParameter(&type, &a.matrix, "param", "");
+	TParameter* param2=new TParameter(&type, &b.matrix, "param", "");
+
+	const char* filename="float64_sgmat_param.txt";
+	// save parameter to an ascii file
+	CSerializableAsciiFile *file=new CSerializableAsciiFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from an ascii file
+	file=new CSerializableAsciiFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Ascii_matrix_equal_COMPLEX64)
+{
+	SGMatrix<complex64_t> a(2, 2);
+	SGMatrix<complex64_t> b(2, 2);
+
+	a.set_const(complex64_t(1.14263158, 2.435754));
+	b.zero();
+
+	TSGDataType type(CT_SGMATRIX, ST_NONE, PT_COMPLEX64, &a.num_rows, &a.num_cols);
+	TParameter* param1=new TParameter(&type, &a.matrix, "param", "");
+	TParameter* param2=new TParameter(&type, &b.matrix, "param", "");
+
+	const char* filename="complex64_sgmat_param.txt";
+	// save parameter to an ascii file
+	CSerializableAsciiFile *file=new CSerializableAsciiFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from an ascii file
+	file=new CSerializableAsciiFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
 #ifdef HAVE_JSON
-TEST(Serialization, Json_scaler_equal_BOOL)
+TEST(Serialization, Json_scalar_equal_BOOL)
 {
 	bool a=true;
 	bool b=false;
@@ -436,13 +570,13 @@ TEST(Serialization, Json_scaler_equal_BOOL)
 	TParameter* param2=new TParameter(&type, &b, "param", "");
 
 	const char* filename="bool_param.json";
-	// save parameter to an json file
+	// save parameter to a json file
 	CSerializableJsonFile *file=new CSerializableJsonFile(filename, 'w');
 	param1->save(file);
 	file->close();
 	SG_UNREF(file);
 
-	// load parameter from an json file
+	// load parameter from a json file
 	file=new CSerializableJsonFile(filename, 'r');
 	param2->load(file);
 	file->close();
@@ -455,7 +589,7 @@ TEST(Serialization, Json_scaler_equal_BOOL)
 	delete param2;
 }
 
-TEST(Serialization, Json_scaler_equal_FLOAT32)
+TEST(Serialization, Json_scalar_equal_FLOAT32)
 {
 	float32_t a=1.7325;
 	float32_t b=0.0;
@@ -465,13 +599,13 @@ TEST(Serialization, Json_scaler_equal_FLOAT32)
 	TParameter* param2=new TParameter(&type, &b, "param", "");
 
 	const char* filename="float32_param.json";
-	// save parameter to an json file
+	// save parameter to a json file
 	CSerializableJsonFile *file=new CSerializableJsonFile(filename, 'w');
 	param1->save(file);
 	file->close();
 	SG_UNREF(file);
 
-	// load parameter from an json file
+	// load parameter from a json file
 	file=new CSerializableJsonFile(filename, 'r');
 	param2->load(file);
 	file->close();
@@ -485,7 +619,7 @@ TEST(Serialization, Json_scaler_equal_FLOAT32)
 	delete param2;
 }
 
-TEST(Serialization, Json_scaler_equal_FLOAT64)
+TEST(Serialization, Json_scalar_equal_FLOAT64)
 {
 	float64_t a=1.7126587125;
 	float64_t b=0.0;
@@ -495,13 +629,13 @@ TEST(Serialization, Json_scaler_equal_FLOAT64)
 	TParameter* param2=new TParameter(&type, &b, "param", "");
 
 	const char* filename="float64_param.json";
-	// save parameter to an json file
+	// save parameter to a json file
 	CSerializableJsonFile *file=new CSerializableJsonFile(filename, 'w');
 	param1->save(file);
 	file->close();
 	SG_UNREF(file);
 
-	// load parameter from an json file
+	// load parameter from a json file
 	file=new CSerializableJsonFile(filename, 'r');
 	param2->load(file);
 	file->close();
@@ -515,7 +649,7 @@ TEST(Serialization, Json_scaler_equal_FLOAT64)
 	delete param2;
 }
 
-TEST(Serialization, Json_scaler_equal_FLOATMAX)
+TEST(Serialization, Json_scalar_equal_FLOATMAX)
 {
 	floatmax_t a=1.7126587125;
 	floatmax_t b=0.0;
@@ -525,13 +659,13 @@ TEST(Serialization, Json_scaler_equal_FLOATMAX)
 	TParameter* param2=new TParameter(&type, &b, "param", "");
 
 	const char* filename="floatmax_param.json";
-	// save parameter to an json file
+	// save parameter to a json file
 	CSerializableJsonFile *file=new CSerializableJsonFile(filename, 'w');
 	param1->save(file);
 	file->close();
 	SG_UNREF(file);
 
-	// load parameter from an json file
+	// load parameter from a json file
 	file=new CSerializableJsonFile(filename, 'r');
 	param2->load(file);
 	file->close();
@@ -545,8 +679,1063 @@ TEST(Serialization, Json_scaler_equal_FLOATMAX)
 	delete param2;
 }
 
+TEST(Serialization, Json_vector_equal_FLOAT64)
+{
+	SGVector<float64_t> a(2);
+	SGVector<float64_t> b(2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGVECTOR, ST_NONE, PT_FLOAT64, &a.vlen);
+	TParameter* param1=new TParameter(&type, &a.vector, "param", "");
+	TParameter* param2=new TParameter(&type, &b.vector, "param", "");
+
+	const char* filename="float64_sgvec_param.json";
+	// save parameter to a json file
+	CSerializableJsonFile *file=new CSerializableJsonFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a json file
+	file=new CSerializableJsonFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=1E-6;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Json_matrix_equal_FLOAT64)
+{
+	SGMatrix<float64_t> a(2, 2);
+	SGMatrix<float64_t> b(2, 2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGMATRIX, ST_NONE, PT_FLOAT64, &a.num_rows, &a.num_cols);
+	TParameter* param1=new TParameter(&type, &a.matrix, "param", "");
+	TParameter* param2=new TParameter(&type, &b.matrix, "param", "");
+
+	const char* filename="float64_sgmat_param.json";
+	// save parameter to a json file
+	CSerializableJsonFile *file=new CSerializableJsonFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a json file
+	file=new CSerializableJsonFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=1E-6;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
 #endif // HAVE_JSON
 
 #ifdef HAVE_XML
+TEST(Serialization, Xml_scalar_equal_BOOL)
+{
+	bool a=true;
+	bool b=false;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_BOOL);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="bool_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_CHAR)
+{
+	char a='a';
+	char b='b';
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_CHAR);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="char_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_INT8)
+{
+	int8_t a=1;
+	int8_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT8);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int8_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_UINT8)
+{
+	uint8_t a=1;
+	uint8_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT8);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint8_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_INT16)
+{
+	int16_t a=1;
+	int16_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT16);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int16_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_UINT16)
+{
+	uint16_t a=1;
+	uint16_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT16);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint16_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_INT132)
+{
+	int32_t a=1;
+	int32_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT32);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int32_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_UINT32)
+{
+	uint32_t a=1;
+	uint32_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT32);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint32_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_INT64)
+{
+	int64_t a=1;
+	int64_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int64_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_UINT64)
+{
+	uint64_t a=1;
+	uint64_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint64_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_FLOAT32)
+{
+	float32_t a=1.71265;
+	float32_t b=0.0;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_FLOAT32);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="float32_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=1E-15;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_FLOAT64)
+{
+	float64_t a=1.7126587125;
+	float64_t b=0.0;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_FLOAT64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="float64_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=1E-15;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_FLOATMAX)
+{
+	floatmax_t a=1.7126587125;
+	floatmax_t b=0.0;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_FLOATMAX);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="floatmax_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=1E-15;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_scalar_equal_COMPLEX64)
+{
+	complex64_t a(1.7126587125, 1.7126587125);
+	complex64_t b(0.0);
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_COMPLEX64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="complex64_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=1E-15;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_vector_equal_FLOAT64)
+{
+	SGVector<float64_t> a(2);
+	SGVector<float64_t> b(2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGVECTOR, ST_NONE, PT_FLOAT64, &a.vlen);
+	TParameter* param1=new TParameter(&type, &a.vector, "param", "");
+	TParameter* param2=new TParameter(&type, &b.vector, "param", "");
+
+	const char* filename="float64_sgvec_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_vector_equal_COMPLEX64)
+{
+	SGVector<complex64_t> a(2);
+	SGVector<complex64_t> b(2);
+
+	a.set_const(complex64_t(1.14263158, 2.83645548));
+	b.zero();
+
+	TSGDataType type(CT_SGVECTOR, ST_NONE, PT_COMPLEX64, &a.vlen);
+	TParameter* param1=new TParameter(&type, &a.vector, "param", "");
+	TParameter* param2=new TParameter(&type, &b.vector, "param", "");
+
+	const char* filename="complex64_sgvec_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_matrix_equal_FLOAT64)
+{
+	SGMatrix<float64_t> a(2, 2);
+	SGMatrix<float64_t> b(2, 2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGMATRIX, ST_NONE, PT_FLOAT64, &a.num_rows, &a.num_cols);
+	TParameter* param1=new TParameter(&type, &a.matrix, "param", "");
+	TParameter* param2=new TParameter(&type, &b.matrix, "param", "");
+
+	const char* filename="float64_sgmat_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Xml_matrix_equal_COMPLEX64)
+{
+	SGMatrix<complex64_t> a(2, 2);
+	SGMatrix<complex64_t> b(2, 2);
+
+	a.set_const(complex64_t(1.14263158, 2.435754));
+	b.zero();
+
+	TSGDataType type(CT_SGMATRIX, ST_NONE, PT_COMPLEX64, &a.num_rows, &a.num_cols);
+	TParameter* param1=new TParameter(&type, &a.matrix, "param", "");
+	TParameter* param2=new TParameter(&type, &b.matrix, "param", "");
+
+	const char* filename="complex64_sgmat_param.xml";
+	// save parameter to a xml file
+	CSerializableXmlFile *file=new CSerializableXmlFile(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a xml file
+	file=new CSerializableXmlFile(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
 
 #endif // HAVE_XML
+
+#ifdef HAVE_HDF5
+TEST(Serialization, Hdf5_scalar_equal_BOOL)
+{
+	bool a=true;
+	bool b=false;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_BOOL);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="bool_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_CHAR)
+{
+	char a='a';
+	char b='b';
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_CHAR);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="char_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_INT8)
+{
+	int8_t a=1;
+	int8_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT8);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int8_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_UINT8)
+{
+	uint8_t a=1;
+	uint8_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT8);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint8_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_INT16)
+{
+	int16_t a=1;
+	int16_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT16);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int16_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_UINT16)
+{
+	uint16_t a=1;
+	uint16_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT16);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint16_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_INT32)
+{
+	int32_t a=1;
+	int32_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT32);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int32_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_UINT32)
+{
+	uint32_t a=1;
+	uint32_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT32);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint32_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_INT64)
+{
+	int64_t a=1;
+	int64_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_INT64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="int64_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_UINT64)
+{
+	uint64_t a=1;
+	uint64_t b=2;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_UINT64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="uint64_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	EXPECT_TRUE(param1->equals(param2));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_FLOAT32)
+{
+	float64_t a=1.71265;
+	float32_t b=0.0;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_FLOAT32);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="float32_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_FLOAT64)
+{
+	float64_t a=1.7126587125;
+	float64_t b=0.0;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_FLOAT64);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="float64_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_scalar_equal_FLOATMAX)
+{
+	floatmax_t a=1.7126587125;
+	floatmax_t b=0.0;
+
+	TSGDataType type(CT_SCALAR, ST_NONE, PT_FLOATMAX);
+	TParameter* param1=new TParameter(&type, &a, "param", "");
+	TParameter* param2=new TParameter(&type, &b, "param", "");
+
+	const char* filename="floatmax_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hd5f_vector_equal_FLOAT64)
+{
+	SGVector<float64_t> a(2);
+	SGVector<float64_t> b(2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGVECTOR, ST_NONE, PT_FLOAT64, &a.vlen);
+	TParameter* param1=new TParameter(&type, &a.vector, "param", "");
+	TParameter* param2=new TParameter(&type, &b.vector, "param", "");
+
+	const char* filename="float64_sgvec_param.hfd5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+TEST(Serialization, Hdf5_matrix_equal_FLOAT64)
+{
+	SGMatrix<float64_t> a(2, 2);
+	SGMatrix<float64_t> b(2, 2);
+
+	a.set_const(1.14263158);
+	b.zero();
+
+	TSGDataType type(CT_SGMATRIX, ST_NONE, PT_FLOAT64, &a.num_rows, &a.num_cols);
+	TParameter* param1=new TParameter(&type, &a.matrix, "param", "");
+	TParameter* param2=new TParameter(&type, &b.matrix, "param", "");
+
+	const char* filename="float64_sgmat_param.hdf5";
+	// save parameter to a hdf5 file
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename, 'w');
+	param1->save(file);
+	file->close();
+	SG_UNREF(file);
+
+	// load parameter from a hdf5 file
+	file=new CSerializableHdf5File(filename, 'r');
+	param2->load(file);
+	file->close();
+	SG_UNREF(file);
+
+	// check for equality
+	float64_t accuracy=0.0;
+	EXPECT_TRUE(param1->equals(param2, accuracy));
+	
+	delete param1;
+	delete param2;
+}
+
+#endif // HAVE_HDF5


### PR DESCRIPTION
- all ptypes covered for all serializable file types. json does not work in unit-tests for char and int data types.
- SGVector<float64_t>, SGVector<complex64_t>, SGMatrix<float64_t>, SGMatrix<complex64_t> tested for all (supported) file types
