### PR TITLE
Multi-threaded dense_dot in HashedDocDotFeatures

### DIFF
--- a/src/shogun/converter/HashedDocConverter.cpp
+++ b/src/shogun/converter/HashedDocConverter.cpp
@@ -58,6 +58,7 @@ void CHashedDocConverter::init(CTokenizer* tzer, int32_t d)
 	else
 		tokenizer = tzer;
 
+	SG_REF(tokenizer);
 	SG_ADD(&dim, "dim", "Dimension of target feature space",
 		MS_NOT_AVAILABLE);
 	SG_ADD(&num_bits, "num_bits", "Number of bits of the hash",

--- a/src/shogun/evaluation/PRCEvaluation.cpp
+++ b/src/shogun/evaluation/PRCEvaluation.cpp
@@ -84,6 +84,7 @@ float64_t CPRCEvaluation::evaluate(CLabels* predicted, CLabels* ground_truth)
 	// set computed indicator
 	m_computed = true;
 
+	SG_FREE(idxs);
 	return m_auPRC;
 }
 

--- a/src/shogun/features/HashedDocDotFeatures.cpp
+++ b/src/shogun/features/HashedDocDotFeatures.cpp
@@ -94,19 +94,20 @@ float64_t CHashedDocDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* ve
 	SGVector<char> sv = doc_collection->get_feature_vector(vec_idx1);
 
 	float64_t result = 0;
+	CTokenizer* local_tzer = tokenizer->get_copy();
 
 	const int32_t seed = 0xdeadbeaf;
-	tokenizer->set_text(sv);
+	local_tzer->set_text(sv);
 	index_t start = 0;
-	while (tokenizer->has_next())
+	while (local_tzer->has_next())
 	{
-		index_t end = tokenizer->next_token_idx(start);
+		index_t end = local_tzer->next_token_idx(start);
 		uint32_t hashed_idx = calculate_token_hash(&sv.vector[start], end-start, num_bits, seed);
 		result += vec2[hashed_idx];
 	}
 
 	doc_collection->free_feature_vector(sv, vec_idx1);
-
+	SG_UNREF(local_tzer);
 	return result;
 }
 
@@ -119,18 +120,20 @@ void CHashedDocDotFeatures::add_to_dense_vec(float64_t alpha, int32_t vec_idx1,
 		alpha = CMath::abs(alpha);
 
 	SGVector<char> sv = doc_collection->get_feature_vector(vec_idx1);
-	
+	CTokenizer* local_tzer = tokenizer->get_copy();
+
 	const int32_t seed = 0xdeadbeaf;
 	index_t start = 0;
-	tokenizer->set_text(sv);
-	while (tokenizer->has_next())
+	local_tzer->set_text(sv);
+	while (local_tzer->has_next())
 	{
-		index_t end = tokenizer->next_token_idx(start);
+		index_t end = local_tzer->next_token_idx(start);
 		uint32_t hashed_idx = calculate_token_hash(&sv.vector[start], end-start, num_bits, seed);
 		vec2[hashed_idx] += alpha;
 	}
 	
 	doc_collection->free_feature_vector(sv, vec_idx1);
+	SG_UNREF(local_tzer);
 }
 
 uint32_t CHashedDocDotFeatures::calculate_token_hash(char* token, 

--- a/src/shogun/lib/DelimiterTokenizer.cpp
+++ b/src/shogun/lib/DelimiterTokenizer.cpp
@@ -14,7 +14,7 @@
 namespace shogun
 {
 
-CDelimiterTokenizer::CDelimiterTokenizer()
+CDelimiterTokenizer::CDelimiterTokenizer() : delimiters(256)
 {
 	last_idx = 0;
 	init();
@@ -22,6 +22,7 @@ CDelimiterTokenizer::CDelimiterTokenizer()
 CDelimiterTokenizer::CDelimiterTokenizer(const CDelimiterTokenizer& orig)
 {
 	CTokenizer::set_text(orig.text);
+	delimiters = orig.delimiters;
 	init();
 }
 
@@ -29,7 +30,7 @@ void CDelimiterTokenizer::init()
 {
 	SG_ADD(&last_idx, "last_idx", "Index of last token",
 		MS_NOT_AVAILABLE);
-	memset(delimiters, 0, sizeof (delimiters));
+	SGVector<bool>::fill_vector(delimiters, 256, 0);
 }
 
 void CDelimiterTokenizer::set_text(SGVector<char> txt)
@@ -55,7 +56,7 @@ bool CDelimiterTokenizer::has_next()
 
 void CDelimiterTokenizer::init_for_whitespace()
 {
-	memset(delimiters, 0, sizeof (delimiters));
+	SGVector<bool>::fill_vector(delimiters, 256, 0);
 	delimiters[' '] = 1;
 	delimiters['\t'] = 1;
 }
@@ -75,5 +76,12 @@ index_t CDelimiterTokenizer::next_token_idx(index_t& start)
 	}
 
 	return last_idx;
+}
+
+CDelimiterTokenizer* CDelimiterTokenizer::get_copy()
+{
+	CDelimiterTokenizer* t = new CDelimiterTokenizer();
+	t->delimiters = delimiters;
+	return t;
 }
 }

