### PR TITLE
Linear operators redesigned (log-det)

### DIFF
--- a/src/shogun/lib/computation/job/DenseExactLogJob.cpp
+++ b/src/shogun/lib/computation/job/DenseExactLogJob.cpp
@@ -31,7 +31,7 @@ CDenseExactLogJob::CDenseExactLogJob()
 }
 
 CDenseExactLogJob::CDenseExactLogJob(CJobResultAggregator* aggregator,
-	CDenseMatrixOperator<float64_t, float64_t>* log_operator,
+	CDenseMatrixOperator<float64_t>* log_operator,
 	SGVector<float64_t> vector)
 	: CIndependentJob(aggregator)
 {

--- a/src/shogun/lib/computation/job/DenseExactLogJob.h
+++ b/src/shogun/lib/computation/job/DenseExactLogJob.h
@@ -18,7 +18,7 @@
 namespace shogun
 {
 template<class T> class SGVector;
-template<class T, class ST> class CDenseMatrixOperator;
+template<class T> class CDenseMatrixOperator;
 
 /** @brief Class that represents the job of applying the log of
  * a CDenseMatrixOperator on a real vector
@@ -37,7 +37,7 @@ public:
 	 * @param vector the sample vector to which operator is to be applied
 	 */
 	CDenseExactLogJob(CJobResultAggregator* aggregator,
-		CDenseMatrixOperator<float64_t, float64_t>* log_operator,
+		CDenseMatrixOperator<float64_t>* log_operator,
 		SGVector<float64_t> vector);
 
 	/** destructor */
@@ -50,7 +50,7 @@ public:
 	SGVector<float64_t> get_vector() const;
 
 	/** @return the linear operator */
-	CDenseMatrixOperator<float64_t, float64_t>* get_operator() const;
+	CDenseMatrixOperator<float64_t>* get_operator() const;
 
 	/** @return object name */
 	virtual const char* get_name() const
@@ -60,7 +60,7 @@ public:
 
 private:
 	/** the log of a CDenseMatrixOperator<float64_t> */
-	CDenseMatrixOperator<float64_t, float64_t>* m_log_operator;
+	CDenseMatrixOperator<float64_t>* m_log_operator;
 
 	/** the trace-sample */
 	SGVector<float64_t> m_vector;

--- a/src/shogun/lib/computation/job/IndividualJobResultAggregator.cpp
+++ b/src/shogun/lib/computation/job/IndividualJobResultAggregator.cpp
@@ -31,7 +31,7 @@ CIndividualJobResultAggregator::CIndividualJobResultAggregator()
 }
 
 CIndividualJobResultAggregator::CIndividualJobResultAggregator(
-	CLinearOperator<float64_t, float64_t>* linear_operator,
+	CLinearOperator<float64_t>* linear_operator,
 	SGVector<float64_t> vector,
 	const float64_t& const_multiplier)
 	: CStoreVectorAggregator<complex64_t>(vector.vlen),

--- a/src/shogun/lib/computation/job/IndividualJobResultAggregator.h
+++ b/src/shogun/lib/computation/job/IndividualJobResultAggregator.h
@@ -19,7 +19,7 @@ namespace shogun
 {
 class CJobResult;
 template<class T> class SGVector;
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Class that aggregates vector job results in each submit_result call
  * of jobs generated from rational approximation of linear operator function
@@ -44,7 +44,7 @@ public:
 	 * @param const_multiplier the constant multiplier to be multiplied with
 	 * the final vector-vector product to give final result
 	 */
-	CIndividualJobResultAggregator(CLinearOperator<float64_t, float64_t>*
+	CIndividualJobResultAggregator(CLinearOperator<float64_t>*
 		linear_operator, SGVector<float64_t> vector,
 		const float64_t& const_multiplier);
 
@@ -64,7 +64,7 @@ public:
 	}
 private:
 	/** the linear operator */
-	CLinearOperator<float64_t, float64_t>* m_linear_operator;
+	CLinearOperator<float64_t>* m_linear_operator;
 
 	/** the sample vector */
 	SGVector<float64_t> m_vector;

--- a/src/shogun/lib/computation/job/RationalApproximationIndividualJob.cpp
+++ b/src/shogun/lib/computation/job/RationalApproximationIndividualJob.cpp
@@ -35,7 +35,7 @@ CRationalApproximationIndividualJob::CRationalApproximationIndividualJob()
 CRationalApproximationIndividualJob::CRationalApproximationIndividualJob(
 	CJobResultAggregator* aggregator,
 	CLinearSolver<complex64_t, float64_t>* linear_solver,
-	CLinearOperator<complex64_t, complex64_t>* linear_operator,
+	CLinearOperator<complex64_t>* linear_operator,
 	SGVector<float64_t> vector,
 	complex64_t weight)
 	: CIndependentJob(aggregator)

--- a/src/shogun/lib/computation/job/RationalApproximationIndividualJob.h
+++ b/src/shogun/lib/computation/job/RationalApproximationIndividualJob.h
@@ -18,7 +18,7 @@
 namespace shogun
 {
 template<class T> class SGVector;
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T, class ST> class CLinearSolver;
 
 /** @brief Implementation of independent job that solves one of the family
@@ -46,7 +46,7 @@ public:
 	 */
 	CRationalApproximationIndividualJob(CJobResultAggregator* aggregator,
 		CLinearSolver<complex64_t, float64_t>* linear_solver,
-		CLinearOperator<complex64_t, complex64_t>* linear_operator,
+		CLinearOperator<complex64_t>* linear_operator,
 		SGVector<float64_t> vector, complex64_t weight);
 
 	/** destructor */
@@ -63,7 +63,7 @@ public:
 
 private:
 	/** the shifted operator for linear system to be solved */
-	CLinearOperator<complex64_t, complex64_t>* m_operator;
+	CLinearOperator<complex64_t>* m_operator;
 
 	/** the vector of the system to be solved */
 	SGVector<float64_t> m_vector;

--- a/src/shogun/mathematics/JacobiEllipticFunctions.h
+++ b/src/shogun/mathematics/JacobiEllipticFunctions.h
@@ -12,7 +12,7 @@
  * NOTE: For higher precision, the methods in this class rely on an external
  * library, ARPREC (http://crd-legacy.lbl.gov/~dhbailey/mpdist/), in absense of
  * which they fallback to shogun datatypes. To use it with shogun, configure 
- * ARPREC with "./configure 'CXX c++ -fPIC'" in order to link.
+ * ARPREC with `CXX="c++ -fPIC" ./configure' in order to link.
  */
 
 #ifndef JACOBI_ELLIPTIC_FUNCTIONS_H_

--- a/src/shogun/mathematics/logdet/CGMShiftedFamilySolver.cpp
+++ b/src/shogun/mathematics/logdet/CGMShiftedFamilySolver.cpp
@@ -35,7 +35,7 @@ CCGMShiftedFamilySolver::~CCGMShiftedFamilySolver()
 }
 
 SGVector<float64_t> CCGMShiftedFamilySolver::solve(
-	CLinearOperator<float64_t, float64_t>* A, SGVector<float64_t> b)
+	CLinearOperator<float64_t>* A, SGVector<float64_t> b)
 {
 	SGVector<complex64_t> shifts(1);
 	shifts[0]=0.0;
@@ -46,7 +46,7 @@ SGVector<float64_t> CCGMShiftedFamilySolver::solve(
 }
 
 SGVector<complex64_t> CCGMShiftedFamilySolver::solve_shifted_weighted(
-	CLinearOperator<float64_t, float64_t>* A, SGVector<float64_t> b,
+	CLinearOperator<float64_t>* A, SGVector<float64_t> b,
 	SGVector<complex64_t> shifts, SGVector<complex64_t> weights)
 {
 	SG_DEBUG("CCGMShiftedFamilySolve::solve_shifted_weighted(): Entering..\n");

--- a/src/shogun/mathematics/logdet/CGMShiftedFamilySolver.h
+++ b/src/shogun/mathematics/logdet/CGMShiftedFamilySolver.h
@@ -17,7 +17,7 @@
 
 namespace shogun
 {
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class SGVector;
 
 /** 
@@ -47,7 +47,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<float64_t> solve(CLinearOperator<float64_t, float64_t>* A,
+	virtual SGVector<float64_t> solve(CLinearOperator<float64_t>* A,
 		SGVector<float64_t> b);
 
 	/**
@@ -62,7 +62,7 @@ public:
 	 * shift
 	 */
 	virtual SGVector<complex64_t> solve_shifted_weighted(
-		CLinearOperator<float64_t, float64_t>* A, SGVector<float64_t> b,
+		CLinearOperator<float64_t>* A, SGVector<float64_t> b,
 		SGVector<complex64_t> shifts, SGVector<complex64_t> weights);
 
 	/** @return object name */

--- a/src/shogun/mathematics/logdet/ConjugateGradientSolver.h
+++ b/src/shogun/mathematics/logdet/ConjugateGradientSolver.h
@@ -17,7 +17,7 @@
 
 namespace shogun
 {
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class SGVector;
 
 /** 
@@ -42,7 +42,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<float64_t> solve(CLinearOperator<float64_t, float64_t>* A,
+	virtual SGVector<float64_t> solve(CLinearOperator<float64_t>* A,
 		SGVector<float64_t> b);
 
 	/** @return object name */

--- a/src/shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.cpp
+++ b/src/shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.cpp
@@ -17,7 +17,6 @@
 #include <shogun/mathematics/logdet/LinearOperator.h>
 #include <shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.h>
 #include <shogun/mathematics/logdet/IterativeSolverIterator.h>
-
 using namespace Eigen;
 
 namespace shogun
@@ -37,7 +36,7 @@ CConjugateOrthogonalCGSolver::~CConjugateOrthogonalCGSolver()
 SGVector<complex64_t> CConjugateOrthogonalCGSolver::solve(
 	CLinearOperator<complex64_t>* A, SGVector<float64_t> b)
 {
-	SG_DEBUG("CConjugateOrthogonalCGSolve::solve(): Entering..\n");
+	SG_DEBUG("CConjugateOrthogonalCGSolver::solve(): Entering..\n");
 
 	// sanity check
 	REQUIRE(A, "Operator is NULL!\n");
@@ -111,7 +110,7 @@ SGVector<complex64_t> CConjugateOrthogonalCGSolver::solve(
 	else
 		SG_WARNING("Did not converge!\n");
 
-	SG_DEBUG("CConjugateOrthogonalCGSolve::solve(): Leaving..\n");
+	SG_DEBUG("CConjugateOrthogonalCGSolver::solve(): Leaving..\n");
 	return result;
 }
 

--- a/src/shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.h
+++ b/src/shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.h
@@ -17,7 +17,7 @@
 
 namespace shogun
 {
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class SGVector;
 
 /** 
@@ -48,7 +48,8 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<complex64_t> solve(CLinearOperator<complex64_t, complex64_t>* A,
+	virtual SGVector<complex64_t> solve(CLinearOperator<complex64_t>* A,
+
 		SGVector<float64_t> b);
 
 	/** @return object name */

--- a/src/shogun/mathematics/logdet/DenseMatrixExactLog.cpp
+++ b/src/shogun/mathematics/logdet/DenseMatrixExactLog.cpp
@@ -36,7 +36,7 @@ CDenseMatrixExactLog::CDenseMatrixExactLog()
 }
 
 CDenseMatrixExactLog::CDenseMatrixExactLog(
-	CDenseMatrixOperator<float64_t, float64_t>* op,
+	CDenseMatrixOperator<float64_t>* op,
 	CIndependentComputationEngine* engine)
 	: COperatorFunction<float64_t>(
 		(CLinearOperator<float64_t>*)op, engine, OF_LOG)

--- a/src/shogun/mathematics/logdet/DenseMatrixExactLog.h
+++ b/src/shogun/mathematics/logdet/DenseMatrixExactLog.h
@@ -19,7 +19,7 @@ namespace shogun
 {
 
 template<class T> class SGVector;
-template<class T, class ST> class CDenseMatrixOperator;
+template<class T> class CDenseMatrixOperator;
 class CJobResultAggregator;
 class CIndependentComputationEngine;
 
@@ -38,7 +38,7 @@ public:
 	 * @param op the dense matrix linear operator for this operator function
 	 * @param engine the computation engine for the independent jobs
 	 */
-	CDenseMatrixExactLog(CDenseMatrixOperator<float64_t, float64_t>* op,
+	CDenseMatrixExactLog(CDenseMatrixOperator<float64_t>* op,
 		CIndependentComputationEngine* engine);
 
 	/** destructor */

--- a/src/shogun/mathematics/logdet/DenseMatrixOperator.cpp
+++ b/src/shogun/mathematics/logdet/DenseMatrixOperator.cpp
@@ -21,18 +21,18 @@ using namespace Eigen;
 namespace shogun
 {
 
-template<class T, class ST>
-CDenseMatrixOperator<T, ST>::CDenseMatrixOperator()
-	: CMatrixOperator<T, ST>()
+template<class T>
+CDenseMatrixOperator<T>::CDenseMatrixOperator()
+	: CMatrixOperator<T>()
 	{
 		init();
 
 		SG_SGCDEBUG("%s created (%p)\n", this->get_name(), this);
 	}
 
-template<class T, class ST>
-CDenseMatrixOperator<T, ST>::CDenseMatrixOperator(SGMatrix<T> op)
-	: CMatrixOperator<T, ST>(op.num_cols),
+template<class T>
+CDenseMatrixOperator<T>::CDenseMatrixOperator(SGMatrix<T> op)
+	: CMatrixOperator<T>(op.num_cols),
 	  m_operator(op)
 	{
 		init();
@@ -40,10 +40,10 @@ CDenseMatrixOperator<T, ST>::CDenseMatrixOperator(SGMatrix<T> op)
 		SG_SGCDEBUG("%s created (%p)\n", this->get_name(), this);
 	}
 
-template<class T, class ST>
-CDenseMatrixOperator<T, ST>::CDenseMatrixOperator(
-	const CDenseMatrixOperator<T, ST>& orig)
-	: CMatrixOperator<T, ST>(orig.get_dimension())
+template<class T>
+CDenseMatrixOperator<T>::CDenseMatrixOperator(
+	const CDenseMatrixOperator<T>& orig)
+	: CMatrixOperator<T>(orig.get_dimension())
 	{
 		init();
 
@@ -57,8 +57,8 @@ CDenseMatrixOperator<T, ST>::CDenseMatrixOperator(
 		SG_SGCDEBUG("%s deep copy created (%p)\n", this->get_name(), this);
 	}
 
-template<class T, class ST>
-void CDenseMatrixOperator<T, ST>::init()
+template<class T>
+void CDenseMatrixOperator<T>::init()
 	{
 		CSGObject::set_generic<T>();
 
@@ -66,20 +66,20 @@ void CDenseMatrixOperator<T, ST>::init()
 			"The dense matrix of the linear operator");
 	}
 
-template<class T, class ST>
-CDenseMatrixOperator<T, ST>::~CDenseMatrixOperator()
+template<class T>
+CDenseMatrixOperator<T>::~CDenseMatrixOperator()
 	{
 		SG_SGCDEBUG("%s destroyed (%p)\n", this->get_name(), this);
 	}
 
-template<class T, class ST>
-SGMatrix<T> CDenseMatrixOperator<T, ST>::get_matrix_operator() const
+template<class T>
+SGMatrix<T> CDenseMatrixOperator<T>::get_matrix_operator() const
 	{
 		return m_operator;
 	}
 
-template<class T, class ST>
-SGVector<T> CDenseMatrixOperator<T, ST>::get_diagonal() const
+template<class T>
+SGVector<T> CDenseMatrixOperator<T>::get_diagonal() const
 	{
 		REQUIRE(m_operator.matrix, "Operator not initialized!\n");
 
@@ -96,8 +96,8 @@ SGVector<T> CDenseMatrixOperator<T, ST>::get_diagonal() const
 		return diag;
 	}
 
-template<class T, class ST>
-void CDenseMatrixOperator<T, ST>::set_diagonal(SGVector<T> diag)
+template<class T>
+void CDenseMatrixOperator<T>::set_diagonal(SGVector<T> diag)
 	{
 		REQUIRE(m_operator.matrix, "Operator not initialized!\n");
 		REQUIRE(diag.vector, "Diagonal not initialized!\n");
@@ -115,19 +115,18 @@ void CDenseMatrixOperator<T, ST>::set_diagonal(SGVector<T> diag)
 		_op.diagonal()=_diag;
 	}
 
-template<class T, class ST>
-SGVector<T> CDenseMatrixOperator<T, ST>::apply(SGVector<ST> b) const
+template<class T>
+SGVector<T> CDenseMatrixOperator<T>::apply(SGVector<T> b) const
 	{
 		REQUIRE(m_operator.matrix, "Operator not initialized!\n");
 		REQUIRE(this->get_dimension()==b.vlen,
 			"Number of rows of vector must be equal to the "
 			"number of cols of the operator!\n");
 
-		typedef Matrix<ST, Dynamic, 1> VectorXst;
 		typedef Matrix<T, Dynamic, 1> VectorXt;
 		typedef Matrix<T, Dynamic, Dynamic> MatrixXt;
 
-		Map<VectorXst> _b(b.vector, b.vlen);
+		Map<VectorXt> _b(b.vector, b.vlen);
 		Map<MatrixXt> _op(m_operator.matrix, m_operator.num_rows,
 			m_operator.num_cols);
 	
@@ -140,7 +139,7 @@ SGVector<T> CDenseMatrixOperator<T, ST>::apply(SGVector<ST> b) const
 
 #define UNDEFINED(type) \
 template<> \
-SGVector<type> CDenseMatrixOperator<type, type>::apply(SGVector<type> b) const \
+SGVector<type> CDenseMatrixOperator<type>::apply(SGVector<type> b) const \
 	{	\
 		SG_SERROR("Not supported for %s\n", #type);\
 		return b; \
@@ -166,6 +165,5 @@ template class CDenseMatrixOperator<float32_t>;
 template class CDenseMatrixOperator<float64_t>;
 template class CDenseMatrixOperator<floatmax_t>;
 template class CDenseMatrixOperator<complex64_t>;
-template class CDenseMatrixOperator<complex64_t, float64_t>;
 }
 #endif // HAVE_EIGEN3

--- a/src/shogun/mathematics/logdet/DenseMatrixOperator.h
+++ b/src/shogun/mathematics/logdet/DenseMatrixOperator.h
@@ -26,7 +26,7 @@ template<class T> class SGMatrix;
  * being the matrix operator and \f$x\in\mathbb{C}^{n}\f$ being the vector.
  * The result is a vector \f$y\in\mathbb{C}^{m}\f$.
  */
-template<class T, class ST=T> class CDenseMatrixOperator : public CMatrixOperator<T, ST>
+template<class T> class CDenseMatrixOperator : public CMatrixOperator<T>
 {
 /** this class has support for complex64_t */
 typedef bool supports_complex64_t;
@@ -40,14 +40,14 @@ public:
 	 *
 	 * @param op the dense matrix to be used as the linear operator
 	 */
-	CDenseMatrixOperator(SGMatrix<T> op);
+	explicit CDenseMatrixOperator(SGMatrix<T> op);
 
 	/** 
 	 * copy constructor that creates a deep copy
 	 *
 	 * @param orig the original dense matrix operator
 	 */
-	CDenseMatrixOperator(const CDenseMatrixOperator<T, ST>& orig);
+	CDenseMatrixOperator(const CDenseMatrixOperator<T>& orig);
 
 	/** destructor */
 	~CDenseMatrixOperator();
@@ -58,7 +58,7 @@ public:
 	 * @param b the vector to which the linear operator applies
 	 * @return the result vector
 	 */
-	virtual SGVector<T> apply(SGVector<ST> b) const;
+	virtual SGVector<T> apply(SGVector<T> b) const;
 
 	/**
 	 * method that sets the main diagonal of the matrix
@@ -76,6 +76,25 @@ public:
 
 	/** @return the dense matrix operator */
 	SGMatrix<T> get_matrix_operator() const;
+
+	/**
+	 * create a new dense matrix operator of Scalar type
+	 */
+	template<class Scalar>
+	inline operator CDenseMatrixOperator<Scalar>*() const
+	{
+		REQUIRE(m_operator.matrix, "Matrix is not initialized!\n");
+
+		SGMatrix<Scalar> casted_m(m_operator.num_rows, m_operator.num_cols);
+		for (index_t i=0; i<m_operator.num_cols; ++i)
+		{
+			for (index_t j=0; j<m_operator.num_rows; ++j)
+				casted_m(j,i)=static_cast<Scalar>(m_operator(j,i));
+		}
+		SG_SDEBUG("DenseMatrixOperator::static_cast(): Creating casted operator!\n");
+
+		return new CDenseMatrixOperator<Scalar>(casted_m);
+	}
 
 	/** @return object name */
 	virtual const char* get_name() const

--- a/src/shogun/mathematics/logdet/DirectEigenSolver.cpp
+++ b/src/shogun/mathematics/logdet/DirectEigenSolver.cpp
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #include <shogun/lib/config.h>
 
 #ifdef HAVE_EIGEN3
@@ -26,8 +27,8 @@ CDirectEigenSolver::CDirectEigenSolver()
 }
 
 CDirectEigenSolver::CDirectEigenSolver(
-	CDenseMatrixOperator<float64_t, float64_t>* linear_operator)
-	: CEigenSolver((CLinearOperator<float64_t, float64_t>*)linear_operator)
+	CDenseMatrixOperator<float64_t>* linear_operator)
+	: CEigenSolver((CLinearOperator<float64_t>*)linear_operator)
 {
 	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 }

--- a/src/shogun/mathematics/logdet/DirectEigenSolver.h
+++ b/src/shogun/mathematics/logdet/DirectEigenSolver.h
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #ifndef DIRECT_EIGEN_SOLVER_H_
 #define DIRECT_EIGEN_SOLVER_H_
 
@@ -16,7 +17,7 @@
 
 namespace shogun
 {
-template<class T, class ST> class CDenseMatrixOperator;
+template<class T> class CDenseMatrixOperator;
 
 /** @brief Class that computes eigenvalues of a real valued, self-adjoint
  * dense matrix linear operator using Eigen3
@@ -33,7 +34,7 @@ public:
 	 * @param linear_operator self-adjoint dense-matrix linear operator whose
 	 * eigenvalues have to be found
 	 */
-	CDirectEigenSolver(CDenseMatrixOperator<float64_t, float64_t>* linear_operator);
+	CDirectEigenSolver(CDenseMatrixOperator<float64_t>* linear_operator);
 
 	/** destructor */
 	virtual ~CDirectEigenSolver();

--- a/src/shogun/mathematics/logdet/DirectLinearSolverComplex.h
+++ b/src/shogun/mathematics/logdet/DirectLinearSolverComplex.h
@@ -55,7 +55,7 @@ public:
 	 * @return the solution vector
 	 */
 	virtual SGVector<complex64_t> solve(
-		CLinearOperator<complex64_t, complex64_t>* A, SGVector<float64_t> b);
+		CLinearOperator<complex64_t>* A, SGVector<float64_t> b);
 
 	/** @return object name */
 	virtual const char* get_name() const

--- a/src/shogun/mathematics/logdet/IterativeLinearSolver.h
+++ b/src/shogun/mathematics/logdet/IterativeLinearSolver.h
@@ -38,7 +38,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<T> solve(CLinearOperator<T, T>* A, SGVector<ST> b) = 0;
+	virtual SGVector<T> solve(CLinearOperator<T>* A, SGVector<ST> b) = 0;
 
 	/** set maximum iteration limit */
 	void set_iteration_limit(int64_t iteration_limit)

--- a/src/shogun/mathematics/logdet/IterativeShiftedLinearFamilySolver.h
+++ b/src/shogun/mathematics/logdet/IterativeShiftedLinearFamilySolver.h
@@ -16,7 +16,7 @@
 namespace shogun
 {
 template <class T> class SGVector;
-template <class T, class ST> class CLinearOperator;
+template <class T> class CLinearOperator;
 
 /** 
  * @brief abstract template base for CG based solvers to the solution of 
@@ -49,7 +49,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<T> solve(CLinearOperator<T, T>* A, SGVector<T> b) = 0;
+	virtual SGVector<T> solve(CLinearOperator<T>* A, SGVector<T> b) = 0;
 
 	/**
 	 * abstract method that solves the shifted family of linear systems, multiples
@@ -62,7 +62,7 @@ public:
 	 * @param weights the weights to be multiplied with each solution for each
 	 * shift
 	 */
-	virtual SGVector<ST> solve_shifted_weighted(CLinearOperator<T, T>* A,
+	virtual SGVector<ST> solve_shifted_weighted(CLinearOperator<T>* A,
 		SGVector<T> b, SGVector<ST> shifts, SGVector<ST> weights) = 0;
 
 	/** @return object name */

--- a/src/shogun/mathematics/logdet/LanczosEigenSolver.cpp
+++ b/src/shogun/mathematics/logdet/LanczosEigenSolver.cpp
@@ -34,7 +34,7 @@ CLanczosEigenSolver::CLanczosEigenSolver()
 }
 
 CLanczosEigenSolver::CLanczosEigenSolver(
-	CLinearOperator<float64_t, float64_t>* linear_operator)
+	CLinearOperator<float64_t>* linear_operator)
 	: CEigenSolver(linear_operator)
 {
 	init();

--- a/src/shogun/mathematics/logdet/LanczosEigenSolver.h
+++ b/src/shogun/mathematics/logdet/LanczosEigenSolver.h
@@ -18,7 +18,7 @@
 
 namespace shogun
 {
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Class that computes eigenvalues of a real valued, self-adjoint
  * linear operator using Lanczos algorithm
@@ -35,7 +35,7 @@ public:
 	 * @param linear_operator self-adjoint linear operator whose eigenvalues 
 	 * are to be found
 	 */
-	CLanczosEigenSolver(CLinearOperator<float64_t, float64_t>* linear_operator);
+	CLanczosEigenSolver(CLinearOperator<float64_t>* linear_operator);
 
 	/** destructor */
 	virtual ~CLanczosEigenSolver();

--- a/src/shogun/mathematics/logdet/LinearOperator.h
+++ b/src/shogun/mathematics/logdet/LinearOperator.h
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #ifndef LINEAR_OPERATOR_H_
 #define LINEAR_OPERATOR_H_
 
@@ -20,7 +21,7 @@ template<class T> class SGVector;
 /** @brief Abstract template base class that represents a linear operator,
  *  e.g. a matrix
  */
-template<class T, class ST=T> class CLinearOperator : public CSGObject
+template<class T> class CLinearOperator : public CSGObject
 {
 public:
 	/** default constructor */
@@ -65,7 +66,7 @@ public:
 	 * @param b the vector to which the linear operator applies
 	 * @return the result vector
 	 */
-	virtual SGVector<T> apply(SGVector<ST> b) const = 0;
+	virtual SGVector<T> apply(SGVector<T> b) const = 0;
 
 	/** @return object name */
 	virtual const char* get_name() const
@@ -103,7 +104,6 @@ template class CLinearOperator<float32_t>;
 template class CLinearOperator<float64_t>;
 template class CLinearOperator<floatmax_t>;
 template class CLinearOperator<complex64_t>;
-template class CLinearOperator<complex64_t, float64_t>;
 }
 
 #endif // LINEAR_OPERATOR_H_

--- a/src/shogun/mathematics/logdet/LinearSolver.h
+++ b/src/shogun/mathematics/logdet/LinearSolver.h
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #ifndef LINEAR_SOLVER_H_
 #define LINEAR_SOLVER_H_
 
@@ -15,7 +16,7 @@
 namespace shogun
 {
 template<class T> class SGVector;
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Abstract template base class that provides an abstract solve method
  * for linear systems, that takes a linear operator \f$A\f$, a vector \f$b\f$,
@@ -44,7 +45,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<T> solve(CLinearOperator<T, T>* A, SGVector<ST> b) = 0;
+	virtual SGVector<T> solve(CLinearOperator<T>* A, SGVector<ST> b) = 0;
 
 	/** @return object name */
 	virtual const char* get_name() const

--- a/src/shogun/mathematics/logdet/LogRationalApproximationIndividual.h
+++ b/src/shogun/mathematics/logdet/LogRationalApproximationIndividual.h
@@ -19,7 +19,7 @@ namespace shogun
 {
 
 template<class T> class SGVector;
-template<class T, class ST> class CDenseMatrixOperator;
+template<class T> class CMatrixOperator;
 template<class T, class ST> class CLinearSolver;
 class CJobResultAggregator;
 class CIndependentComputationEngine;
@@ -40,7 +40,7 @@ public:
 	/** 
 	 * constructor
 	 *
-	 * @param linear_operator dense-matrix linear operator of the log function
+	 * @param linear_operator matrix linear operator of the log function
 	 * @param computation_engine engine that computes the independent jobs
 	 * @param eigen_solver eigen solver for computing min and max eigenvalues
 	 * needed for computing shifts, weights and multiplier in the rational
@@ -50,7 +50,7 @@ public:
 	 * of discretization of the contour integral
 	 */
 	CLogRationalApproximationIndividual(
-		CDenseMatrixOperator<float64_t, float64_t>* linear_operator,
+		CMatrixOperator<float64_t>* linear_operator,
 		CIndependentComputationEngine* computation_engine,
 		CEigenSolver* eigen_solver,
 		CLinearSolver<complex64_t, float64_t>* linear_solver,

--- a/src/shogun/mathematics/logdet/MatrixOperator.h
+++ b/src/shogun/mathematics/logdet/MatrixOperator.h
@@ -23,12 +23,12 @@ namespace shogun
  * \mathbb{C}^{n}\f$ being the vector. The result is a vector \f$y\in
  * \mathbb{C}^{m}\f$.
  */
-template<class T, class ST=T> class CMatrixOperator : public CLinearOperator<T, ST>
+template<class T> class CMatrixOperator : public CLinearOperator<T>
 {
 public:
 	/** default constructor */
 	CMatrixOperator()
-	: CLinearOperator<T, ST>()
+	: CLinearOperator<T>()
 	{
 	}
 
@@ -38,7 +38,7 @@ public:
 	 * @param dimension the dimension of the vector on which this it can apply
 	 */
 	CMatrixOperator(index_t dimension)
-	: CLinearOperator<T, ST>(dimension)
+	: CLinearOperator<T>(dimension)
 	{
 	}
 
@@ -53,7 +53,7 @@ public:
 	 * @param b the vector to which the linear operator applies
 	 * @return the result vector
 	 */
-	virtual SGVector<T> apply(SGVector<ST> b) const = 0;
+	virtual SGVector<T> apply(SGVector<T> b) const = 0;
 
 	/**
 	 * abstract method that sets the main diagonal
@@ -91,7 +91,6 @@ template class CMatrixOperator<float32_t>;
 template class CMatrixOperator<float64_t>;
 template class CMatrixOperator<floatmax_t>;
 template class CMatrixOperator<complex64_t>;
-template class CMatrixOperator<complex64_t, float64_t>;
 
 }
 

--- a/src/shogun/mathematics/logdet/OperatorFunction.h
+++ b/src/shogun/mathematics/logdet/OperatorFunction.h
@@ -30,7 +30,7 @@ enum EOperatorFunction
 
 template<class T> class SGVector;
 class CJobResultAggregator;
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Abstract template base class for computing \f$s^{T} f(C) s\f$ for a
  * linear operator C and a vector s. submit_jobs method creates a bunch of jobs
@@ -57,7 +57,7 @@ public:
 	 * @param engine the computation engine for the independent jobs
 	 * @param type the type of the operator function (sqrt, log, etc)
 	 */
-	COperatorFunction(CLinearOperator<T, T>* op,
+	COperatorFunction(CLinearOperator<T>* op,
 		CIndependentComputationEngine* engine,
 		EOperatorFunction type=OF_UNDEFINED)
 	: CSGObject(),
@@ -84,7 +84,7 @@ public:
 	}
 
 	/** @return the operator */
-	CLinearOperator<T, T>* get_operator() const
+	CLinearOperator<T>* get_operator() const
 	{
 		return m_linear_operator;
 	}
@@ -115,7 +115,7 @@ public:
 	}
 protected:
 	/** the linear operator */
-	CLinearOperator<T, T>* m_linear_operator;
+	CLinearOperator<T>* m_linear_operator;
 
 	/** the computation engine */
 	CIndependentComputationEngine* m_computation_engine;

--- a/src/shogun/mathematics/logdet/RationalApproximation.cpp
+++ b/src/shogun/mathematics/logdet/RationalApproximation.cpp
@@ -100,6 +100,8 @@ void CRationalApproximation::precompute()
 {
 	// compute extremal eigenvalues
 	m_eigen_solver->compute();
+	SG_DEBUG("max_eig=%.15lf\n", m_eigen_solver->get_max_eigenvalue());
+	SG_DEBUG("min_eig=%.15lf\n", m_eigen_solver->get_min_eigenvalue());
 
 	compute_shifts_weights_const();
 }

--- a/src/shogun/mathematics/logdet/RationalApproximation.h
+++ b/src/shogun/mathematics/logdet/RationalApproximation.h
@@ -17,7 +17,7 @@ namespace shogun
 {
 
 template<class T> class SGVector;
-template<class T, class ST> class CLinearOperator;
+template<class T> class CLinearOperator;
 class CIndependentComputationEngine;
 class CJobResultAggregator;
 class CEigenSolver;

--- a/tests/unit/lib/computation/RationalApproximationIndividualJob_unittest.cc
+++ b/tests/unit/lib/computation/RationalApproximationIndividualJob_unittest.cc
@@ -34,13 +34,11 @@ TEST(RationalApproximationIndividualJob, compute)
 	mi(0,1)=0.0;
 	mi(1,0)=0.0;
 	mi(1,1)=1.0;
-	CDenseMatrixOperator<float64_t, float64_t>* identity
-		=new CDenseMatrixOperator<float64_t, float64_t>(mi);
+	CDenseMatrixOperator<float64_t>* identity=new CDenseMatrixOperator<float64_t>(mi);
 	SG_REF(identity);
 
 	SG_SDEBUG("creating op\n");
-	CDenseMatrixOperator<complex64_t, complex64_t>* op
-		=new CDenseMatrixOperator<complex64_t>(m);
+	CDenseMatrixOperator<complex64_t>* op=new CDenseMatrixOperator<complex64_t>(m);
 	SG_REF(op);
 	
 	const float64_t const_multiplier=2.0;

--- a/tests/unit/lib/computation/SerialComputationEngine_unittest.cc
+++ b/tests/unit/lib/computation/SerialComputationEngine_unittest.cc
@@ -44,8 +44,7 @@ TEST(SerialComputationEngine, dense_log_det)
 	log_m=m.log();
 
 	// create linear operator and aggregator	
-	CDenseMatrixOperator<float64_t, float64_t>* log_op
-		=new CDenseMatrixOperator<float64_t, float64_t>(log_mat);
+	CDenseMatrixOperator<float64_t>* log_op=new CDenseMatrixOperator<float64_t>(log_mat);
 	SG_REF(log_op);
 	CStoreScalarAggregator<float64_t>* agg=new CStoreScalarAggregator<float64_t>;
 	SG_REF(agg);

--- a/tests/unit/mathematics/logdet/CGMShiftedFamilySolver_unittest.cc
+++ b/tests/unit/mathematics/logdet/CGMShiftedFamilySolver_unittest.cc
@@ -42,7 +42,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_noshift)
 	// Creating sparse system to solve with CG_M
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t>* A
+	CSparseMatrixOperator<float64_t>* A
 		=new CSparseMatrixOperator<float64_t>(mat);
 
 	// Solve with CG_M
@@ -88,7 +88,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_real_shift)
 	// Creating sparse system to solve with CG_M
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t>* A
+	CSparseMatrixOperator<float64_t>* A
 		=new CSparseMatrixOperator<float64_t>(mat);
 
 	// Solve with CG_M
@@ -143,7 +143,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_complex_shift)
 	// Creating sparse system to solve with CG_M
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t>* A
+	CSparseMatrixOperator<float64_t>* A
 		=new CSparseMatrixOperator<float64_t>(mat);
 
 	// Solve with CG_M
@@ -158,7 +158,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_complex_shift)
 	for (index_t i=0; i<size; ++i)
 		m2(i,i)=m(i,i)+shift;
 
-	CDenseMatrixOperator<complex64_t, complex64_t>* B
+	CDenseMatrixOperator<complex64_t>* B
 		=new CDenseMatrixOperator<complex64_t>(m2);
 
 	CDirectLinearSolverComplex direct_solver;

--- a/tests/unit/mathematics/logdet/ConjugateGradientSolver_unittest.cc
+++ b/tests/unit/mathematics/logdet/ConjugateGradientSolver_unittest.cc
@@ -33,7 +33,7 @@ TEST(ConjugateGradientSolver, solve)
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
 
-	CSparseMatrixOperator<float64_t, float64_t>* A
+	CSparseMatrixOperator<float64_t>* A
 		=new CSparseMatrixOperator<float64_t>(mat);
 
 	CConjugateGradientSolver linear_solver;

--- a/tests/unit/mathematics/logdet/ConjugateOrthogonalCGSolver_unittest.cc
+++ b/tests/unit/mathematics/logdet/ConjugateOrthogonalCGSolver_unittest.cc
@@ -41,7 +41,7 @@ TEST(ConjugateOrthogonalCGSolver, solve)
 	// Creating sparse system to solve with COCG
 	CSparseFeatures<complex64_t> feat(m);
 	SGSparseMatrix<complex64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<complex64_t, complex64_t>* A
+	CSparseMatrixOperator<complex64_t>* A
 		=new CSparseMatrixOperator<complex64_t>(mat);
 
 	// Solve with COCG
@@ -50,7 +50,7 @@ TEST(ConjugateOrthogonalCGSolver, solve)
 	SGVector<complex64_t> x_cg=cocg_linear_solver.solve(A, b);
 
 	// Creating dense system to solve with direct solver
-	CDenseMatrixOperator<complex64_t, complex64_t>* B
+	CDenseMatrixOperator<complex64_t>* B
 		=new CDenseMatrixOperator<complex64_t>(m);
 
 	// Solve with direct triangular solver

--- a/tests/unit/mathematics/logdet/DenseExactLogJob_unittest.cc
+++ b/tests/unit/mathematics/logdet/DenseExactLogJob_unittest.cc
@@ -42,8 +42,7 @@ TEST(DenseExactLogJob, log_det)
 	log_m=m.log();
 
 	// create linear operator and aggregator	
-	CDenseMatrixOperator<float64_t, float64_t>* log_op=new CDenseMatrixOperator<float64_t, float64_t>
-		(log_mat);
+	CDenseMatrixOperator<float64_t>* log_op=new CDenseMatrixOperator<float64_t>(log_mat);
 	SG_REF(log_op);
 	CStoreScalarAggregator<float64_t>* agg=new CStoreScalarAggregator<float64_t>;
 	SG_REF(agg);

--- a/tests/unit/mathematics/logdet/DenseMatrixExactLog_unittest.cc
+++ b/tests/unit/mathematics/logdet/DenseMatrixExactLog_unittest.cc
@@ -43,7 +43,7 @@ TEST(DenseMatrixExactLog, dense_log_det)
 	mat(0,1)=1.0;
 	mat(1,0)=1.0;
 	mat(1,1)=3.0;
-	CDenseMatrixOperator<float64_t, float64_t>* op=new CDenseMatrixOperator<float64_t, float64_t>(mat);
+	CDenseMatrixOperator<float64_t>* op=new CDenseMatrixOperator<float64_t>(mat);
 	SG_REF(op);
 	
 	// create operator function with the operator and the engine to submit jobs

--- a/tests/unit/mathematics/logdet/DenseMatrixOperator_unittest.cc
+++ b/tests/unit/mathematics/logdet/DenseMatrixOperator_unittest.cc
@@ -29,7 +29,7 @@ TEST(DenseMatrixOperator, apply)
 	SGMatrix<float64_t> m1(size, size);
 	m1.set_const(0.5);
 
-	CDenseMatrixOperator<float64_t, float64_t> op11(m1);
+	CDenseMatrixOperator<float64_t> op11(m1);
 	SGVector<float64_t> r1=op11.apply(b1);
 
 	for (index_t i=0; i<r1.vlen; ++i)
@@ -41,7 +41,7 @@ TEST(DenseMatrixOperator, apply)
 	typedef Matrix<float64_t, size, size> MatrixSd;
 	Map<MatrixSd> mapped1(m1.matrix, m1.num_rows, m1.num_cols);
 	mapped1=MatrixSd::Identity();
-	CDenseMatrixOperator<float64_t, float64_t> op12(m1);
+	CDenseMatrixOperator<float64_t> op12(m1);
 	r1=op12.apply(b1);
 
 	for (index_t i=0; i<r1.vlen; ++i)
@@ -56,7 +56,7 @@ TEST(DenseMatrixOperator, apply)
 	SGMatrix<complex64_t> m2(size, size);
 	m2.set_const(complex64_t(0.5, 0.25));
 
-	CDenseMatrixOperator<complex64_t, complex64_t> op21(m2);
+	CDenseMatrixOperator<complex64_t> op21(m2);
 	SGVector<complex64_t> r2=op21.apply(b2);
 
 	for (index_t i=0; i<r2.vlen; ++i)
@@ -69,7 +69,7 @@ TEST(DenseMatrixOperator, apply)
 	typedef Matrix<complex64_t, size, size> MatrixScd;
 	Map<MatrixScd> mapped2(m2.matrix, m2.num_rows, m2.num_cols);
 	mapped2=MatrixScd::Identity();
-	CDenseMatrixOperator<complex64_t, complex64_t> op22(m2);
+	CDenseMatrixOperator<complex64_t> op22(m2);
 	r2=op22.apply(b2);
 
 	for (index_t i=0; i<r2.vlen; ++i)
@@ -82,7 +82,7 @@ TEST(DenseMatrixOperator, apply)
 TEST(DenseMatrixOperator, shift_apply)
 {
 	const index_t size=5;
-	SGVector<float64_t> b(size);
+	SGVector<complex64_t> b(size);
 	b.set_const(0.25);
 
 	// complex64_t, fixed matrix	
@@ -90,7 +90,7 @@ TEST(DenseMatrixOperator, shift_apply)
 	m.set_const(complex64_t(0.5, 0.0));
 
 	// shifting the diagonal via interface
-	CDenseMatrixOperator<complex64_t, float64_t> op(m);
+	CDenseMatrixOperator<complex64_t> op(m);
 	SGVector<complex64_t> diag=op.get_diagonal();
 	for (index_t i=0; i<diag.vlen; ++i)
 	{

--- a/tests/unit/mathematics/logdet/DirectEigenSolver_unittest.cc
+++ b/tests/unit/mathematics/logdet/DirectEigenSolver_unittest.cc
@@ -25,7 +25,7 @@ TEST(DirectEigenSolver, compute)
 	m(1,0)=1.0;
 	m(1,1)=3.0;
 
-	CDenseMatrixOperator<float64_t, float64_t>* A=new CDenseMatrixOperator<float64_t, float64_t>(m);
+	CDenseMatrixOperator<float64_t>* A=new CDenseMatrixOperator<float64_t>(m);
 	SG_REF(A);
 
 	CDirectEigenSolver eig_solver(A);

--- a/tests/unit/mathematics/logdet/DirectLinearSolverComplex_unittest.cc
+++ b/tests/unit/mathematics/logdet/DirectLinearSolverComplex_unittest.cc
@@ -29,7 +29,7 @@ TEST(DirectLinearSolverComplex, solve_SVD)
 	m(1,0)=complex64_t(1.0, 2.0);
 	m(1,1)=complex64_t(3.0);
 
-	CDenseMatrixOperator<complex64_t, complex64_t>* A
+	CDenseMatrixOperator<complex64_t>* A
 		=new CDenseMatrixOperator<complex64_t>(m);
 
 	SGVector<float64_t> b(size);
@@ -37,7 +37,7 @@ TEST(DirectLinearSolverComplex, solve_SVD)
 
 	CDirectLinearSolverComplex solver(DS_SVD);
 	SGVector<complex64_t> x
-		=solver.solve((CLinearOperator<complex64_t, complex64_t>*)A, b);
+		=solver.solve((CLinearOperator<complex64_t>*)A, b);
 
 	SGVector<complex64_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -58,7 +58,7 @@ TEST(DirectLinearSolverComplex, solve_QR_NOPERM)
 	m(1,0)=complex64_t(1.0, 2.0);
 	m(1,1)=complex64_t(3.0);
 
-	CDenseMatrixOperator<complex64_t, complex64_t>* A
+	CDenseMatrixOperator<complex64_t>* A
 		=new CDenseMatrixOperator<complex64_t>(m);
 
 	SGVector<float64_t> b(size);
@@ -66,7 +66,7 @@ TEST(DirectLinearSolverComplex, solve_QR_NOPERM)
 
 	CDirectLinearSolverComplex solver(DS_QR_NOPERM);
 	SGVector<complex64_t> x
-		=solver.solve((CLinearOperator<complex64_t, complex64_t>*)A, b);
+		=solver.solve((CLinearOperator<complex64_t>*)A, b);
 
 	SGVector<complex64_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -87,7 +87,7 @@ TEST(DirectLinearSolverComplex, solve_QR_COLPERM)
 	m(1,0)=complex64_t(1.0, 2.0);
 	m(1,1)=complex64_t(3.0);
 
-	CDenseMatrixOperator<complex64_t, complex64_t>* A
+	CDenseMatrixOperator<complex64_t>* A
 		=new CDenseMatrixOperator<complex64_t>(m);
 
 	SGVector<float64_t> b(size);
@@ -95,7 +95,7 @@ TEST(DirectLinearSolverComplex, solve_QR_COLPERM)
 
 	CDirectLinearSolverComplex solver(DS_QR_COLPERM);
 	SGVector<complex64_t> x
-		=solver.solve((CLinearOperator<complex64_t, complex64_t>*)A, b);
+		=solver.solve((CLinearOperator<complex64_t>*)A, b);
 
 	SGVector<complex64_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -116,7 +116,7 @@ TEST(DirectLinearSolverComplex, solve_QR_FULLPERM)
 	m(1,0)=complex64_t(1.0, 2.0);
 	m(1,1)=complex64_t(3.0);
 
-	CDenseMatrixOperator<complex64_t, complex64_t>* A
+	CDenseMatrixOperator<complex64_t>* A
 		=new CDenseMatrixOperator<complex64_t>(m);
 
 	SGVector<float64_t> b(size);
@@ -146,7 +146,7 @@ TEST(DirectLinearSolverComplex, solve_LLT)
 	m(1,0)=complex64_t(1.0, 0.0);
 	m(1,1)=complex64_t(2.5, 0.0);
 
-	CDenseMatrixOperator<complex64_t, complex64_t>* A
+	CDenseMatrixOperator<complex64_t>* A
 		=new CDenseMatrixOperator<complex64_t>(m);
 
 	SGVector<float64_t> b(size);
@@ -154,7 +154,7 @@ TEST(DirectLinearSolverComplex, solve_LLT)
 
 	CDirectLinearSolverComplex solver(DS_LLT);
 	SGVector<complex64_t> x
-		=solver.solve((CLinearOperator<complex64_t, complex64_t>*)A, b);
+		=solver.solve((CLinearOperator<complex64_t>*)A, b);
 
 	SGVector<complex64_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);

--- a/tests/unit/mathematics/logdet/LanczosEigenSolver_unittest.cc
+++ b/tests/unit/mathematics/logdet/LanczosEigenSolver_unittest.cc
@@ -39,8 +39,7 @@ TEST(LanczosEigenSolver, compute)
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
 	CEigenSolver* eig_solver=NULL;
 
-	CLinearOperator<float64_t, float64_t>* A
-		=new CSparseMatrixOperator<float64_t, float64_t>(mat);
+	CLinearOperator<float64_t>* A=new CSparseMatrixOperator<float64_t>(mat);
 	SG_REF(A);
 
 	eig_solver=new CLanczosEigenSolver(A);
@@ -53,8 +52,7 @@ TEST(LanczosEigenSolver, compute)
 	SG_UNREF(A);
 
 	// create dense linear operator to use with direct eigensolver
-	CDenseMatrixOperator<float64_t, float64_t>* B
-		=new CDenseMatrixOperator<float64_t, float64_t>(m);
+	CDenseMatrixOperator<float64_t>* B=new CDenseMatrixOperator<float64_t>(m);
 	SG_REF(B);
 
 	eig_solver=new CDirectEigenSolver(B);

--- a/tests/unit/mathematics/logdet/LogDetEstimator_unittest.cc
+++ b/tests/unit/mathematics/logdet/LogDetEstimator_unittest.cc
@@ -14,12 +14,16 @@
 #include <shogun/mathematics/Statistics.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGMatrix.h>
+#include <shogun/features/SparseFeatures.h>
 #include <shogun/mathematics/logdet/DenseMatrixOperator.h>
+#include <shogun/mathematics/logdet/SparseMatrixOperator.h>
 #include <shogun/mathematics/logdet/DenseMatrixExactLog.h>
 #include <shogun/mathematics/logdet/LogRationalApproximationIndividual.h>
 #include <shogun/mathematics/logdet/NormalSampler.h>
 #include <shogun/mathematics/logdet/DirectEigenSolver.h>
+#include <shogun/mathematics/logdet/LanczosEigenSolver.h>
 #include <shogun/mathematics/logdet/DirectLinearSolverComplex.h>
+#include <shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.h>
 #include <shogun/mathematics/logdet/LogDetEstimator.h>
 #include <shogun/lib/computation/job/ScalarResult.h>
 #include <shogun/lib/computation/engine/SerialComputationEngine.h>
@@ -40,8 +44,7 @@ TEST(LogDetEstimator, sample)
 	mat(1,0)=1.0;
 	mat(1,1)=3.0;
 
-	CDenseMatrixOperator<float64_t, float64_t>* op
-		=new CDenseMatrixOperator<float64_t>(mat);
+	CDenseMatrixOperator<float64_t>* op=new CDenseMatrixOperator<float64_t>(mat);
 	SG_REF(op);
 
 	CDenseMatrixExactLog *op_func=new CDenseMatrixExactLog(op, e);
@@ -68,7 +71,7 @@ TEST(LogDetEstimator, sample)
 }
 #endif // EIGEN_VERSION_AT_LEAST(3,1,0)
 
-TEST(LogDetEstimator, sample_ratapp)
+TEST(LogDetEstimator, sample_ratapp_dense)
 {
 	CSerialComputationEngine* e=new CSerialComputationEngine;
 	SG_REF(e);
@@ -80,8 +83,7 @@ TEST(LogDetEstimator, sample_ratapp)
 	mat(1,0)=0.5;
 	mat(1,1)=1000.0;
 
-	CDenseMatrixOperator<float64_t, float64_t>* op
-		=new CDenseMatrixOperator<float64_t>(mat);
+	CDenseMatrixOperator<float64_t>* op=new CDenseMatrixOperator<float64_t>(mat);
 	SG_REF(op);
 
 	CDirectEigenSolver* eig_solver=new CDirectEigenSolver(op);
@@ -117,6 +119,5 @@ TEST(LogDetEstimator, sample_ratapp)
 	SG_UNREF(op);
 	SG_UNREF(e);
 }
-
 #endif // HAVE_EIGEN3
 

--- a/tests/unit/mathematics/logdet/MatrixOperator_unittest.cc
+++ b/tests/unit/mathematics/logdet/MatrixOperator_unittest.cc
@@ -1,0 +1,75 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2013 Soumyajit De
+ */
+ 
+#include <shogun/lib/common.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/SGSparseMatrix.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/logdet/SparseMatrixOperator.h>
+#include <shogun/mathematics/logdet/DenseMatrixOperator.h>
+#include <shogun/features/SparseFeatures.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+using namespace Eigen;
+
+TEST(MatrixOperator, cast_dense_double_complex)
+{
+	const int32_t size=2;
+	SGMatrix<float64_t> m(size, size);
+	m.set_const(1.0);
+
+	CDenseMatrixOperator<float64_t>* orig_op
+		=new CDenseMatrixOperator<float64_t>(m);
+	CDenseMatrixOperator<complex64_t>* casted_op
+		=static_cast<CDenseMatrixOperator<complex64_t>*>(*orig_op);
+
+	SGMatrix<float64_t> orig_m=orig_op->get_matrix_operator();
+	SGMatrix<complex64_t> casted_m=casted_op->get_matrix_operator();
+
+	Map<MatrixXd> eig_orig(orig_m.matrix, orig_m.num_rows, orig_m.num_cols);
+	Map<MatrixXcd> eig_casted(casted_m.matrix, casted_m.num_rows, casted_m.num_cols);
+	
+	EXPECT_NEAR((eig_orig.cast<complex64_t>()-eig_casted).norm(), 0.0, 1E-15);
+
+	SG_UNREF(orig_op);
+	SG_UNREF(casted_op);
+}
+
+TEST(MatrixOperator, cast_sparse_double_complex)
+{
+	const int32_t size=4;
+	SGMatrix<float64_t> m(size, size);
+	m.set_const(0.0);
+
+	for (index_t i=0; i<size; ++i)
+		m(i,i)=1.0;
+
+	CSparseFeatures<float64_t> feat(m);
+	SGSparseMatrix<float64_t> sm=feat.get_sparse_feature_matrix();
+
+	CSparseMatrixOperator<float64_t>* orig_op
+		=new CSparseMatrixOperator<float64_t>(sm);
+	CSparseMatrixOperator<complex64_t>* casted_op
+		=static_cast<CSparseMatrixOperator<complex64_t>*>(*orig_op);
+
+	SGSparseMatrix<complex64_t> casted_m=casted_op->get_matrix_operator();
+	const SparseMatrix<complex64_t>& eig_casted
+		=EigenSparseUtil<complex64_t>::toEigenSparse(casted_m);
+
+	Map<MatrixXd> eig_orig(m.matrix, m.num_rows, m.num_cols);
+
+	EXPECT_NEAR((eig_orig*eig_casted).norm(), 2.0, 1E-15);
+
+	SG_UNREF(orig_op);
+	SG_UNREF(casted_op);
+}
+#endif // HAVE_EIGEN3

--- a/tests/unit/mathematics/logdet/RationalApproximation_unittest.cc
+++ b/tests/unit/mathematics/logdet/RationalApproximation_unittest.cc
@@ -12,15 +12,20 @@
 #ifdef HAVE_EIGEN3
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/SGSparseMatrix.h>
 #include <shogun/lib/DynamicObjectArray.h>
 #include <shogun/lib/computation/engine/SerialComputationEngine.h>
 #include <shogun/lib/computation/job/ScalarResult.h>
 #include <shogun/lib/computation/job/IndividualJobResultAggregator.h>
 #include <shogun/lib/computation/job/RationalApproximationIndividualJob.h>
+#include <shogun/features/SparseFeatures.h>
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/logdet/DenseMatrixOperator.h>
+#include <shogun/mathematics/logdet/SparseMatrixOperator.h>
 #include <shogun/mathematics/logdet/DirectLinearSolverComplex.h>
+#include <shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.h>
 #include <shogun/mathematics/logdet/DirectEigenSolver.h>
+#include <shogun/mathematics/logdet/NormalSampler.h>
 #include <shogun/mathematics/logdet/LogRationalApproximationIndividual.h>
 #include <unsupported/Eigen/MatrixFunctions>
 #include <gtest/gtest.h>
@@ -40,7 +45,7 @@ TEST(RationalApproximation, precompute)
 	m(1,0)=1.0;
 	m(1,1)=3.0;
 
-	CDenseMatrixOperator<float64_t, float64_t>* op=new CDenseMatrixOperator<float64_t, float64_t>(m);
+	CDenseMatrixOperator<float64_t>* op=new CDenseMatrixOperator<float64_t>(m);
 	SG_REF(op);
 
 	CDirectEigenSolver* eig_solver=new CDirectEigenSolver(op);
@@ -112,7 +117,7 @@ TEST(RationalApproximation, trace_accuracy)
 	}
 
 	// create the operator
-	CDenseMatrixOperator<float64_t, float64_t>* op=new CDenseMatrixOperator<float64_t, float64_t>(m);
+	CDenseMatrixOperator<float64_t>* op=new CDenseMatrixOperator<float64_t>(m);
 	SG_REF(op);
 
 	// create the eigen solver for finding max/min eigenvalues
@@ -202,4 +207,86 @@ TEST(RationalApproximation, trace_accuracy)
 	SG_UNREF(op);
 }
 
+TEST(RationalApproximation, compare_direct_vs_cocg_accuracy)
+{
+	CSerialComputationEngine* e=new CSerialComputationEngine;
+	SG_REF(e);
+	
+	const index_t size=2;
+	SGMatrix<float64_t> m(size, size);
+	m(0,0)=1000.0;
+	m(0,1)=0.0;
+	m(1,0)=0.0;
+	m(1,1)=1005.0;
+
+	CDenseMatrixOperator<float64_t>* op=new CDenseMatrixOperator<float64_t>(m);
+	SG_REF(op);
+
+	CDirectEigenSolver* eig_solver=new CDirectEigenSolver(op);
+	SG_REF(eig_solver);
+
+	CDirectLinearSolverComplex* dense_solver=new CDirectLinearSolverComplex();
+	SG_REF(dense_solver);
+
+	CConjugateOrthogonalCGSolver *sparse_solver
+		=new CConjugateOrthogonalCGSolver();
+	sparse_solver->set_absolute_tolerence(0.001);
+	sparse_solver->set_iteration_limit(500);
+
+	CLogRationalApproximationIndividual *op_func
+		=new CLogRationalApproximationIndividual(
+			op, e, eig_solver, (CLinearSolver<complex64_t, float64_t>*)dense_solver, 4);
+	SG_REF(op_func);
+
+	op_func->precompute();
+
+	SGVector<complex64_t> shifts=op_func->get_shifts();
+
+	CNormalSampler* trace_sampler=new CNormalSampler(size);
+	trace_sampler->precompute();
+
+	// create complex copies of operators, complex_dense/sparse
+	CDenseMatrixOperator<complex64_t>* complex_dense
+		=static_cast<CDenseMatrixOperator<complex64_t>*>(*op);
+
+	for (index_t i=0; i<shifts.vlen; ++i)
+	{
+		SGVector<float64_t> sample=trace_sampler->sample(0);
+
+		CDenseMatrixOperator<complex64_t>* shifted_dense
+			=new CDenseMatrixOperator<complex64_t>(*complex_dense);
+
+		SGVector<complex64_t> diag=shifted_dense->get_diagonal();
+		for (index_t j=0; j<diag.vlen; ++j)
+			diag[j]-=shifts[i];
+	
+		shifted_dense->set_diagonal(diag);
+
+		SGMatrix<complex64_t> shifted_m=shifted_dense->get_matrix_operator();
+
+		CSparseFeatures<complex64_t> feat(shifted_m);
+		SGSparseMatrix<complex64_t> shifted_sm=feat.get_sparse_feature_matrix();
+		CSparseMatrixOperator<complex64_t>* shifted_sparse
+			=new CSparseMatrixOperator<complex64_t>(shifted_sm);
+
+		SGVector<complex64_t> xd=dense_solver->solve(shifted_dense, sample);
+		SGVector<complex64_t> xs=sparse_solver->solve(shifted_sparse, sample);
+
+		Map<VectorXcd> map_xd(xd.vector, xd.vlen);
+		Map<VectorXcd> map_xs(xs.vector, xs.vlen);
+
+		EXPECT_NEAR((map_xd-map_xs).norm(), 0.0, 0.001);
+
+		SG_UNREF(shifted_dense);
+		SG_UNREF(shifted_sparse);
+	}
+
+	SG_UNREF(complex_dense);
+	SG_UNREF(eig_solver);
+	SG_UNREF(dense_solver);
+	SG_UNREF(sparse_solver);
+	SG_UNREF(op_func);
+	SG_UNREF(e);
+	SG_UNREF(op);
+}
 #endif // HAVE_EIGEN3

--- a/tests/unit/mathematics/logdet/SparseMatrixOperator_unittest.cc
+++ b/tests/unit/mathematics/logdet/SparseMatrixOperator_unittest.cc
@@ -33,7 +33,7 @@ TEST(SparseMatrixOperator, symmetric_apply)
 
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t> op(mat);
+	CSparseMatrixOperator<float64_t> op(mat);
 
 	SGVector<float64_t> b(size);
 	b.set_const(0.25);
@@ -52,7 +52,7 @@ TEST(SparseMatrixOperator, symmetric_apply)
 #endif
 }
 
-TEST(SparseMatrixOperator, symmetric_apply_complex_float)
+TEST(SparseMatrixOperator, symmetric_apply_complex)
 {
 	const index_t size=2;
 
@@ -64,9 +64,9 @@ TEST(SparseMatrixOperator, symmetric_apply_complex_float)
 
 	CSparseFeatures<complex64_t> feat(m);
 	SGSparseMatrix<complex64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<complex64_t, float64_t> op(mat);
+	CSparseMatrixOperator<complex64_t> op(mat);
 
-	SGVector<float64_t> b(size);
+	SGVector<complex64_t> b(size);
 	b.set_const(0.25);
 
 	SGVector<complex64_t> result=op.apply(b);
@@ -77,9 +77,9 @@ TEST(SparseMatrixOperator, symmetric_apply_complex_float)
 #else
 	const SparseMatrix<complex64_t> &eig_m
 		=EigenSparseUtil<complex64_t>::toEigenSparse(mat);
-	Map<VectorXd> map_b(b.vector, b.vlen);
+	Map<VectorXcd> map_b(b.vector, b.vlen);
 
-	EXPECT_NEAR(map_result.norm(), (eig_m*map_b.cast<complex64_t>()).norm(), 1E-16);
+	EXPECT_NEAR(map_result.norm(), (eig_m*map_b).norm(), 1E-16);
 #endif
 }
 
@@ -98,7 +98,7 @@ TEST(SparseMatrixOperator, asymmetric_apply)
 
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t> op(mat);
+	CSparseMatrixOperator<float64_t> op(mat);
 
 	SGVector<float64_t> b(size*10);
 	b.set_const(0.25);
@@ -129,7 +129,7 @@ TEST(SparseMatrixOperator, get_set_diagonal_no_alloc)
 
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t> op(mat);
+	CSparseMatrixOperator<float64_t> op(mat);
 
 	// get the old diagonal and check if it works fine
 	SGVector<float64_t> old_diag=op.get_diagonal();
@@ -162,7 +162,7 @@ TEST(SparseMatrixOperator, get_set_diagonal_realloc)
 
 	CSparseFeatures<float64_t> feat(m);
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<float64_t, float64_t> op(mat);
+	CSparseMatrixOperator<float64_t> op(mat);
 
 	// get the old diagonal and check if it works fine
 	SGVector<float64_t> old_diag=op.get_diagonal();
@@ -195,7 +195,7 @@ TEST(SparseMatrixOperator, get_set_diagonal_realloc_complex64)
 
 	CSparseFeatures<complex64_t> feat(m);
 	SGSparseMatrix<complex64_t> mat=feat.get_sparse_feature_matrix();
-	CSparseMatrixOperator<complex64_t, float64_t> op(mat);
+	CSparseMatrixOperator<complex64_t> op(mat);
 
 	// get the old diagonal and check if it works fine
 	SGVector<complex64_t> old_diag=op.get_diagonal();


### PR DESCRIPTION
- CLinearOperator and subclasses changed to single template in order to make swig interfaces easier
- added CSparseMatrixOperator copy constructor
- added operator for static_cast in CDenseMatrixOperator and CSparseMatrixOperator, added unit-test for this
- modified CLogRationalApproximationIndividual to use RTTI to make it work for both types of CMatrixOperators
- added a unit-test in mathematics/logdet/RationalApproximation_unittest.cc which compares accuracy for shifted dense/sparse linear system with NormalSampler with DirectLinearSolverComplex and ConjugateOrthogonalCGSolver
