### PR TITLE
Unbiased estimation of log-marginal likelihood ...

### DIFF
--- a/src/NEWS
+++ b/src/NEWS
@@ -3,6 +3,11 @@
 	* SHOGUN Release version 2.2.0 (libshogun 14.0, data 0.6, parameter 1)
 	* This release contains several cleanups and bugfixes:
 	* Features:
+		- Added method to importance sample the (true) marginal likelihood of a
+		  Gaussian Process using a posterior approximation.
+		- Added a new class for classical probability distribution that can be
+		  sampled and whose log-pdf can be evaluated. Added the multivariate
+		  Gaussian with various numerical flavours.
 		- Added nu-SVR for LibSVR class
 		- Modelselection is now supported for parameters of sub-kernels of
 		  combined kernels in the MKL context. Thanks to Evangelos Anagnostopoulos

--- a/src/shogun/distributions/classical/GaussianDistribution.cpp
+++ b/src/shogun/distributions/classical/GaussianDistribution.cpp
@@ -1,0 +1,247 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Heiko Strathmann
+ */
+
+#ifdef HAVE_EIGEN3
+
+#include <shogun/distributions/classical/GaussianDistribution.h>
+#include <shogun/base/Parameter.h>
+#include <shogun/mathematics/eigen3.h>
+
+using namespace shogun;
+using namespace Eigen;
+
+CGaussianDistribution::CGaussianDistribution() : CProbabilityDistribution()
+{
+	init();
+}
+
+CGaussianDistribution::CGaussianDistribution(SGVector<float64_t> mean,
+		SGMatrix<float64_t> cov,
+		ECovarianceFactorization factorization, bool cov_is_factor) :
+				CProbabilityDistribution(mean.vlen)
+{
+	REQUIRE(cov.num_rows==cov.num_cols, "Covariance must be square but is "
+			"%dx%d\n", cov.num_rows, cov.num_cols);
+	REQUIRE(mean.vlen==cov.num_cols, "Mean must have same dimension as "
+			"covariance, which is %dx%d, but is %d\n",
+			cov.num_rows, cov.num_cols, mean.vlen);
+
+	init();
+
+	m_mean=mean;
+	m_factorization=factorization;
+
+	if (!cov_is_factor)
+		compute_covariance_factorization(cov, factorization);
+	else
+		m_L=cov;
+}
+
+CGaussianDistribution::~CGaussianDistribution()
+{
+
+}
+
+SGMatrix<float64_t> CGaussianDistribution::sample(int32_t num_samples,
+		SGMatrix<float64_t> pre_samples) const
+{
+	REQUIRE(num_samples>0, "Number of samples must be positive, but is %d\n",
+			num_samples);
+
+	/* use pre-allocated samples? */
+	SGMatrix<float64_t> samples;
+	if (pre_samples.matrix)
+	{
+		REQUIRE(pre_samples.num_rows==m_dimension, "Dimension of pre-samples"
+				" (%d) does not match dimension of Gaussian (%d)\n",
+				pre_samples.num_rows, m_dimension);
+
+		REQUIRE(pre_samples.num_cols==num_samples, "Number of pre-samples"
+				" (%d) does not desired number of samples (%d)\n",
+				pre_samples.num_cols, num_samples);
+
+		samples=pre_samples;
+	}
+	else
+	{
+		/* allocate memory and sample from std normal */
+		samples=SGMatrix<float64_t>(m_dimension, num_samples);
+		for (index_t i=0; i<m_dimension*num_samples; ++i)
+			samples.matrix[i]=sg_rand->std_normal_distrib();
+	}
+
+	/* map into desired Gaussian covariance */
+	Map<MatrixXd> eigen_samples(samples.matrix, samples.num_rows,
+			samples.num_cols);
+	Map<MatrixXd> eigen_L(m_L.matrix, m_L.num_rows, m_L.num_cols);
+	eigen_samples=eigen_L*eigen_samples;
+
+	/* add mean */
+	Map<VectorXd> eigen_mean(m_mean.vector, m_mean.vlen);
+	eigen_samples.colwise()+=eigen_mean;
+
+	return samples;
+}
+
+SGVector<float64_t> CGaussianDistribution::log_pdf(SGMatrix<float64_t> samples) const
+{
+	REQUIRE(samples.num_cols>0, "Number of samples must be positive, but is %d\n",
+			samples.num_cols);
+	REQUIRE(samples.num_rows=m_dimension, "Sample dimension (%d) does not match"
+			"Gaussian dimension (%d)\n", samples.num_rows, m_dimension);
+
+	/* for easier to read code */
+	index_t num_samples=samples.num_cols;
+
+	float64_t const_part=-0.5 * m_dimension * CMath::log(2 * CMath::PI);
+
+	/* log-determinant */
+	float64_t log_det_part=0;
+	Map<MatrixXd> eigen_L(m_L.matrix, m_L.num_rows, m_L.num_cols);
+	switch (m_factorization)
+	{
+		case CF_CHOLESKY:
+		{
+			/* determinant is product of diagonal elements of triangular matrix */
+			VectorXd diag=eigen_L.diagonal();
+			log_det_part=-diag.array().log().sum();
+			break;
+		}
+		case CF_SVD_QR:
+		{
+			/* use QR for computing log-determinant, which abs(log-det R),
+			 * note that since covariance is psd, determinant is positive, so
+			 * absolute value here is fine (and necessary, since determinant
+			 * of R might be negative. */
+			Map<MatrixXd> eigen_R(m_R.matrix, m_R.num_rows, m_R.num_cols);
+			VectorXd diag=eigen_R.diagonal();
+			log_det_part=-0.5*diag.array().abs().log().sum();
+			break;
+		}
+	}
+
+	/* sample based part */
+	Map<MatrixXd> eigen_samples(samples.matrix, samples.num_rows,
+			samples.num_cols);
+	Map<VectorXd> eigen_mean(m_mean.vector, m_mean.vlen);
+
+	/* substract mean from samples (create copy) */
+	SGMatrix<float64_t> centred(m_dimension, num_samples);
+	Map<MatrixXd> eigen_centred(centred.matrix, centred.num_rows,
+			centred.num_cols);
+	for (index_t dim=0; dim<m_dimension; ++dim)
+	{
+		for (index_t sample_idx=0; sample_idx<num_samples; ++sample_idx)
+			centred(dim,sample_idx)=samples(dim,sample_idx)-m_mean[dim];
+	}
+
+	/* solve the linear system based on factorization */
+	MatrixXd solved;
+	switch (m_factorization)
+	{
+		case CF_CHOLESKY:
+		{
+			/* use triangular solver */
+			solved=eigen_L.triangularView<Lower>().solve(eigen_centred);
+			solved=eigen_L.transpose().triangularView<Upper>().solve(solved);
+			break;
+		}
+		case CF_SVD_QR:
+		{
+			/* use orthogonality of Q and triangular solver */
+			Map<MatrixXd> eigen_Q(m_Q.matrix, m_Q.num_rows, m_Q.num_cols);
+			Map<MatrixXd> eigen_R(m_R.matrix, m_R.num_rows, m_R.num_cols);
+
+			solved=eigen_Q.transpose()*eigen_centred;
+			solved=eigen_R.triangularView<Upper>().solve(solved);
+			break;
+		}
+	}
+
+	/* one quadratic part x^T C^-1 x for each sample x */
+	SGVector<float64_t> result(num_samples);
+	Map<VectorXd> eigen_result(result.vector, result.vlen);
+	for (index_t i=0; i<num_samples; ++i)
+	{
+		/* i-th centred sample */
+		VectorXd left=eigen_centred.block(0, i, m_dimension, 1);
+
+		/* inverted covariance times i-th centred sample */
+		VectorXd right=solved.block(0,i,m_dimension,1);
+		result[i]=-0.5*left.dot(right);
+	}
+
+	/* combine and return */
+	eigen_result=eigen_result.array()+(log_det_part+const_part);
+
+	/* contains everything */
+	return result;
+
+}
+
+void CGaussianDistribution::init()
+{
+	m_factorization=CF_CHOLESKY;
+
+	SG_ADD(&m_mean, "mean", "Mean of the Gaussian.", MS_NOT_AVAILABLE);
+	SG_ADD(&m_L, "L", "Lower factor of covariance matrix, "
+			"depending on the factorization type.", MS_NOT_AVAILABLE);
+	SG_ADD(&m_Q, "Q", "Orthogonal Q factor of QR of covariance, if used.",
+			MS_NOT_AVAILABLE);
+	SG_ADD(&m_R, "R", "Triangular R factor of QR of covariance, if used.",
+			MS_NOT_AVAILABLE);
+	SG_ADD((machine_int_t*)&m_factorization, "factorization", "Type of the "
+			"factorization of the covariance matrix.", MS_NOT_AVAILABLE);
+}
+
+void CGaussianDistribution::compute_covariance_factorization(
+		SGMatrix<float64_t> cov, ECovarianceFactorization factorization)
+{
+	Map<MatrixXd> eigen_cov(cov.matrix, cov.num_rows, cov.num_cols);
+	m_L=SGMatrix<float64_t>(cov.num_rows, cov.num_cols);
+	Map<MatrixXd> eigen_factor(m_L.matrix, m_L.num_rows, m_L.num_cols);
+
+	switch (m_factorization)
+	{
+		case CF_CHOLESKY:
+		{
+			LLT<MatrixXd> llt(eigen_cov);
+			if (llt.info()==NumericalIssue)
+				SG_ERROR("Error computing Cholesky\n");
+
+			eigen_factor=llt.matrixL();
+			break;
+		}
+		case CF_SVD_QR:
+		{
+			JacobiSVD<MatrixXd> svd(eigen_cov, ComputeFullU);
+			MatrixXd U=svd.matrixU();
+			VectorXd s=svd.singularValues();
+
+			/* square root of covariance using all eigenvectors */
+			eigen_factor=U.array().rowwise()*s.transpose().array().sqrt();
+
+			/* QR factorization of covariance for log-pdf */
+			m_Q=SGMatrix<float64_t>(cov.num_rows, cov.num_cols);
+			m_R=SGMatrix<float64_t>(cov.num_rows, cov.num_cols);
+			Map<MatrixXd> eigen_Q(m_Q.matrix, m_Q.num_rows, m_Q.num_cols);
+			Map<MatrixXd> eigen_R(m_R.matrix, m_R.num_rows, m_R.num_cols);
+
+			ColPivHouseholderQR<MatrixXd> qr(eigen_cov);
+			eigen_Q=qr.householderQ();
+			eigen_R=qr.matrixQR().triangularView<Upper>();
+			break;
+		}
+		default:
+			SG_ERROR("Unknown factorization type: %d\n", m_factorization);
+			break;
+	}
+}
+
+#endif // HAVE_EIGEN3

