### PR TITLE
K-skip ngrams for quadratic support in HashedDoc classes [WIP]

### DIFF
--- a/src/shogun/converter/HashedDocConverter.cpp
+++ b/src/shogun/converter/HashedDocConverter.cpp
@@ -23,19 +23,19 @@ namespace shogun
 {
 CHashedDocConverter::CHashedDocConverter() : CConverter()
 {
-	init(NULL, 16, false);
+	init(NULL, 16, false, 1, 0);
 }
 
-CHashedDocConverter::CHashedDocConverter(int32_t hash_bits, bool normalize)
-: CConverter()
+CHashedDocConverter::CHashedDocConverter(int32_t hash_bits, bool normalize,
+	int32_t n_grams, int32_t skips) : CConverter()
 {
-	init(NULL, hash_bits, normalize);
+	init(NULL, hash_bits, normalize, n_grams, skips);
 }
 
 CHashedDocConverter::CHashedDocConverter(CTokenizer* tzer,
-	int32_t hash_bits, bool normalize) : CConverter()
+	int32_t hash_bits, bool normalize, int32_t n_grams, int32_t skips) : CConverter()
 {
-	init(tzer, hash_bits, normalize);
+	init(tzer, hash_bits, normalize, n_grams, skips);
 }
 
 CHashedDocConverter::~CHashedDocConverter()
@@ -43,10 +43,13 @@ CHashedDocConverter::~CHashedDocConverter()
 	SG_UNREF(tokenizer);
 }
 	
