### PR TITLE
Add methods of the moments (for EP) to classes of the likelihood models

### DIFF
--- a/src/shogun/machine/gp/GaussianLikelihood.h
+++ b/src/shogun/machine/gp/GaussianLikelihood.h
@@ -74,37 +74,6 @@ public:
 	 */
 	static CGaussianLikelihood* obtain_from_generic(CLikelihoodModel* lik);
 
-	/** returns the logarithm of the predictive density of \f$y_*\f$:
-	 *
-	 * \f[
-	 * log(p(y_*|X,y,x_*)) = log\left(\int p(y_*|f_*) p(f_*|X,y,x_*) df_*\right)
-	 * \f]
-	 *
-	 * which approximately equals to
-	 *
-	 * \f[
-	 * log\left(\int p(y_*|f_*) \mathcal{N}(f*|\mu,\sigma^2) df*\right)
-	 * \f]
-	 *
-	 * where normal distribution \f$\mathcal{N}(\mu,\sigma^2)\f$ is an
-	 * approximation to the posterior marginal \f$p(f_*|X,y,x_*)\f$.
-	 *
-	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
-	 *
-	 * @param mu posterior mean of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param s2 posterior variance of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param lab labels \f$y_*\f$
-	 *
-	 * @return \f$log(p(y_*|X, y, x*))\f$ for each label \f$y_*\f$
-	 */
-	virtual SGVector<float64_t> get_predictive_log_probabilities(
-			SGVector<float64_t> mu, SGVector<float64_t> s2,
-			const CLabels* lab=NULL) const;
-
 	/** returns mean of the predictive marginal \f$p(y_*|X,y,x_*)\f$.
 	 *
 	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
@@ -210,6 +179,59 @@ public:
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
 			const TParameter* param, SGVector<float64_t> func) const;
+
+	/** returns the zeroth moment of a given (unnormalized) probability
+	 * distribution:
+	 *
+	 * \f[
+	 * log(Z_i) = log\left(\int p(y_i|f_i) \mathcal{N}(f_i|\mu,\sigma^2)
+	 * df_i\right)
+	 * \f]
+	 *
+	 * for each \f$f_i\f$.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return log zeroth moments \f$log(Z_i)\f$
+	 */
+	virtual SGVector<float64_t> get_log_zeroth_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const;
+
+	/** returns the first moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return first moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_first_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
+
+	/** returns the second moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return the second moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_second_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
 
 	/** return whether Gaussian likelihood function supports regression
 	 *

--- a/src/shogun/machine/gp/LikelihoodModel.cpp
+++ b/src/shogun/machine/gp/LikelihoodModel.cpp
@@ -22,6 +22,12 @@ CLikelihoodModel::~CLikelihoodModel()
 {
 }
 
+SGVector<float64_t> CLikelihoodModel::get_predictive_log_probabilities(
+		SGVector<float64_t> mu, SGVector<float64_t> s2, const CLabels *lab)
+{
+	return get_log_zeroth_moments(mu, s2, lab);
+}
+
 SGVector<float64_t> CLikelihoodModel::get_log_probability_fmatrix(
 		const CLabels* lab,	SGMatrix<float64_t> F) const
 {
@@ -39,6 +45,40 @@ SGVector<float64_t> CLikelihoodModel::get_log_probability_fmatrix(
 		SGVector<float64_t> f(&F.matrix[i*F.num_rows], F.num_rows, false);
 		result[i]=SGVector<float64_t>::sum(get_log_probability_f(lab, f));
 	}
+
+	return result;
+}
+
+SGVector<float64_t> CLikelihoodModel::get_first_moments(SGVector<float64_t> mu,
+		SGVector<float64_t> s2, const CLabels* lab) const
+{
+	REQUIRE(lab, "Labels are required (lab should not be NULL)\n")
+	REQUIRE((mu.vlen==s2.vlen) && (mu.vlen==lab->get_num_labels()),
+			"Length of the vector of means (%d), length of the vector of "
+			"variances (%d) and number of labels (%d) should be the same\n",
+			mu.vlen, s2.vlen, lab->get_num_labels())
+
+	SGVector<float64_t> result(mu.vlen);
+
+	for (index_t i=0; i<mu.vlen; i++)
+		result[i]=get_first_moment(mu, s2, lab, i);
+
+	return result;
+}
+
+SGVector<float64_t> CLikelihoodModel::get_second_moments(SGVector<float64_t> mu,
+		SGVector<float64_t> s2, const CLabels* lab) const
+{
+	REQUIRE(lab, "Labels are required (lab should not be NULL)\n")
+	REQUIRE((mu.vlen==s2.vlen) && (mu.vlen==lab->get_num_labels()),
+			"Length of the vector of means (%d), length of the vector of "
+			"variances (%d) and number of labels (%d) should be the same\n",
+			mu.vlen, s2.vlen, lab->get_num_labels())
+
+	SGVector<float64_t> result(mu.vlen);
+
+	for (index_t i=0; i<mu.vlen; i++)
+		result[i]=get_second_moment(mu, s2, lab, i);
 
 	return result;
 }

--- a/src/shogun/machine/gp/LikelihoodModel.h
+++ b/src/shogun/machine/gp/LikelihoodModel.h
@@ -51,7 +51,7 @@ public:
 	 * which approximately equals to
 	 *
 	 * \f[
-	 * log\left(\int p(y_*|f_*) \mathcal{N}(f*|\mu,\sigma^2) df*\right)
+	 * log\left(\int p(y_*|f_*) \mathcal{N}(f_*|\mu,\sigma^2) df_*\right)
 	 * \f]
 	 *
 	 * where normal distribution \f$\mathcal{N}(\mu,\sigma^2)\f$ is an
@@ -71,14 +71,13 @@ public:
 	 */
 	virtual SGVector<float64_t> get_predictive_log_probabilities(
 			SGVector<float64_t> mu, SGVector<float64_t> s2,
-			const CLabels* lab=NULL) const=0;
+			const CLabels* lab=NULL);
 
 	/** returns mean of the predictive marginal \f$p(y_*|X,y,x_*)\f$
 	 *
 	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
 	 *
 	 * @param mu posterior mean of a Gaussian distribution
-
 	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
 	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
 	 * @param s2 posterior variance of a Gaussian distribution
@@ -193,6 +192,91 @@ public:
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
 			const TParameter* param, SGVector<float64_t> func) const=0;
+
+	/** returns the zeroth moment of a given (unnormalized) probability
+	 * distribution:
+	 *
+	 * \f[
+	 * log(Z_i) = log\left(\int p(y_i|f_i) \mathcal{N}(f_i|\mu,\sigma^2)
+	 * df_i\right)
+	 * \f]
+	 *
+	 * for each \f$f_i\f$.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return log zeroth moment \f$log(Z_i)\f$
+	 */
+	virtual SGVector<float64_t> get_log_zeroth_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const=0;
+
+	/** returns the first moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return first moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_first_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const=0;
+
+	/** returns the first moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$ for each \f$f_i\f$, where \f$
+	 * Z_i=\int p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * Wrapper method which calls get_first_moment multiple times.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return the first moment of \f$q(f_i)\f$ for each \f$f_i\f$
+	 */
+	virtual SGVector<float64_t> get_first_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const;
+
+	/** returns the second moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return the second moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_second_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const=0;
+
+	/** returns the second moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$ for each \f$f_i\f$, where \f$
+	 * Z_i=\int p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * Wrapper method which calls get_second_moment multiple times.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return the second moment of \f$q(f_i)\f$ for each \f$f_i\f$
+	 */
+	virtual SGVector<float64_t> get_second_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const;
 
 	/** return whether likelihood function supports regression
 	 *

--- a/src/shogun/machine/gp/LogitLikelihood.h
+++ b/src/shogun/machine/gp/LogitLikelihood.h
@@ -39,37 +39,6 @@ public:
 	 */
 	virtual const char* get_name() const { return "LogitLikelihood"; }
 