--- a/src/shogun/distributions/classical/GaussianDistribution.h
+++ b/src/shogun/distributions/classical/GaussianDistribution.h
@@ -1,0 +1,151 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Heiko Strathmann
+ */
+#ifdef HAVE_EIGEN3
+
+#ifndef GAUSSIANDISTRIBUTION_H
+#define GAUSSIANDISTRIBUTION_H
+
+#include <shogun/distributions/classical/ProbabilityDistribution.h>
+#include <shogun/lib/SGVector.h>
+
+namespace shogun
+{
+
+/** Different types of covariance factorizations. See CGaussianDistribution. */
+enum ECovarianceFactorization
+{
+	CF_CHOLESKY,
+	CF_SVD_QR
+};
+
+
+/** @brief Dense version of the well-known Gaussian probability distribution,
+ * defined as
+ * \f[
+ * \mathcal{N}_x(\mu,\Sigma)=
+ * \frac{1}{\sqrt{|2\pi\Sigma|}}
+ * \exp\left(-\frac{1}{2}(x-\mu)^T\Sigma^{-1}(x-\mu\right)
+ * \f]
+ *
+ * The implementation offers various techniques for representing the covariance
+ * matrix \f$\Sigma \f$, such as Cholesky factorisation, SVD-decomposition,
+ * QR factorization, etc.
+ *
+ * All factorizations store a matrix \f$F\f$, such that the covariance can be
+ * computed as \f$\Sigma=LL^T\f$.
+ *
+ * For Cholesky factorization, the lower factor \f$\Sigma=LL^T\f$ is computed
+ * with a eigen3's LLT (classic Cholesky.
+ * The factor \f$L\f$ can be used for both sampling and computing the log-pdf.
+ *
+ * For SVD factorization \f$\Sigma=USV^T\f$, the factor \f$U*\text{diag}(S)\f$
+ * (column-wise product) is stored for sampling. For evaluating the
+ * log-determinant of the log-pdf, a QR factorization of the covariance
+ * \f$\Sigma=QR\f$ is used.
+ */
+
+class CGaussianDistribution: public CProbabilityDistribution
+{
+public:
+	/** Default constructor */
+	CGaussianDistribution();
+
+	/** Constructor for which takes Gaussian mean and its covariance matrix.
+	 * It is also possible to pass a precomputed matrix factor of the specified
+	 * form. In this case, the factorization is not explicitly computed.
+	 *
+	 * @param mean mean of the Gaussian
+	 * @param cov covariance of the Gaussian, or covariance factor
+	 * @param factorization factorization type of covariance matrix (default is
+	 * Cholesky, others are for increased numerical stability)
+	 * @param cov_is_factor whether cov is a factor of the covariance or not
+	 * (default is false). If false, the factorization is explicitly computed
+	 */
+	CGaussianDistribution(SGVector<float64_t> mean, SGMatrix<float64_t> cov,
+			ECovarianceFactorization factorization=CF_CHOLESKY,
+			bool cov_is_factor=false);
+
+	/** Destructor */
+	virtual ~CGaussianDistribution();
+
+	/** Samples from the distribution multiple times
+	 *
+	 * @param num_samples number of samples to generate
+	 * @param pre_samples a matrix of standard normal samples that might be used
+	 * for sampling the Gaussian. Ignored by default. If passed, the pre-samples
+	 * will be modified.
+	 * @return matrix with samples (column vectors)
+	 */
+	virtual SGMatrix<float64_t> sample(int32_t num_samples,
+			SGMatrix<float64_t> pre_samples=SGMatrix<float64_t>()) const;
+
+	/** Computes the log-pdf for all provided samples. That is
+	 *
+	 * \f[
+	 * \log(\mathcal{N}_x(\mu,\Sigma))=
+	 * - \frac{d}{2}  \log(2\pi)
+	 * -\frac{1}{2}\log(\det(\Sigma))
+	 * -\frac{1}{2}(x-\mu)^T\Sigma^{-1}(x-\mu),
+	 * \f]
+	 *
+	 * where \f$d\f$ is the dimension of the Gaussian.
+	 * The method to compute the log-determinant is based on the factorization
+	 * of the covariance matrix. If a Cholesky based factorization is used, the
+	 * log-determinant is computed using the triangular factor. If an SVD
+	 * factorization is used for sampling, the log-pdf is computed using a QR
+	 * factorization (which is computed once).
+	 *
+	 * The inversion of the covariance is done using the factorization.
+	 *
+	 * @param samples samples to compute log-pdf of (column vectors)
+	 * @return vector with log-pdfs of given samples
+	 */
+	virtual SGVector<float64_t> log_pdf(SGMatrix<float64_t> samples) const;
+
+	/** @return name of the SGSerializable */
+	virtual const char* get_name() const
+	{
+		return "GaussianDistribution";
+	}
+
+private:
+
+	/** Initialses and registers parameters */
+	void init();
+
+	/** Computes and stores the factorization of the covariance matrix
+	 *
+	 * @param cov positive definite covariance matrix to compute factorization of
+	 * @param factorization the factorizaation type to be used
+	 */
+	void compute_covariance_factorization(SGMatrix<float64_t> cov,
+			ECovarianceFactorization factorization);
+
+protected:
+	/** Mean */
+	SGVector<float64_t> m_mean;
+
+	/** Lower factor of covariance matrix (depends on factorization type).
+	 * Covariance (approximation) is given by \f$\Sigma=LL^T\f$ */
+	SGMatrix<float64_t> m_L;
+
+	/** Orthogonal Q factor of \f$\Sigma=QR\f$ factorization of covariance */
+	SGMatrix<float64_t> m_Q;
+
+	/** Triangular R factor of \f$\Sigma=QR\f$ factorization of covariance */
+	SGMatrix<float64_t> m_R;
+
+	/** Type of the factorization of the covariance matrix */
+	ECovarianceFactorization m_factorization;
+};
+
+}
+
+#endif // GAUSSIANDISTRIBUTION_H
+#endif // HAVE_EIGEN3

