### PR TITLE
few base classes and implementations for the log-det framework added

### DIFF
--- a/src/shogun/lib/computation/job/DenseExactLogJob.cpp
+++ b/src/shogun/lib/computation/job/DenseExactLogJob.cpp
@@ -1,0 +1,92 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#include <shogun/lib/common.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/computation/job/ScalarResult.h>
+#include <shogun/mathematics/logdet/DenseMatrixOperator.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/lib/computation/job/DenseExactLogJob.h>
+
+using namespace Eigen;
+
+namespace shogun
+{
+
+CDenseExactLogJob::CDenseExactLogJob()
+	: CIndependentJob(), m_log_operator(NULL)
+{
+	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+}
+
+CDenseExactLogJob::CDenseExactLogJob(CJobResultAggregator* aggregator)
+	: CIndependentJob(aggregator), m_log_operator(NULL)
+{
+	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+}
+
+CDenseExactLogJob::~CDenseExactLogJob()
+{
+	SG_UNREF(m_log_operator);
+	SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
+}
+
+void CDenseExactLogJob::compute()
+{
+	SG_DEBUG("Entering...\n")
+
+	// apply the log to m_vector
+	SGVector<float64_t> vec=m_log_operator->apply(m_vector);
+
+	// compute the vector-vector dot product using Eigen3
+	Map<VectorXd> v(vec.vector, vec.vlen);
+	Map<VectorXd> s(m_vector.vector, m_vector.vlen);
+	
+	CScalarResult<float64_t>* result=new CScalarResult<float64_t>(s.dot(v));
+	SG_REF(result);
+	m_aggregator->submit_result(result);
+	SG_UNREF(result);
+
+	SG_DEBUG("Leaving...\n")
+}
+
+SGVector<float64_t> CDenseExactLogJob::get_vector() const
+{
+	return m_vector;
+}
+
+void CDenseExactLogJob::set_vector(SGVector<float64_t> vec)
+{
+	m_vector=vec;
+}
+
+CDenseMatrixOperator<float64_t>* CDenseExactLogJob::get_operator() const
+{
+	return m_log_operator;
+}
+
+void CDenseExactLogJob::set_operator(CDenseMatrixOperator<float64_t>* op)
+{
+	// DEBUG COMMENT: SG_REF should increase here!!
+	// Its important that we first increase the refcount and then
+	// decrease it. Param might be same, for example, and unref-ing it
+	// first may accidentally delete it!
+	// The following is surely a weird way, but works!
+	CDenseMatrixOperator<float64_t>* old_op=m_log_operator;
+	SG_UNREF(m_log_operator);
+	m_log_operator=op;
+	SG_REF(m_log_operator);
+	SG_UNREF(old_op);
+}
+
+}
+#endif // HAVE_EIGEN3

--- a/src/shogun/lib/computation/job/DenseExactLogJob.h
+++ b/src/shogun/lib/computation/job/DenseExactLogJob.h
@@ -1,0 +1,70 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#ifndef DENSE_EXACT_LOG_JOB_H_
+#define DENSE_EXACT_LOG_JOB_H_
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/computation/job/IndependentJob.h>
+
+namespace shogun
+{
+template<class T> class SGVector;
+template<class T> class CDenseMatrixOperator;
+
+/** @brief Class that represents the job of applying the log of
+ * a CDenseMatrixOperator on a real vector
+ */
+class CDenseExactLogJob : public CIndependentJob
+{
+public:
+	/** default constructor, no args */
+	CDenseExactLogJob();
+
+	/** default constructor, one arg */
+	CDenseExactLogJob(CJobResultAggregator* aggregator);
+
+	/** destructor */
+	virtual ~CDenseExactLogJob();
+
+	/** implementation of compute method for the job */
+	virtual void compute();
+
+	/** get the vector */
+	SGVector<float64_t> get_vector() const;
+
+	/** set the vector */
+	void set_vector(SGVector<float64_t> vec);
+
+	/** get the linear operator */
+	CDenseMatrixOperator<float64_t>* get_operator() const;
+
+	/** set the linear operator */
+	void set_operator(CDenseMatrixOperator<float64_t>* op);
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "CDenseExactLogJob";
+	}
+
+private:
+	/** the log of a CDenseMatrixOperator<float64_t> */
+	CDenseMatrixOperator<float64_t>* m_log_operator;
+
+	/** the trace-sample */
+	SGVector<float64_t> m_vector;
+};
+
+}
+
+#endif // HAVE_EIGEN3
+#endif // DENSE_EXACT_LOG_JOB_H_

