### PR TITLE
Quadratic support for rest numerical hashed classes

### DIFF
--- a/src/shogun/features/HashedSparseFeatures.h
+++ b/src/shogun/features/HashedSparseFeatures.h
@@ -31,29 +31,40 @@ public:
 	/** constructor
 	 *
 	 * @param size cache size
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedSparseFeatures(int32_t size=0);
+	CHashedSparseFeatures(int32_t size=0, bool use_quadr = false, bool keep_lin_terms = true);
 
 	/** constructor
 	 *
 	 * @param feats	the sparse features to use as a base
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedSparseFeatures(CSparseFeatures<ST>* feats, int32_t d);
+	CHashedSparseFeatures(CSparseFeatures<ST>* feats, int32_t d, bool use_quadr = false,
+			bool keep_lin_terms = true);
 
 	/** constructor
 	 *
 	 * @param matrix feature matrix
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedSparseFeatures(SGSparseMatrix<ST> matrix, int32_t d);
+	CHashedSparseFeatures(SGSparseMatrix<ST> matrix, int32_t d, bool use_quadr = false,
+			bool keep_lin_terms = true);
 
 	/** constructor loading features from file
 	 *
 	 * @param loader File object via which to load data
 	 * @param d new feature space dimension
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
-	CHashedSparseFeatures(CFile* loader, int32_t d);
+	CHashedSparseFeatures(CFile* loader, int32_t d, bool use_quadr = false,
+			bool keep_lin_terms = true);
 	
 	/** copy constructor */
 	CHashedSparseFeatures(const CHashedSparseFeatures & orig);
@@ -182,20 +193,26 @@ public:
 	 *
 	 * @param vec the vector to hash
 	 * @param dim the dimension of the new feature space
+	 * @param use_quadratic whether to use quadratic features or not
+	 * @param keep_linear_terms whether to maintain the linear terms in the computations
 	 * @return the hashed representation of the vector vec
 	 */
-	static SGSparseVector<ST> hash_vector(SGVector<ST> vec, int32_t dim);
+	static SGSparseVector<ST> hash_vector(SGVector<ST> vec, int32_t dim,
+		bool use_quadratic = false, bool keep_linear_terms = true);
 
 
 	/** Get the hashed representation of the given sparse vector
 	 *
 	 * @param vec the vector to hash
 	 * @param dim the dimension of the hashed target space
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 * @return the hashed representation of the vector vec
 	 */
-	static SGSparseVector<ST> hash_vector(SGSparseVector<ST> vec, int32_t dim);
+	static SGSparseVector<ST> hash_vector(SGSparseVector<ST> vec, int32_t dim,
+		bool use_quadratic = false, bool keep_linear_terms = true);
 protected:
-	void init(CSparseFeatures<ST>* feats, int32_t d);
+	void init(CSparseFeatures<ST>* feats, int32_t d, bool use_quadr, bool keep_lin_terms);
 
 protected:
 
@@ -204,6 +221,12 @@ protected:
 
 	/** new feature space dimension */
 	int32_t dim;
+
+	/** use quadratic features */
+	bool use_quadratic;
+
+	/** keep linear terms */
+	bool keep_linear_terms;
 };
 }
 

--- a/src/shogun/features/streaming/StreamingHashedDenseFeatures.h
+++ b/src/shogun/features/streaming/StreamingHashedDenseFeatures.h
@@ -40,9 +40,11 @@ public:
 	 * @param is_labelled Whether examples are labelled or not.
 	 * @param size Number of examples to be held in the parser's "ring".
 	 * @param d the dimensionality of the target feature space
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
 	CStreamingHashedDenseFeatures(CStreamingFile* file, bool is_labelled, int32_t size,
-			 int32_t d = 512);
+			 int32_t d = 512, bool use_quadr = false, bool keep_lin_terms = true);
 
 	/**
 	 * Constructor taking a CDotFeatures object and optionally,
@@ -55,10 +57,12 @@ public:
 	 *
 	 * @param dot_features CDotFeatures object
 	 * @param d the dimensionality of the target feature space
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 * @param lab labels (optional)
 	 */
 	CStreamingHashedDenseFeatures(CDenseFeatures<ST>* dot_features, int32_t d = 512,
-			float64_t* lab = NULL);
+			bool use_quadr = false, bool keep_lin_terms = true, float64_t* lab = NULL);
 
 	/** Destructor */
 	virtual ~CStreamingHashedDenseFeatures();
@@ -203,7 +207,7 @@ public:
 
 private:
 	void init(CStreamingFile* file, bool is_labelled, int32_t size,
-		int32_t d);
+		int32_t d, bool use_quadr, bool keep_lin_terms);
 
 protected:
 	
@@ -218,6 +222,12 @@ protected:
 
 	/** The current example's label */
 	float64_t current_label;