--- a/src/shogun/distributions/classical/ProbabilityDistribution.cpp
+++ b/src/shogun/distributions/classical/ProbabilityDistribution.cpp
@@ -1,0 +1,78 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Heiko Strathmann
+ */
+
+#include <shogun/distributions/classical/ProbabilityDistribution.h>
+#include <shogun/base/Parameter.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+
+using namespace shogun;
+
+CProbabilityDistribution::CProbabilityDistribution() : CSGObject()
+{
+	init();
+}
+
+CProbabilityDistribution::CProbabilityDistribution(int32_t dimension) :
+		CSGObject()
+{
+	init();
+
+	REQUIRE(dimension>0, "Dimension of Distribution must be positive\n",
+			dimension);
+
+	m_dimension=dimension;
+}
+
+
+CProbabilityDistribution::~CProbabilityDistribution()
+{
+
+}
+
+SGMatrix<float64_t> CProbabilityDistribution::sample(int32_t num_samples,
+		SGMatrix<float64_t> pre_samples) const
+{
+	SG_ERROR("Not implemented in sub-class\n");
+	return SGMatrix<float64_t>();
+}
+
+SGVector<float64_t> CProbabilityDistribution::sample() const
+{
+	SGMatrix<float64_t> s=sample(1);
+	SGVector<float64_t> result(m_dimension);
+	memcpy(result.vector, s.matrix, m_dimension*sizeof(float64_t));
+	return result;
+}
+
+SGVector<float64_t> CProbabilityDistribution::log_pdf(
+		SGMatrix<float64_t> samples) const
+{
+	SG_ERROR("Not implemented in sub-class\n");
+	return SGVector<float64_t>();
+}
+
+float64_t CProbabilityDistribution::log_pdf(SGVector<float64_t> single_sample) const
+{
+	REQUIRE(single_sample.vlen==m_dimension, "Sample dimension (%d) does not "
+			"match dimension of distribution (%d)\n", single_sample.vlen,
+			m_dimension);
+
+	SGMatrix<float64_t> s(m_dimension, 1);
+	memcpy(s.matrix, single_sample.vector, m_dimension*sizeof(float64_t));
+	return log_pdf(s)[0];
+}
+
+void CProbabilityDistribution::init()
+{
+	m_dimension=0;
+
+	SG_ADD(&m_dimension, "dimension", "Dimension of distribution.",
+			MS_NOT_AVAILABLE);
+}

