### PR TITLE
Removed m_loss from CStructuredOutputMachine

### DIFF
--- a/examples/undocumented/libshogun/so_multiclass.cpp
+++ b/examples/undocumented/libshogun/so_multiclass.cpp
@@ -111,7 +111,7 @@ int main(int argc, char ** argv)
 
 	// Create SO-SVM
 	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, loss, labels);
-	CDualLibQPBMSOSVM* bundle = new CDualLibQPBMSOSVM(model, loss, labels, 1000);
+	CDualLibQPBMSOSVM* bundle = new CDualLibQPBMSOSVM(model, labels, 1000);
 	bundle->set_verbose(false);
 	SG_REF(sosvm);
 	SG_REF(bundle);

--- a/examples/undocumented/libshogun/so_multiclass_BMRM.cpp
+++ b/examples/undocumented/libshogun/so_multiclass_BMRM.cpp
@@ -14,7 +14,6 @@
 #include <shogun/labels/MulticlassLabels.h>
 #include <shogun/labels/StructuredLabels.h>
 #include <shogun/lib/common.h>
-#include <shogun/loss/HingeLoss.h>
 #include <shogun/machine/LinearMulticlassMachine.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/multiclass/MulticlassOneVsRestStrategy.h>
@@ -200,14 +199,10 @@ int main(int argc, char * argv[])
 	// Create structured model
 	CMulticlassModel* model = new CMulticlassModel(features, labels);
 
-	// Create loss function
-	CHingeLoss* loss = new CHingeLoss();
-
 	// Create SO-SVM
 	CDualLibQPBMSOSVM* sosvm =
 		new CDualLibQPBMSOSVM(
 				model,
-				loss,
 				labels,
 				lambda);
 	SG_REF(sosvm);

--- a/examples/undocumented/python_modular/structure_discrete_hmsvm_bmrm.py
+++ b/examples/undocumented/python_modular/structure_discrete_hmsvm_bmrm.py
@@ -10,7 +10,6 @@ parameter_list=[[data_dict]]
 
 def structure_discrete_hmsvm_bmrm (m_data_dict=data_dict):
 	from shogun.Features   import RealMatrixFeatures
-	from shogun.Loss       import HingeLoss
 	from shogun.Structure  import SequenceLabels, HMSVMModel, Sequence, TwoStateModel, SMT_TWO_STATE
 	from shogun.Evaluation import StructuredAccuracy
 	from shogun.Structure  import DualLibQPBMSOSVM
@@ -23,11 +22,10 @@ def structure_discrete_hmsvm_bmrm (m_data_dict=data_dict):
 	labels = SequenceLabels(labels_array, 250, 500, 2)
 	features = RealMatrixFeatures(m_data_dict['signal'].astype(float), 250, 500)
 
-	loss = HingeLoss()
 	num_obs = 4	# given by the data file used
 	model = HMSVMModel(features, labels, SMT_TWO_STATE, num_obs)
 
-	sosvm = DualLibQPBMSOSVM(model, loss, labels, 5000.0)
+	sosvm = DualLibQPBMSOSVM(model, labels, 5000.0)
 	sosvm.train()
 	#print sosvm.get_w()
 

--- a/examples/undocumented/python_modular/structure_plif_hmsvm_bmrm.py
+++ b/examples/undocumented/python_modular/structure_plif_hmsvm_bmrm.py
@@ -4,13 +4,11 @@ parameter_list=[[100, 250, 10, 2]]
 
 def structure_plif_hmsvm_bmrm (num_examples, example_length, num_features, num_noise_features):
 	from shogun.Features   import RealMatrixFeatures
-	from shogun.Loss       import HingeLoss
 	from shogun.Structure  import TwoStateModel, DualLibQPBMSOSVM
 	from shogun.Evaluation import StructuredAccuracy
 
 	model = TwoStateModel.simulate_data(num_examples, example_length, num_features, num_noise_features)
-	loss = HingeLoss()
-	sosvm = DualLibQPBMSOSVM(model, loss, model.get_labels(), 5000.0)
+	sosvm = DualLibQPBMSOSVM(model, model.get_labels(), 5000.0)
 
 	sosvm.train()
 	#print sosvm.get_w()

--- a/src/shogun/machine/KernelStructuredOutputMachine.cpp
+++ b/src/shogun/machine/KernelStructuredOutputMachine.cpp
@@ -20,10 +20,9 @@ CKernelStructuredOutputMachine::CKernelStructuredOutputMachine()
 
 CKernelStructuredOutputMachine::CKernelStructuredOutputMachine(
 		CStructuredModel*  model,
-		CLossFunction*     loss,
 		CStructuredLabels* labs,
 		CKernel*           kernel)
