### PR TITLE
Changed display messages

### DIFF
--- a/src/shogun/features/Alphabet.cpp
+++ b/src/shogun/features/Alphabet.cpp
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <math.h>
+#include <ctype.h>
 
 #include <shogun/features/Alphabet.h>
 #include <shogun/io/SGIO.h>
@@ -588,7 +589,23 @@ void CAlphabet::print_histogram()
 	for (int32_t i=0; i<(int32_t) (1 <<(sizeof(uint8_t)*8)); i++)
 	{
 		if (histogram[i])
-			SG_PRINT("hist[%d]=%lld\n", i, histogram[i])
+		{	
+			if (isprint(i))
+				SG_PRINT("hist['%c']=%lld", i, histogram[i])
+			else if (i == '\t')
+				SG_PRINT("hist['\\t']=%lld", histogram[i])
+			else if (i == '\n')
+				SG_PRINT("hist['\\n']=%lld", histogram[i])
+			else if (i == '\r')
+				SG_PRINT("hist['\\r']=%lld", histogram[i])
+			else
+				SG_PRINT("hist[%d]=%lld", i, histogram[i])
+			
+			if (!valid_chars[i])
+				SG_PRINT(" - Character not in Alphabet.\n")
+			else
+				SG_PRINT("\n");			
+		}
 	}
 }
 

--- a/src/shogun/io/SGIO.cpp
+++ b/src/shogun/io/SGIO.cpp
@@ -45,7 +45,7 @@ char SGIO::directory_name[FBUFSIZE];
 
 SGIO::SGIO()
 : target(stdout), last_progress_time(0), progress_start_time(0),
-	last_progress(1), show_progress(false), location_info(MSG_FUNCTION),
+	last_progress(1), show_progress(false), location_info(MSG_NONE),
 	syntax_highlight(true), loglevel(MSG_WARN), refcount(0)
 {
 }


### PR DESCRIPTION
Changed the histogram display of Alphcabet.cpp to make it a bit more explanatory. Also removed the default display of the function name, when calling SG_PRINT. 