--- a/src/shogun/distributions/classical/ProbabilityDistribution.h
+++ b/src/shogun/distributions/classical/ProbabilityDistribution.h
@@ -1,0 +1,84 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Heiko Strathmann
+ */
+
+#ifndef PROBABILITYDISTRIBUTION_H
+#define PROBABILITYDISTRIBUTION_H
+
+#include <shogun/base/SGObject.h>
+#include <shogun/lib/SGMatrix.h>
+
+namespace shogun
+{
+
+template <class T> class SGVector;
+
+/** @brief A base class for representing n-dimensional probability distribution
+ * over the real numbers (64bit) for which various statistics can be computed
+ * and which can be sampled.
+ */
+class CProbabilityDistribution: public CSGObject
+{
+public:
+	/** Default constructor */
+	CProbabilityDistribution();
+
+	/** Constructur that sets the distribution's dimension */
+	CProbabilityDistribution(int32_t dimension);
+
+	/** Destructor */
+	virtual ~CProbabilityDistribution();
+
+	/** Samples from the distribution multiple times
+	 *
+	 * @param num_samples number of samples to generate
+	 * @param pre_samples a matrix of pre-samples that might be used for
+	 * sampling. For example, a matrix with standard normal samples for the
+	 * CGaussianDistribution. For reproducible results. Ignored by default.
+	 * @return matrix with samples (column vectors)
+	 */
+	virtual SGMatrix<float64_t> sample(int32_t num_samples,
+			SGMatrix<float64_t> pre_samples=SGMatrix<float64_t>()) const;
+
+	/** Samples from the distribution once. Wrapper method. No pre-sample
+	 * passing is possible with this method.
+	 *
+	 * @return vector with single sample
+	 */
+	virtual SGVector<float64_t> sample() const;
+
+	/** Computes the log-pdf for all provided samples
+	 *
+	 * @param samples samples to compute log-pdf of (column vectors)
+	 * @return vector with log-pdfs of given samples
+	 */
+	virtual SGVector<float64_t> log_pdf(SGMatrix<float64_t> samples) const;
+
+	/** Computes the log-pdf for a single provided sample. Wrapper method.
+	 *
+	 * @param sample sample to compute log-pdf for
+	 * @return log-pdf of the given sample
+	 */
+	virtual float64_t log_pdf(SGVector<float64_t> single_sample) const;
+
+	/** @return name of the SGSerializable */
+	virtual const char* get_name() const=0;
+
+private:
+
+	/** Initialses and registers parameters */
+	void init();
+
+protected:
+	/** Dimension of the distribution */
+	int32_t m_dimension;
+};
+
+}
+
+#endif // PROBABILITYDISTRIBUTION_H

--- a/src/shogun/machine/gp/InferenceMethod.cpp
+++ b/src/shogun/machine/gp/InferenceMethod.cpp
@@ -5,11 +5,15 @@
  * (at your option) any later version.
  *
  * Written (W) 2013 Roman Votyakov
+ * Written (W) 2013 Heiko Strathmann
  * Copyright (C) 2012 Jacob Walker
  * Copyright (C) 2013 Roman Votyakov
+ *
  */
 
 #include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/distributions/classical/GaussianDistribution.h>
+#include <shogun/mathematics/Statistics.h>
 
 using namespace shogun;
 
@@ -95,4 +99,55 @@ void CInferenceMethod::set_model(CLikelihoodModel* mod)
 void CInferenceMethod::set_scale(float64_t s)
 {
 	m_scale=s;
+}
+
+float64_t CInferenceMethod::get_log_ml_estimate(
+		int32_t num_importance_samples, ECovarianceFactorization factorization)
+{
+	/* sample from Gaussian approximation to q(f|y) */
+	SGMatrix<float64_t> cov=get_posterior_approximation_covariance();
+	SGVector<float64_t> mean=get_posterior_approximation_mean();
+
+	CGaussianDistribution* post_approx=new CGaussianDistribution(mean, cov,
+			factorization);
+	SGMatrix<float64_t> samples=post_approx->sample(num_importance_samples);
+
+	/* evaluate q(f^i|y), p(f^i|\theta), p(y|f^i), i.e.,
+	 * log pdf of approximation, prior and likelihood */
+
+	/* log pdf q(f^i|y) */
+	SGVector<float64_t> log_pdf_post_approx=post_approx->log_pdf(samples);
+
+	/* dont need gaussian anymore, free memory */
+	SG_UNREF(post_approx);
+	post_approx=NULL;
+
+	/* log pdf p(f^i|\theta) and free memory afterwise. Scale kernel before */
+	SGMatrix<float64_t> scaled_kernel(m_ktrtr.num_rows, m_ktrtr.num_cols);
+	memcpy(scaled_kernel.matrix, m_ktrtr.matrix,
+			sizeof(float64_t)*m_ktrtr.num_rows*m_ktrtr.num_cols);
+	for (index_t i=0; i<m_ktrtr.num_rows*m_ktrtr.num_cols; ++i)
+		scaled_kernel.matrix[i]*=CMath::sq(m_scale);
+
+	CGaussianDistribution* prior=new CGaussianDistribution(
+			m_mean->get_mean_vector(m_feature_matrix), scaled_kernel,
+			factorization);
+	SGVector<float64_t> log_pdf_prior=prior->log_pdf(samples);
+	SG_UNREF(prior);
+	prior=NULL;
+
+	/* p(y|f^i) */
+	SGVector<float64_t> log_likelihood=m_model->get_log_probability_f(
+			m_labels, samples);
+
+	/* combine probabilities */
+	ASSERT(log_likelihood.vlen==num_importance_samples);
+	ASSERT(log_likelihood.vlen==log_pdf_prior.vlen);
+	ASSERT(log_likelihood.vlen==log_pdf_post_approx.vlen);
+	SGVector<float64_t> sum(log_likelihood);
+	for (index_t i=0; i<log_likelihood.vlen; ++i)
+		sum[i]=log_likelihood[i]+log_pdf_prior[i]-log_pdf_post_approx[i];
+
+	/* use log-sum-exp (in particular, log-mean-exp) trick to combine values */
+	return CMath::log_mean_exp(sum);
 }

