### PR TITLE
SOBI changed AJD method to JADiagOrth because the time lagged matrices m...

### DIFF
--- a/src/shogun/converter/ica/SOBI.cpp
+++ b/src/shogun/converter/ica/SOBI.cpp
@@ -15,7 +15,7 @@
 
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/eigen3.h>
-#include <shogun/mathematics/ajd/JADiag.h>
+#include <shogun/mathematics/ajd/JADiagOrth.h>
 
 using namespace Eigen;
 
@@ -95,7 +95,7 @@ CFeatures* CSOBI::apply(CFeatures* features)
 	}
 
 	// Diagonalize
-	SGMatrix<float64_t> Q = CJADiag::diagonalize(M);
+	SGMatrix<float64_t> Q = CJADiagOrth::diagonalize(M);
 	Eigen::Map<EMatrix> EQ(Q.matrix,n,n);
 
 	// Compute Mixing Matrix


### PR DESCRIPTION
...ay not be pos def