--- a/src/shogun/lib/computation/job/IndependentJob.h
+++ b/src/shogun/lib/computation/job/IndependentJob.h
@@ -1,0 +1,67 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#ifndef INDEPENDENT_JOB_H_
+#define INDEPENDENT_JOB_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/base/SGObject.h>
+#include <shogun/lib/computation/job/JobResultAggregator.h>
+
+namespace shogun
+{
+
+/** @brief Abstract base for general computation jobs to be registered
+ * in CIndependentComputationEngine. compute method produces a job result
+ * and submits it to the internal JobResultAggregator. Each set of jobs
+ * that form a result will share the same job result aggregator.
+ */
+class CIndependentJob : public CSGObject
+{
+public:
+	/** default constructor, no args */
+	CIndependentJob()
+	: CSGObject(), m_aggregator(NULL)
+	{
+		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+	}
+
+	/** default constructor, one arg */
+	CIndependentJob(CJobResultAggregator* aggregator)
+	: CSGObject(), m_aggregator(aggregator)
+	{
+		SG_REF(m_aggregator);
+		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+	}
+
+	/** destructor */
+	virtual ~CIndependentJob()
+	{
+		SG_UNREF(m_aggregator);
+		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
+	}
+
+	/** abstract compute method that computes the job, creates a CJobResult,
+	 * submits the result to the job result aggregator
+	 */
+	virtual void compute() = 0;
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "CIndependentJob";
+	}
+protected:
+	/** the job result aggregator for the current job */
+	CJobResultAggregator* m_aggregator;
+};
+
+}
+
+#endif // INDEPENDENT_JOB_H_

--- a/src/shogun/lib/computation/job/JobResultAggregator.h
+++ b/src/shogun/lib/computation/job/JobResultAggregator.h
@@ -1,0 +1,70 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#ifndef JOB_RESULT_AGGREGATOR_H_
+#define JOB_RESULT_AGGREGATOR_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/base/SGObject.h>
+#include <shogun/lib/computation/job/JobResult.h>
+
+namespace shogun
+{
+
+/** @brief Abstract base class that provides an interface for computing an
+ * aggeregation of the job results of independent computation jobs as
+ * they are submitted and also for finalizing the aggregation.
+ */
+class CJobResultAggregator : public CSGObject
+{
+public:
+	/** default constructor */
+	CJobResultAggregator()
+	: CSGObject(), m_result(NULL)
+	{
+		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+	}
+
+	/** destructor */
+	virtual ~CJobResultAggregator()
+	{
+		SG_UNREF(m_result);
+		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
+	}
+
+	/** abstract method that submits the result of an independent job, and
+	 * computes the aggregation with the previously submitted result
+	 * @param the result of an independent job
+	 */
+	virtual void submit_result(CJobResult* result) = 0;
+
+	/** abstract method that finalizes the aggregation and computes the result,
+	 * its necessary to call finalize before getting the final result
+	 */
+	virtual void finalize() = 0;
+
+	/** @return the final result */
+	CJobResult* get_final_result() const
+	{
+		return m_result;
+	}
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "CJobResultAggregator";
+	}
+protected:
+	/** the final job result */
+	CJobResult* m_result;
+};
+
+}
+
+#endif // JOB_RESULT_AGGREGATOR_H_