--- a/src/shogun/machine/gp/InferenceMethod.h
+++ b/src/shogun/machine/gp/InferenceMethod.h
@@ -5,6 +5,7 @@
  * (at your option) any later version.
  *
  * Written (W) 2013 Roman Votyakov
+ * Written (W) 2013 Heiko Strathmann
  * Copyright (C) 2012 Jacob Walker
  * Copyright (C) 2013 Roman Votyakov
  */
@@ -19,6 +20,7 @@
 #include <shogun/machine/gp/LikelihoodModel.h>
 #include <shogun/machine/gp/MeanFunction.h>
 #include <shogun/evaluation/DifferentiableFunction.h>
+#include <shogun/distributions/classical/GaussianDistribution.h>
 
 namespace shogun
 {
@@ -36,6 +38,9 @@ enum EInferenceType
  *
  * The Inference Method computes (approximately) the posterior
  * distribution for a given Gaussian Process.
+ *
+ * It is possible to sample the (true) log-marginal likelihood on the base of
+ * any implemented approximation. See log_ml_estimate.
  */
 class CInferenceMethod : public CDifferentiableFunction
 {
@@ -79,7 +84,8 @@ public:
 	/** get log marginal likelihood gradient
 	 *
 	 * @return vector of the marginal likelihood function gradient
-	 * with respect to hyperparameters:
+	 * with respect to hyperparameters (under the current approximation
+	 * to the posterior \f$q(f|y)\approx p(f|y)\f$:
 	 *
 	 * \f[
 	 * -\frac{\partial log(p(y|X, \theta))}{\partial \theta}
@@ -145,7 +151,8 @@ public:
 	 */
 	virtual SGVector<float64_t> get_posterior_approximation_mean()
 	{
-		SG_ERROR("Inference method doesn't use approximation to the posterior")
+		SG_ERROR("Inference method doesn't use a Gaussian approximation to the"
+				" posterior")
 		return SGVector<float64_t>();
 	}
 
@@ -161,7 +168,8 @@ public:
 	 */
 	virtual SGMatrix<float64_t> get_posterior_approximation_covariance()
 	{
-		SG_ERROR("Inference method doesn't use approximation to the posterior")
+		SG_ERROR("Inference method doesn't use a gaussian approximation to the "
+				"posterior")
 		return SGMatrix<float64_t>();
 	}
 
@@ -261,6 +269,41 @@ public:
 	/** update all matrices */
 	virtual void update_all()=0;
 
+	/** Computes an unbiased estimate of the log-marginal-likelihood,
+	 *
+	 * \f[
+	 * log(p(y|X,\theta)),
+	 * \f]
+	 * where \f$y\f$ are the labels, \f$X\f$ are the features (omitted from
+	 * in the following expressions), and \f$\theta\f$ represent hyperparameters.
+	 *
+	 * This is done via an approximation to the posterior
+	 * \f$q(f|y, \theta)\approx p(f|y, \theta)\f$, which is computed by the
+	 * underlying CInferenceMethod instance (if implemented, otherwise error),
+	 * and then using an importance sample estimator
+	 *
+	 * \f[
+	 * p(y|\theta)=\int p(y|f)p(f|\theta)df
+	 * =\int p(y|f)\frac{p(f|\theta)}{q(f|y, \theta)}q(f|y, \theta)df
+	 * \approx\frac{1}{n}\sum_{i=1}^n p(y|f^{(i)})\frac{p(f^{(i)}|\theta)}{q(f^{(i)}|y, \theta)},
+	 * \f]
+	 *
+	 * where \f$ f^{(i)} \f$ are samples from the posterior approximation
+	 * \f$ q(f|y, \theta) \f$. The resulting estimator has a low variance if
+	 * \f$ q(f|y, \theta) \f$ is a good approximation. It has large variance
+	 * otherwise (while still being consistent).
+	 *
+	 * @param num_importance_samples the number of importance samples \f$n\f$
+	 * from \f$ q(f|y, \theta) \f$.
+	 * @param factorization type to factorize the Gaussian covariances. Default
+	 * is Cholesky but this might be changed to SVD/QR for greater numerical
+	 * stability.
+	 * @return unbiased estimate of the  log of the marginal likelihood
+	 * function \f$ log(p(y|\theta)) \f$
+	 */
+	float64_t get_log_ml_estimate(int32_t num_importance_samples=1,
+			ECovarianceFactorization factorization=CF_CHOLESKY);
+
 protected:
 	/** update alpha matrix */
 	virtual void update_alpha()=0;
@@ -302,7 +345,7 @@ protected:
 	/** kernel scale */
 	float64_t m_scale;
 
-	/** kernel matrix from features */
+	/** kernel matrix from features (non-scalled by inference scalling) */
 	SGMatrix<float64_t> m_ktrtr;
 };
 }

--- a/src/shogun/machine/gp/LikelihoodModel.cpp
+++ b/src/shogun/machine/gp/LikelihoodModel.cpp
@@ -5,6 +5,7 @@
  * (at your option) any later version.
  *
  * Written (W) 2013 Roman Votyakov