--- a/src/shogun/lib/DelimiterTokenizer.h
+++ b/src/shogun/lib/DelimiterTokenizer.h
@@ -68,12 +68,15 @@ public:
 	 *  as the delimiters for the tokenization process;
 	 */
 	void init_for_whitespace();
+
+	CDelimiterTokenizer* get_copy();
+
 private:
 	void init();
 
 public:
 	/* delimiters */
-	bool delimiters[256];
+	SGVector<bool> delimiters;
 
 protected:
 	/* index of last token */

--- a/src/shogun/lib/NGramTokenizer.cpp
+++ b/src/shogun/lib/NGramTokenizer.cpp
@@ -58,4 +58,10 @@ index_t CNGramTokenizer::next_token_idx(index_t& start)
 	start = last_idx++;
 	return start + n;	
 }
+
+CNGramTokenizer* CNGramTokenizer::get_copy()
+{
+	CNGramTokenizer* t = new CNGramTokenizer(n);
+	return t;
+}
 }

--- a/src/shogun/lib/NGramTokenizer.h
+++ b/src/shogun/lib/NGramTokenizer.h
@@ -63,6 +63,8 @@ public:
 	 */
     virtual const char* get_name() const;
 
+	virtual CNGramTokenizer* get_copy();
+
 private:
 	void init();
 

--- a/src/shogun/lib/Tokenizer.h
+++ b/src/shogun/lib/Tokenizer.h
@@ -22,7 +22,7 @@ template<class T> class SGVector;
 
 /** @brief The class CTokenizer acts as a base class in order
  * to implement tokenizers. Sub-classes must implement
- * the methods has_next() and next_token_idx().
+ * the methods has_next(), next_token_idx() and get_copy().
  */
 class CTokenizer: public CSGObject
 {
@@ -56,6 +56,12 @@ public:
 	 * @return token's ending index (inclusive)
 	 */
 	virtual index_t next_token_idx(index_t& start)=0;
+
+	/** Creates a copy of the appropriate runtime 
+	 * instance of a CTokenizer subclass 
+	 * Needs to be overriden
+	 */
+	virtual CTokenizer* get_copy()=0;
 
 private:
 	void init();

--- a/tests/unit/features/HashedDocDotFeatures_unittest.cc
+++ b/tests/unit/features/HashedDocDotFeatures_unittest.cc
@@ -52,7 +52,6 @@ TEST(HashedDocDotFeaturesTest, computed_features_test)
 	CHashedDocDotFeatures* hddf = new CHashedDocDotFeatures(hash_bits, doc_collection,
 			tokenizer);
 
-	SG_REF(tokenizer);
 	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, dimension);
 	
 	CSparseFeatures<uint32_t>* converted_docs = (CSparseFeatures<uint32_t>* ) converter->apply(doc_collection);
@@ -107,7 +106,6 @@ TEST(HashedDocDotFeaturesTest, dense_dot_test)
 	CHashedDocDotFeatures* hddf = new CHashedDocDotFeatures(hash_bits, doc_collection,
 			tokenizer);
 	
-	SG_REF(tokenizer);
 	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, dimension);
 	CSparseFeatures<uint32_t>* converted_docs = (CSparseFeatures<uint32_t>* ) converter->apply(doc_collection);
 


### PR DESCRIPTION
Made dense_dot() and add_to_dense() of HashedDocDotFeatures work in multi-threaded situations. This happened by adding a virtual get_copy() method to the CTokenizer, that allows to create a copy of the appropriate subclass.
Also, made CHashedDocConverter correctly SG_REF the tokenizer it uses.
Finally, SG_FREE'd an array in CPRCEvaluation class to fix a memory leak.
