### PR TITLE
NNZ: added unit test and fixed get_next_feature()

### DIFF
--- a/src/shogun/features/CombinedDotFeatures.cpp
+++ b/src/shogun/features/CombinedDotFeatures.cpp
@@ -237,8 +237,15 @@ bool CCombinedDotFeatures::get_next_feature(int32_t& index, float64_t& value, vo
 			return true;
 		}
 
+		if (++iterator_idx == get_num_feature_obj())
+		{
+			index = -1;
+			break;
+		}
+
 		it->f->free_feature_iterator(it->iterator);
-		it->f=get_feature_obj(++iterator_idx);
+		SG_UNREF(it->f);
+		it->f=get_feature_obj(iterator_idx);
 		if (it->f)
 			it->iterator=it->f->get_feature_iterator(it->vector_index);
 		else

--- a/tests/unit/features/CombinedDotFeatures_unittest.cc
+++ b/tests/unit/features/CombinedDotFeatures_unittest.cc
@@ -119,6 +119,17 @@ TEST(CombinedDotFeaturesTest, nnz_features)
 		data_2[i] = -i;
 		data_3[i] = 2*i;
 	}
+	/* the concatenation of the first vector of the matrices gives:
+	 * 0, 1, 2, 0, -1, -2, 0, 2, 4
+	 * and so the non-zero features are 1, 2, -1, -2, 2, 4.
+	 */
+	SGVector<float64_t> nnz(6);
+	nnz[0] = 1;
+	nnz[1] = 2;
+	nnz[2] = -1;
+	nnz[3] = -2;
+	nnz[4] = 2;
+	nnz[5] = 4;
 	
 	CCombinedDotFeatures* comb_feat = new CCombinedDotFeatures();
 	CSparseFeatures<float64_t>* feat_1 = new CSparseFeatures<float64_t>(data_1);
@@ -129,11 +140,14 @@ TEST(CombinedDotFeaturesTest, nnz_features)
 	comb_feat->append_feature_obj(feat_3);
 
 	EXPECT_EQ(comb_feat->get_nnz_features_for_vector(0), 6);
-	SG_SPRINT("Before feat_1\n");
-	void* it1=feat_1->get_feature_iterator(0);
-	feat_1->free_feature_iterator(it1);
-	SG_SPRINT("Before first\n");
-	void* itcomb = comb_feat->get_feature_iterator(1);
+	
+	float64_t value=0;
+	int32_t index=0;
+	index_t nnz_index=0;
+	void* itcomb = comb_feat->get_feature_iterator(0);
+	while (comb_feat->get_next_feature(index, value, itcomb))
+		ASSERT_EQ(nnz[nnz_index++], value);
+
 	comb_feat->free_feature_iterator(itcomb);
 	SG_UNREF(comb_feat);
 }


### PR DESCRIPTION
Added a test for the nnz iterator in CCombinedDotFeatures class and fixed an issue with get_next_feature() that caused a memory leak or even a seg fault if used in a while loop (like it is used now) and not in a for loop ( for get_nnz_features_for_vector() times that is ).