-	/** returns the logarithm of the predictive density of \f$y_*\f$:
-	 *
-	 * \f[
-	 * log(p(y_*|X,y,x_*)) = log\left(\int p(y_*|f_*) p(f_*|X,y,x_*) df_*\right)
-	 * \f]
-	 *
-	 * which approximately equals to
-	 *
-	 * \f[
-	 * log\left(\int p(y_*|f_*) \mathcal{N}(f*|\mu,\sigma^2) df*\right)
-	 * \f]
-	 *
-	 * where normal distribution \f$\mathcal{N}(\mu,\sigma^2)\f$ is an
-	 * approximation to the posterior marginal \f$p(f_*|X,y,x_*)\f$.
-	 *
-	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
-	 *
-	 * @param mu posterior mean of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param s2 posterior variance of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param lab labels \f$y_*\f$
-	 *
-	 * @return \f$log(p(y_*|X, y, x*))\f$ for each label \f$y_*\f$
-	 */
-	virtual SGVector<float64_t> get_predictive_log_probabilities(
-			SGVector<float64_t> mu, SGVector<float64_t> s2,
-			const CLabels* lab=NULL) const;
-
 	/** returns mean of the predictive marginal \f$p(y_*|X,y,x_*)\f$.
 	 *
 	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
@@ -174,6 +143,59 @@ public:
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
 			const TParameter* param, SGVector<float64_t> func) const;
+
+	/** returns the zeroth moment of a given (unnormalized) probability
+	 * distribution:
+	 *
+	 * \f[
+	 * log(Z_i) = log\left(\int p(y_i|f_i) \mathcal{N}(f_i|\mu,\sigma^2)
+	 * df_i\right)
+	 * \f]
+	 *
+	 * for each \f$f_i\f$.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return log zeroth moments \f$log(Z_i)\f$
+	 */
+	virtual SGVector<float64_t> get_log_zeroth_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const;
+
+	/** returns the first moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return first moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_first_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
+
+	/** returns the second moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return the second moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_second_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
 
 	/** return whether logit likelihood function supports binary classification
 	 *

--- a/src/shogun/machine/gp/ProbitLikelihood.h
+++ b/src/shogun/machine/gp/ProbitLikelihood.h
@@ -42,37 +42,6 @@ public:
 	 */
 	virtual const char* get_name() const { return "ProbitLikelihood"; }
 