+ * Written (W) 2013 Heiko Strathmann
  * Copyright (C) 2012 Jacob Walker
  * Copyright (C) 2013 Roman Votyakov
  */
@@ -19,4 +20,25 @@ CLikelihoodModel::CLikelihoodModel()
 
 CLikelihoodModel::~CLikelihoodModel()
 {
+}
+
+SGVector<float64_t> CLikelihoodModel::get_log_probability_f(CLabels* lab,
+		SGMatrix<float64_t> F)
+{
+	REQUIRE(lab, "Given labels are NULL!\n");
+	REQUIRE(lab->get_num_labels()==F.num_rows, "Number of labels (%d) does "
+			"not match dimension of functions (%d)\n",
+			lab->get_num_labels(),F.num_rows);
+	REQUIRE(F.num_cols>0, "Number of passed functions (%d) must be positive\n",
+			F.num_cols);
+
+	SGVector<float64_t> result(F.num_cols);
+	for (index_t i=0; i<F.num_cols; ++i)
+	{
+		/* extract current sample from matrix, assume col-major, dont copy */
+		SGVector<float64_t> f(&F.matrix[i*F.num_rows], F.num_rows, false);
+		result[i]=SGVector<float64_t>::sum(get_log_probability_f(lab, f));
+	}
+
+	return result;
 }

--- a/src/shogun/machine/gp/LikelihoodModel.h
+++ b/src/shogun/machine/gp/LikelihoodModel.h
@@ -5,6 +5,7 @@
  * (at your option) any later version.
  *
  * Written (W) 2013 Roman Votyakov
+ * Written (W) 2013 Heiko Strathmann
  * Copyright (C) 2012 Jacob Walker
  * Copyright (C) 2013 Roman Votyakov
  */
@@ -115,7 +116,7 @@ public:
 	 */
 	virtual ELikelihoodModelType get_model_type() { return LT_NONE; }
 
-	/** returns the logarithm of the point-wise likelihood
+	/** Returns the logarithm of the point-wise likelihood
 	 * \f$log(p(y_i|f_i))\f$ for each label \f$y_i\f$.
 	 *
 	 * One can evaluate log-likelihood like: \f$log(p(y|f)) =
@@ -128,6 +129,21 @@ public:
 	 */
 	virtual SGVector<float64_t> get_log_probability_f(CLabels* lab,
 			SGVector<float64_t> func)=0;
+
+	/** Returns the log-likelihood
+	 * \f$log(p(y|f)) = \sum_{i=1}^{n} log(p(y_i|f_i))\f$
+	 * for each of the provided functions \f$ f \f$ in the given matrix.
+	 *
+	 * Wrapper method which calls get_log_probability_f multiple times.
+	 *
+	 * @param lab labels \f$y_i\f$
+	 * @param F values of the function \f$f_i\f$ where each column of the matrix
+	 * is one function \f$ f \f$.
+	 *
+	 * @return log-likelihood for every provided function
+	 */
+	virtual SGVector<float64_t> get_log_probability_f(CLabels* lab,
+			SGMatrix<float64_t> F);
 
 	/** get derivative of log likelihood \f$log(p(y|f))\f$ with
 	 * respect to location function \f$f\f$

--- a/src/shogun/mathematics/Random.h
+++ b/src/shogun/mathematics/Random.h
@@ -250,7 +250,6 @@ namespace shogun
 			/**
 			 * Sample a normal distrbution.
 			 * Using Ziggurat algorithm
-			 * @TODO check it's correctness
 			 *
 			 * @param mu mean
 			 * @param sigma variance
@@ -261,7 +260,6 @@ namespace shogun
 			/**
 			 * Sample a standard normal distribution, 
 			 * i.e. mean = 0, var = 1.0
-			 * @TODO check it's correctness!
 			 *
 			 * @return sample from the std normal distrib
 			 */

