### PR TITLE
Enabled/fixed streaming_onlineliblinear example

### DIFF
--- a/examples/undocumented/libshogun/Makefile
+++ b/examples/undocumented/libshogun/Makefile
@@ -111,6 +111,7 @@ TARGETS = basic_minimal \
   		  base_migration_new_buggy \
   		  regression_libsvr \
   		  classifier_multiclass_prob_heuristics \
+		  streaming_onlineliblinear \
   		  
 
 all: $(TARGETS)

--- a/examples/undocumented/libshogun/streaming_onlineliblinear.cpp
+++ b/examples/undocumented/libshogun/streaming_onlineliblinear.cpp
@@ -13,8 +13,8 @@
 
 #include <shogun/lib/common.h>
 
-#include <shogun/io/StreamingAsciiFile.h>
-#include <shogun/features/StreamingDenseFeatures.h>
+#include <shogun/io/streaming/StreamingAsciiFile.h>
+#include <shogun/features/streaming/StreamingDenseFeatures.h>
 #include <shogun/classifier/svm/OnlineLibLinear.h>
 
 using namespace shogun;
@@ -30,7 +30,7 @@ int main()
 
 	// The bool value is true if examples are labelled.
 	// 1024 is a good standard value for the number of examples for the parser to hold at a time.
-	CStreamingDenseFeatures<float64_t>* train_features = new CStreamingDenseFeatures<float64_t>(train_file, true, 1024);
+	CStreamingDenseFeatures<float32_t>* train_features = new CStreamingDenseFeatures<float32_t>(train_file, true, 1024);
 	SG_REF(train_features);
 
 	// Create an OnlineLiblinear object from the features. The first parameter is 'C'.
@@ -57,6 +57,7 @@ int main()
 		SG_SPRINT("For example %d, predicted label is %f.\n", i, test_labels->get_label(i));
 
 	SG_UNREF(test_features);
+	SG_UNREF(test_labels);
 	SG_UNREF(test_file);
 	SG_UNREF(train_features);
 	SG_UNREF(train_file);

--- a/src/shogun/machine/OnlineLinearMachine.cpp
+++ b/src/shogun/machine/OnlineLinearMachine.cpp
@@ -75,6 +75,7 @@ SGVector<float64_t> COnlineLinearMachine::apply_get_outputs(CFeatures* data)
 	for (int32_t i=0; i<num_labels; i++)
 		labels_array.vector[i]=(*labels_dynarray)[i];
 
+	delete labels_dynarray;
 	return labels_array;
 }
 


### PR DESCRIPTION
In streaming_onlineliblinear example:
- Fixed streaming header includes (have been moved to streaming subfolders).
- Fixed dynamic_cast from CStreamingDenseFeatures<float64_t> to CStreamingDenseFeatures<float32_t>.
- Fixed memory leak
- Added streaming_onlineliblinear to target list in examples Makefile

In OnlineLinearMachine:
- Fixed small memory leak (did not free DynArray).
