### PR TITLE
Made thread-safe refcounting in SGIO, Version and Parallel

### DIFF
--- a/src/shogun/base/Parallel.cpp
+++ b/src/shogun/base/Parallel.cpp
@@ -20,18 +20,21 @@
 
 using namespace shogun;
 
-Parallel::Parallel() : refcount(0)
+Parallel::Parallel()
 {
 	num_threads=get_num_cpus();
+	m_refcount = new RefCount();
 }
 
-Parallel::Parallel(const Parallel& orig) : refcount(0)
+Parallel::Parallel(const Parallel& orig)
 {
 	num_threads=orig.get_num_threads();
+	m_refcount = new RefCount(orig.m_refcount->ref_count());
 }
 
 Parallel::~Parallel()
 {
+	delete m_refcount;
 }
 
 int32_t Parallel::get_num_cpus() const
@@ -62,22 +65,23 @@ int32_t Parallel::get_num_threads() const
 
 int32_t Parallel::ref()
 {
-	++refcount;
-	return refcount;
+	return m_refcount->ref();
 }
 
 int32_t Parallel::ref_count() const
 {
-	return refcount;
+	return m_refcount->ref_count();
 }
 
 int32_t Parallel::unref()
 {
-	if (refcount==0 || --refcount==0)
+	int32_t rc = m_refcount->unref();
+
+	if (rc==0)
 	{
 		delete this;
 		return 0;
 	}
-	else
-		return refcount;
+
+	return rc;
 }

--- a/src/shogun/base/Parallel.h
+++ b/src/shogun/base/Parallel.h
@@ -13,10 +13,12 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/lib/common.h>
+#include <shogun/lib/RefCount.h>
 #include <shogun/io/SGIO.h>
 
 namespace shogun
 {
+class RefCount;
 /** @brief Class Parallel provides helper functions for multithreading.
  *
  * For example it can be used to determine the number of CPU cores in your
@@ -67,7 +69,7 @@ public:
 
 private:
 	/** ref counter */
-	int32_t refcount;
+	RefCount* m_refcount;
 
 	/** number of threads */
 	int32_t num_threads;

--- a/src/shogun/base/Version.cpp
+++ b/src/shogun/base/Version.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <shogun/base/Version.h>
+#include <shogun/base/SGObject.h>
 #include <shogun/lib/versionstring.h>
 
 using namespace shogun;
@@ -26,13 +27,15 @@ const char Version::version_extra[128] = VERSION_EXTRA;
 const char Version::version_release[128] = VERSION_RELEASE;
 }
 
-Version::Version() : refcount(0)
+Version::Version()
 {
+	m_refcount = new RefCount();
 }
 
 
 Version::~Version()
 {
+	delete m_refcount;
 }
 
 void Version::print_version()
@@ -102,22 +105,23 @@ int64_t Version::get_version_in_minutes()
 
 int32_t Version::ref()
 {
-	++refcount;
-	return refcount;
+	return m_refcount->ref();
 }
 
 int32_t Version::ref_count() const
 {
-	return refcount;
+	return m_refcount->ref_count();
 }
 
 int32_t Version::unref()
 {
-	if (refcount==0 || --refcount==0)
+	int32_t rc = m_refcount->unref();
+
+	if (rc==0)
 	{
 		delete this;
 		return 0;
 	}
-	else
-		return refcount;
+
+	return rc;
 }

--- a/src/shogun/base/Version.h
+++ b/src/shogun/base/Version.h
@@ -13,6 +13,7 @@
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/lib/config.h>
+#include <shogun/lib/RefCount.h>
 
 #ifndef VERSION_H__
 #define VERSION_H__
@@ -105,7 +106,7 @@ protected:
 	static const int32_t version_parameter;
 
 private:
-	int32_t refcount;
+	RefCount* m_refcount;
 };
 }
 #endif

--- a/src/shogun/io/SGIO.cpp
+++ b/src/shogun/io/SGIO.cpp
@@ -46,8 +46,9 @@ char SGIO::directory_name[FBUFSIZE];
 SGIO::SGIO()
 : target(stdout), last_progress_time(0), progress_start_time(0),
 	last_progress(1), show_progress(false), location_info(MSG_NONE),
-	syntax_highlight(true), loglevel(MSG_WARN), refcount(0)
+	syntax_highlight(true), loglevel(MSG_WARN)
 {
+	m_refcount = new RefCount();	
 }
 
 SGIO::SGIO(const SGIO& orig)
@@ -56,8 +57,9 @@ SGIO::SGIO(const SGIO& orig)
 	show_progress(orig.get_show_progress()),
 	location_info(orig.get_location_info()),
 	syntax_highlight(orig.get_syntax_highlight()),
-	loglevel(orig.get_loglevel()), refcount(0)
+	loglevel(orig.get_loglevel())
 {
+	m_refcount = new RefCount(orig.m_refcount->ref_count());	
 }
 
 void SGIO::message(EMessageType prio, const char* function, const char* file,
@@ -393,4 +395,31 @@ int SGIO::filter(CONST_DIRENT_T* d)
 	}
 
 	return 0;