--- a/tests/unit/distribution/classical/GaussianDistribution_unittest.cc
+++ b/tests/unit/distribution/classical/GaussianDistribution_unittest.cc
@@ -1,0 +1,300 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Heiko Strathmann
+ */
+
+#ifdef HAVE_EIGEN3
+
+#include <shogun/distributions/classical/GaussianDistribution.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/eigen3.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+using namespace Eigen;
+
+TEST(GaussianDistribution_CF_CHOLESKY,log_pdf_single_1d)
+{
+	SGVector<float64_t> mean(1);
+	SGMatrix<float64_t> cov(1,1);
+	mean[0]=1;
+	cov(0,0)=2;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_CHOLESKY);
+
+	SGVector<float64_t> x(1);
+	x[0]=0;
+	float64_t result=((CProbabilityDistribution*)gauss)->log_pdf(x);
+	
+	EXPECT_NEAR(result, -1.5155121234846454, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_CHOLESKY,log_pdf_multiple_1d)
+{
+	SGVector<float64_t> mean(1);
+	SGMatrix<float64_t> cov(1,1);
+	mean[0]=1;
+	cov(0,0)=2;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_CHOLESKY);
+
+	SGMatrix<float64_t> x(1,2);
+	x(0,0)=0;
+	x(0,1)=1;
+	SGVector<float64_t> result=(gauss)->log_pdf(x);
+
+	EXPECT_NEAR(result[0], -1.5155121234846454, 1e-15);
+	EXPECT_NEAR(result[1], -1.2655121234846454, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_CHOLESKY,log_pdf_single_2d)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_CHOLESKY);
+
+	SGVector<float64_t> x(2);
+	x[0]=0;
+	x[1]=0;
+	float64_t result=((CProbabilityDistribution*)gauss)->log_pdf(x);
+	
+	EXPECT_NEAR(result, -3.375079401517433, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_CHOLESKY,log_pdf_multiple_2d)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_CHOLESKY);
+
+	SGMatrix<float64_t> x(2,2);
+	x(0,0)=1;
+	x(1,0)=2;
+	x(0,1)=3;
+	x(1,1)=4;
+	SGVector<float64_t> result=(gauss)->log_pdf(x);
+	
+	EXPECT_NEAR(result[0], -2.539698566136597, 1e-15);
+	EXPECT_NEAR(result[1], -3.620779647217678, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_SVD_QR,log_pdf_single_1d)
+{
+	SGVector<float64_t> mean(1);
+	SGMatrix<float64_t> cov(1,1);
+	mean[0]=1;
+	cov(0,0)=2;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_SVD_QR);
+
+	SGVector<float64_t> x(1);
+	x[0]=0;
+	float64_t result=((CProbabilityDistribution*)gauss)->log_pdf(x);
+	
+	EXPECT_NEAR(result, -1.5155121234846454, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_SVD_QR,log_pdf_multiple_1d)
+{
+	SGVector<float64_t> mean(1);
+	SGMatrix<float64_t> cov(1,1);
+	mean[0]=1;
+	cov(0,0)=2;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_SVD_QR);
+
+	SGMatrix<float64_t> x(1,2);
+	x(0,0)=0;
+	x(0,1)=1;
+	SGVector<float64_t> result=(gauss)->log_pdf(x);
+
+	EXPECT_NEAR(result[0], -1.5155121234846454, 1e-15);
+	EXPECT_NEAR(result[1], -1.2655121234846454, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_SVD_QR,log_pdf_single_2d)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_SVD_QR);
+
+	SGVector<float64_t> x(2);
+	x[0]=0;
+	x[1]=0;
+	float64_t result=((CProbabilityDistribution*)gauss)->log_pdf(x);
+	
+	EXPECT_NEAR(result, -3.375079401517433, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_SVD_QR,log_pdf_multiple_2d)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_SVD_QR);
+
+	SGMatrix<float64_t> x(2,2);
+	x(0,0)=1;
+	x(1,0)=2;
+	x(0,1)=3;
+	x(1,1)=4;
+	SGVector<float64_t> result=(gauss)->log_pdf(x);
+	
+	EXPECT_NEAR(result[0], -2.539698566136597, 1e-15);
+	EXPECT_NEAR(result[1], -3.620779647217678, 1e-15);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_CHOLESKY,sample_2d_fixed)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_CHOLESKY);
+
+	/* fake std normal samples */
+	SGMatrix<float64_t> pre_samples(2,2);
+	pre_samples(0,0)=-1.93251186;
+	pre_samples(1,0)=1.64881715;
+	pre_samples(0,1)=0.44701692;
+	pre_samples(1,1)=-1.17987856;
+	SGMatrix<float64_t> result=gauss->sample(pre_samples.num_cols, pre_samples);
+	
+	EXPECT_NEAR(result(0,0), -1.9938345, 1e-7);
+	EXPECT_NEAR(result(0,1), 1.69251563, 1e-7);
+	EXPECT_NEAR(result(1,0), 2.52549802, 1e-7);
+	EXPECT_NEAR(result(1,1), 0.83862562, 1e-7);
+	
+	
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_SVD_QR,sample_2d_fixed)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_SVD_QR);
+
+	/* fake std normal samples */
+	SGMatrix<float64_t> pre_samples(2,2);
+	pre_samples(0,0)=-1.93251186;
+	pre_samples(1,0)=1.64881715;
+	pre_samples(0,1)=0.44701692;
+	pre_samples(1,1)=-1.17987856;
+	SGMatrix<float64_t> result=gauss->sample(pre_samples.num_cols, pre_samples);
+	
+	/* SVD basis is non-unique, so catch all cases here */
+	EXPECT_TRUE(CMath::abs(result(0,0)+1.9938345)<1e-7 || CMath::abs(result(0,0)+2.85129583)<1e-7);
+	EXPECT_TRUE(CMath::abs(result(0,1)-1.69251563)<1e-7 || CMath::abs(result(0,1)-2.4830301)<1e-7);
+	EXPECT_TRUE(CMath::abs(result(1,0)+1.9938345)<1e-7 || CMath::abs(result(1,0)-0.59429522)<1e-7);
+	EXPECT_TRUE(CMath::abs(result(1,1)+1.9938345)<1e-7 || CMath::abs(result(1,1)-1.73298739)<1e-7);
+	
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_CHOLESKY,sample_2d)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov);
+
+	index_t num_samples=100000;
+	SGMatrix<float64_t> samples=gauss->sample(num_samples);
+	SGMatrix<float64_t> emp_cov(2,2);
+	Map<MatrixXd> eigen_samples(samples.matrix, samples.num_rows, samples.num_cols);
+	Map<MatrixXd> eigen_emp_cov(emp_cov.matrix, emp_cov.num_rows, emp_cov.num_cols);
+
+	/* center and compute empirical covariance */
+	MatrixXd centered = eigen_samples.colwise() - eigen_samples.rowwise().mean();
+	eigen_emp_cov = 1.0/(num_samples-1)*(centered * centered.transpose());
+
+	for (index_t i=0; i<cov.num_rows*cov.num_cols; ++i)
+		EXPECT_NEAR(cov.matrix[i], emp_cov.matrix[i], 1e-1);
+
+	SG_UNREF(gauss);
+}
+
+TEST(GaussianDistribution_CF_SVD_QR,sample_2d)
+{
+	SGVector<float64_t> mean(2);
+	SGMatrix<float64_t> cov(2,2);
+	mean[0]=1;
+	mean[1]=2;
+	cov(0,0)=2.4;
+	cov(0,1)=1.3;
+	cov(1,0)=1.3;
+	cov(1,1)=2.4;
+	CGaussianDistribution* gauss=new CGaussianDistribution(mean,cov,CF_SVD_QR);
+
+	index_t num_samples=100000;
+	SGMatrix<float64_t> samples=gauss->sample(num_samples);
+	SGMatrix<float64_t> emp_cov(2,2);
+	Map<MatrixXd> eigen_samples(samples.matrix, samples.num_rows, samples.num_cols);
+	Map<MatrixXd> eigen_emp_cov(emp_cov.matrix, emp_cov.num_rows, emp_cov.num_cols);
+
+	/* center and compute empirical covariance */
+	MatrixXd centered = eigen_samples.colwise() - eigen_samples.rowwise().mean();
+	eigen_emp_cov = 1.0/(num_samples-1)*(centered * centered.transpose());
+
+	for (index_t i=0; i<cov.num_rows*cov.num_cols; ++i)
+		EXPECT_NEAR(cov.matrix[i], emp_cov.matrix[i], 1e-1);
+
+	SG_UNREF(gauss);
+}
+
+#endif // HAVE_EIGEN3