--- a/src/shogun/lib/computation/job/StoreScalarAggregator.cpp
+++ b/src/shogun/lib/computation/job/StoreScalarAggregator.cpp
@@ -1,0 +1,78 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#include <shogun/lib/common.h>
+#include <shogun/lib/computation/job/ScalarResult.h>
+#include <shogun/lib/computation/job/StoreScalarAggregator.h>
+
+namespace shogun
+{
+template<class T>
+CStoreScalarAggregator<T>::CStoreScalarAggregator()
+	: CJobResultAggregator(), m_aggregate(static_cast<T>(0))
+	{
+		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+	}
+
+template<class T>
+CStoreScalarAggregator<T>::~CStoreScalarAggregator()
+	{
+		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
+	}
+
+template<class T>
+void CStoreScalarAggregator<T>::submit_result(CJobResult* result)
+	{
+		SG_GCDEBUG("Entering ...\n")
+
+		// check for proper typecast
+		// DEBUG COMMENT : the following does NOT increase refcount of result
+		CScalarResult<T>* new_result=dynamic_cast<CScalarResult<T>*>(result);
+		if (!new_result)
+			SG_ERROR("result is not of CScalarResult type!\n");
+		// aggregate it with previous
+		m_aggregate+=new_result->get_result();
+
+		SG_GCDEBUG("Leaving ...\n")
+	}
+
+template<>
+void CStoreScalarAggregator<bool>::submit_result(CJobResult* result)
+	{
+		SG_NOTIMPLEMENTED
+	}
+
+template<>
+void CStoreScalarAggregator<char>::submit_result(CJobResult* result)
+	{
+		SG_NOTIMPLEMENTED
+	}
+
+template<class T>
+void CStoreScalarAggregator<T>::finalize()
+	{
+		m_result=(CJobResult*)(new CScalarResult<T>(m_aggregate));
+		SG_REF(m_result);
+	}
+
+template class CStoreScalarAggregator<bool>;
+template class CStoreScalarAggregator<char>;
+template class CStoreScalarAggregator<int8_t>;
+template class CStoreScalarAggregator<uint8_t>;
+template class CStoreScalarAggregator<int16_t>;
+template class CStoreScalarAggregator<uint16_t>;
+template class CStoreScalarAggregator<int32_t>;
+template class CStoreScalarAggregator<uint32_t>;
+template class CStoreScalarAggregator<int64_t>;
+template class CStoreScalarAggregator<uint64_t>;
+template class CStoreScalarAggregator<float32_t>;
+template class CStoreScalarAggregator<float64_t>;
+template class CStoreScalarAggregator<floatmax_t>;
+template class CStoreScalarAggregator<complex64_t>;
+}

--- a/src/shogun/lib/computation/job/StoreScalarAggregator.h
+++ b/src/shogun/lib/computation/job/StoreScalarAggregator.h
@@ -1,0 +1,57 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#ifndef STORE_SCALAR_AGGREGATOR_H_
+#define STORE_SCALAR_AGGREGATOR_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/computation/job/JobResultAggregator.h>
+
+namespace shogun
+{
+class CJobResult;
+template<class T> class CScalarResult;
+
+/** @brief Template class that aggregates scalar job results in each
+ * submit_result call, finalize then transforms current aggregation into
+ * a CScalarResult.
+ */
+template<class T> class CStoreScalarAggregator : public CJobResultAggregator
+{
+public:
+	/** default constructor, no args */
+	CStoreScalarAggregator();
+
+	/** destructor */
+	virtual ~CStoreScalarAggregator();
+
+	/** method that submits the result (scalar) of an independent job, and
+	 * computes the aggregation with the previously submitted result
+	 * @param the result of an independent job
+	 */
+	virtual void submit_result(CJobResult* result);
+
+	/** method that finalizes the aggregation and computes the result (scalar),
+	 * its necessary to call finalize before getting the final result
+	 */
+	virtual void finalize();
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "CStoreScalarAggregator";
+	}
+private:
+	/** the aggregation */
+	T m_aggregate;
+};
+
+}
+
+#endif // STORE_SCALAR_AGGREGATOR_H_