-void CHashedDocConverter::init(CTokenizer* tzer, int32_t hash_bits, bool normalize)
+void CHashedDocConverter::init(CTokenizer* tzer, int32_t hash_bits, bool normalize,
+	int32_t n_grams, int32_t skips)
 {
 	num_bits = hash_bits;
 	should_normalize = normalize;
+	ngrams = n_grams;
+	tokens_to_skip = skips;
 
 	if (tzer==NULL)
 	{
@@ -60,6 +63,10 @@ void CHashedDocConverter::init(CTokenizer* tzer, int32_t hash_bits, bool normali
 
 	SG_REF(tokenizer);
 	SG_ADD(&num_bits, "num_bits", "Number of bits of the hash",
+		MS_NOT_AVAILABLE);
+	SG_ADD(&ngrams, "ngrams", "Number of consecutive tokens",
+		MS_NOT_AVAILABLE);
+	SG_ADD(&tokens_to_skip, "tokens_to_skip", "Number of tokens to skip",
 		MS_NOT_AVAILABLE);
 	SG_ADD(&should_normalize, "should_normalize", "Whether to normalize vectors or not",
 		MS_NOT_AVAILABLE);
@@ -97,33 +104,76 @@ SGSparseVector<float64_t> CHashedDocConverter::apply(SGVector<char> document)
 	ASSERT(document.size()>0)
 	const int32_t array_size = 1024*1024;
 	CDynamicArray<uint32_t> hashed_indices(array_size);
+	CDynamicArray<uint32_t>* cached_hashes = new CDynamicArray<uint32_t>(ngrams);
+	CDynamicArray<index_t>* ngram_indices = new CDynamicArray<index_t>(ngrams*(ngrams+1)/2*(1+tokens_to_skip));
 
 	const int32_t seed = 0xdeadbeaf;
 	tokenizer->set_text(document);
 	index_t token_start = 0;
-	while (tokenizer->has_next())
+	int32_t n = 0;
+
+	/** Reading n+s-1 tokens */
+	while (n<ngrams-1+tokens_to_skip && tokenizer->has_next())
 	{
-		index_t next_token_idx = tokenizer->next_token_idx(token_start);		
-		uint32_t hashed_idx = CHashedDocDotFeatures::calculate_token_hash(
-				&document.vector[token_start], next_token_idx-token_start, num_bits, seed);
-		hashed_indices.push_back(hashed_idx);
+		index_t end = tokenizer->next_token_idx(token_start);
+		uint32_t token_hash = CHash::MurmurHash3((uint8_t* ) &document.vector[token_start],
+				end-token_start, seed);
+		cached_hashes->append_element(token_hash);
+		n++;
 	}
 
-	CMath::qsort(hashed_indices.get_array(), hashed_indices.get_num_elements());
-	int32_t num_nnz_features = 0;
-	for (index_t i=0; i<hashed_indices.get_num_elements(); i++)
+	/** Reading token and storing index to hashed_indices */
+	while (tokenizer->has_next())
 	{
-		num_nnz_features++;
-		while ( (i+1<hashed_indices.get_num_elements()) && 
-				(hashed_indices[i+1]==hashed_indices[i]) )
+		index_t end = tokenizer->next_token_idx(token_start);
+		uint32_t token_hash = CHash::MurmurHash3((uint8_t* ) &document.vector[token_start],
+				end-token_start, seed);
+		cached_hashes->append_element(token_hash);
+		CHashedDocConverter::generate_ngram_hashes(cached_hashes, ngram_indices, num_bits,
+				ngrams, tokens_to_skip);
+
+		for (index_t i=0; i<ngram_indices->get_num_elements(); i++)
+			hashed_indices.append_element(ngram_indices->get_element(i));
+
+		cached_hashes->delete_element(0);
+	}
+
+	/** For remaining combinations */
+	if (ngrams>1)
+	{
+		while (cached_hashes->get_num_elements()>0)
 		{
-			i++;
+			CHashedDocConverter::generate_ngram_hashes(cached_hashes, ngram_indices, num_bits,
+					ngrams, tokens_to_skip);
+
+			for (index_t i=0; i<ngram_indices->get_num_elements(); i++)
+				hashed_indices.append_element(ngram_indices->get_element(i));
+
+			cached_hashes->delete_element(0);
 		}
 	}
+	SG_UNREF(cached_hashes);
+	SG_UNREF(ngram_indices);
+
+	SGSparseVector<float64_t> sparse_doc_rep = create_hashed_representation(hashed_indices);	
+
+	/** Normalizing vector */
+	if (should_normalize)
+	{
+		float64_t norm_const = CMath::sqrt((float64_t) document.size());
+		for (index_t i=0; i<sparse_doc_rep.num_feat_entries; i++)
+			sparse_doc_rep.features[i].entry /= norm_const; 
+	}
+	
+	return sparse_doc_rep;
+}
+
+SGSparseVector<float64_t> CHashedDocConverter::create_hashed_representation(CDynamicArray<uint32_t>& hashed_indices)
+{
+	int32_t num_nnz_features = count_distinct_indices(hashed_indices);
 
 	SGSparseVector<float64_t> sparse_doc_rep(num_nnz_features);
 	index_t sparse_idx = 0;
-
 	for (index_t i=0; i<hashed_indices.get_num_elements(); i++)
 	{
 		sparse_doc_rep.features[sparse_idx].feat_index = hashed_indices[i];
@@ -136,13 +186,47 @@ SGSparseVector<float64_t> CHashedDocConverter::apply(SGVector<char> document)
 		}
 		sparse_idx++;
 	}
-
-	if (should_normalize)
-	{
-		float64_t norm_const = CMath::sqrt((float64_t) document.size());
-		for (index_t i=0; i<sparse_doc_rep.num_feat_entries; i++)
-			sparse_doc_rep.features[i].entry /= norm_const; 
-	}
 	return sparse_doc_rep;
+}
+
+void CHashedDocConverter::generate_ngram_hashes(CDynamicArray<uint32_t>* hashes,
+	CDynamicArray<index_t>* ngram_hashes, int32_t num_bits, int32_t ngrams, int32_t tokens_to_skip)
+{
+	while (ngram_hashes->get_num_elements()>0)
+		ngram_hashes->delete_element(0);
+
+	ngram_hashes->append_element(hashes->get_element(0) & ((1 << num_bits) -1));
+	for (index_t n=1; n<ngrams; n++)
+	{
+		for (index_t s=0; s<=tokens_to_skip; s++)
+		{
+			if ( n+s >= hashes->get_num_elements())
+				break;
+
+			uint32_t ngram_hash = hashes->get_element(0);
+			for (index_t i=1+s; i<=n+s; i++)
+				ngram_hash = ngram_hash ^ hashes->get_element(i);
+			ngram_hash = ngram_hash & ((1 << num_bits) - 1);
+			ngram_hashes->append_element(ngram_hash);
+		}
+	}
+}
+
+int32_t CHashedDocConverter::count_distinct_indices(CDynamicArray<uint32_t>& hashed_indices)
+{
+	CMath::qsort(hashed_indices.get_array(), hashed_indices.get_num_elements());
+
+	/** Counting nnz features */
+	int32_t num_nnz_features = 0;
+	for (index_t i=0; i<hashed_indices.get_num_elements(); i++)
+	{
+		num_nnz_features++;
+		while ( (i+1<hashed_indices.get_num_elements()) && 
+				(hashed_indices[i+1]==hashed_indices[i]) )
+		{
+			i++;
+		}
+	}
+	return num_nnz_features;	
 }
 }

