### PR TITLE
params registered, sample modified (log-det), gitignore modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ examples/undocumented/python_modular/*
 
 # /tests
 /tests/unit/shogun-unit-test
+/tests/unit/*.txt
+/tests/unit/*.xml
+/tests/unit/*.hdf5

--- a/src/shogun/lib/computation/engine/IndependentComputationEngine.h
+++ b/src/shogun/lib/computation/engine/IndependentComputationEngine.h
@@ -40,7 +40,9 @@ public:
 		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 	}
 	
-	/** abstract method that submits the jobs to the engine
+	/** 
+	 * abstract method that submits the jobs to the engine
+	 * 
 	 * @param job the job to be computed
 	 */
 	virtual void submit_job(CIndependentJob* job) = 0;

--- a/src/shogun/lib/computation/engine/SerialComputationEngine.cpp
+++ b/src/shogun/lib/computation/engine/SerialComputationEngine.cpp
@@ -28,7 +28,10 @@ CSerialComputationEngine::~CSerialComputationEngine()
 void CSerialComputationEngine::submit_job(CIndependentJob* job)
 {
 	SG_DEBUG("Entering. The job is being computed!\n");
+
+	REQUIRE(job, "Job to be computed is NULL\n");
 	job->compute();
+
 	SG_DEBUG("The job is computed. Leaving!\n");
 }
 

--- a/src/shogun/lib/computation/engine/SerialComputationEngine.h
+++ b/src/shogun/lib/computation/engine/SerialComputationEngine.h
@@ -28,13 +28,16 @@ public:
 	/** destructor */
 	virtual ~CSerialComputationEngine();
 
-	/** method that calls the job's compute method in each call, therefore
+	/** 
+	 * method that calls the job's compute method in each call, therefore
 	 * blocks until the its computation is done
+	 *
 	 * @param job the job to be computed
 	 */
 	virtual void submit_job(CIndependentJob* job);
 	
-	/** method that returns when all the jobs computed, in this case it does
+	/** 
+	 * method that returns when all the jobs computed, in this case it does
 	 * nothing
 	 */
 	virtual void wait_for_all();

--- a/src/shogun/lib/computation/job/DenseExactLogJob.h
+++ b/src/shogun/lib/computation/job/DenseExactLogJob.h
@@ -29,7 +29,9 @@ public:
 	/** default constructor */
 	CDenseExactLogJob();
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param aggregator the job result aggregator for this job
 	 * @param log_operator the dense matrix operator to be applied to the vector
 	 * @param vector the sample vector to which operator is to be applied
@@ -61,6 +63,10 @@ private:
 
 	/** the trace-sample */
 	SGVector<float64_t> m_vector;
+
+private:
+	/** initialize with default values and register params */
+	void init();
 };
 
 }

--- a/src/shogun/lib/computation/job/IndependentJob.h
+++ b/src/shogun/lib/computation/job/IndependentJob.h
@@ -12,6 +12,7 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
+#include <shogun/base/Parameter.h>
 #include <shogun/lib/computation/job/JobResultAggregator.h>
 
 namespace shogun
@@ -27,18 +28,26 @@ class CIndependentJob : public CSGObject
 public:
 	/** default constructor*/
 	CIndependentJob()
-	: CSGObject(), m_aggregator(NULL)
+	: CSGObject()
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param aggregator the job result aggregator for the current job
 	 */
 	CIndependentJob(CJobResultAggregator* aggregator)
 	: CSGObject(), m_aggregator(aggregator)
 	{
+		init();
+
+		m_aggregator=aggregator;
 		SG_REF(m_aggregator);
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
@@ -46,10 +55,12 @@ public:
 	virtual ~CIndependentJob()
 	{
 		SG_UNREF(m_aggregator);
+
 		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 	}
 
-	/** abstract compute method that computes the job, creates a CJobResult,
+	/** 
+	 * abstract compute method that computes the job, creates a CJobResult,
 	 * submits the result to the job result aggregator
 	 */
 	virtual void compute() = 0;
@@ -62,6 +73,16 @@ public:
 protected:
 	/** the job result aggregator for the current job */
 	CJobResultAggregator* m_aggregator;
+
+private:
+	/** initialize with default values and register params */
+	void init()
+	{
+		m_aggregator=NULL;
+
+		SG_ADD((CSGObject**)&m_aggregator, "job_result_aggregator",
+			"Job result aggregator for current job", MS_NOT_AVAILABLE);
+	}
 };
 
 }