--- a/tests/unit/machine/gp/InferenceMethod_unittest.cc
+++ b/tests/unit/machine/gp/InferenceMethod_unittest.cc
@@ -1,0 +1,58 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Heiko Strathmann
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+
+#include <shogun/labels/BinaryLabels.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/kernel/GaussianKernel.h>
+#include <shogun/machine/gp/LaplacianInferenceMethod.h>
+#include <shogun/machine/gp/ZeroMean.h>
+#include <shogun/machine/gp/LogitLikelihood.h>
+#include <shogun/classifier/GaussianProcessBinaryClassification.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(InferenceMethod,get_log_ml_estimate_binary_logit_laplace)
+{
+	index_t n=2;
+	index_t d=1;
+
+	SGMatrix<float64_t> feat_train(d, n);
+	SGVector<float64_t> lab_train(n);
+
+	feat_train(0,0)=1;
+	feat_train(0,1)=-1;
+	lab_train[0]=1;
+	lab_train[1]=-1;
+
+	CDenseFeatures<float64_t>* features_train=new CDenseFeatures<float64_t>(feat_train);
+	CBinaryLabels* labels_train=new CBinaryLabels(lab_train);
+
+	CGaussianKernel* kernel=new CGaussianKernel(10, 8);
+	CZeroMean* mean=new CZeroMean();
+	CLogitLikelihood* likelihood=new CLogitLikelihood();
+	CLaplacianInferenceMethod* inf=new CLaplacianInferenceMethod(kernel,
+			features_train,	mean, labels_train, likelihood);
+	inf->set_scale(2.0);
+
+	/* sample estimate and compare against a number from my python implementation,
+	 * and also against the approximate marginal likelihood. Since this is random,
+	 * use low accuracy. */
+	float64_t sample=inf->get_log_ml_estimate(100000);
+	EXPECT_NEAR(sample, -1.67990517588, 1e-1);
+	EXPECT_NEAR(sample, -inf->get_negative_marginal_likelihood(), 1e-1);
+
+	SG_UNREF(inf);
+}
+
+#endif // HAVE_EIGEN3

--- a/tests/unit/machine/gp/LogitLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/LogitLikelihood_unittest.cc
@@ -229,6 +229,65 @@ TEST(LogitLikelihood,get_log_probability_f)
 	SG_UNREF(labels);
 }
 
+TEST(LogitLikelihood,get_log_probability_f_sum_multiple)
+{
+	// create some easy data:
+	// f(x) approximately equals to 3*sin(sin(x^2)*sin(sin(2*x))), y = sign(f(x))
+	index_t n=10;
+
+	SGVector<float64_t> lab(n);
+	SGMatrix<float64_t> func(n,2);
+
+	lab[0]=1.0;
+	lab[1]=1.0;
+	lab[2]=-1.0;
+	lab[3]=-1.0;
+	lab[4]=1.0;
+	lab[5]=-1.0;
+	lab[6]=-1.0;
+	lab[7]=1.0;
+	lab[8]=-1.0;
+	lab[9]=1.0;
+
+	func(0,0)=0.889099;
+	func(1,0)=0.350840;
+	func(2,0)=-2.116356;
+	func(3,0)=-0.184742;
+	func(4,0)=0.182117;
+	func(5,0)=-1.108930;
+	func(6,0)=-0.062437;
+	func(7,0)=0.482987;
+	func(8,0)=-0.149445;
+	func(9,0)=0.106952;
+	
+	func(0,1)=0.889099;
+	func(1,1)=0.350840;
+	func(2,1)=-2.116356;
+	func(3,1)=-0.184742;
+	func(4,1)=0.182117;
+	func(5,1)=-1.108930;
+	func(6,1)=-0.062437;
+	func(7,1)=0.482987;
+	func(8,1)=-0.149445;
+	func(9,1)=0.106952;
+
+	// shogun representation of labels
+	CBinaryLabels* labels=new CBinaryLabels(lab);
+
+	// logit likelihood
+	CLogitLikelihood* likelihood=new CLogitLikelihood();
+
+	SGVector<float64_t> lp=((CLikelihoodModel*)likelihood)->get_log_probability_f(labels, func);
+
+	// comparison of log likelihood with result from GPML package
+	EXPECT_NEAR(lp[0], -4.8927, 1E-4);
+	EXPECT_NEAR(lp[1], -4.8927, 1E-4);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
 TEST(LogitLikelihood,get_log_probability_derivative_f)
 {
 	// create some easy data:

--- a/tests/unit/mathematics/Math_unittest.cc
+++ b/tests/unit/mathematics/Math_unittest.cc
@@ -150,3 +150,17 @@ TEST(CMath, linspace_test)
 		EXPECT_EQ(vec[i], val);
 	}
 }
+
+TEST(CMath, log_sum_exp)
+{
+	SGVector<float64_t> values(3);
+	values.range_fill();
+	EXPECT_NEAR(CMath::log_sum_exp(values), 2.4076059644443801, 1e-15);
+}
+
+TEST(CMath, log_mean_exp)
+{
+	SGVector<float64_t> values(3);
+	values.range_fill();
+	EXPECT_NEAR(CMath::log_mean_exp(values), 1.3089936757762706, 1e-15);
+}


### PR DESCRIPTION
...using posterior approximations, importance sampling, and various tricks. This gives a sample of the true (!) marginal likelihood. Pretty cool stuff from a yet to be published paper in IEEE by some guys here in London. Will be useful for hyperparameter inference in GPs.

-Method is added to CInferenceMethod
-added method to compute likelihood for multiple functions in CLikelihoodModel
-New class ProbabilityDistribution (statistic style interface, not sure where to put it, open for suggestions :)
-Implementation GaussianDistribution which is a numerically stable version of a Gaussian sampler and log-pdf
-log-sum-exp log-mean-exp trick
Unit tests for everything.
