### PR TITLE
move risk() from StructuredModel to DualLibQPSOSVM

### DIFF
--- a/examples/undocumented/libshogun/so_hmsvm_mosek.cpp
+++ b/examples/undocumented/libshogun/so_hmsvm_mosek.cpp
@@ -17,9 +17,9 @@ int main(int argc, char ** argv)
 	CStructuredLabels* labels = model->get_labels();
 	CFeatures* features = model->get_features();
 
-	CHingeLoss* loss = new CHingeLoss();
+	// CHingeLoss* loss = new CHingeLoss();
 
-	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, loss, labels);
+	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, labels);
 	SG_REF(sosvm);
 
 	sosvm->train();

--- a/examples/undocumented/libshogun/so_hmsvm_mosek_simple.cpp
+++ b/examples/undocumented/libshogun/so_hmsvm_mosek_simple.cpp
@@ -48,8 +48,7 @@ int main(int argc, char ** argv)
 
 	CHMSVMModel* model = new CHMSVMModel(features, labels, SMT_TWO_STATE, 3);
 	SG_REF(model);
-	CHingeLoss* loss = new CHingeLoss();
-	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, loss, labels);
+	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, labels);
 	SG_REF(sosvm);
 
 	sosvm->train();

--- a/examples/undocumented/libshogun/so_multiclass.cpp
+++ b/examples/undocumented/libshogun/so_multiclass.cpp
@@ -106,11 +106,8 @@ int main(int argc, char ** argv)
 	// Create structured model
 	CMulticlassModel* model = new CMulticlassModel(features, labels);
 
-	// Create loss function
-	CHingeLoss* loss = new CHingeLoss();
-
 	// Create SO-SVM
-	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, loss, labels);
+	CPrimalMosekSOSVM* sosvm = new CPrimalMosekSOSVM(model, labels);
 	CDualLibQPBMSOSVM* bundle = new CDualLibQPBMSOSVM(model, labels, 1000);
 	bundle->set_verbose(false);
 	SG_REF(sosvm);

--- a/examples/undocumented/python_modular/graphical/so_multiclass_BMRM.py
+++ b/examples/undocumented/python_modular/graphical/so_multiclass_BMRM.py
@@ -4,7 +4,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from shogun.Features 	import RealFeatures
-from shogun.Loss     	import HingeLoss
 from shogun.Structure	import MulticlassModel, MulticlassSOLabels, RealNumber, DualLibQPBMSOSVM
 from shogun.Structure 	import BMRM, PPBMRM, P3BMRM
 from shogun.Evaluation 	import StructuredAccuracy
@@ -53,10 +52,9 @@ labels = MulticlassSOLabels(y)
 features = RealFeatures(X.T)
 
 model = MulticlassModel(features, labels)
-loss = HingeLoss()
 
 lambda_ = 1e1
-sosvm = DualLibQPBMSOSVM(model, loss, labels, lambda_)
+sosvm = DualLibQPBMSOSVM(model, labels, lambda_)
 
 sosvm.set_cleanAfter(10)	# number of iterations that cutting plane has to be inactive for to be removed
 sosvm.set_cleanICP(True)	# enables inactive cutting plane removal feature

--- a/examples/undocumented/python_modular/graphical/so_multiclass_director_BMRM.py
+++ b/examples/undocumented/python_modular/graphical/so_multiclass_director_BMRM.py
@@ -4,7 +4,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from shogun.Features 	import RealFeatures
-from shogun.Loss     	import HingeLoss
 from shogun.Structure	import MulticlassModel, MulticlassSOLabels, RealNumber, DualLibQPBMSOSVM, DirectorStructuredModel
 from shogun.Structure 	import BMRM, PPBMRM, P3BMRM, ResultSet, RealVector
 from shogun.Evaluation 	import StructuredAccuracy
@@ -18,8 +17,6 @@ class MulticlassStructuredModel(DirectorStructuredModel):
 		self.n_classes = labels.get_num_classes()
 		self.n_feats = features.get_dim_feature_space()
 		#self.use_director_risk()
-	def director_risk(self,subgrad,w,params):
-		return 0.0
 	def get_dim(self):
 		return self.dim
 	def argmax(self,w,feat_idx,training):
@@ -101,10 +98,9 @@ labels = MulticlassSOLabels(y)
 features = RealFeatures(X.T)
 
 model = MulticlassStructuredModel(features, labels)
-loss = HingeLoss()
 
 lambda_ = 1e1
-sosvm = DualLibQPBMSOSVM(model, loss, labels, lambda_)
+sosvm = DualLibQPBMSOSVM(model, labels, lambda_)
 
 sosvm.set_cleanAfter(10)	# number of iterations that cutting plane has to be inactive for to be removed
 sosvm.set_cleanICP(True)	# enables inactive cutting plane removal feature

--- a/examples/undocumented/python_modular/so_multiclass.py
+++ b/examples/undocumented/python_modular/so_multiclass.py
@@ -28,7 +28,6 @@ parameter_list = [[traindat,label_traindat]]
 def so_multiclass (fm_train_real=traindat,label_train_multiclass=label_traindat):
 	try:
 		from shogun.Features 	import RealFeatures
-		from shogun.Loss     	import HingeLoss
 		from shogun.Structure	import MulticlassModel, MulticlassSOLabels, PrimalMosekSOSVM, RealNumber
 	except ImportError:
 		print("Mosek not available")