--- a/src/shogun/lib/computation/job/JobResultAggregator.h
+++ b/src/shogun/lib/computation/job/JobResultAggregator.h
@@ -13,6 +13,7 @@
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
 #include <shogun/lib/computation/job/JobResult.h>
+#include <shogun/base/Parameter.h>
 
 namespace shogun
 {
@@ -26,8 +27,10 @@ class CJobResultAggregator : public CSGObject
 public:
 	/** default constructor */
 	CJobResultAggregator()
-	: CSGObject(), m_result(NULL)
+	: CSGObject()
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
@@ -35,16 +38,20 @@ public:
 	virtual ~CJobResultAggregator()
 	{
 		SG_UNREF(m_result);
+
 		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 	}
 
-	/** abstract method that submits the result of an independent job, and
+	/** 
+	 * abstract method that submits the result of an independent job, and
 	 * computes the aggregation with the previously submitted result
+	 *
 	 * @param result the result of an independent job
 	 */
 	virtual void submit_result(CJobResult* result) = 0;
 
-	/** abstract method that finalizes the aggregation and computes the result,
+	/** 
+	 * abstract method that finalizes the aggregation and computes the result,
 	 * its necessary to call finalize before getting the final result
 	 */
 	virtual void finalize() = 0;
@@ -63,6 +70,16 @@ public:
 protected:
 	/** the final job result */
 	CJobResult* m_result;
+
+private:
+	/** initialize with default values and register params */
+	void init()
+	{
+		m_result=NULL;
+
+		SG_ADD((CSGObject**)&m_result, "final_result",
+			"Aggregation of computation job results", MS_NOT_AVAILABLE);
+	}
 };
 
 }

--- a/src/shogun/lib/computation/job/ScalarResult.h
+++ b/src/shogun/lib/computation/job/ScalarResult.h
@@ -12,6 +12,7 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/lib/computation/job/JobResult.h>
+#include <shogun/base/Parameter.h>
 
 namespace shogun
 {
@@ -22,19 +23,27 @@ namespace shogun
 template<class T> class CScalarResult : public CJobResult
 {
 public:
-	/** default constructor, no args */
+	/** default constructor */
 	CScalarResult()
-	: CJobResult(), m_result(static_cast<T>(0))
+	: CJobResult()
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param result the scalar result
 	 */
 	CScalarResult(const T& result)
-	: CJobResult(), m_result(result)
+	: CJobResult()
 	{
+		init();
+
+		m_result=result;
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
@@ -59,6 +68,16 @@ public:
 protected:
 	/** the scalar result */
 	T m_result;
+
+private:
+	/** initialize with default values and register params */
+	void init()
+	{
+		m_result=static_cast<T>(0);
+
+		SG_ADD(&m_result, "scalar_result", "Scalar result of a computation job",
+			MS_NOT_AVAILABLE);
+	}
 };
 
 template class CScalarResult<bool>;

--- a/src/shogun/lib/computation/job/StoreScalarAggregator.cpp
+++ b/src/shogun/lib/computation/job/StoreScalarAggregator.cpp
@@ -7,7 +7,7 @@
  * Written (W) 2013 Soumyajit De
  */
 
-#include <shogun/lib/common.h>
+#include <shogun/lib/config.h>
 #include <shogun/lib/computation/job/ScalarResult.h>
 #include <shogun/lib/computation/job/StoreScalarAggregator.h>
 
@@ -15,9 +15,20 @@ namespace shogun
 {
 template<class T>
 CStoreScalarAggregator<T>::CStoreScalarAggregator()
-	: CJobResultAggregator(), m_aggregate(static_cast<T>(0))
+	: CJobResultAggregator()
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+	}
+
+template<class T>
+void CStoreScalarAggregator<T>::init()
+	{
+		m_aggregate=static_cast<T>(0);
+
+		SG_ADD(&m_aggregate, "current_aggregate",
+			"Aggregation of computation job results", MS_NOT_AVAILABLE);
 	}
 
 template<class T>
@@ -32,7 +43,6 @@ void CStoreScalarAggregator<T>::submit_result(CJobResult* result)
 		SG_GCDEBUG("Entering ...\n")
 
 		// check for proper typecast
-		// DEBUG COMMENT : the following does NOT increase refcount of result
 		CScalarResult<T>* new_result=dynamic_cast<CScalarResult<T>*>(result);
 		if (!new_result)
 			SG_ERROR("result is not of CScalarResult type!\n");

--- a/src/shogun/lib/computation/job/StoreScalarAggregator.h
+++ b/src/shogun/lib/computation/job/StoreScalarAggregator.h
@@ -31,13 +31,16 @@ public:
 	/** destructor */
 	virtual ~CStoreScalarAggregator();
 
-	/** method that submits the result (scalar) of an independent job, and
+	/** 
+	 * method that submits the result (scalar) of an independent job, and
 	 * computes the aggregation with the previously submitted result
+	 *
 	 * @param result the result of an independent job
 	 */
 	virtual void submit_result(CJobResult* result);
 
-	/** method that finalizes the aggregation and computes the result (scalar),
+	/** 
+	 * method that finalizes the aggregation and computes the result (scalar),
 	 * its necessary to call finalize before getting the final result
 	 */
 	virtual void finalize();
@@ -50,6 +53,9 @@ public:
 private:
 	/** the aggregation */
 	T m_aggregate;
+
+	/** initialize with default values and register params */
+	void init();
 };
 
 }