--- a/src/shogun/converter/HashedDocConverter.h
+++ b/src/shogun/converter/HashedDocConverter.h
@@ -34,16 +34,21 @@ public:
 	 *
 	 * @param hash_bits the number of bits of the hash. Means a dimension of size 2^(hash_bits).
 	 * @param normalize whether to normalize vectors or not
+	 * @param n_grams the max number of tokens to consider when combining tokens
+	 * @param skips the max number of tokens to skip when combining tokens
 	 */
-	CHashedDocConverter(int32_t hash_bits, bool normalize = false);
+	CHashedDocConverter(int32_t hash_bits, bool normalize = false, int32_t n_grams = 1, int32_t skips = 0);
 
 	/** Constructor
 	 *
 	 * @param tzer the tokenizer to use
 	 * @param hash_bits the number of bits of the hash. Means a dimension of size 2^(hash_bits).
 	 * @param normalize whether to normalize vectors or not
+	 * @param n_grams the max number of tokens to consider when combining tokens
+	 * @param skips the max number of tokens to skip when combining tokens
 	 */
-	CHashedDocConverter(CTokenizer* tzer, int32_t hash_bits, bool normalize = false);
+	CHashedDocConverter(CTokenizer* tzer, int32_t hash_bits, bool normalize = false, int32_t n_grams = 1,
+		int32_t skips = 0);
 
 	/** Destructor */
 	virtual ~CHashedDocConverter();
@@ -55,14 +60,48 @@ public:
 	 */
 	virtual CFeatures* apply(CFeatures* features);
 
+	/** Hashes the tokens contained in document
+	 *
+	 * @param document the char vector to tokenize and hash 
+	 * @return a SGSparseVector with the hashed representation of the document
+	 */
 	SGSparseVector<float64_t> apply(SGVector<char> document);
+
+	/** Generate all the k-skip ngram combinations for the tokens in the CDynArray hashes
+	 * and then hash limit them to a specific dimension
+	 *
+	 * @param hashes the hashes of the tokens to combine as k-skip ngrams
+	 * @param ngram_hashes the dynamic array in which to store the created indices
+	 * @param num_bits the dimension in which to limit the hashed indices (means a dimension of size 2^num_bits) 
+	 * @param ngrams the max number of tokens to combine
+	 * @param tokens_to_skip the max number of tokens to skip when combining (starting always from the second one)
+	 * @return an array containing the hashed indices of the combined tokens
+	 */
+	static void generate_ngram_hashes(CDynamicArray<uint32_t>* hashes, CDynamicArray<index_t>* ngram_hashes,
+			int32_t num_bits, int32_t ngrams, int32_t tokens_to_skip);
 
 	virtual const char* get_name() const;
 
 protected:
 	
 	/** init */
-	void init(CTokenizer* tzer, int32_t d, bool normalize);
+	void init(CTokenizer* tzer, int32_t d, bool normalize, int32_t n_grams, int32_t skips);
+
+	/** This method takes a dynamic array as an argument, sorts it and returns the number
+	 * of the distinct elements(indices here) in the array.
+	 *
+	 * @param hashed_indices the array to sort and count elements
+	 * @return the number of distinct elements
+	 */
+	int32_t count_distinct_indices(CDynamicArray<uint32_t>& hashed_indices);
+
+	/** This method takes the dynamic array containing all the hashed indices of a document and returns a compact
+	 * sparse representation with each index found and with the count of such index
+	 * 
+	 * @param hashed_indices the array containing the hashed indices
+	 * @return the compact hashed document representation
+	 */
+	SGSparseVector<float64_t> create_hashed_representation(CDynamicArray<uint32_t>& hashed_indices);
 
 protected:
 