-	/** returns the logarithm of the predictive density of \f$y_*\f$:
-	 *
-	 * \f[
-	 * log(p(y_*|X,y,x_*)) = log\left(\int p(y_*|f_*) p(f_*|X,y,x_*) df_*\right)
-	 * \f]
-	 *
-	 * which approximately equals to
-	 *
-	 * \f[
-	 * log\left(\int p(y_*|f_*) \mathcal{N}(f*|\mu,\sigma^2) df*\right)
-	 * \f]
-	 *
-	 * where normal distribution \f$\mathcal{N}(\mu,\sigma^2)\f$ is an
-	 * approximation to the posterior marginal \f$p(f_*|X,y,x_*)\f$.
-	 *
-	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
-	 *
-	 * @param mu posterior mean of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param s2 posterior variance of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param lab labels \f$y_*\f$
-	 *
-	 * @return \f$log(p(y_*|X, y, x*))\f$ for each label \f$y_*\f$
-	 */
-	virtual SGVector<float64_t> get_predictive_log_probabilities(
-			SGVector<float64_t> mu, SGVector<float64_t> s2,
-			const CLabels* lab=NULL) const;
-
 	/** returns variance of the predictive marginal \f$p(y_*|X,y,x_*)\f$.
 	 *
 	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
@@ -177,6 +146,59 @@ public:
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
 			const TParameter* param, SGVector<float64_t> func) const;
+
+	/** returns the zeroth moment of a given (unnormalized) probability
+	 * distribution:
+	 *
+	 * \f[
+	 * log(Z_i) = log\left(\int p(y_i|f_i) \mathcal{N}(f_i|\mu,\sigma^2)
+	 * df_i\right)
+	 * \f]
+	 *
+	 * for each \f$f_i\f$.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return log zeroth moments \f$log(Z_i)\f$
+	 */
+	virtual SGVector<float64_t> get_log_zeroth_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const;
+
+	/** returns the first moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return first moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_first_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
+
+	/** returns the second moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return the second moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_second_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
 
 	/** return whether logit likelihood function supports binary classification
 	 *

--- a/src/shogun/machine/gp/StudentsTLikelihood.h
+++ b/src/shogun/machine/gp/StudentsTLikelihood.h
@@ -95,37 +95,6 @@ public:
 	 */
 	static CStudentsTLikelihood* obtain_from_generic(CLikelihoodModel* likelihood);
 