--- a/src/shogun/mathematics/logdet/DenseMatrixExactLog.h
+++ b/src/shogun/mathematics/logdet/DenseMatrixExactLog.h
@@ -32,7 +32,9 @@ public:
 	/** default constructor */
 	CDenseMatrixExactLog();
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param op the dense matrix linear operator for this operator function
 	 * @param engine the computation engine for the independent jobs
 	 */
@@ -42,15 +44,18 @@ public:
 	/** destructor */
 	virtual ~CDenseMatrixExactLog();
 
-	/** init method that computes the log of the linear operator using Eigen3,
-	 * creates a new linear operator and sets that as the operator to apply to
-	 * vectors for this operator function
+	/** 
+	 * precompute method that computes the log of the linear operator using 
+	 * Eigen3, creates a new linear operator and sets that as the operator to 
+	 * apply to vectors for this operator function
 	 */
-	virtual void init();
+	virtual void precompute();
 
-	/** method that creates a scalar job result aggregator, then creates one
+	/** 
+	 * method that creates a scalar job result aggregator, then creates one
 	 * job per sample, attaches the aggregator with it, and submits the job to
 	 * computation engine and then returns the aggregator
+	 *
 	 * @param sample the vector for which a new computation job has to be created
 	 * @return the array of generated independent jobs
 	 */

--- a/src/shogun/mathematics/logdet/DenseMatrixOperator.cpp
+++ b/src/shogun/mathematics/logdet/DenseMatrixOperator.cpp
@@ -7,10 +7,10 @@
  * Written (W) 2013 Soumyajit De
  */
 
-#include <shogun/lib/common.h>
-#include <shogun/mathematics/logdet/DenseMatrixOperator.h>
+#include <shogun/lib/config.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGMatrix.h>
+#include <shogun/mathematics/logdet/DenseMatrixOperator.h>
 
 #ifdef HAVE_EIGEN3
 #include <shogun/mathematics/eigen3.h>
@@ -30,7 +30,8 @@ CDenseMatrixOperator<T>::CDenseMatrixOperator()
 
 template<class T>
 CDenseMatrixOperator<T>::CDenseMatrixOperator(SGMatrix<T> op)
-	: CLinearOperator<T>(op.num_cols), m_operator(op)
+	: CLinearOperator<T>(op.num_cols),
+	  m_operator(op)
 	{
 		SG_SGCDEBUG("%s created (%p)\n", this->get_name(), this);
 	}

--- a/src/shogun/mathematics/logdet/DenseMatrixOperator.h
+++ b/src/shogun/mathematics/logdet/DenseMatrixOperator.h
@@ -30,7 +30,9 @@ public:
 	/** default constructor */
 	CDenseMatrixOperator();
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param op the dense matrix to be used as the linear operator
 	 */
 	CDenseMatrixOperator(SGMatrix<T> op);
