### PR TITLE
FactorGraph_unittest memory leak fixed

### DIFF
--- a/src/shogun/structure/FactorGraph.cpp
+++ b/src/shogun/structure/FactorGraph.cpp
@@ -13,25 +13,16 @@
 using namespace shogun;
 
 CFactorGraph::CFactorGraph() 
-	: m_factors(NULL), m_datasources(NULL)
 {
 	SG_UNSTABLE("CFactorGraph::CFactorGraph()", "\n");
 
 	register_parameters();
-
-	SG_REF(m_factors);
-	SG_REF(m_datasources);
 }
 
 CFactorGraph::CFactorGraph(SGVector<int32_t> card)
-	: m_cardinalities(card),
-	m_factors(new CDynamicObjectArray()), 
-	m_datasources(new CDynamicObjectArray())
+	: m_cardinalities(card)
 {
 	register_parameters();
-
-	SG_REF(m_factors);
-	SG_REF(m_datasources);
 }
 
 CFactorGraph::CFactorGraph(const CFactorGraph &fg)
@@ -39,6 +30,7 @@ CFactorGraph::CFactorGraph(const CFactorGraph &fg)
 	register_parameters();
 	m_cardinalities = fg.get_cardinalities();
 	// No need to unref and ref in this case
+	// TODO test if need to copy element by element
 	m_factors = fg.get_factors();
 	m_datasources = fg.get_factor_data_sources();
 }
@@ -47,6 +39,14 @@ CFactorGraph::~CFactorGraph()
 {
 	SG_UNREF(m_factors);
 	SG_UNREF(m_datasources);
+
+	if (m_factors != NULL)
+		SG_DEBUG("CFactorGraph::~CFactorGraph(): m_factors->ref_count() = %d.\n", m_factors->ref_count());
+
+	if (m_datasources != NULL)
+		SG_DEBUG("CFactorGraph::~CFactorGraph(): m_datasources->ref_count() = %d.\n", m_datasources->ref_count());
+
+	SG_DEBUG("CFactorGraph::~CFactorGraph(): this->ref_count() = %d.\n", this->ref_count());
 }
 
 void CFactorGraph::register_parameters()
@@ -54,6 +54,17 @@ void CFactorGraph::register_parameters()
 	SG_ADD(&m_cardinalities, "m_cardinalities", "Cardinalities", MS_NOT_AVAILABLE);
 	SG_ADD((CSGObject**)&m_factors, "m_factors", "Factors", MS_NOT_AVAILABLE);
 	SG_ADD((CSGObject**)&m_datasources, "m_datasources", "Factor data sources", MS_NOT_AVAILABLE);
+
+	m_factors = NULL;
+	m_datasources = NULL;
+	m_factors = new CDynamicObjectArray();
+	m_datasources = new CDynamicObjectArray();
+
+	if (m_factors != NULL)
+		SG_DEBUG("CFactorGraph::register_parameters(): m_factors->ref_count() = %d.\n", m_factors->ref_count());
+
+	SG_REF(m_factors);
+	SG_REF(m_datasources);
 }
 
 CDynamicObjectArray* CFactorGraph::get_factors() const

--- a/tests/unit/structure/FactorGraph_unittest.cc
+++ b/tests/unit/structure/FactorGraph_unittest.cc
@@ -243,7 +243,7 @@ TEST(FactorGraph, evaluate_energy_data_dep)
 	SG_UNREF(fac1b);
 }
 
-TEST(FactorGraph, DISABLED_evaluate_energy_param_data)
+TEST(FactorGraph, evaluate_energy_param_data)
 {
 	// Create one simple pairwise factor type
 	SGVector<int32_t> card(2);
@@ -309,6 +309,7 @@ TEST(FactorGraph, DISABLED_evaluate_energy_param_data)
 	marginals[3] = 0.25;
 
 	SGVector<float64_t> gradients(8);
+	gradients.zero();
 	CDynamicObjectArray* allfac = fg.get_factors();
 	//for (int32_t fi = 0; fi < allfac->get_num_elements(); fi++)
 	int32_t fi = 0;
@@ -317,6 +318,7 @@ TEST(FactorGraph, DISABLED_evaluate_energy_param_data)
 		ft->compute_gradients(marginals, gradients);
 		SG_UNREF(ft);
 	}
+	SG_UNREF(allfac);
 
 	EXPECT_NEAR(0.025, gradients[0], 1E-10);
 	EXPECT_NEAR(0.05, gradients[1], 1E-10);
@@ -333,7 +335,7 @@ TEST(FactorGraph, DISABLED_evaluate_energy_param_data)
 	SG_UNREF(fac1b);
 }
 
-TEST(FactorGraph, DISABLED_evaluate_energy_param_data_sparse)
+TEST(FactorGraph, evaluate_energy_param_data_sparse)
 {
 	// Create one simple pairwise factor type
 	SGVector<int32_t> card(2);
@@ -411,6 +413,7 @@ TEST(FactorGraph, DISABLED_evaluate_energy_param_data_sparse)
 	marginals[3] = 0.25;
 
 	SGVector<float64_t> gradients(8);
+	gradients.zero();
 	CDynamicObjectArray* allfac = fg.get_factors();
 	for (int32_t fi = 0; fi < allfac->get_num_elements(); fi++)
 	{
@@ -418,6 +421,7 @@ TEST(FactorGraph, DISABLED_evaluate_energy_param_data_sparse)
 		ft->compute_gradients(marginals, gradients);
 		SG_UNREF(ft);
 	}
+	SG_UNREF(allfac);
 
 	// factor 3
 	EXPECT_NEAR(0.225, gradients[0], 1E-10);
@@ -429,13 +433,13 @@ TEST(FactorGraph, DISABLED_evaluate_energy_param_data_sparse)
 	EXPECT_NEAR(0.225, gradients[6], 1E-10);
 	EXPECT_NEAR(0.3, gradients[7], 1E-10);
 
-	delete[] sdata;
-	delete[] sdata1;
-	delete[] sdata2;
 	SG_UNREF(factortype);
 	SG_UNREF(fac1);
 	SG_UNREF(fac1a);
 	SG_UNREF(fac1b);
 
+	//delete[] sdata;
+	//delete[] sdata1;
+	//delete[] sdata2;
 }
 


### PR DESCRIPTION
@iglesias the bug in https://github.com/shogun-toolbox/shogun/issues/1298 is because I forgot to unref something in the unit tests. I hope no problem now.