-	/** returns the logarithm of the predictive density of \f$y_*\f$:
-	 *
-	 * \f[
-	 * log(p(y_*|X,y,x_*)) = log\left(\int p(y_*|f_*) p(f_*|X,y,x_*) df_*\right)
-	 * \f]
-	 *
-	 * which approximately equals to
-	 *
-	 * \f[
-	 * log\left(\int p(y_*|f_*) \mathcal{N}(f*|\mu,\sigma^2) df*\right)
-	 * \f]
-	 *
-	 * where normal distribution \f$\mathcal{N}(\mu,\sigma^2)\f$ is an
-	 * approximation to the posterior marginal \f$p(f_*|X,y,x_*)\f$.
-	 *
-	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
-	 *
-	 * @param mu posterior mean of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param s2 posterior variance of a Gaussian distribution
-	 * \f$\mathcal{N}(\mu,\sigma^2)\f$, which is an approximation to the
-	 * posterior marginal \f$p(f_*|X,y,x_*)\f$
-	 * @param lab labels \f$y_*\f$
-	 *
-	 * @return \f$log(p(y_*|X, y, x*))\f$ for each label \f$y_*\f$
-	 */
-	virtual SGVector<float64_t> get_predictive_log_probabilities(
-			SGVector<float64_t> mu, SGVector<float64_t> s2,
-			const CLabels* lab=NULL) const;
-
 	/** returns mean of the predictive marginal \f$p(y_*|X,y,x_*)\f$.
 	 *
 	 * NOTE: if lab equals to NULL, then each \f$y_*\f$ equals to one.
@@ -230,6 +199,59 @@ public:
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
 			const TParameter* param, SGVector<float64_t> func) const;
+
+	/** returns the zeroth moment of a given (unnormalized) probability
+	 * distribution:
+	 *
+	 * \f[
+	 * log(Z_i) = log\left(\int p(y_i|f_i) \mathcal{N}(f_i|\mu,\sigma^2)
+	 * df_i\right)
+	 * \f]
+	 *
+	 * for each \f$f_i\f$.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 *
+	 * @return log zeroth moments \f$log(Z_i)\f$
+	 */
+	virtual SGVector<float64_t> get_log_zeroth_moments(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab) const;
+
+	/** returns the first moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return first moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_first_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
+
+	/** returns the second moment of a given (unnormalized) probability
+	 * distribution \f$q(f_i) = Z_i^-1
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2)\f$, where \f$ Z_i=\int
+	 * p(y_i|f_i)\mathcal{N}(f_i|\mu,\sigma^2) df_i\f$.
+	 *
+	 * This method is useful for EP local likelihood approximation.
+	 *
+	 * @param mu mean of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param s2 variance of the \f$\mathcal{N}(f_i|\mu,\sigma^2)\f$
+	 * @param lab labels \f$y_i\f$
+	 * @param i index i
+	 *
+	 * @return the second moment of \f$q(f_i)\f$
+	 */
+	virtual float64_t get_second_moment(SGVector<float64_t> mu,
+			SGVector<float64_t> s2, const CLabels* lab, index_t i) const;
 
 	/** return whether Student's likelihood function supports regression
 	 *

--- a/tests/unit/machine/gp/GaussianLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/GaussianLikelihood_unittest.cc
@@ -52,7 +52,7 @@ TEST(GaussianLikelihood,get_predictive_log_probabilities)
 
 	SGVector<float64_t> lp=likelihood->get_predictive_log_probabilities(mu, s2, labels);
 
-	// comparison of the first moment with result from GPML package
+	// comparison of the log probabilities with result from GPML package
 	EXPECT_NEAR(lp[0], -20.216529436592481, 1E-15);
 	EXPECT_NEAR(lp[1], -4.105074362196638, 1E-15);
 	EXPECT_NEAR(lp[2], -1.054630503782619, 1E-15);
@@ -386,4 +386,92 @@ TEST(GaussianLikelihood,get_third_derivative)
 	SG_UNREF(labels);
 }
 
-#endif // HAVE_EIGEN3
+TEST(GaussianLikelihood,get_first_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to (x^3+sin(x)^2)/10, y=0
+	index_t n=5;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(0.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+
+	mu[0]=-2.18236;
+	mu[1]=-1.30906;
+	mu[2]=-0.50885;
+	mu[3]=-0.17185;
+	mu[4]=0.00388;
+
+	// shogun representation of labels
+	CRegressionLabels* labels=new CRegressionLabels(lab);
+
+	// Gaussian likelihood with sigma = 0.13
+	CGaussianLikelihood* likelihood=new CGaussianLikelihood(0.13);
+
+	mu=likelihood->get_first_moments(mu, s2, labels);
+
+	// comparison of the first moment with result from GPML package
+	EXPECT_NEAR(mu[0], -3.15499435414885e-01, 1E-15);
+	EXPECT_NEAR(mu[1], -1.01996837252190e-01, 1E-15);
+	EXPECT_NEAR(mu[2], -8.45664765463661e-03, 1E-15);
+	EXPECT_NEAR(mu[3], -4.05114381364208e-03, 1E-15);
+	EXPECT_NEAR(mu[4], 2.06917008520038e-04, 1E-15);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+TEST(GaussianLikelihood,get_second_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to (x^3+sin(x)^2)/10, y=0
+	index_t n=5;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(0.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+
+	mu[0]=-2.18236;
+	mu[1]=-1.30906;
+	mu[2]=-0.50885;
+	mu[3]=-0.17185;
+	mu[4]=0.00388;
+
+	// shogun representation of labels
+	CRegressionLabels* labels=new CRegressionLabels(lab);
+
+	// Gaussian likelihood with sigma = 0.13
+	CGaussianLikelihood* likelihood=new CGaussianLikelihood(0.13);
+
+	s2=likelihood->get_second_moments(mu, s2, labels);
+
+	// comparison of the second moment with result from GPML package
+	EXPECT_NEAR(s2[0], 0.0144568006843456, 1E-15);
+	EXPECT_NEAR(s2[1], 0.0155832180728446, 1E-15);
+	EXPECT_NEAR(s2[2], 0.0166191365916019, 1E-15);
+	EXPECT_NEAR(s2[3], 0.0165016041288882, 1E-15);
+	EXPECT_NEAR(s2[4], 0.0159987377721679, 1E-15);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+#endif /* HAVE_EIGEN3 */