@@ -38,7 +40,9 @@ public:
 	/** destructor */
 	~CDenseMatrixOperator();
 
-	/** method that applies the dense-matrix linear operator to a vector
+	/** 
+	 * method that applies the dense-matrix linear operator to a vector
+	 *
 	 * @param b the vector to which the linear operator applies
 	 * @return the result vector
 	 */
@@ -56,6 +60,7 @@ public:
 private:
 	/** the dense matrix operator */
 	const SGMatrix<T> m_operator;
+
 };
 
 }

--- a/src/shogun/mathematics/logdet/LinearOperator.h
+++ b/src/shogun/mathematics/logdet/LinearOperator.h
@@ -24,23 +24,28 @@ template<class T> class CLinearOperator : public CSGObject
 public:
 	/** default constructor */
 	CLinearOperator()
-	: CSGObject(), dim(0)
+	: CSGObject(),
+	  m_dimension(0)
 	{
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
-	/** constructor
-	 * @param _dim dimension of the vector on which the operator can be applied
+	/** 
+	 * constructor
+	 *
+	 * @param dimension dimension of the vector on which the operator can be applied
 	 */
-	CLinearOperator(index_t _dim)
-	: CSGObject(), dim(_dim)
+	CLinearOperator(index_t dimension)
+	: CSGObject(),
+	  m_dimension(dimension)
 	{
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
 	/** copy constructor */
 	CLinearOperator(const CLinearOperator<T>& orig)
-	: CSGObject(orig), dim(orig.get_dim())
+	: CSGObject(orig),
+	  m_dimension(orig.m_dimension)
 	{
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
@@ -51,13 +56,15 @@ public:
 		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 	}
 
-	/** getter for the dimension */
+	/** @return the dimension on which the linear operator can apply */
 	const index_t get_dim() const
 	{
-		return dim;
+		return m_dimension;
 	}
 
-	/** abstract method that applies the linear operator to a vector
+	/** 
+	 * abstract method that applies the linear operator to a vector
+	 *
 	 * @param b the vector to which the linear operator applies
 	 * @return the result vector
 	 */
@@ -70,7 +77,8 @@ public:
 	}
 protected:
 	/** the dimension of vector on which the linear operator can apply */
-	const index_t dim;
+	const index_t m_dimension;
+
 };
 
 template class CLinearOperator<bool>;

--- a/src/shogun/mathematics/logdet/LogDetEstimator.h
+++ b/src/shogun/mathematics/logdet/LogDetEstimator.h
@@ -11,6 +11,7 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
+#include <shogun/base/Parameter.h>
 
 namespace shogun
 {
@@ -33,7 +34,9 @@ public:
 	/** default constructor */
 	CLogDetEstimator();
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param sampler the trace sampler
 	 * @param op_func the operator function
 	 * @param engine the independent computation engine
@@ -45,15 +48,19 @@ public:
 	/** destructor */
 	virtual ~CLogDetEstimator();
 
-	/** method that gives num_estimates number of log-det estimates with running
+	/** 
+	 * method that gives num_estimates number of log-det estimates with running
 	 * averaging of the estimates
+	 *
 	 * @param num_estimates the number of log-det estimates to be computed
 	 * @return the log-det estimates
 	 */
 	SGVector<float64_t> sample(index_t num_estimates);
 
-	/** method that gives num_estimates number of log-det estimates without any
+	/** 
+	 * method that gives num_estimates number of log-det estimates without any
 	 * averaging of the estimates
+	 *
 	 * @param num_estimates the number of log-det estimates to be computed
 	 * @return the log-det estimates
 	 */
@@ -74,6 +81,9 @@ private:
 
 	/** the computation engine for the independent jobs */
 	CIndependentComputationEngine* m_computation_engine;
+
+	/** initialize with default values and register params */
+	void init();
 };
 
 }

--- a/src/shogun/mathematics/logdet/NormalSampler.cpp
+++ b/src/shogun/mathematics/logdet/NormalSampler.cpp
@@ -8,7 +8,7 @@
  */
 #include <shogun/lib/common.h>
 #include <shogun/lib/SGVector.h>