@@ -74,6 +113,12 @@ protected:
 
 	/** whether to normalize or not */
 	bool should_normalize;
+
+	/** the number of consecutives tokens for quadratic */
+	int32_t ngrams;
+
+	/** the number of tokens to skip */
+	int32_t tokens_to_skip;
 };
 }
 

--- a/src/shogun/features/HashedDocDotFeatures.cpp
+++ b/src/shogun/features/HashedDocDotFeatures.cpp
@@ -16,15 +16,22 @@
 namespace shogun
 {
 CHashedDocDotFeatures::CHashedDocDotFeatures(int32_t hash_bits, CStringFeatures<char>* docs, 
-	CTokenizer* tzer, bool normalize, int32_t size) : CDotFeatures(size)
+	CTokenizer* tzer, bool normalize, int32_t n_grams, int32_t skips, int32_t size) : CDotFeatures(size)
 {
-	init(hash_bits, docs, tzer, normalize);
+	if (n_grams < 1)
+		n_grams = 1;
+
+	if ( (n_grams==1 && skips!=0) || (skips<0))
+		skips = 0;
+
+	init(hash_bits, docs, tzer, normalize, n_grams, skips);
 }
 
 CHashedDocDotFeatures::CHashedDocDotFeatures(const CHashedDocDotFeatures& orig)
 : CDotFeatures(orig)
 {
-	init(orig.num_bits, orig.doc_collection, orig.tokenizer, orig.should_normalize);
+	init(orig.num_bits, orig.doc_collection, orig.tokenizer, orig.should_normalize,
+			orig.ngrams, orig.tokens_to_skip);
 }
 
 CHashedDocDotFeatures::CHashedDocDotFeatures(CFile* loader)
@@ -33,10 +40,11 @@ CHashedDocDotFeatures::CHashedDocDotFeatures(CFile* loader)
 }
 
 void CHashedDocDotFeatures::init(int32_t hash_bits, CStringFeatures<char>* docs, 
-	CTokenizer* tzer, bool normalize)
+	CTokenizer* tzer, bool normalize, int32_t n_grams, int32_t skips)
 {
 	num_bits = hash_bits;
-
+	ngrams = n_grams;
+	tokens_to_skip = skips;
 	doc_collection = docs;
 	tokenizer = tzer;
 	should_normalize = normalize;
@@ -48,6 +56,10 @@ void CHashedDocDotFeatures::init(int32_t hash_bits, CStringFeatures<char>* docs,
 	}
 
 	SG_ADD(&num_bits, "num_bits", "Number of bits of hash", MS_NOT_AVAILABLE);
+	SG_ADD(&ngrams, "ngrams", "Number of tokens to combine for quadratic feature support",
+			MS_NOT_AVAILABLE);
+	SG_ADD(&tokens_to_skip, "tokens_to_skip", "Number of tokens to skip when combining features",
+			MS_NOT_AVAILABLE);
 	SG_ADD((CSGObject**) &doc_collection, "doc_collection", "Document collection",
 			MS_NOT_AVAILABLE);
 	SG_ADD((CSGObject**) &tokenizer, "tokenizer", "Document tokenizer",
@@ -81,7 +93,7 @@ float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 	SGVector<char> sv2 = hddf->doc_collection->get_feature_vector(vec_idx2);
 
 	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, num_bits,
-			should_normalize);
+			should_normalize, ngrams, tokens_to_skip);
 	SGSparseVector<float64_t> cv1 = converter->apply(sv1);
 	SGSparseVector<float64_t> cv2 = converter->apply(sv2);
 	float64_t result = SGSparseVector<float64_t>::sparse_dot(cv1,cv2);