-: CStructuredOutputMachine(model, loss, labs), m_kernel(NULL)
+: CStructuredOutputMachine(model, labs), m_kernel(NULL)
 {
 	set_kernel(kernel);
 	register_parameters();

--- a/src/shogun/machine/KernelStructuredOutputMachine.h
+++ b/src/shogun/machine/KernelStructuredOutputMachine.h
@@ -27,11 +27,10 @@ class CKernelStructuredOutputMachine : public CStructuredOutputMachine
 		/** standard constructor
 		 *
 		 * @param model structured model with application specific functions
-		 * @param loss loss function
 		 * @param labs structured labels
 		 * @param kernel kernel
 		 */
-		CKernelStructuredOutputMachine(CStructuredModel* model, CLossFunction* loss, CStructuredLabels* labs, CKernel* kernel);
+		CKernelStructuredOutputMachine(CStructuredModel* model, CStructuredLabels* labs, CKernel* kernel);
 
 		/** destructor */
 		virtual ~CKernelStructuredOutputMachine();

--- a/src/shogun/machine/LinearStructuredOutputMachine.cpp
+++ b/src/shogun/machine/LinearStructuredOutputMachine.cpp
@@ -21,9 +21,8 @@ CLinearStructuredOutputMachine::CLinearStructuredOutputMachine()
 
 CLinearStructuredOutputMachine::CLinearStructuredOutputMachine(
 		CStructuredModel*  model, 
-		CLossFunction*     loss, 
 		CStructuredLabels* labs)
-: CStructuredOutputMachine(model, loss, labs)
+: CStructuredOutputMachine(model, labs)
 {
 	register_parameters();
 }

--- a/src/shogun/machine/LinearStructuredOutputMachine.h
+++ b/src/shogun/machine/LinearStructuredOutputMachine.h
@@ -27,10 +27,9 @@ class CLinearStructuredOutputMachine : public CStructuredOutputMachine
 		/** standard constructor
 		 *
 		 * @param model structured model with application specific functions
-		 * @param loss loss function
 		 * @param labs structured labels
 		 */
-		CLinearStructuredOutputMachine(CStructuredModel* model, CLossFunction* loss, CStructuredLabels* labs);
+		CLinearStructuredOutputMachine(CStructuredModel* model, CStructuredLabels* labs);
 
 		/** destructor */
 		virtual ~CLinearStructuredOutputMachine();

--- a/src/shogun/machine/StructuredOutputMachine.cpp
+++ b/src/shogun/machine/StructuredOutputMachine.cpp
@@ -13,19 +13,17 @@
 using namespace shogun;
 
 CStructuredOutputMachine::CStructuredOutputMachine()
-: CMachine(), m_model(NULL), m_loss(NULL)
+: CMachine(), m_model(NULL)
 {
 	register_parameters();
 }
 
 CStructuredOutputMachine::CStructuredOutputMachine(
 		CStructuredModel*  model,
-		CLossFunction*     loss,
 		CStructuredLabels* labs)
-: CMachine(), m_model(model), m_loss(loss)
+: CMachine(), m_model(model)
 {
 	SG_REF(m_model);
-	SG_REF(m_loss);
 	set_labels(labs);
 	register_parameters();
 }
@@ -33,7 +31,6 @@ CStructuredOutputMachine::CStructuredOutputMachine(
 CStructuredOutputMachine::~CStructuredOutputMachine()
 {
 	SG_UNREF(m_model);
-	SG_UNREF(m_loss);
 }
 
 void CStructuredOutputMachine::set_model(CStructuredModel* model)
@@ -49,23 +46,9 @@ CStructuredModel* CStructuredOutputMachine::get_model() const
 	return m_model;
 }
 
-void CStructuredOutputMachine::set_loss(CLossFunction* loss)
-{
-	SG_UNREF(m_loss);
-	SG_REF(loss);
-	m_loss = loss;
-}
-
-CLossFunction* CStructuredOutputMachine::get_loss() const
-{
-	SG_REF(m_loss);
-	return m_loss;
-}
-
 void CStructuredOutputMachine::register_parameters()
 {
 	SG_ADD((CSGObject**)&m_model, "m_model", "Structured model", MS_NOT_AVAILABLE);
-	SG_ADD((CSGObject**)&m_loss, "m_loss", "Structured loss", MS_NOT_AVAILABLE);
 }
 
 void CStructuredOutputMachine::set_labels(CLabels* lab)

--- a/src/shogun/machine/StructuredOutputMachine.h
+++ b/src/shogun/machine/StructuredOutputMachine.h
@@ -14,13 +14,11 @@
 #include <shogun/labels/StructuredLabels.h>
 #include <shogun/lib/StructuredData.h>
 #include <shogun/machine/Machine.h>
-#include <shogun/loss/LossFunction.h>
 #include <shogun/structure/StructuredModel.h>
 
 namespace shogun
 {
 class CStructuredModel;
-class CLossFunction;
 
 /** TODO doc */
 class CStructuredOutputMachine : public CMachine
@@ -35,10 +33,9 @@ class CStructuredOutputMachine : public CMachine
 		/** standard constructor
 		 *
 		 * @param model structured model with application specific functions
-		 * @param loss loss function
 		 * @param labs structured labels
 		 */
-		CStructuredOutputMachine(CStructuredModel* model, CLossFunction* loss, CStructuredLabels* labs);
+		CStructuredOutputMachine(CStructuredModel* model, CStructuredLabels* labs);
 
 		/** destructor */
 		virtual ~CStructuredOutputMachine();
@@ -54,18 +51,6 @@ class CStructuredOutputMachine : public CMachine
 		 * @return structured model
 		 */
 		CStructuredModel* get_model() const;
-
-		/** set loss function
-		 *
-		 * @param loss loss function to set
-		 */
-		void set_loss(CLossFunction* loss);
-
-		/** get loss function
-		 *
-		 * @return loss function
-		 */
-		CLossFunction* get_loss() const;
 
 		/** @return object name */
 		virtual const char* get_name() const
@@ -86,9 +71,6 @@ class CStructuredOutputMachine : public CMachine
 	protected:
 		/** the model that contains the application dependent modules */
 		CStructuredModel* m_model;
-
-		/** the general loss function */
-		CLossFunction* m_loss;
 
 
 }; /* class CStructuredOutputMachine */

--- a/src/shogun/structure/CCSOSVM.cpp
+++ b/src/shogun/structure/CCSOSVM.cpp
@@ -24,7 +24,7 @@ CCCSOSVM::CCCSOSVM()
 }
 
 CCCSOSVM::CCCSOSVM(CStructuredModel* model, SGVector<float64_t> w)