+}
+
+SGIO::~SGIO()
+{
+	delete m_refcount;
+}
+
+int32_t SGIO::ref()
+{
+	return m_refcount->ref();
+}
+
+int32_t SGIO::ref_count() const
+{
+	return m_refcount->ref_count();
+}
+
+int32_t SGIO::unref()
+{
+	int32_t rc = m_refcount->unref();
+	if (rc==0)
+	{
+		delete this;
+		return 0;
+	}
+
+	return rc;
 }

--- a/src/shogun/io/SGIO.h
+++ b/src/shogun/io/SGIO.h
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <shogun/lib/RefCount.h>
 #include <shogun/lib/common.h>
 #include <shogun/base/init.h>
 
@@ -228,6 +229,9 @@ class SGIO
 		SGIO();
 		/** copy constructor */
 		SGIO(const SGIO& orig);
+
+		/** destructor */
+		virtual ~SGIO();
 
 		/** set loglevel
 		 *
@@ -505,36 +509,20 @@ class SGIO
 		 *
 		 * @return reference count
 		 */
-		inline int32_t ref()
-		{
-			++refcount;
-			return refcount;
-		}
+		int32_t ref();
 
 		/** display reference counter
 		 *
 		 * @return reference count
 		 */
-		inline int32_t ref_count() const
-		{
-			return refcount;
-		}
+		int32_t ref_count() const;
 
 		/** decrement reference counter and deallocate object if refcount is zero
 		 * before or after decrementing it
 		 *
 		 * @return reference count
 		 */
-		inline int32_t unref()
-		{
-			if (refcount==0 || --refcount==0)
-			{
-				delete this;
-				return 0;
-			}
-			else
-				return refcount;
-		}
+		int32_t unref();
 
 		/** @return object name */
 		inline const char* get_name() { return "SGIO"; }
@@ -580,7 +568,7 @@ class SGIO
         static char directory_name[FBUFSIZE];
 
 	private:
-		int32_t refcount;
+		RefCount* m_refcount;
 };
 }
 #endif // __SGIO_H__

--- a/src/shogun/lib/RefCount.cpp
+++ b/src/shogun/lib/RefCount.cpp
@@ -1,0 +1,42 @@
+#include <shogun/lib/RefCount.h>
+
+using namespace shogun;
+
+int32_t RefCount::ref()
+{
+#ifdef HAVE_CXX11_ATOMIC
+	int32_t ref_count = rc.fetch_add(1)+1;
+#else
+	lock.lock();
+	int32_t ref_count = ++rc;
+	lock.unlock();
+#endif
+
+	return ref_count;
+}
+
+int32_t RefCount::unref()
+{
+#ifdef HAVE_CXX11_ATOMIC
+	int32_t ref_count = rc.fetch_sub(1)-1;
+#else
+	lock.lock();
+	int32_t ref_count = --rc;
+	lock.unlock();
+#endif
+
+	return ref_count;
+}
+
+int32_t RefCount::ref_count()
+{
+#ifdef HAVE_CXX11_ATOMIC
+	int32_t ref_count = rc.load();
+#else
+	lock.lock();
+	int32_t ref_count = rc;
+	lock.unlock();
+#endif
+
+	return ref_count;
+}

--- a/src/shogun/lib/RefCount.h
+++ b/src/shogun/lib/RefCount.h
@@ -1,0 +1,52 @@
+#ifdef HAVE_CXX11_ATOMIC
+#include <atomic>
+#endif
+
+#include <shogun/lib/Lock.h>
+
+#ifndef _REFCOUNT__H__
+#define _REFCOUNT__H__
+
+namespace shogun
+{
+/** brief This class implements a thread-safe counter used for
+ * reference counting.
+ */
+class RefCount 
+{
+public:
+	/** Constructor 
+	 *
+	 * @param ref_start starting value for counter
+	 */
+	RefCount(int32_t ref_start=0) : rc(ref_start) {}
+
+	/** Increase ref count
+	 *
+	 * @return the new reference count
+	 */
+	int32_t ref();
+
+	/** Decrease reference count
+	 *
+	 * @return the new reference count
+	 */
+	int32_t unref();
+
+	/** Get the reference count
+	 *
+	 * @return the reference count
+	 */
+	int32_t ref_count();
+
+	/** reference count */
+#ifdef HAVE_CXX11_ATOMIC
+    volatile std::atomic<int> rc;
+#else
+	int32_t rc;
+	CLock lock;
+#endif
+};
+}
+
+#endif //_REFCOUNT__H__

--- a/src/shogun/lib/SGReferencedData.h
+++ b/src/shogun/lib/SGReferencedData.h
@@ -10,6 +10,7 @@
 #define __SGREFERENCED_DATA_H__
 
 #include <shogun/lib/common.h>
+#include <shogun/lib/RefCount.h>
 
 namespace shogun
 {


### PR DESCRIPTION
Moved RefCount to own file and used that class for ref counting instead of a plain int in the classes SGIO,Version and Parallel