--- a/tests/unit/machine/gp/LogitLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/LogitLikelihood_unittest.cc
@@ -53,17 +53,17 @@ TEST(LogitLikelihood,get_predictive_log_probabilities)
 
 	SGVector<float64_t> lp=likelihood->get_predictive_log_probabilities(mu, s2);
 
-	// comparison of the first moment with result from GPML package
-	EXPECT_NEAR(lp[0], -0.350067368640123, 1E-3);
-	EXPECT_NEAR(lp[1], -0.539595630725218, 1E-3);
-	EXPECT_NEAR(lp[2], -1.948742077218326, 1E-3);
-	EXPECT_NEAR(lp[3], -0.776497165015726, 1E-3);
-	EXPECT_NEAR(lp[4], -0.611648769423109, 1E-3);
-	EXPECT_NEAR(lp[5], -1.376387887056822, 1E-3);
-	EXPECT_NEAR(lp[6], -0.719289371775576, 1E-3);
-	EXPECT_NEAR(lp[7], -0.499251131748656, 1E-3);
-	EXPECT_NEAR(lp[8], -0.760072326237507, 1E-3);
-	EXPECT_NEAR(lp[9], -0.645354698503709, 1E-3);
+	// comparison of the log probability moment with result from GPstuff package
+	EXPECT_NEAR(lp[0], -0.350198840161869, 1E-12);
+	EXPECT_NEAR(lp[1], -0.539624476809011, 1E-12);
+	EXPECT_NEAR(lp[2], -1.948931616372461, 1E-12);
+	EXPECT_NEAR(lp[3], -0.776466860087816, 1E-12);
+	EXPECT_NEAR(lp[4], -0.611670932246864, 1E-12);
+	EXPECT_NEAR(lp[5], -1.375834322985607, 1E-12);
+	EXPECT_NEAR(lp[6], -0.719282270936539, 1E-12);
+	EXPECT_NEAR(lp[7], -0.499316643759375, 1E-12);
+	EXPECT_NEAR(lp[8], -0.760048135207748, 1E-12);
+	EXPECT_NEAR(lp[9], -0.645370763225588, 1E-12);
 
 	// clean up
 	SG_UNREF(likelihood);
