### PR TITLE
Quadratic support in HashedDenseFeatures

### DIFF
--- a/src/shogun/features/HashedDenseFeatures.h
+++ b/src/shogun/features/HashedDenseFeatures.h
@@ -29,22 +29,30 @@ public:
 	/** constructor
 	 *
 	 * @param size cache size
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedDenseFeatures(int32_t size=0);
+	CHashedDenseFeatures(int32_t size=0, bool use_quadr = false, bool keep_lin_terms = true);
 
 	/** constructor
 	 *
 	 * @param feats	the dense features to use as a base
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedDenseFeatures(CDenseFeatures<ST>* feats, int32_t d);
+	CHashedDenseFeatures(CDenseFeatures<ST>* feats, int32_t d, bool use_quadr = false,
+			bool keep_lin_terms = true);
 
 	/** constructor
 	 *
 	 * @param matrix feature matrix
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedDenseFeatures(SGMatrix<ST> matrix, int32_t d);
+	CHashedDenseFeatures(SGMatrix<ST> matrix, int32_t dm, bool use_quadr = false,
+			bool keep_lin_terms = true);
 
 	/** constructor
 	 *
@@ -52,15 +60,21 @@ public:
 	 * @param num_feat number of features in matrix
 	 * @param num_vec number of vectors in matrix
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedDenseFeatures(ST* src, int32_t num_feat, int32_t num_vec, int32_t d);
+	CHashedDenseFeatures(ST* src, int32_t num_feat, int32_t num_vec, int32_t d,
+			bool use_quadr = false, bool keep_lin_terms = true);
 
 	/** constructor loading features from file
 	 *
 	 * @param loader File object via which to load data
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedDenseFeatures(CFile* loader, int32_t d);
+	CHashedDenseFeatures(CFile* loader, int32_t d, bool use_quadr = false,
+			bool keep_lin_terms = false);
 	
 	/** copy constructor */
 	CHashedDenseFeatures(const CHashedDenseFeatures& orig);
@@ -190,12 +204,15 @@ public:
 	 *
 	 * @param vec the vector to hash
 	 * @param dim the size of the new dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 * @return the hashed representation
 	 */
-	static SGSparseVector<ST> hash_vector(SGVector<ST> vec, int32_t dim);
+	static SGSparseVector<ST> hash_vector(SGVector<ST> vec, int32_t dim, bool use_quadratic = false,
+			bool keep_linear_terms = true);
 
 protected:
-	void init(CDenseFeatures<ST>* feats, int32_t d);
+	void init(CDenseFeatures<ST>* feats, int32_t d, bool use_quadr, bool keep_lin_terms);
 
 protected:
 
@@ -204,6 +221,12 @@ protected:
 
 	/** new feature space dimension */
 	int32_t dim;
+
+	/** use quadratic feature or not */
+	bool use_quadratic;
+
+	/** keep linear terms or not */
+	bool keep_linear_terms;
 };
 }
 