+
+	/** use quadratic feature or not */
+	bool use_quadratic;
+
+	/** keep linear terms or not */
+	bool keep_linear_terms;
 };
 }
 

--- a/src/shogun/features/streaming/StreamingHashedSparseFeatures.h
+++ b/src/shogun/features/streaming/StreamingHashedSparseFeatures.h
@@ -40,9 +40,11 @@ public:
 	 * @param is_labelled Whether examples are labelled or not.
 	 * @param size Number of examples to be held in the parser's "ring".
 	 * @param d the dimensionality of the target feature space
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 */
 	CStreamingHashedSparseFeatures (CStreamingFile* file, bool is_labelled, int32_t size,
-			 int32_t d = 512);
+				int32_t d = 512, bool use_quadr = false, bool keep_lin_terms = true);
 
 	/**
 	 * Constructor taking a CDotFeatures object and optionally,
@@ -55,10 +57,12 @@ public:
 	 *
 	 * @param dot_features CDotFeatures object
 	 * @param d the dimensionality of the target feature space
+	 * @param use_quadr whether to use quadratic features or not
+	 * @param keep_lin_terms whether to maintain the linear terms in the computations
 	 * @param lab labels (optional)
 	 */
 	CStreamingHashedSparseFeatures (CSparseFeatures<ST>* dot_features, int32_t d = 512,
-			float64_t* lab = NULL);
+				bool use_quadr = false, bool keep_lin_terms = true, float64_t* lab = NULL);
 
 	/** Destructor */
 	virtual ~CStreamingHashedSparseFeatures ();
@@ -203,7 +207,7 @@ public:
 
 private:
 	void init(CStreamingFile* file, bool is_labelled, int32_t size,
-		int32_t d);
+		int32_t d, bool use_quadr, bool keep_lin_terms);
 
 protected:
 	
@@ -218,6 +222,12 @@ protected:
 
 	/** The current example's label */
 	float64_t current_label;
+
+	/** use quadratic feature or not */
+	bool use_quadratic;
+
+	/** keep linear terms or not */
+	bool keep_linear_terms;
 };
 }
 

--- a/tests/unit/features/HashedSparseFeatures_unittest.cc
+++ b/tests/unit/features/HashedSparseFeatures_unittest.cc
@@ -58,6 +58,70 @@ TEST(HashedSparseFeaturesTest, dot)
 	SG_UNREF(h_feats);
 }
 
+TEST(HashedSparseFeaturesTest, quadratic_dot)
+{
+	index_t n=3;
+	index_t dim=4;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+	int32_t hashing_dim = 8;
+	CSparseFeatures<float64_t>* s_feats = new CSparseFeatures<float64_t>(data);
+	CHashedSparseFeatures<float64_t>* h_feats = new CHashedSparseFeatures<float64_t>(s_feats, hashing_dim, true);
+
+	EXPECT_EQ(h_feats->get_num_vectors(), n);
+
+	for (index_t i=0; i<1; i++)
+	{
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
+		for (index_t j=0; j<dim; j++)
+		{
+			if (data(j,i)==0)
+				continue;
+
+			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+			hash = hash % hashing_dim;
+			tmp[hash] += data(j,i);
+		}
+
+		for (index_t j=0; j<dim; j++)
+		{
+			for (index_t k=j; k<dim; k++)
+			{
+				if (data(j,i)==0 || data(k,i)==0)
+					continue;
+
+				if (k!=j)
+				{
+					uint32_t hash_j = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+					uint32_t hash_k = CHash::MurmurHash3((uint8_t* ) &k, sizeof (index_t), k);
+					uint32_t hash = (hash_j ^ hash_k) % hashing_dim;
+					tmp[hash] += data(j,i) * data(k,i);
+				}
+				else
+				{
+					index_t n_idx = j + j;
+					uint32_t hash = CHash::MurmurHash3((uint8_t* ) &n_idx, sizeof (index_t), j);
+					tmp[hash % hashing_dim] += data(j,i) * data(k,i);
+				}
+			}
+		}
+
+		float64_t dot_product = 0;
+		for (index_t j=0; j<hashing_dim; j++)
+			dot_product += tmp[j] * tmp[j];
+
+		float64_t feat_dot = h_feats->dot(i, h_feats, i);
+		EXPECT_EQ(feat_dot, dot_product);
+	}
+
+	SG_UNREF(h_feats);
+}
 
 TEST(HashedSparseFeaturesTest, dense_dot)
 {
@@ -101,6 +165,70 @@ TEST(HashedSparseFeaturesTest, dense_dot)
 	SG_UNREF(h_feats);
 }
 