@@ -38,8 +37,7 @@ def so_multiclass (fm_train_real=traindat,label_train_multiclass=label_traindat)
 	features = RealFeatures(fm_train_real.T)
 
 	model = MulticlassModel(features, labels)
-	loss = HingeLoss()
-	sosvm = PrimalMosekSOSVM(model, loss, labels)
+	sosvm = PrimalMosekSOSVM(model, labels)
 	sosvm.train()
 
 	out = sosvm.apply()

--- a/examples/undocumented/python_modular/structure_discrete_hmsvm_mosek.py
+++ b/examples/undocumented/python_modular/structure_discrete_hmsvm_mosek.py
@@ -10,7 +10,6 @@ parameter_list=[[data_dict]]
 
 def structure_discrete_hmsvm_mosek (m_data_dict=data_dict):
 	from shogun.Features   import RealMatrixFeatures
-	from shogun.Loss       import HingeLoss
 	from shogun.Structure  import SequenceLabels, HMSVMModel, Sequence, TwoStateModel, SMT_TWO_STATE
 	from shogun.Evaluation import StructuredAccuracy
 
@@ -28,11 +27,10 @@ def structure_discrete_hmsvm_mosek (m_data_dict=data_dict):
 	labels = SequenceLabels(labels_array, 250, 500, 2)
 	features = RealMatrixFeatures(m_data_dict['signal'].astype(float), 250, 500)
 
-	loss = HingeLoss()
 	num_obs = 4	# given by the data file used
 	model = HMSVMModel(features, labels, SMT_TWO_STATE, num_obs)
 
-	sosvm = PrimalMosekSOSVM(model, loss, labels)
+	sosvm = PrimalMosekSOSVM(model, labels)
 	sosvm.train()
 	#print(sosvm.get_w())
 

--- a/examples/undocumented/python_modular/structure_plif_hmsvm_mosek.py
+++ b/examples/undocumented/python_modular/structure_plif_hmsvm_mosek.py
@@ -4,7 +4,6 @@ parameter_list=[[100, 250, 10, 2]]
 
 def structure_plif_hmsvm_mosek (num_examples, example_length, num_features, num_noise_features):
 	from shogun.Features   import RealMatrixFeatures
-	from shogun.Loss       import HingeLoss
 	from shogun.Structure  import TwoStateModel
 	from shogun.Evaluation import StructuredAccuracy
 