@@ -103,21 +115,55 @@ float64_t CHashedDocDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* ve
 	ASSERT(vec2_len == CMath::pow(2,num_bits))
 	SGVector<char> sv = doc_collection->get_feature_vector(vec_idx1);
 
+	CDynamicArray<uint32_t>* hashes = new CDynamicArray<uint32_t>(ngrams);
+	CDynamicArray<index_t>* hashed_indices = new CDynamicArray<index_t>(ngrams*(ngrams+1)/2*(1+tokens_to_skip));
+
 	float64_t result = 0;
 	CTokenizer* local_tzer = tokenizer->get_copy();
 
 	const int32_t seed = 0xdeadbeaf;
 	local_tzer->set_text(sv);
 	index_t start = 0;
+	int32_t n = 0;
+	while (n<ngrams-1+tokens_to_skip && local_tzer->has_next())
+	{
+		index_t end = local_tzer->next_token_idx(start);
+		uint32_t token_hash = CHash::MurmurHash3((uint8_t* ) &sv.vector[start], end-start, seed);
+		hashes->append_element(token_hash);
+		n++;
+	}
+
 	while (local_tzer->has_next())
 	{
 		index_t end = local_tzer->next_token_idx(start);
-		uint32_t hashed_idx = calculate_token_hash(&sv.vector[start], end-start, num_bits, seed);
-		result += vec2[hashed_idx];
+		uint32_t token_hash = CHash::MurmurHash3((uint8_t* ) &sv.vector[start], end-start, seed);
+		hashes->append_element(token_hash);
+		CHashedDocConverter::generate_ngram_hashes(hashes, hashed_indices, num_bits, ngrams,
+				tokens_to_skip);
+
+		for (index_t i=0; i<hashed_indices->get_num_elements(); i++)
+			result += vec2[hashed_indices->get_element(i)];
+
+		hashes->delete_element(0);
+	}
+
+	if (ngrams>1)
+	{
+		while (hashes->get_num_elements()>0)
+		{
+			CHashedDocConverter::generate_ngram_hashes(hashes, hashed_indices, num_bits, ngrams,
+					tokens_to_skip);
+
+			for (index_t i=0; i<hashed_indices->get_num_elements(); i++)
+				result += vec2[hashed_indices->get_element(i)];
+
+			hashes->delete_element(0);
+		}
 	}
 	doc_collection->free_feature_vector(sv, vec_idx1);
 	SG_UNREF(local_tzer);
-
+	SG_UNREF(hashes);
+	SG_UNREF(hashed_indices);
 	return should_normalize ? result / CMath::sqrt((float64_t) sv.size()) : result;
 }
 