--- a/tests/unit/features/HashedDenseFeatures_unittest.cc
+++ b/tests/unit/features/HashedDenseFeatures_unittest.cc
@@ -33,13 +33,71 @@ TEST(HashedDenseFeaturesTest, dot)
 
 	for (index_t i=0; i<n; i++)
 	{
-		SGVector<uint32_t> tmp(hashing_dim);
-		SGVector<uint32_t>::fill_vector(tmp, hashing_dim, 0);
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
 		for (index_t j=0; j<dim; j++)
 		{
 			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
 			hash = hash % hashing_dim;
 			tmp[hash] += data(j,i);
+		}
+
+		float64_t dot_product = 0;
+		for (index_t j=0; j<hashing_dim; j++)
+			dot_product += tmp[j] * tmp[j];
+
+		float64_t feat_dot = h_feats->dot(i, h_feats, i);
+		EXPECT_EQ(feat_dot, dot_product);
+	}
+
+	SG_UNREF(h_feats);
+}
+
+TEST(HashedDenseFeaturesTest, quadratic_dot)
+{
+	index_t n=3;
+	index_t dim=10;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+
+	int32_t hashing_dim = 8;
+	CHashedDenseFeatures<float64_t>* h_feats = new CHashedDenseFeatures<float64_t>(data, hashing_dim, true);
+	EXPECT_EQ(h_feats->get_num_vectors(), n);
+
+	for (index_t i=0; i<n; i++)
+	{
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
+		for (index_t j=0; j<dim; j++)
+		{
+			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+			hash = hash % hashing_dim;
+			tmp[hash] += data(j,i);
+		}
+
+		for (index_t j=0; j<dim; j++)
+		{
+			for (index_t k=j; k<dim; k++)
+			{
+				if (k!=j)
+				{
+					uint32_t hash_j = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+					uint32_t hash_k = CHash::MurmurHash3((uint8_t* ) &k, sizeof (index_t), k);
+					uint32_t hash = (hash_j ^ hash_k) % hashing_dim;
+					tmp[hash] += data(j,i) * data(k,i);
+				}
+				else
+				{
+					index_t n_idx = j * dim + k;
+					uint32_t hash = CHash::MurmurHash3((uint8_t* ) &n_idx, sizeof (index_t), n_idx);
+					tmp[hash % hashing_dim] += data(j,i) * data(k,i);
+				}
+			}
 		}
 
 		float64_t dot_product = 0;
@@ -91,6 +149,64 @@ TEST(HashedDenseFeaturesTest, dense_dot)
 	SG_UNREF(h_feats);
 }
 
+TEST(HashedDenseFeaturesTest, quadratic_dense_dot)
+{
+	index_t n=3;
+	index_t dim=10;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+
+	int32_t hashing_dim = 8;
+	CHashedDenseFeatures<float64_t>* h_feats = new CHashedDenseFeatures<float64_t>(data, hashing_dim, true);
+	EXPECT_EQ(h_feats->get_num_vectors(), n);
+
+	for (index_t i=0; i<n; i++)
+	{
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
+		for (index_t j=0; j<dim; j++)
+		{
+			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+			hash = hash % hashing_dim;
+			tmp[hash] += data(j,i);
+		}
+
+		for (index_t j=0; j<dim; j++)
+		{
+			for (index_t k=j; k<dim; k++)
+			{
+				if (k!=j)
+				{
+					uint32_t hash_j = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+					uint32_t hash_k = CHash::MurmurHash3((uint8_t* ) &k, sizeof (index_t), k);
+					uint32_t hash = (hash_j ^ hash_k) % hashing_dim;
+					tmp[hash] += data(j,i) * data(k,i);
+				}
+				else
+				{
+					index_t n_idx = j * dim + k;
+					uint32_t hash = CHash::MurmurHash3((uint8_t* ) &n_idx, sizeof (index_t), n_idx);
+					tmp[hash % hashing_dim] += data(j,i) * data(k,i);
+				}
+			}
+		}
+
+		float64_t dot_product = 0;
+		for (index_t j=0; j<hashing_dim; j++)
+			dot_product += tmp[j] * tmp[j];
+
+		float64_t feat_dot = h_feats->dense_dot(i, tmp.vector, tmp.vlen);
+		EXPECT_EQ(feat_dot, dot_product);
+	}
+
+	SG_UNREF(h_feats);
+}
+
 TEST(HashedDenseFeaturesTest, add_to_dense)
 {
 	index_t n=3;
@@ -127,5 +243,92 @@ TEST(HashedDenseFeaturesTest, add_to_dense)
 			EXPECT_EQ(tmp2[j], tmp[j]);
 	}
 
+	SG_UNREF(h_feats);
+}
+
+
+TEST(HashedDenseFeaturesTest, quadratic_add_to_dense)
+{
+	index_t n=3;
+	index_t dim=10;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+
+	int32_t hashing_dim = 8;
+	CHashedDenseFeatures<float64_t>* h_feats = new CHashedDenseFeatures<float64_t>(data, hashing_dim, true);
+	EXPECT_EQ(h_feats->get_num_vectors(), n);
+
+	for (index_t i=0; i<3; i++)
+	{
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
+		for (index_t j=0; j<dim; j++)
+		{
+			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+			hash = hash % hashing_dim;
+			tmp[hash] += data(j,i);
+		}
+
+		for (index_t j=0; j<dim; j++)
+		{
+			for (index_t k=j; k<dim; k++)
+			{
+				if (k!=j)
+				{
+					uint32_t hash_j = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+					uint32_t hash_k = CHash::MurmurHash3((uint8_t* ) &k, sizeof (index_t), k);
+					uint32_t hash = (hash_j ^ hash_k) % hashing_dim;
+					tmp[hash] += data(j,i) * data(k,i);
+				}
+				else
+				{
+					index_t n_idx = j * dim + k;
+					uint32_t hash = CHash::MurmurHash3((uint8_t* ) &n_idx, sizeof (index_t), n_idx);
+					tmp[hash % hashing_dim] += data(j,i) * data(k,i);
+				}
+			}
+		}
+
+		SGVector<float64_t> tmp2(hashing_dim);
+		for (index_t j=0; j<hashing_dim; j++)
+			tmp2[j] = 3 * tmp[j];
+
+		h_feats->add_to_dense_vec(2, i, tmp.vector, tmp.vlen);
+		for (index_t j=0; j<hashing_dim; j++)
+			EXPECT_EQ(tmp2[j], tmp[j]);
+	}
+
+	SG_UNREF(h_feats);
+}
+
+TEST(HashedDenseFeaturesTest, dense_comparison)
+{
+	index_t n=3;
+	index_t dim=10;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+
+	int32_t hashing_dim = 300;
+	CHashedDenseFeatures<float64_t>* h_feats = new CHashedDenseFeatures<float64_t>(data, hashing_dim);
+	CDenseFeatures<float64_t>* d_feats = new CDenseFeatures<float64_t>(data);
+
+	SGVector<float64_t> dense_vec(hashing_dim);
+	for (index_t i=0; i<hashing_dim; i++)
+		dense_vec[i] = CMath::random(-hashing_dim, hashing_dim);
+
+	for (index_t i=0; i<n; i++)
+		EXPECT_EQ(h_feats->dot(i, h_feats, i), d_feats->dot(i, d_feats, i));
+
+	SG_UNREF(d_feats);
 	SG_UNREF(h_feats);
 }


### PR DESCRIPTION
Checked results using a PolyKernel of d = 1 using the HashedDenseFeatures with quadratic and multiplying each cross term with sqrt(2), against a PolyKernel of d = 2 using DenseFeatures and got the same results. 
https://gist.github.com/van51/6072287
