### PR TITLE
Changed CDelimiterTokenizer behavior on consecutive delimiters

### DIFF
--- a/src/shogun/lib/DelimiterTokenizer.cpp
+++ b/src/shogun/lib/DelimiterTokenizer.cpp
@@ -46,12 +46,7 @@ const char* CDelimiterTokenizer::get_name() const
 
 bool CDelimiterTokenizer::has_next()
 {
-	for (index_t i=last_idx; i<text.size(); i++)
-	{
-		if (!delimiters[(uint8_t) text[i]])
-			return true;
-	}
-	return false; 
+	return last_idx<text.size();
 }
 
 void CDelimiterTokenizer::init_for_whitespace()
@@ -63,19 +58,18 @@ void CDelimiterTokenizer::init_for_whitespace()
 
 index_t CDelimiterTokenizer::next_token_idx(index_t& start)
 {
-	while (delimiters[(uint8_t) text[last_idx]])
-	{
-		last_idx++;
-	}
 	start = last_idx;
- 
-	for (last_idx=start+1; last_idx<text.size(); last_idx++)
+ 	
+	if (delimiters[(uint8_t) text[start]]==0)
 	{
-		if (delimiters[(uint8_t) text[last_idx]])
-			break;
+		for (last_idx=start+1; last_idx<text.size(); last_idx++)
+		{
+			if (delimiters[(uint8_t) text[last_idx]])
+				break;
+		}
 	}
 
-	return last_idx;
+	return last_idx++;
 }
 
 CDelimiterTokenizer* CDelimiterTokenizer::get_copy()

--- a/src/shogun/lib/DelimiterTokenizer.h
+++ b/src/shogun/lib/DelimiterTokenizer.h
@@ -22,7 +22,6 @@ class CTokenizer;
  *  One can set the delimiters to use by setting to 1 the appropriate
  *  index of the public field delimiters. Eg. to set as delimiter the
  *  character ':', one should do: tokenizer->delimiters[':'] = 1;
- *  Also, note that consecutive delimiters will be skipped.
  */
 class CDelimiterTokenizer: public CTokenizer
 {
@@ -51,6 +50,8 @@ public:
 
 	/** Method that returns the indices, start and end, of
 	 *  the next token in line.
+	 *  If next_token starts with a delimiter, it returns the same indices
+	 *	as start and end.
 	 *
 	 * @param start token's starting index
 	 * @return token's ending index (exclusive)

--- a/tests/unit/lib/DelimiterTokenizer_unittest.cc
+++ b/tests/unit/lib/DelimiterTokenizer_unittest.cc
@@ -19,8 +19,10 @@ TEST(DelimiterTokenizerTest, tokenization)
 	while (tokenizer->has_next())
 	{
 		index_t token_end = tokenizer->next_token_idx(token_start);
-		char token[token_end-token_start+1];
+		if (token_end==token_start)
+			continue;
 
+		char token[token_end-token_start+1];
 		for (index_t i=token_start; i<token_end; i++)
 		{
 			token[i-token_start] = text[i];


### PR DESCRIPTION
Now it won't skip consecutive delimiters, but if it reaches one it will return the same indices, start and end, on the SGVector.