@@ -130,21 +176,57 @@ void CHashedDocDotFeatures::add_to_dense_vec(float64_t alpha, int32_t vec_idx1,
 		alpha = CMath::abs(alpha);
 
 	SGVector<char> sv = doc_collection->get_feature_vector(vec_idx1);
+	const float64_t value = should_normalize ? alpha / CMath::sqrt((float64_t) sv.size()) : alpha;
+
+	CDynamicArray<uint32_t>* hashes = new CDynamicArray<uint32_t>(ngrams);
+	CDynamicArray<index_t>* hashed_indices = new CDynamicArray<index_t>((ngrams+1)*ngrams/2*(tokens_to_skip+1));
+
 	CTokenizer* local_tzer = tokenizer->get_copy();
 
-	const float64_t value = should_normalize ? alpha / CMath::sqrt((float64_t) sv.size()) : alpha;
 	const int32_t seed = 0xdeadbeaf;
-	index_t start = 0;
 	local_tzer->set_text(sv);
+	index_t start = 0;
+	int32_t n = 0;
+	while (n<ngrams-1+tokens_to_skip && local_tzer->has_next())
+	{
+		index_t end = local_tzer->next_token_idx(start);
+		uint32_t token_hash = CHash::MurmurHash3((uint8_t* ) &sv.vector[start], end-start, seed);
+		hashes->append_element(token_hash);
+		n++;
+	}
+
 	while (local_tzer->has_next())
 	{
 		index_t end = local_tzer->next_token_idx(start);
-		uint32_t hashed_idx = calculate_token_hash(&sv.vector[start], end-start, num_bits, seed);
-		vec2[hashed_idx] += value;
+		uint32_t token_hash = CHash::MurmurHash3((uint8_t* ) &sv.vector[start], end-start, seed);
+		hashes->append_element(token_hash);
+		CHashedDocConverter::generate_ngram_hashes(hashes, hashed_indices, num_bits, ngrams,
+				tokens_to_skip);
+
+		for (index_t i=0; i<hashed_indices->get_num_elements(); i++)
+			vec2[hashed_indices->get_element(i)] += value;	
+
+		hashes->delete_element(0);
+	}
+
+	if (ngrams>1)
+	{
+		while (hashes->get_num_elements()>0)
+		{
+			CHashedDocConverter::generate_ngram_hashes(hashes, hashed_indices, num_bits, ngrams,
+					tokens_to_skip);
+		
+			for (index_t i=0; i<hashed_indices->get_num_elements(); i++)
+				vec2[hashed_indices->get_element(i)] += value;
+
+			hashes->delete_element(0);
+		}
 	}
 	
 	doc_collection->free_feature_vector(sv, vec_idx1);
 	SG_UNREF(local_tzer);
+	SG_UNREF(hashes);
+	SG_UNREF(hashed_indices);
 }
 
 uint32_t CHashedDocDotFeatures::calculate_token_hash(char* token, 

--- a/src/shogun/features/HashedDocDotFeatures.h
+++ b/src/shogun/features/HashedDocDotFeatures.h
@@ -23,6 +23,16 @@ class CDotFeatures;
 class CHashedDocConverter;
 class CTokenizer;
 
+/** This class can be used to provide on-the-fly vectorization of a document collection. 
+ * Like in the standard Bag-of-Words representation, this class considers each document as a collection of tokens,
+ * which are then hashed into a new feature space of a specified dimension.
+ * This class is very flexible and allows the user to specify the tokenizer used to tokenize each document,
+ * specify whether the results should be normalized with regards to the sqrt of the document size, as well
+ * as to specify whether he wants to combine different tokens.
+ * The latter implements a k-skip n-grams approach, meaning that you can combine up to n tokens, while skipping up to k.
+ * Eg. for the tokens ["a", "b", "c", "d"], with n_grams = 2 and skips = 2, one would get the following combinations :
+ * ["a", "ab", "ac" (skipped 1), "ad" (skipped 2), "b", "bc", "bd" (skipped 1), "c", "cd", "d"].
+ */
 class CHashedDocDotFeatures: public CDotFeatures
 {
 public:
@@ -33,10 +43,12 @@ public:
 	 * @param docs the document collection
 	 * @param tzer the tokenizer to use on the documents
 	 * @param normalize whether or not to normalize the result of the dot products
+	 * @param n_grams max number of consecutive tokens to hash together (extra features)
+	 * @param skips max number of tokens to skip when combining tokens
 	 * @param size cache size
 	 */
 	CHashedDocDotFeatures(int32_t hash_bits=0, CStringFeatures<char>* docs=NULL, 
-			CTokenizer* tzer=NULL, bool normalize=1, int32_t size=0);
+			CTokenizer* tzer=NULL, bool normalize=true, int32_t n_grams=1, int32_t skips=0, int32_t size=0);
 
 	/** copy constructor */
 	CHashedDocDotFeatures(const CHashedDocDotFeatures& orig);
@@ -180,7 +192,7 @@ public:
 
 private:
 	void init(int32_t hash_bits, CStringFeatures<char>* docs, CTokenizer* tzer, 
-		bool normalize);
+		bool normalize, int32_t n_grams, int32_t skips);
 
 protected:
 	/** the document collection*/
@@ -194,6 +206,12 @@ protected:
 
 	/** if should normalize the dot product results */
 	bool should_normalize;
+
+	/** n for ngrams for quadratic features */
+	int32_t ngrams;
+
+	/** tokens to skip when combining tokens */
+	int32_t tokens_to_skip;
 };
 }
 


### PR DESCRIPTION
Still a WIP, since it remains(at least) to add this support in the conversion of the Converter and as well to remove the first commit. @sonney2k: have a look when you have some time