--- a/tests/unit/lib/computation/StoreScalarAggregator_unittest.cc
+++ b/tests/unit/lib/computation/StoreScalarAggregator_unittest.cc
@@ -1,0 +1,36 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Soumyajit De
+ */
+ 
+#include <shogun/lib/common.h>
+#include <shogun/lib/computation/job/ScalarResult.h>
+#include <shogun/lib/computation/job/StoreScalarAggregator.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(StoreScalarAggregator, submit_result)
+{
+	CStoreScalarAggregator<float64_t>* agg=new CStoreScalarAggregator<float64_t>;
+	const index_t num_results=10;
+
+	for (index_t i=0; i<num_results; ++i)
+	{
+		CScalarResult<float64_t>* result
+			=new CScalarResult<float64_t>((float64_t)i);
+		agg->submit_result((CJobResult*)result);
+		delete result;
+	}
+	agg->finalize();
+	float64_t result=dynamic_cast<CScalarResult<float64_t>*>
+		(agg->get_final_result())->get_result();
+
+	EXPECT_NEAR(result, 45.0, 1E-16);
+	delete agg;
+}
+

--- a/tests/unit/mathematics/logdet/DenseExactLogJob_unittest.cc
+++ b/tests/unit/mathematics/logdet/DenseExactLogJob_unittest.cc
@@ -1,0 +1,75 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Soumyajit De
+ */
+ 
+#include <shogun/lib/common.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/mathematics/eigen3.h>
+
+#if EIGEN_VERSION_AT_LEAST(3,1,0)
+#include <unsupported/Eigen/MatrixFunctions>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/mathematics/logdet/DenseMatrixOperator.h>
+#include <shogun/lib/computation/job/ScalarResult.h>
+#include <shogun/lib/computation/job/StoreScalarAggregator.h>
+#include <shogun/lib/computation/job/DenseExactLogJob.h>
+#include <shogun/mathematics/Statistics.h>
+#include <gtest/gtest.h>
+
+using namespace Eigen;
+using namespace shogun;
+
+TEST(DenseExactLogJob, log_det)
+{
+	const index_t size=2;
+
+	// create the matrix whose log-det has to be found
+	SGMatrix<float64_t> mat(size, size);
+	SGMatrix<float64_t> log_mat(size, size);
+	mat(0,0)=2.0;
+	mat(0,1)=1.0;
+	mat(1,0)=1.0;
+	mat(1,1)=3.0;
+	Map<MatrixXd> m(mat.matrix, mat.num_rows, mat.num_cols);
+	Map<MatrixXd> log_m(log_mat.matrix, log_mat.num_rows, log_mat.num_cols);
+	log_m=m.log();
+
+	// create linear operator and aggregator	
+	CDenseMatrixOperator<float64_t>* log_op=new CDenseMatrixOperator<float64_t>
+		(log_mat);
+	SG_REF(log_op);
+	CStoreScalarAggregator<float64_t>* agg=new CStoreScalarAggregator<float64_t>;
+	SG_REF(agg);
+
+	// create jobs with unit-vectors to extract the trace of log(mat)
+	for (index_t i=0; i<size; ++i)
+	{
+		SGVector<float64_t> s(size);
+		s.set_const(0.0);
+		s[i]=1.0;
+		CDenseExactLogJob *job=new CDenseExactLogJob((CJobResultAggregator*)agg);
+		job->set_operator(log_op);
+		job->set_vector(s);
+		job->compute();
+		delete job;
+	}
+	// its really important we call finalize before getting the final result
+	agg->finalize();
+
+	CScalarResult<float64_t>* r=dynamic_cast<CScalarResult<float64_t>*>
+		(agg->get_final_result());
+	
+	EXPECT_NEAR(r->get_result(), CStatistics::log_det(mat), 1E-16);
+
+	SG_UNREF(log_op);
+	SG_UNREF(agg);
+}
+#endif // EIGEN_VERSION_AT_LEAST(3,1,0)
+#endif // HAVE_EIGEN3


### PR DESCRIPTION
Added
- base class CJobResultAggregator, implementation CStoreScalarAggregator, a unit-test for it
- base class CIndependentJob, implementation CDenseExactLogJob, a unit-test for it
