### PR TITLE
Fix discrete libshogun HM-SVM example

### DIFF
--- a/examples/undocumented/libshogun/structure_discrete_hmsvm_bmrm.cpp
+++ b/examples/undocumented/libshogun/structure_discrete_hmsvm_bmrm.cpp
@@ -10,13 +10,14 @@ int main()
 {
 	init_shogun_with_defaults();
 	
-	float64_t features_dat[] = {0,1, 2,1, 0,1, 0,2};
-	SGMatrix<float64_t> features_mat(features_dat,1,8,false);
-	CMatrixFeatures<float64_t>* features = new CMatrixFeatures<float64_t>(features_mat,2,4);
+	float64_t features_dat[] = {0,1,1, 2,1,2, 0,1,0, 0,2,2};
+	SGMatrix<float64_t> features_mat(features_dat,1,12,false);
+	CMatrixFeatures<float64_t>* features = new CMatrixFeatures<float64_t>(features_mat,3,4);
 
-	int32_t labels_dat[] = {0,0, 1,1, 0,0, 1,1};
-	SGVector<int32_t> labels_vec(labels_dat,8,false);
-	CSequenceLabels* labels = new CSequenceLabels(labels_vec,2,4,2);
+	int32_t labels_dat[] = {0,0,0, 1,1,1, 0,0,0, 1,1,1};
+	SGVector<int32_t> labels_vec(labels_dat,12,false);
+	CSequenceLabels* labels = new CSequenceLabels(labels_vec,3,4,2);
+	labels->io->set_loglevel(MSG_DEBUG);
 
 	CHMSVMModel* model = new CHMSVMModel(features, labels, SMT_TWO_STATE, 3);
 	CDualLibQPBMSOSVM* sosvm = new CDualLibQPBMSOSVM(model, labels, 5000,0);

--- a/src/shogun/structure/HMSVMModel.cpp
+++ b/src/shogun/structure/HMSVMModel.cpp
@@ -320,6 +320,10 @@ CResultSet* CHMSVMModel::argmax(
 		}
 	}
 
+	REQUIRE(opt_path[T-1]!=-1, "Viterbi decoding found no possible sequence states.\n"
+			"Maybe the state model used cannot produce such sequence.\n"
+			"If using the TwoStateModel, please use sequences of length greater than two.\n");
+
 	for ( int32_t i = T-1 ; i > 0 ; --i )
 		opt_path[i-1] = trb[opt_path[i]*T + i];
 


### PR DESCRIPTION
The problem was with the data used. Given the two state model, it makes no much sense to have sequences of length equal to two or less. An error message notifies that now.

Valgrind does not complain about the cpp example, but it seems that the python structure_discrete_hmsvm_bmrm.py still has got something.