-	: CLinearStructuredOutputMachine(model, NULL, model->get_labels())
+	: CLinearStructuredOutputMachine(model, model->get_labels())
 {
 	init();
 

--- a/src/shogun/structure/DualLibQPBMSOSVM.cpp
+++ b/src/shogun/structure/DualLibQPBMSOSVM.cpp
@@ -23,11 +23,10 @@ CDualLibQPBMSOSVM::CDualLibQPBMSOSVM()
 
 CDualLibQPBMSOSVM::CDualLibQPBMSOSVM(
 		CStructuredModel*   	model,
-		CLossFunction*      	loss,
 		CStructuredLabels*  	labs,
 		float64_t           	_lambda,
 		SGVector< float64_t >	W)
- : CLinearStructuredOutputMachine(model, loss, labs)
+ : CLinearStructuredOutputMachine(model, labs)
 {
 	set_TolRel(0.001);
 	set_TolAbs(0.0);

--- a/src/shogun/structure/DualLibQPBMSOSVM.h
+++ b/src/shogun/structure/DualLibQPBMSOSVM.h
@@ -53,14 +53,12 @@ class CDualLibQPBMSOSVM : public CLinearStructuredOutputMachine
 		/** constructor
 		 *
 		 * @param model 		Structured Model
-		 * @param loss			Loss function
 		 * @param labs			Structured labels
 		 * @param _lambda		Regularization constant
 		 * @param W				initial solution of weight vector
 		 */
 		CDualLibQPBMSOSVM(
 				CStructuredModel* 		model,
-				CLossFunction* 			loss,
 				CStructuredLabels* 		labs,
 				float64_t 				_lambda,
 				SGVector< float64_t > 	W=0);

--- a/src/shogun/structure/PrimalMosekSOSVM.h
+++ b/src/shogun/structure/PrimalMosekSOSVM.h
@@ -74,6 +74,18 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 		 */
 		void set_regularization(float64_t C);
 
+		/** set loss function
+		 *
+		 * @param loss loss function to set
+		 */
+		void set_surrogate_loss(CLossFunction* loss);
+
+		/** get loss function
+		 *
+		 * @return loss function
+		 */
+		CLossFunction* get_surrogate_loss() const;
+
 	protected:
 		/** train primal SO-SVM
 		 *
@@ -125,6 +137,9 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 		bool add_constraint(CMosek* mosek, CResultSet* result, index_t con_idx, index_t train_idx) const;
 
 	private:
+		/** the surrogate loss */
+		CLossFunction* m_surrogate_loss;
+
 		/** slack variables associated to each training example */
 		SGVector< float64_t > m_slacks;
 


### PR DESCRIPTION
The m_loss has been removed from CStructuredOutputMachine, since this depends on particular solver. A attribute m_surrogate_loss has been added to CPrimalMosekSOSVM, which plays the same role as m_loss before. 

@ppletscher, @iglesias, @vigsterkr What do you think this change? Other points may also need to refine. I haven't done that because there are already lots of files involved.
- These functions put in CStructuredOutputMachine better:
  float64_t CStructuredModel::risk(float64_t\* subgrad, float64_t\* W, TMultipleCPinfo\* info=0);
  void CStructuredModel::init_opt(...);
- CFeatures\* CLinearStructuredOutputMachine:: m_features; seems never
  being used, and it's not necessary, since we got m_features in CStructuredModel.

If you think these are okay, I'll update later in this PR.
