### PR TITLE
added base class for AJD and an example of a derived class header

### DIFF
--- a/src/shogun/mathematics/ajd/ApproxJointDiagonalizer.h
+++ b/src/shogun/mathematics/ajd/ApproxJointDiagonalizer.h
@@ -12,6 +12,8 @@
 #ifndef APPROXJOINTDIAGONALIZER_H_
 #define APPROXJOINTDIAGONALIZER_H_
 
+#ifdef HAVE_EIGEN3
+
 #include <shogun/lib/common.h>
 #include <shogun/base/SGObject.h>
 #include <shogun/lib/SGMatrix.h>
@@ -68,4 +70,5 @@ class CApproxJointDiagonalizer : public CSGObject
 
 };
 }
+#endif //HAVE_EIGEN3
 #endif //APPROXJOINTDIAGONALIZER_H_ 

--- a/src/shogun/mathematics/ajd/JADiag.cpp
+++ b/src/shogun/mathematics/ajd/JADiag.cpp
@@ -1,4 +1,6 @@
-#include "JADiag.h"
+#ifdef HAVE_EIGEN3
+
+#include <shogun/mathematics/ajd/JADiag.h>
 
 #include <shogun/base/init.h>
 #include <shogun/lib/common.h>
@@ -217,3 +219,4 @@ void jadiagw(double c[], double w[], int *ptn, int *ptm, double a[],
 
 	return;
 }
+#endif //HAVE_EIGEN3

--- a/src/shogun/mathematics/ajd/JADiag.h
+++ b/src/shogun/mathematics/ajd/JADiag.h
@@ -12,7 +12,9 @@
 #ifndef JADIAG_H_
 #define JADIAG_H_
 
-#include "ApproxJointDiagonalizer.h"
+#ifdef HAVE_EIGEN3
+
+#include <shogun/mathematics/ajd/ApproxJointDiagonalizer.h>
 
 #include <shogun/lib/common.h>
 #include <shogun/base/SGObject.h>
@@ -74,4 +76,5 @@ class CJADiag : public CApproxJointDiagonalizer
 		virtual const char* get_name() const { return "JADiag"; }
 };
 }
+#endif //HAVE_EIGEN3
 #endif //JADIAG_H_ 

--- a/tests/unit/mathematics/ajd/JADiag_unittest.cc
+++ b/tests/unit/mathematics/ajd/JADiag_unittest.cc
@@ -1,0 +1,114 @@
+#include <shogun/base/init.h>
+#include <shogun/lib/common.h>
+#include <gtest/gtest.h>
+
+#ifdef HAVE_EIGEN3
+
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/SGNDArray.h>
+
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/ajd/JADiag.h>
+
+using namespace Eigen;
+
+typedef Matrix< float64_t, Dynamic, Dynamic, ColMajor > EMatrix;
+typedef Matrix< float64_t, Dynamic, 1, ColMajor > EVector;
+
+using namespace shogun;
+
+/*
+Function that tests if a SGMatrix is a permutation matrix
+*/
+bool is_permutation_matrix(SGMatrix<float64_t> &mat)
+{
+	// scale
+	for(int i = 0; i < mat.num_rows; i++)
+		for(int j = 0; j < mat.num_cols; j++)
+			mat(i,j) *= 10;
+			
+	// check only a single 1 per row
+	for(int i = 0; i < mat.num_rows; i++)
+	{
+		int num_ones = 0;
+		for(int j = 0; j < mat.num_cols; j++)
+		{
+			if(CMath::abs(CMath::round(mat(i,j))) >= 1.0)
+				num_ones++;
+		}
+
+		if(num_ones != 1)
+			return false;
+	}
+	
+	// check only a single 1 per col
+	for(int j = 0; j < mat.num_cols; j++)
+	{
+		int num_ones = 0;
+		for(int i = 0; i < mat.num_rows; i++)
+		{
+			if(CMath::abs(CMath::round(mat(i,j))) >= 1.0)
+				num_ones++; 
+		}
+		
+		if(num_ones != 1)
+			return false;
+	}
+	
+	return true;
+}
+
+TEST(CJADiag, diagonalize)
+{
+	// Generating diagonal matrices
+	index_t * C_dims = SG_MALLOC(index_t, 3);
+	C_dims[0] = 10;
+	C_dims[1] = 10;
+	C_dims[2] = 30;
+	SGNDArray< float64_t > C(C_dims, 3);
+	
+	for(int i = 0; i < C_dims[2]; i++)
+	{
+		Eigen::Map<EMatrix> tmp(C.get_matrix(i),C_dims[0], C_dims[1]);
+		tmp.setIdentity();
+		
+		for(int j = 0; j < C_dims[0]; j++)
+		{
+			// change to chi square when it is easy to do so			
+			tmp(j,j) += CMath::random(); 
+		}
+	}
+	
+	// Mixing and demixing matrices
+	EMatrix B(C_dims[0], C_dims[1]); B.setRandom();
+	EMatrix A = B.inverse();
+	
+	for(int i = 0; i < C_dims[2]; i++)
+	{
+		Eigen::Map<EMatrix> Ci(C.get_matrix(i),C_dims[0], C_dims[1]);
+		Ci = A * Ci * A.transpose();
+	}	
+
+	/** Diagonalize **/
+	SGMatrix<float64_t> V = CJADiag::diagonalize(C);
+
+	// Test output size
+	EXPECT_EQ(V.num_rows, C_dims[0]);
+	EXPECT_EQ(V.num_cols, C_dims[1]);
+
+	// Close to a permutation matrix (with random scales)
+	Eigen::Map<EMatrix> EV(V.matrix,C_dims[0], C_dims[1]);
+	EMatrix Eperm = EV * A;
+
+	// Test if permutation matrix
+	SGMatrix<float64_t> perm(C_dims[0], C_dims[1]);
+	memcpy(Eperm.data(), perm.matrix, C_dims[0]*C_dims[1]*sizeof(float64_t));
+
+	bool isperm = is_permutation_matrix(perm);
+
+	EXPECT_EQ(isperm,true);
+}
+
+#endif //HAVE_EIGEN3


### PR DESCRIPTION
A base class for the Approximate Joint Diagonalization (AJD) Algorithms. AJD is itself a mathematical process so I think it belongs in shogun/mathematics/ajd (I made a folder because there will be a few techniques and I thought this would keep everything neat and tidy), the ICA and BSS methods that will make use of these AJD techniques will live else where (most likely shogun/converters).

This interface allows for creating an instance of an AJD algorithm or using polymorphism and the base class. The work flow for this would look like:
CApproxJointDiagonalizer *d = new JADiag();
d->compute(...)
SGMatrix<float64_t> V = d->V();
// or simply
SGMatrix<float64_t> V = d->compute(...)

but it also allows a one liner like this:
SGMatrix<float64_t> V = JADiag::diagonalize(...);

I came up with this design after a bit of thought but I would like to hear what other people think! 

If everyone thinks its okay I will add the implementation files and the other algorithms along with unit tests!