@@ -15,8 +14,7 @@ def structure_plif_hmsvm_mosek (num_examples, example_length, num_features, num_
 		return
 
 	model = TwoStateModel.simulate_data(num_examples, example_length, num_features, num_noise_features)
-	loss = HingeLoss()
-	sosvm = PrimalMosekSOSVM(model, loss, model.get_labels())
+	sosvm = PrimalMosekSOSVM(model, model.get_labels())
 
 	sosvm.train()
 	#print(sosvm.get_w())

--- a/src/interfaces/modular/modshogun_ignores.i
+++ b/src/interfaces/modular/modshogun_ignores.i
@@ -31,10 +31,9 @@
 
 
 #ifdef SWIGCSHARP
-%ignore shogun::CStructuredModel::director_risk;
 %ignore shogun::CKernelMachine::CKernelMachine(CKernel* k, const SGVector<float64_t> alphas, const SGVector<int32_t> svs, float64_t b);
 %ignore shogun::SGMatrix::matrix_multiply;
-%ignore shogun::CStructuredModel::init_opt;
+%ignore shogun::CStructuredModel::init_primal_opt;
 %ignore shogun::CIndexBlockTree::CIndexBlockTree(SGVector<float64_t> G, SGVector<float64_t> ind_t);
 %ignore shogun::CMulticlassStrategy::rescale_outputs(SGVector<float64_t> outputs, const SGVector<float64_t> As, const SGVector<float64_t> Bs);
 %ignore shogun::CMulticlassOneVsRestStrategy::rescale_outputs(SGVector<float64_t> outputs, const SGVector<float64_t> As, const SGVector<float64_t> Bs);

--- a/src/shogun/machine/LinearStructuredOutputMachine.cpp
+++ b/src/shogun/machine/LinearStructuredOutputMachine.cpp
@@ -31,16 +31,6 @@ CLinearStructuredOutputMachine::~CLinearStructuredOutputMachine()
 {
 }
 
-void CLinearStructuredOutputMachine::set_features(CFeatures* f)
-{
-	m_model->set_features(f);
-}
-
-CFeatures* CLinearStructuredOutputMachine::get_features() const
-{
-	return m_model->get_features();
-}
-
 void CLinearStructuredOutputMachine::set_w(SGVector< float64_t > w)
 {
 	m_w = w;

--- a/src/shogun/machine/LinearStructuredOutputMachine.h
+++ b/src/shogun/machine/LinearStructuredOutputMachine.h
@@ -34,18 +34,6 @@ class CLinearStructuredOutputMachine : public CStructuredOutputMachine
 		/** destructor */
 		virtual ~CLinearStructuredOutputMachine();
 
-		/** set features
-		 *
-		 * @param f features
-		 */
-		void set_features(CFeatures* f);
-
-		/** get features
-		 *
-		 * @return features
-		 */
-		CFeatures* get_features() const;
-
 		/** set w (useful for modular interfaces)
 		 *
 		 * @param w weight vector to set
@@ -85,9 +73,6 @@ class CLinearStructuredOutputMachine : public CStructuredOutputMachine
 		void register_parameters();
 
 	protected:
-		/** feature vectors */
-		CFeatures* m_features;
-
 		/** weight vector */
 		SGVector< float64_t > m_w;
 

--- a/src/shogun/structure/DirectorStructuredModel.cpp
+++ b/src/shogun/structure/DirectorStructuredModel.cpp
@@ -53,7 +53,7 @@ bool CDirectorStructuredModel::check_training_setup() const
 	return false;
 }
 
-void CDirectorStructuredModel::init_opt(
+void CDirectorStructuredModel::init_primal_opt(
 		float64_t regularization,
 		SGMatrix< float64_t > & A,
 		SGVector< float64_t > a,
@@ -63,7 +63,7 @@ void CDirectorStructuredModel::init_opt(
 		SGVector< float64_t > ub,
 		SGMatrix< float64_t > & C)
 {
-	SG_ERROR("Please implemement init_opt(regularization,A,a,B,b,lb,ub,C) in your target language before use\n")
+	SG_ERROR("Please implemement init_primal_opt(regularization,A,a,B,b,lb,ub,C) in your target language before use\n")
 }
 
 void CDirectorStructuredModel::init_training()

--- a/src/shogun/structure/DirectorStructuredModel.h
+++ b/src/shogun/structure/DirectorStructuredModel.h
@@ -98,17 +98,13 @@ IGNORE_IN_CLASSLIST class CDirectorStructuredModel : public CStructuredModel
 		 * @param ub
 		 * @param C
 		 */
-		virtual void init_opt(
+		virtual void init_primal_opt(
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
 				SGVector< float64_t > lb, SGVector< float64_t > ub,
 				SGMatrix < float64_t > & C);
 		
-		using CStructuredModel::director_risk;
-
-		using CStructuredModel::risk;
-
 		/** @return name of SGSerializable */
 		virtual const char* get_name() const { return "DirectorStructuredModel"; }
 

--- a/src/shogun/structure/DualLibQPBMSOSVM.cpp
+++ b/src/shogun/structure/DualLibQPBMSOSVM.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <shogun/structure/DualLibQPBMSOSVM.h>
+#include <shogun/structure/libbmrm.h>
 #include <shogun/structure/libppbm.h>
 #include <shogun/structure/libp3bm.h>
 #include <shogun/structure/libncbm.h>
@@ -93,22 +94,22 @@ bool CDualLibQPBMSOSVM::train_machine(CFeatures* data)
 	switch(m_solver)
 	{
 		case BMRM:
-			m_result=svm_bmrm_solver(m_model, m_w.vector, m_TolRel, m_TolAbs,
+			m_result=svm_bmrm_solver(this, m_w.vector, m_TolRel, m_TolAbs,
 					m_lambda, m_BufSize, m_cleanICP, m_cleanAfter, m_K, m_Tmax,
 					m_verbose);
 			break;
 		case PPBMRM:
-			m_result=svm_ppbm_solver(m_model, m_w.vector, m_TolRel, m_TolAbs,
+			m_result=svm_ppbm_solver(this, m_w.vector, m_TolRel, m_TolAbs,
 					m_lambda, m_BufSize, m_cleanICP, m_cleanAfter, m_K, m_Tmax,
 					m_verbose);
 			break;
 		case P3BMRM:
-			m_result=svm_p3bm_solver(m_model, m_w.vector, m_TolRel, m_TolAbs,
+			m_result=svm_p3bm_solver(this, m_w.vector, m_TolRel, m_TolAbs,
 					m_lambda, m_BufSize, m_cleanICP, m_cleanAfter, m_K, m_Tmax,
 					m_cp_models, m_verbose);
 			break;
 		case NCBM:
-			m_result=svm_ncbm_solver(m_model, m_w.vector, m_TolRel, m_TolAbs,
+			m_result=svm_ncbm_solver(this, m_w.vector, m_TolRel, m_TolAbs,
 					m_lambda, m_BufSize, m_cleanICP, m_cleanAfter, true /* convex */,
 					true /* use line search*/, m_verbose);
 	}

--- a/src/shogun/structure/DualLibQPBMSOSVM.h
+++ b/src/shogun/structure/DualLibQPBMSOSVM.h
@@ -12,7 +12,6 @@
 #define _DUALLIBQPBMSOSVM__H__
 
 #include <shogun/machine/LinearStructuredOutputMachine.h>
-#include <shogun/structure/libbmrm.h>
 #include <shogun/features/DotFeatures.h>
 
 namespace shogun

--- a/src/shogun/structure/HMSVMModel.cpp
+++ b/src/shogun/structure/HMSVMModel.cpp
@@ -349,7 +349,7 @@ float64_t CHMSVMModel::delta_loss(CStructuredData* y1, CStructuredData* y2)
 	return m_state_model->loss(seq1, seq2);
 }
 
-void CHMSVMModel::init_opt(
+void CHMSVMModel::init_primal_opt(
 		float64_t regularization,
 		SGMatrix< float64_t > & A,
 		SGVector< float64_t > a,

--- a/src/shogun/structure/HMSVMModel.h
+++ b/src/shogun/structure/HMSVMModel.h
@@ -99,7 +99,7 @@ class CHMSVMModel : public CStructuredModel
 		 * @param ub
 		 * @param C
 		 */
-		virtual void init_opt(
+		virtual void init_primal_opt(
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,

--- a/src/shogun/structure/MulticlassModel.cpp
+++ b/src/shogun/structure/MulticlassModel.cpp
@@ -145,7 +145,7 @@ float64_t CMulticlassModel::delta_loss(float64_t y1, float64_t y2)
 	return (y1 == y2) ? 0 : 1;
 }
 
-void CMulticlassModel::init_opt(
+void CMulticlassModel::init_primal_opt(
 		float64_t regularization,
 		SGMatrix< float64_t > & A,
 		SGVector< float64_t > a,
@@ -164,66 +164,5 @@ void CMulticlassModel::init()
 			MS_NOT_AVAILABLE);
 
 	m_num_classes = 0;
-}
-
-float64_t CMulticlassModel::risk(float64_t* subgrad, float64_t* W, TMultipleCPinfo* info)
-{
-	CDotFeatures* X=(CDotFeatures*)m_features;
-	CMulticlassSOLabels* y=(CMulticlassSOLabels*)m_labels;
-	m_num_classes = y->get_num_classes();
-	uint32_t from, to;
-
-	if (info)
-	{
-		from=info->m_from;
-		to=(info->m_N == 0) ? X->get_num_vectors() : from+info->m_N;
-	} else {
-		from=0;
-		to=X->get_num_vectors();
-	}
-
-	uint32_t num_classes=y->get_num_classes();
-	uint32_t feats_dim=X->get_dim_feature_space();
-	const uint32_t w_dim=get_dim();
-
-	float64_t R=0.0;
-	for (uint32_t i=0; i<w_dim; i++)
-		subgrad[i] = 0;
-
-	float64_t Rtmp=0.0;
-	float64_t Rmax=0.0;
-	float64_t loss=0.0;
-	uint32_t yhat=0;
-	uint32_t GT=0;
-	CRealNumber* GT_rn=NULL;
-
-	/* loop through examples */
-	for(uint32_t i=from; i<to; ++i)
-	{
-		Rmax=-CMath::INFTY;
-		GT_rn=CRealNumber::obtain_from_generic(y->get_label(i));
-		GT=(uint32_t)GT_rn->value;
-
-		for (uint32_t c = 0; c < num_classes; ++c)
-		{
-			loss=(c == GT) ? 0.0 : 1.0;
-			Rtmp=loss+X->dense_dot(i, W+c*feats_dim, feats_dim)
-				-X->dense_dot(i, W+GT*feats_dim, feats_dim);
-
-			if (Rtmp > Rmax)
-			{
-				Rmax=Rtmp;
-				yhat=c;
-			}
-		}
-		R += Rmax;
-
-		X->add_to_dense_vec(1.0, i, subgrad+yhat*feats_dim, feats_dim);
-		X->add_to_dense_vec(-1.0, i, subgrad+GT*feats_dim, feats_dim);
-
-		SG_UNREF(GT_rn);
-	}
-
-	return R;
 }
 

--- a/src/shogun/structure/MulticlassModel.h
+++ b/src/shogun/structure/MulticlassModel.h
@@ -92,7 +92,7 @@ class CMulticlassModel : public CStructuredModel
 		 * @param ub
 		 * @param C
 		 */
-		virtual void init_opt(
+		virtual void init_primal_opt(
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
@@ -101,37 +101,6 @@ class CMulticlassModel : public CStructuredModel
 
 		/** @return name of SGSerializable */
 		virtual const char* get_name() const { return "MulticlassModel"; }
-
-		/** implements risk function for multiclass SO-SVM
-		 *
-		 * Implementation of risk function for structured output multiclass SVM.
-		 *
-		 * The value of the risk is evaluated as
-		 *
-		 * \f[
-		 * R({\bf w}) = \sum_{i=1}^{m} \max_{y \in \mathcal{Y}} \left[ \ell(y_i, y)
-		 * + \langle {\bf w}, \Psi(x_i, y) - \Psi(x_i, y_i)  \rangle  \right]
-		 * \f]
-		 *
-		 * The subgradient is by Danskin's theorem given as
-		 *
-		 * \f[
-		 * R'({\bf w}) = \sum_{i=1}^{m} \Psi(x_i, \hat{y}_i) - \Psi(x_i, y_i),
-		 * \f]
-		 *
-		 * where \f$ \hat{y}_i \f$ is the most violated label, i.e.
-		 *
-		 * \f[
-		 * \hat{y}_i = \arg\max_{y \in \mathcal{Y}} \left[ \ell(y_i, y)
-		 * + \langle {\bf w}, \Psi(x_i, y)  \rangle \right]
-		 * \f]
-		 *
-		 * @param subgrad Subgradient computed at given point W
-		 * @param W Given weight vector
-		 * @param info Helper info for multiple cutting plane models algorithm
-		 * @return Value of the computed risk at given point W
-		 */
-		virtual float64_t risk(float64_t* subgrad, float64_t* W, TMultipleCPinfo* info=0);
 
 	private:
 		void init();

--- a/src/shogun/structure/PrimalMosekSOSVM.h
+++ b/src/shogun/structure/PrimalMosekSOSVM.h
@@ -13,7 +13,6 @@
 
 #ifdef USE_MOSEK
 
-#include <shogun/loss/LossFunction.h>
 #include <shogun/machine/LinearStructuredOutputMachine.h>
 #include <shogun/mathematics/Mosek.h>
 
@@ -39,10 +38,9 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 		/** standard constructor
 		 *
 		 * @param model structured model with application specific functions
-		 * @param loss structured loss function
 		 * @param labs structured labels
 		 */
-		CPrimalMosekSOSVM(CStructuredModel* model, CLossFunction* loss, CStructuredLabels* labs);
+		CPrimalMosekSOSVM(CStructuredModel* model, CStructuredLabels* labs);
 
 		/** destructor */
 		~CPrimalMosekSOSVM();
@@ -73,18 +71,6 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 		 * @param C regularization constant
 		 */
 		void set_regularization(float64_t C);
-
-		/** set loss function
-		 *
-		 * @param loss loss function to set
-		 */
-		void set_surrogate_loss(CLossFunction* loss);
-
-		/** get loss function
-		 *
-		 * @return loss function
-		 */
-		CLossFunction* get_surrogate_loss() const;
 
 	protected:
 		/** train primal SO-SVM
@@ -137,9 +123,6 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 		bool add_constraint(CMosek* mosek, CResultSet* result, index_t con_idx, index_t train_idx) const;
 
 	private:
-		/** the surrogate loss */
-		CLossFunction* m_surrogate_loss;
-
 		/** slack variables associated to each training example */
 		SGVector< float64_t > m_slacks;
 

--- a/src/shogun/structure/StructuredModel.h
+++ b/src/shogun/structure/StructuredModel.h
@@ -98,17 +98,17 @@ class CStructuredModel : public CSGObject
 		/** destructor */
 		virtual ~CStructuredModel();
 
-		/** initialize the optimization problem
+		/** initialize the optimization problem for primal solver 
 		 *
-		 * @param A
+		 * @param A  is [-dPsi(y) | -I_N ] with M+N columns => max. M+1 nnz per row 
 		 * @param a
 		 * @param B
-		 * @param b
-		 * @param lb
-		 * @param ub
-		 * @param C
+		 * @param b  upper bounds of the constraints, Ax <= b
+		 * @param lb lower bounds for w
+		 * @param ub upper bounds for w
+		 * @param C  regularization matrix, w'Cw
 		 */
-		virtual void init_opt(
+		virtual void init_primal_opt(
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
@@ -246,21 +246,6 @@ class CStructuredModel : public CSGObject
 		 */
 		virtual int32_t get_num_aux_con() const;
 
-		/** computes the value of the risk function and sub-gradient at given point
-		 *
-		 * @param subgrad Subgradient computed at given point W
-		 * @param W Given weight vector
-		 * @param info Helper info for multiple cutting plane models algorithm
-		 * @return Value of the computed risk at given point W
-		 */
-		virtual float64_t risk(float64_t* subgrad, float64_t* W, TMultipleCPinfo* info=0);
-
-#ifdef USE_SWIG_DIRECTORS
-		virtual float64_t director_risk(SGVector<float64_t> subgrad, SGVector<float64_t> W, TMultipleCPinfo info);
-
-		void use_director_risk() { m_use_director_risk = true; }
-#endif
-
 	private:
 		/** internal initialization */
 		void init();
@@ -271,11 +256,6 @@ class CStructuredModel : public CSGObject
 
 		/** feature vectors */
 		CFeatures* m_features;
-
-#ifdef USE_SWIG_DIRECTORS
-		/** Whether to use custom risk function */
-		bool m_use_director_risk;
-#endif
 
 }; /* class CStructuredModel */
 

--- a/src/shogun/structure/libbmrm.cpp
+++ b/src/shogun/structure/libbmrm.cpp
@@ -177,7 +177,7 @@ static const float64_t *get_col( uint32_t i)
 }
 
 BmrmStatistics svm_bmrm_solver(
-		CStructuredModel* model,
+		CDualLibQPBMSOSVM  *machine, 
 		float64_t*       W,
 		float64_t        TolRel,
 		float64_t        TolAbs,
@@ -196,7 +196,7 @@ BmrmStatistics svm_bmrm_solver(
 	floatmax_t rsum, sq_norm_W, sq_norm_Wdiff=0.0;
 	uint32_t *I;
 	uint8_t S=1;
-	uint32_t nDim=model->get_dim();
+	uint32_t nDim=machine->get_model()->get_dim();
 
 	CTime ttime;
 	float64_t tstart, tstop;
@@ -339,7 +339,7 @@ BmrmStatistics svm_bmrm_solver(
 	bmrm.hist_wdist = SGVector< float64_t >(BufSize);
 
 	/* Iinitial solution */
-	R=model->risk(subgrad, W);
+	R=machine->risk(subgrad, W);
 
 	bmrm.nCP=0;
 	bmrm.nIter=0;
@@ -464,7 +464,7 @@ BmrmStatistics svm_bmrm_solver(
 		}
 
 		/* risk and subgradient computation */
-		R = model->risk(subgrad, W);
+		R = machine->risk(subgrad, W);
 		add_cutting_plane(&CPList_tail, map, A,
 				find_free_idx(map, BufSize), subgrad, nDim);
 

--- a/src/shogun/structure/libbmrm.h
+++ b/src/shogun/structure/libbmrm.h
@@ -11,12 +11,12 @@
  * Implementation of the BMRM solver
  *--------------------------------------------------------------------- */
 
-#include <shogun/lib/common.h>
-#include <shogun/structure/StructuredModel.h>
-#include <shogun/structure/BmrmStatistics.h>
-
 #ifndef libbmrm_h
 #define libbmrm_h
+
+#include <shogun/lib/common.h>
+#include <shogun/structure/BmrmStatistics.h>
+#include <shogun/structure/DualLibQPBMSOSVM.h>
 
 #define LIBBMRM_PLUS_INF (-log(0.0))
 #define LIBBMRM_CALLOC(x, y) calloc(x, y)
@@ -125,7 +125,7 @@ inline uint32_t find_free_idx(bool *map, uint32_t size)
 
 /** Standard BMRM Solver for Structured Output Learning
  *
- * @param model			Pointer to user defined CStructuredModel
+ * @param machine		Pointer to the BMRM machine	
  * @param W				Weight vector
  * @param TolRel		Relative tolerance
  * @param TolAbs		Absolute tolerance
@@ -142,17 +142,17 @@ inline uint32_t find_free_idx(bool *map, uint32_t size)
  * @return Structure with BMRM algorithm result
  */
 BmrmStatistics svm_bmrm_solver(
-		CStructuredModel *model,
-		float64_t        *W,
-		float64_t        TolRel,
-		float64_t        TolAbs,
-		float64_t        _lambda,
-		uint32_t         _BufSize,
-		bool             cleanICP,
-		uint32_t         cleanAfter,
-		float64_t        K,
-		uint32_t         Tmax,
-		bool             verbose
+		CDualLibQPBMSOSVM  *machine, 
+		float64_t          *W,
+		float64_t          TolRel,
+		float64_t          TolAbs,
+		float64_t          _lambda,
+		uint32_t           _BufSize,
+		bool               cleanICP,
+		uint32_t           cleanAfter,
+		float64_t          K,
+		uint32_t           Tmax,
+		bool               verbose
 		);
 
 }

--- a/src/shogun/structure/libncbm.cpp
+++ b/src/shogun/structure/libncbm.cpp
@@ -40,7 +40,7 @@ IGNORE_IN_CLASSLIST struct line_search_res
 
 inline static line_search_res zoom
 (
- CStructuredModel* model,
+ CDualLibQPBMSOSVM *machine, 
  float64_t lambda,
  float64_t a_lo,
  float64_t a_hi,
@@ -90,7 +90,7 @@ inline static line_search_res zoom
 				initial_solution.vector, a_j,
 				search_dir.vector, cur_solution.vlen);
 
-		float64_t cur_fval = model->risk(cur_grad.vector, cur_solution.vector);
+		float64_t cur_fval = machine->risk(cur_grad.vector, cur_solution.vector);
 		float64_t cur_reg
 			= 0.5*lambda*cur_solution.dot(cur_solution.vector,
 					cur_solution.vector, cur_solution.vlen);
@@ -157,7 +157,7 @@ inline static line_search_res zoom
 
 inline std::vector<line_search_res> line_search_with_strong_wolfe
 (
-		CStructuredModel *model,
+		CDualLibQPBMSOSVM *machine, 
 		float64_t lambda,
 		float64_t initial_val,
 		SGVector<float64_t>& initial_solution,
@@ -196,7 +196,7 @@ inline std::vector<line_search_res> line_search_with_strong_wolfe
 		SGVector<float64_t> cur_subgrad(initial_solution.vlen);
 
 		x.add(x.vector, 1.0, initial_solution.vector, cur_a, search_dir.vector, x.vlen);
-		float64_t cur_fval = model->risk(cur_subgrad.vector, x.vector);
+		float64_t cur_fval = machine->risk(cur_subgrad.vector, x.vector);
 		float64_t cur_reg = 0.5*lambda*x.dot(x.vector, x.vector, x.vlen);
 		cur_fval += cur_reg;
 
@@ -222,7 +222,7 @@ inline std::vector<line_search_res> line_search_with_strong_wolfe
 			)
 		{
 			ret.push_back(
-					zoom(model, lambda, prev_a, cur_a, initial_val,
+					zoom(machine, lambda, prev_a, cur_a, initial_val,
 						initial_solution, search_dir, wolfe_c1, wolfe_c2,
 						initial_lgrad, prev_fval, prev_lgrad, cur_fval, cur_lgrad)
 					);
@@ -244,7 +244,7 @@ inline std::vector<line_search_res> line_search_with_strong_wolfe
 		if (cur_lgrad >= 0)
 		{
 			ret.push_back(
-					zoom(model, lambda, cur_a, prev_a, initial_val,
+					zoom(machine, lambda, cur_a, prev_a, initial_val,
 						initial_solution, search_dir, wolfe_c1, wolfe_c2,
 						initial_lgrad, cur_fval, cur_lgrad, prev_fval, prev_lgrad)
 					);
@@ -306,22 +306,22 @@ inline void update_H(BmrmStatistics& ncbm,
 
 
 BmrmStatistics svm_ncbm_solver(
-		CStructuredModel *model,
-		float64_t        *w,
-		float64_t        TolRel,
-		float64_t        TolAbs,
-		float64_t        _lambda,
-		uint32_t         _BufSize,
-		bool             cleanICP,
-		uint32_t         cleanAfter,
-		bool             is_convex,
-		bool             line_search,
-		bool             verbose
+		CDualLibQPBMSOSVM *machine, 
+		float64_t         *w,
+		float64_t         TolRel,
+		float64_t         TolAbs,
+		float64_t         _lambda,
+		uint32_t          _BufSize,
+		bool              cleanICP,
+		uint32_t          cleanAfter,
+		bool              is_convex,
+		bool              line_search,
+		bool              verbose
 		)
 {
 	BmrmStatistics ncbm;
 	libqp_state_T qp_exitflag={0, 0, 0, 0};
-	int32_t w_dim = model->get_dim();
+	int32_t w_dim = machine->get_model()->get_dim();
 
 	maxCPs = _BufSize;
 
@@ -401,7 +401,7 @@ BmrmStatistics svm_ncbm_solver(
 	SGVector<float64_t> cur_w(w_dim);
 	memcpy(cur_w.vector, w, sizeof(float64_t)*w_dim);
 
-	float64_t cur_risk = model->risk(cur_subgrad.vector, cur_w.vector);
+	float64_t cur_risk = machine->risk(cur_subgrad.vector, cur_w.vector);
 	bias[0] = -cur_risk;
 	best_Fp = 0.5*_lambda*cur_w.dot(cur_w.vector, cur_w.vector, cur_w.vlen) + cur_risk;
 	best_risk = cur_risk;
@@ -534,7 +534,7 @@ BmrmStatistics svm_ncbm_solver(
 		std::vector<line_search_res> wbest_candidates;
 		if (!line_search)
 		{
-			cur_risk = model->risk(cur_subgrad.vector, cur_w.vector);
+			cur_risk = machine->risk(cur_subgrad.vector, cur_w.vector);
 
 			add_cutting_plane(&CPList_tail, map, A.matrix,
 					find_free_idx(map, maxCPs), cur_subgrad.vector, w_dim);
@@ -574,7 +574,7 @@ BmrmStatistics svm_ncbm_solver(
 
 			/* line search */
 			std::vector<line_search_res> ls_res
-				= line_search_with_strong_wolfe(model, _lambda, best_Fp, best_w, best_subgrad, search_dir, astart);
+				= line_search_with_strong_wolfe(machine, _lambda, best_Fp, best_w, best_subgrad, search_dir, astart);
 
 			if (ls_res[0].fval != ls_res[1].fval)
 			{
@@ -607,7 +607,7 @@ BmrmStatistics svm_ncbm_solver(
 
 			if ((best_Fp <= ls_res[1].fval) && (astart != 1))
 			{
-				cur_risk = model->risk(cur_subgrad.vector, cur_w.vector);
+				cur_risk = machine->risk(cur_subgrad.vector, cur_w.vector);
 
 				add_cutting_plane(&CPList_tail, map, A.matrix,
 							find_free_idx(map, maxCPs), cur_subgrad.vector, w_dim);

--- a/src/shogun/structure/libncbm.h
+++ b/src/shogun/structure/libncbm.h
@@ -24,7 +24,7 @@ namespace shogun
 	 * where R(w) is a risk funciton of any kind.
 	 */
 	BmrmStatistics svm_ncbm_solver(
-			CStructuredModel *model,
+			CDualLibQPBMSOSVM  *machine, 
 			float64_t        *w,
 			float64_t        TolRel,
 			float64_t        TolAbs,

--- a/src/shogun/structure/libp3bm.cpp
+++ b/src/shogun/structure/libp3bm.cpp
@@ -32,7 +32,7 @@ static const float64_t *get_col( uint32_t i)
 }
 
 BmrmStatistics svm_p3bm_solver(
-		CStructuredModel* model,
+		CDualLibQPBMSOSVM *machine, 
 		float64_t*      W,
 		float64_t       TolRel,
 		float64_t       TolAbs,
@@ -60,7 +60,7 @@ BmrmStatistics svm_p3bm_solver(
 	bool *map=NULL, tuneAlpha=true, flag=true;
 	bool alphaChanged=false, isThereGoodSolution=false;
 	TMultipleCPinfo **info=NULL;
-	uint32_t nDim=model->get_dim();
+	uint32_t nDim=machine->get_model()->get_dim();
 	uint32_t to=0, N=0, cp_i=0;
 
 	CTime ttime;
@@ -120,7 +120,7 @@ BmrmStatistics svm_p3bm_solver(
 
 	info= (TMultipleCPinfo**) LIBBMRM_CALLOC(cp_models, sizeof(TMultipleCPinfo*));
 
-	int32_t num_feats = model->get_features()->get_num_vectors();
+	int32_t num_feats = machine->get_model()->get_features()->get_num_vectors();
 
 	/* CP cleanup variables */
 	ICP_stats icp_stats;
@@ -202,7 +202,7 @@ BmrmStatistics svm_p3bm_solver(
 	p3bmrm.hist_wdist.resize_vector(BufSize);
 
 	/* Iinitial solution */
-	Rt[0] = model->risk(subgrad_t[0], W, info[0]);
+	Rt[0] = machine->risk(subgrad_t[0], W, info[0]);
 
 	p3bmrm.nCP=0;
 	p3bmrm.nIter=0;
@@ -222,7 +222,7 @@ BmrmStatistics svm_p3bm_solver(
 
 	for (uint32_t p=1; p<cp_models; ++p)
 	{
-		Rt[p] = model->risk(subgrad_t[p], W, info[p]);
+		Rt[p] = machine->risk(subgrad_t[p], W, info[p]);
 		b[p]=SGVector<float64_t>::dot(subgrad_t[p], W, nDim) - Rt[p];
 		add_cutting_plane(&CPList_tail, map, A, find_free_idx(map, BufSize), subgrad_t[p], nDim);
 	}
@@ -554,7 +554,7 @@ BmrmStatistics svm_p3bm_solver(
 
 		for (uint32_t p=0; p<cp_models; ++p)
 		{
-			Rt[p] = model->risk(subgrad_t[p], W, info[p]);
+			Rt[p] = machine->risk(subgrad_t[p], W, info[p]);
 			b[p3bmrm.nCP+p] = SGVector<float64_t>::dot(subgrad_t[p], W, nDim) - Rt[p];
 			add_cutting_plane(&CPList_tail, map, A, find_free_idx(map, BufSize), subgrad_t[p], nDim);
 			R+=Rt[p];

--- a/src/shogun/structure/libp3bm.h
+++ b/src/shogun/structure/libp3bm.h
@@ -11,18 +11,18 @@
  * Implementation of the Proximal Point P-BMRM (3pbm)
  *--------------------------------------------------------------------- */
 
-#include <shogun/lib/common.h>
-#include <shogun/structure/libbmrm.h>
-
 #ifndef libp3bm_h
 #define libp3bm_h
+
+#include <shogun/lib/common.h>
+#include <shogun/structure/libbmrm.h>
 
 namespace shogun
 {
 	/** Proximal Point P-BMRM (multiple cutting plane models) Solver for
 	 * 	Structured Output Learning
 	 *
-	 * @param model			Pointer to user defined CStructuredModel
+ 	 * @param machine		Pointer to the BMRM machine	
 	 * @param W				Weight vector
 	 * @param TolRel		Relative tolerance
 	 * @param TolAbs		Absolute tolerance
@@ -39,7 +39,7 @@ namespace shogun
 	 * @return Structure with BMRM algorithm result
 	 */
 	BmrmStatistics svm_p3bm_solver(
-			CStructuredModel *model,
+			CDualLibQPBMSOSVM  *machine, 
 			float64_t   	*W,
 			float64_t   	TolRel,
 			float64_t   	TolAbs,

--- a/src/shogun/structure/libppbm.cpp
+++ b/src/shogun/structure/libppbm.cpp
@@ -32,7 +32,7 @@ static const float64_t *get_col( uint32_t i)
 }
 
 BmrmStatistics svm_ppbm_solver(
-		CStructuredModel* model,
+		CDualLibQPBMSOSVM *machine, 
 		float64_t*      W,
 		float64_t       TolRel,
 		float64_t       TolAbs,
@@ -53,7 +53,7 @@ BmrmStatistics svm_ppbm_solver(
 	floatmax_t rsum, sq_norm_W, sq_norm_Wdiff, sq_norm_prevW, eps;
 	uint32_t *I, *I2, *I_start, *I_good;
 	uint8_t S=1;
-	uint32_t nDim=model->get_dim();
+	uint32_t nDim=machine->get_model()->get_dim();
 	uint32_t qp_cnt=0;
 	bmrm_ll *CPList_head, *CPList_tail, *cp_ptr, *cp_ptr2, *cp_list=NULL;
 	float64_t *A_1=NULL, *A_2=NULL;
@@ -172,7 +172,7 @@ BmrmStatistics svm_ppbm_solver(
 	ppbmrm.hist_wdist.resize_vector(BufSize);
 
 	/* Iinitial solution */
-	R = model->risk(subgrad, W);
+	R = machine->risk(subgrad, W);
 
 	ppbmrm.nCP=0;
 	ppbmrm.nIter=0;
@@ -508,7 +508,7 @@ BmrmStatistics svm_ppbm_solver(
 		}
 
 		/* risk and subgradient computation */
-		R = model->risk(subgrad, W);
+		R = machine->risk(subgrad, W);
 		add_cutting_plane(&CPList_tail, map, A,
 				find_free_idx(map, BufSize), subgrad, nDim);
 

--- a/src/shogun/structure/libppbm.h
+++ b/src/shogun/structure/libppbm.h
@@ -11,17 +11,17 @@
  * Implementation of the Proximal Point Bundle Method solver
  *--------------------------------------------------------------------- */
 
-#include <shogun/lib/common.h>
-#include <shogun/structure/libbmrm.h>
-
 #ifndef libppbm_h
 #define libppbm_h
+
+#include <shogun/lib/common.h>
+#include <shogun/structure/libbmrm.h>
 
 namespace shogun
 {
 	/** Proximal Point BMRM Solver for Structured Output Learning
 	 *
-	 * @param model			Pointer to user defined CStructuredModel
+ 	 * @param machine		Pointer to the BMRM machine	
 	 * @param W				Weight vector
 	 * @param TolRel		Relative tolerance
 	 * @param TolAbs		Absolute tolerance
@@ -37,7 +37,7 @@ namespace shogun
 	 * @return Structure with BMRM algorithm result
 	 */
 	BmrmStatistics svm_ppbm_solver(
-			CStructuredModel *model,
+			CDualLibQPBMSOSVM  *machine, 
 			float64_t   	*W,
 			float64_t   	TolRel,
 			float64_t   	TolAbs,


### PR DESCRIPTION
I try to move model independent stuff out of the StructuredModel. 
1) risk() is only used by BMRM, so it has moved to DualLibQPSOSVM.
2) Changed a little bit the interfaces to libqp, so it doesn't depends on StructuredModel any more.
3) Keep m_features and m_labels in StructuredModel, since joint_feature_map(), argmax() and delta_loss() need them.
4) fix surrogate loss to Hinge loss, but keep a member variable m_surrogate_loss in StructuredOutputMachine, since we may need it for future extension for non-convex losses.

@ppletscher, @iglesias, @vigsterkr : please let me know your opinion :)