-#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/Random.h>
 #include <shogun/mathematics/logdet/NormalSampler.h>
 
 namespace shogun
@@ -31,7 +31,7 @@ CNormalSampler::~CNormalSampler()
 	SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 }
 
-void CNormalSampler::init()
+void CNormalSampler::precompute()
 {
 	m_num_samples=1;
 }
@@ -44,7 +44,7 @@ SGVector<float64_t> CNormalSampler::sample(index_t idx) const
 	else
 	{
 		for (index_t i=0; i<m_dimension; ++i)
-			s[i]=CMath::randn_double();
+			s[i]=sg_rand->std_normal_distrib();
 	}
 	return s;
 }

--- a/src/shogun/mathematics/logdet/NormalSampler.h
+++ b/src/shogun/mathematics/logdet/NormalSampler.h
@@ -38,8 +38,8 @@ public:
  	 */
 	virtual SGVector<float64_t> sample(index_t idx) const;
 
-	/** init method that sets the num_samples of the base */
-	virtual void init();
+	/** precompute method that sets the num_samples of the base */
+	virtual void precompute();
 
 	/** @return object name */
 	virtual const char* get_name() const

--- a/src/shogun/mathematics/logdet/OperatorFunction.h
+++ b/src/shogun/mathematics/logdet/OperatorFunction.h
@@ -12,6 +12,7 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
+#include <shogun/base/Parameter.h>
 #include <shogun/mathematics/logdet/LinearOperator.h>
 #include <shogun/lib/computation/engine/IndependentComputationEngine.h>
 
@@ -41,14 +42,16 @@ public:
 	/** default constructor */
 	COperatorFunction()
 	: CSGObject(),
-	  m_linear_operator(NULL),
-	  m_computation_engine(NULL),
 	  m_function_type(OF_UNDEFINED)
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param op the linear operator of this operator function
 	 * @param engine the computation engine for the independent jobs
 	 * @param type the type of the operator function (sqrt, log, etc)
@@ -57,12 +60,16 @@ public:
 		CIndependentComputationEngine* engine,
 		EOperatorFunction type=OF_UNDEFINED)
 	: CSGObject(),
-	  m_linear_operator(op),
-	  m_computation_engine(engine),
 	  m_function_type(type)
 	{
+		init();
+
+		m_linear_operator=op;
 		SG_REF(m_linear_operator);
+
+		m_computation_engine=engine;
 		SG_REF(m_computation_engine);
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
@@ -71,6 +78,7 @@ public:
 	{
 		SG_UNREF(m_linear_operator);
 		SG_UNREF(m_computation_engine);
+
 		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 	}
 
@@ -80,17 +88,20 @@ public:
 		return m_linear_operator;
 	}
 
-	/** abstract init method that must be called before using submit jobs
+	/** 
+	 * abstract precompute method that must be called before using submit jobs
 	 * for performing preliminary computations that are necessary for the
 	 * rest of the computation jobs
 	 */
-	virtual void init() = 0;
+	virtual void precompute() = 0;
 
-	/** abstract method that creates a job result aggregator, then creates a
+	/** 
+	 * abstract method that creates a job result aggregator, then creates a
 	 * number of jobs based on its implementation, attaches the aggregator
 	 * with all those jobs, hands over the responsility of those to the
 	 * computation engine and then returns the aggregator for collecting the
 	 * job results
+	 *
 	 * @param sample the vector for which new computation job(s) are to be created
 	 * @return the array of generated independent jobs
 	 */
@@ -110,6 +121,20 @@ protected:
 
 	/** the linear operator function type */
 	const EOperatorFunction m_function_type;
+
+private:
+	/** initialize with default values and register params */
+	void init()
+	{
+	  m_linear_operator=NULL;
+	  m_computation_engine=NULL;
+
+		SG_ADD((CSGObject**)&m_linear_operator, "linear_operator",
+			"Linear operator of this operator function", MS_NOT_AVAILABLE);
+
+		SG_ADD((CSGObject**)&m_computation_engine, "computation_engine",
+			"Computation engine for the jobs this will generate", MS_NOT_AVAILABLE);
+	}
 };
 
 template class COperatorFunction<bool>;