@@ -362,6 +362,124 @@ TEST(LogitLikelihood,get_log_probability_derivative_f)
 	EXPECT_NEAR(d3lp[7], 0.0559024, 1E-7);
 	EXPECT_NEAR(d3lp[8], -0.0185422, 1E-7);
 	EXPECT_NEAR(d3lp[9], 0.0133181, 1E-7);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+TEST(LogitLikelihood,get_first_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to 3*sin(sin(x^2)*sin(sin(2*x)))
+	index_t n=10;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(1.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+	s2[5]=0.1;
+	s2[6]=1.0;
+	s2[7]=0.5;
+	s2[8]=0.7;
+	s2[9]=0.4;
+
+	mu[0]=0.889099;
+	mu[1]=0.350840;
+	mu[2]=-2.116356;
+	mu[3]=-0.184742;
+	mu[4]=0.182117;
+	mu[5]=-1.108930;
+	mu[6]=-0.062437;
+	mu[7]=0.482987;
+	mu[8]=-0.149445;
+	mu[9]=0.106952;
+
+	// shogun representation of labels
+	CBinaryLabels* labels=new CBinaryLabels(lab);
+
+	// logit likelihood
+	CLogitLikelihood* likelihood=new CLogitLikelihood();
+
+	mu=likelihood->get_first_moments(mu, s2, labels);
+
+	// comparison of the first moment with result from GPstuff package
+	EXPECT_NEAR(mu[0], 0.918049083665528, 1E-12);
+	EXPECT_NEAR(mu[1], 0.430531572020201, 1E-12);
+	EXPECT_NEAR(mu[2], -1.355657470903866, 1E-12);
+	EXPECT_NEAR(mu[3], 0.143217044149134, 1E-12);
+	EXPECT_NEAR(mu[4], 0.310423961197736, 1E-12);
+	EXPECT_NEAR(mu[5], -1.035568055325363, 1E-12);
+	EXPECT_NEAR(mu[6], 0.361497809480844, 1E-12);
+	EXPECT_NEAR(mu[7], 0.660207081799274, 1E-12);
+	EXPECT_NEAR(mu[8], 0.173820061932222, 1E-12);
+	EXPECT_NEAR(mu[9], 0.281174465384849, 1E-12);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+TEST(LogitLikelihood,get_second_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to 3*sin(sin(x^2)*sin(sin(2*x)))
+	index_t n=10;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(1.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+	s2[5]=0.1;
+	s2[6]=1.0;
+	s2[7]=0.5;
+	s2[8]=0.7;
+	s2[9]=0.4;
+
+	mu[0]=0.889099;
+	mu[1]=0.350840;
+	mu[2]=-2.116356;
+	mu[3]=-0.184742;
+	mu[4]=0.182117;
+	mu[5]=-1.108930;
+	mu[6]=-0.062437;
+	mu[7]=0.482987;
+	mu[8]=-0.149445;
+	mu[9]=0.106952;
+
+	// shogun representation of labels
+	CBinaryLabels* labels=new CBinaryLabels(lab);
+
+	// logit likelihood
+	CLogitLikelihood* likelihood=new CLogitLikelihood();
+
+	s2=likelihood->get_second_moments(mu, s2, labels);
+
+	// comparison of the second moment with result from GPstuff package
+	EXPECT_NEAR(s2[0], 0.0980234586350819, 1E-10);
+	EXPECT_NEAR(s2[1], 0.1912218579195400, 1E-10);
+	EXPECT_NEAR(s2[2], 0.8641409409085339, 1E-10);
+	EXPECT_NEAR(s2[3], 0.6068410369351058, 1E-10);
+	EXPECT_NEAR(s2[4], 0.2806505994684253, 1E-10);
+	EXPECT_NEAR(s2[5], 0.0981186506243787, 1E-10);
+	EXPECT_NEAR(s2[6], 0.8282719372050090, 1E-10);
+	EXPECT_NEAR(s2[7], 0.4528079266638572, 1E-10);
+	EXPECT_NEAR(s2[8], 0.6069841059325981, 1E-10);
+	EXPECT_NEAR(s2[9], 0.3667340355471636, 1E-10);
 
 	// clean up
 	SG_UNREF(likelihood);

--- a/tests/unit/machine/gp/ProbitLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/ProbitLikelihood_unittest.cc
@@ -53,7 +53,7 @@ TEST(ProbitLikelihood,get_predictive_log_probabilities)
 
 	SGVector<float64_t> lp=likelihood->get_predictive_log_probabilities(mu, s2);
 
-	// comparison of the first moment with result from GPML package
+	// comparison of the log probability with result from GPML package
 	EXPECT_NEAR(lp[0], -0.221016102, 1E-9);
 	EXPECT_NEAR(lp[1], -0.469014056, 1E-9);
 	EXPECT_NEAR(lp[2], -2.699144260, 1E-9);
@@ -303,6 +303,124 @@ TEST(ProbitLikelihood,get_log_probability_derivative_f)
 	EXPECT_NEAR(d3lp[7], 0.269474219, 1E-9);
 	EXPECT_NEAR(d3lp[8], -0.235025555, 1E-9);
 	EXPECT_NEAR(d3lp[9], 0.230230621, 1E-9);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+TEST(ProbitLikelihood,get_first_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to 3*sin(sin(x^2)*sin(sin(2*x)))
+	index_t n=10;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(1.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+	s2[5]=0.1;
+	s2[6]=1.0;
+	s2[7]=0.5;
+	s2[8]=0.7;
+	s2[9]=0.4;
+
+	mu[0]=0.889099;
+	mu[1]=0.350840;
+	mu[2]=-2.116356;
+	mu[3]=-0.184742;
+	mu[4]=0.182117;
+	mu[5]=-1.108930;
+	mu[6]=-0.062437;
+	mu[7]=0.482987;
+	mu[8]=-0.149445;
+	mu[9]=0.106952;
+
+	// shogun representation of labels
+	CBinaryLabels* labels=new CBinaryLabels(lab);
+
+	// probit likelihood
+	CProbitLikelihood* likelihood=new CProbitLikelihood();
+
+	mu=likelihood->get_first_moments(mu, s2, labels);
+
+	// comparison of the first moment with result from GPstuff package
+	EXPECT_NEAR(mu[0], 0.922223587528548, 1E-10);
+	EXPECT_NEAR(mu[1], 0.461442771893249, 1E-10);
+	EXPECT_NEAR(mu[2], -0.747614837845594, 1E-10);
+	EXPECT_NEAR(mu[3], 0.293196189957756, 1E-10);
+	EXPECT_NEAR(mu[4], 0.366051285301334, 1E-10);
+	EXPECT_NEAR(mu[5], -0.959118595310375, 1E-10);
+	EXPECT_NEAR(mu[6], 0.521775976041116, 1E-10);
+	EXPECT_NEAR(mu[7], 0.713621395240100, 1E-10);
+	EXPECT_NEAR(mu[8], 0.318848193810383, 1E-10);
+	EXPECT_NEAR(mu[9], 0.357538428547672, 1E-10);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+TEST(ProbitLikelihood,get_second_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to 3*sin(sin(x^2)*sin(sin(2*x)))
+	index_t n=10;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(1.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+	s2[5]=0.1;
+	s2[6]=1.0;
+	s2[7]=0.5;
+	s2[8]=0.7;
+	s2[9]=0.4;
+
+	mu[0]=0.889099;
+	mu[1]=0.350840;
+	mu[2]=-2.116356;
+	mu[3]=-0.184742;
+	mu[4]=0.182117;
+	mu[5]=-1.108930;
+	mu[6]=-0.062437;
+	mu[7]=0.482987;
+	mu[8]=-0.149445;
+	mu[9]=0.106952;
+
+	// shogun representation of labels
+	CBinaryLabels* labels=new CBinaryLabels(lab);
+
+	// probit likelihood
+	CProbitLikelihood* likelihood=new CProbitLikelihood();
+
+	s2=likelihood->get_second_moments(mu, s2, labels);
+
+	// comparison of the second moment with result from GPstuff package
+	EXPECT_NEAR(s2[0], 0.0962253946422413, 1E-10);
+	EXPECT_NEAR(s2[1], 0.1812997141010253, 1E-10);
+	EXPECT_NEAR(s2[2], 0.5749194165104299, 1E-10);
+	EXPECT_NEAR(s2[3], 0.5079319571460353, 1E-10);
+	EXPECT_NEAR(s2[4], 0.2584379724823283, 1E-10);
+	EXPECT_NEAR(s2[5], 0.0926593031160547, 1E-10);
+	EXPECT_NEAR(s2[6], 0.6769334514177224, 1E-10);
+	EXPECT_NEAR(s2[7], 0.4096766375142901, 1E-10);
+	EXPECT_NEAR(s2[8], 0.5095184572451623, 1E-10);
+	EXPECT_NEAR(s2[9], 0.3295490933402853, 1E-10);
 
 	// clean up
 	SG_UNREF(likelihood);

--- a/tests/unit/machine/gp/StudentsTLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/StudentsTLikelihood_unittest.cc
@@ -20,6 +20,50 @@
 
 using namespace shogun;
 
+TEST(StudentsTLikelihood,get_predictive_log_probabilities)
+{
+	// create some easy data:
+	// mu(x) approximately equals to (x^3+sin(x)^2)/10, y=0
+	index_t n=5;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(0.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+
+	mu[0]=-2.18236;
+	mu[1]=-1.30906;
+	mu[2]=-0.50885;
+	mu[3]=-0.17185;
+	mu[4]=0.00388;
+
+	// shogun representation of labels
+	CRegressionLabels* labels=new CRegressionLabels(lab);
+
+	// Stundent's-t likelihood with sigma = 0.17, df = 3
+	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(0.17, 3);
+
+	SGVector<float64_t> lp=likelihood->get_predictive_log_probabilities(mu, s2, labels);
+
+	// comparison of the log probability moment with result from GPstuff package
+	EXPECT_NEAR(lp[0], -7.048027785472147, 1E-10);
+	EXPECT_NEAR(lp[1], -3.450707321209273, 1E-10);
+	EXPECT_NEAR(lp[2], -1.073679429165726, 1E-10);
+	EXPECT_NEAR(lp[3], -0.804586438080387, 1E-10);
+	EXPECT_NEAR(lp[4], -0.406520554213667, 1E-10);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
 TEST(StudentsTLikelihood,get_predictive_means)
 {
 	// create some easy data:
@@ -375,4 +419,92 @@ TEST(StudentsTLikelihood,get_third_derivative)
 	SG_UNREF(labels);
 }
 
-#endif // HAVE_EIGEN3
+TEST(StudentsTLikelihood,get_first_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to (x^3+sin(x)^2)/10, y=0
+	index_t n=5;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(0.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+
+	mu[0]=-2.18236;
+	mu[1]=-1.30906;
+	mu[2]=-0.50885;
+	mu[3]=-0.17185;
+	mu[4]=0.00388;
+
+	// shogun representation of labels
+	CRegressionLabels* labels=new CRegressionLabels(lab);
+
+	// Stundent's-t likelihood with sigma = 0.13, df = 4
+	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(0.13, 4);
+
+	mu=likelihood->get_first_moments(mu, s2, labels);
+
+	// comparison of the first moment with result from GPstuff package
+	EXPECT_NEAR(mu[0], -1.91822633104012e+00, 1E-10);
+	EXPECT_NEAR(mu[1], -2.38637983911711e-01, 1E-10);
+	EXPECT_NEAR(mu[2], -1.51721564537775e-02, 1E-10);
+	EXPECT_NEAR(mu[3], -7.02852818764603e-03, 1E-10);
+	EXPECT_NEAR(mu[4], 3.26984704842959e-04, 1E-10);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+TEST(StudentsTLikelihood,get_second_moments)
+{
+	// create some easy data:
+	// mu(x) approximately equals to (x^3+sin(x)^2)/10, y=0
+	index_t n=5;
+
+	SGVector<float64_t> lab(n);
+	SGVector<float64_t> s2(n);
+	SGVector<float64_t> mu(n);
+
+	lab.set_const(0.0);
+
+	s2[0]=0.1;
+	s2[1]=0.2;
+	s2[2]=1.0;
+	s2[3]=0.7;
+	s2[4]=0.3;
+
+	mu[0]=-2.18236;
+	mu[1]=-1.30906;
+	mu[2]=-0.50885;
+	mu[3]=-0.17185;
+	mu[4]=0.00388;
+
+	// shogun representation of labels
+	CRegressionLabels* labels=new CRegressionLabels(lab);
+
+	// Stundent's-t likelihood with sigma = 0.13, df = 4
+	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(0.13, 4);
+
+	s2=likelihood->get_second_moments(mu, s2, labels);
+
+	// comparison of the second moment with result from GPstuff package
+	EXPECT_NEAR(s2[0], 0.1166949785176628, 1E-10);
+	EXPECT_NEAR(s2[1], 0.0821809540192921, 1E-10);
+	EXPECT_NEAR(s2[2], 0.0301390579119477, 1E-10);
+	EXPECT_NEAR(s2[3], 0.0286878038416459, 1E-10);
+	EXPECT_NEAR(s2[4], 0.0252824052815258, 1E-10);
+
+	// clean up
+	SG_UNREF(likelihood);
+	SG_UNREF(labels);
+}
+
+#endif /* HAVE_EIGEN3 */


### PR DESCRIPTION
Docs are very briefly, i'll fix them later.
This stuff is useful for EP local likelihood approximation.
I've decided to use moments instead of derivative wrt mean like in GPML, since it's more simple.
Many things i've compared with GPstuff toolbox, since GPML has worst accuracy.