+TEST(HashedSparseFeaturesTest, quadratic_dense_dot)
+{
+	index_t n=3;
+	index_t dim=10;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+
+	int32_t hashing_dim = 8;
+	CSparseFeatures<float64_t>* s_feats = new CSparseFeatures<float64_t>(data);
+	CHashedSparseFeatures<float64_t>* h_feats = new CHashedSparseFeatures<float64_t>(s_feats, hashing_dim, true);
+	EXPECT_EQ(h_feats->get_num_vectors(), n);
+
+	for (index_t i=0; i<n; i++)
+	{
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
+		for (index_t j=0; j<dim; j++)
+		{
+			if (data(j,i)==0)
+				continue;
+
+			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+			hash = hash % hashing_dim;
+			tmp[hash] += data(j,i);
+		}
+
+		for (index_t j=0; j<dim; j++)
+		{
+			for (index_t k=j; k<dim; k++)
+			{
+				if (data(j,i)==0)
+					continue;
+
+				if (k!=j)
+				{
+					uint32_t hash_j = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+					uint32_t hash_k = CHash::MurmurHash3((uint8_t* ) &k, sizeof (index_t), k);
+					uint32_t hash = (hash_j ^ hash_k) % hashing_dim;
+					tmp[hash] += data(j,i) * data(k,i);
+				}
+				else
+				{
+					index_t n_idx = j + j;
+					uint32_t hash = CHash::MurmurHash3((uint8_t* ) &n_idx, sizeof (index_t), j);
+					tmp[hash % hashing_dim] += data(j,i) * data(k,i);
+				}
+			}
+		}
+
+		float64_t dot_product = 0;
+		for (index_t j=0; j<hashing_dim; j++)
+			dot_product += tmp[j] * tmp[j];
+
+		float64_t feat_dot = h_feats->dense_dot(i, tmp.vector, tmp.vlen);
+		EXPECT_EQ(feat_dot, dot_product);
+	}
+
+	SG_UNREF(h_feats);
+}
 
 TEST(HashedSparseFeaturesTest, add_to_dense)
 {
@@ -131,6 +259,66 @@ TEST(HashedSparseFeaturesTest, add_to_dense)
 			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
 			hash = hash % hashing_dim;
 			tmp[hash] += data(j,i);
+		}
+
+		SGVector<float64_t> tmp2(hashing_dim);
+		for (index_t j=0; j<hashing_dim; j++)
+			tmp2[j] = 3 * tmp[j];
+
+		h_feats->add_to_dense_vec(2, i, tmp.vector, tmp.vlen);
+		for (index_t j=0; j<hashing_dim; j++)
+			EXPECT_EQ(tmp2[j], tmp[j]);
+	}
+
+	SG_UNREF(h_feats);
+}
+
+TEST(HashedSparseFeaturesTest, quadratic_add_to_dense)
+{
+	index_t n=3;
+	index_t dim=10;
+
+	SGMatrix<float64_t> data(dim,n);
+	for (index_t i=0; i<n; i++)
+	{
+		for (index_t j=0; j<dim; j++)
+			data(j,i) = j + i * dim;
+	}
+
+	int32_t hashing_dim = 8;
+	CSparseFeatures<float64_t>* s_feats = new CSparseFeatures<float64_t>(data);
+	CHashedSparseFeatures<float64_t>* h_feats = new CHashedSparseFeatures<float64_t>(s_feats, hashing_dim, true);
+	EXPECT_EQ(h_feats->get_num_vectors(), n);
+
+	for (index_t i=0; i<3; i++)
+	{
+		SGVector<float64_t> tmp(hashing_dim);
+		SGVector<float64_t>::fill_vector(tmp, hashing_dim, 0);
+		for (index_t j=0; j<dim; j++)
+		{
+			uint32_t hash = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+			hash = hash % hashing_dim;
+			tmp[hash] += data(j,i);
+		}
+
+		for (index_t j=0; j<dim; j++)
+		{
+			for (index_t k=j; k<dim; k++)
+			{
+				if (k!=j)
+				{
+					uint32_t hash_j = CHash::MurmurHash3((uint8_t* ) &j, sizeof (index_t), j);
+					uint32_t hash_k = CHash::MurmurHash3((uint8_t* ) &k, sizeof (index_t), k);
+					uint32_t hash = (hash_j ^ hash_k) % hashing_dim;
+					tmp[hash] += data(j,i) * data(k,i);
+				}
+				else
+				{
+					index_t n_idx = j + j;
+					uint32_t hash = CHash::MurmurHash3((uint8_t* ) &n_idx, sizeof (index_t), j);
+					tmp[hash % hashing_dim] += data(j,i) * data(k,i);
+				}
+			}
 		}
 
 		SGVector<float64_t> tmp2(hashing_dim);


### PR DESCRIPTION
Added support for quadratic features in the following classes :
    CHashedSparseFeatures
    CStreamingHashedDenseFeatures
    CStreamingHashedSparseFeatures.

Also checked again the (modified) CHashedSparseFeatures with the polykernel and the results were the same.