--- a/src/shogun/mathematics/logdet/TraceSampler.h
+++ b/src/shogun/mathematics/logdet/TraceSampler.h
@@ -11,6 +11,7 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
+#include <shogun/base/Parameter.h>
 
 namespace shogun
 {
@@ -24,17 +25,25 @@ class CTraceSampler : public CSGObject
 public:
 	/** default constructor */
 	CTraceSampler()
-	: CSGObject(), m_dimension(0), m_num_samples(0)
+	: CSGObject(),
+	  m_dimension(0)
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
-	/** constructor
+	/** 
+	 * constructor
+	 *
 	 * @param dimension the dimension of the sample vectors
 	 */
 	CTraceSampler(index_t dimension)
-	: CSGObject(), m_dimension(dimension), m_num_samples(0)
+	: CSGObject(),
+	  m_dimension(dimension)
 	{
+		init();
+
 		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 	}
 
@@ -44,16 +53,19 @@ public:
 		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 	}
 
-	/** abstract method that generates the samples
+	/** 
+	 * abstract method that generates the samples
+	 *
  	 * @param idx the index which determines which sample to draw
 	 * @return the sample vector
  	 */
 	virtual SGVector<float64_t> sample(index_t idx) const = 0;
 
-	/** abstract method for initializing the sampler, number of samples etc,
+	/**
+	 * abstract method for initializing the sampler, number of samples etc,
 	 * must be called before sample
 	 */
-	virtual void init() = 0;
+	virtual void precompute() = 0;
 
 	/** @return the number of samples */
 	virtual const index_t get_num_samples() const
@@ -72,6 +84,16 @@ public:
 protected:
 	/** the number of samples this sampler will generate, set by implementation */
 	index_t m_num_samples;
+
+private:
+	/** initialize with default values and register params */
+	void init()
+	{
+		m_num_samples=0;
+
+		SG_ADD(&m_num_samples, "num_samples",
+			"Number of samples this sampler can generate", MS_NOT_AVAILABLE);
+	}
 };
 
 }

--- a/tests/unit/mathematics/logdet/DenseMatrixExactLog_unittest.cc
+++ b/tests/unit/mathematics/logdet/DenseMatrixExactLog_unittest.cc
@@ -50,8 +50,8 @@ TEST(DenseMatrixExactLog, dense_log_det)
 	CDenseMatrixExactLog *op_func=new CDenseMatrixExactLog(op, e);
 	SG_REF(op_func);
 
-	// its really important we call the init on the operato function
-	op_func->init();
+	// its really important we call the precompute on the operato function
+	op_func->precompute();
 
 	// for storing the aggregators that submit_jobs return
 	CDynamicObjectArray aggregators;

--- a/tests/unit/mathematics/logdet/LogDetEstimator_unittest.cc
+++ b/tests/unit/mathematics/logdet/LogDetEstimator_unittest.cc
@@ -45,7 +45,7 @@ TEST(LogDetEstimator, sample)
 	SG_REF(trace_sampler);
 
 	CLogDetEstimator estimator(trace_sampler, op_func, e);
-	const index_t num_estimates=1000;
+	const index_t num_estimates=5000;
 	SGVector<float64_t> estimates=estimator.sample(num_estimates);
 	
 	float64_t result=0.0;

--- a/tests/unit/mathematics/logdet/NormalSampler_unittest.cc
+++ b/tests/unit/mathematics/logdet/NormalSampler_unittest.cc
@@ -22,11 +22,11 @@ using namespace Eigen;
 TEST(NormalSampler, sample)
 {
 	const index_t dimension=2;
-	const index_t num_samples=1000;
+	const index_t num_samples=5000;
 	SGMatrix<float64_t> samples(num_samples, dimension);
 
 	CNormalSampler sampler(dimension);
-	sampler.init();
+	sampler.precompute();
 	for (index_t i=0; i<num_samples; ++i)
 	{
 		SGVector<float64_t> s=sampler.sample(0);


### PR DESCRIPTION
- Registered params in log-det classes private init method
- CLogDetEstimator::sample modified (does not rely on sample_without_averaging anymore)
- NormalSampler uses CRandom::std_normal_distrib instead of CMath::randn_double
- unit-tests updated
- .gitignore file updated to ignore serialization unit-tests files
