### PR TITLE
probing sampler added (log-det)

### DIFF
--- a/src/shogun/mathematics/eigen3.cpp
+++ b/src/shogun/mathematics/eigen3.cpp
@@ -66,6 +66,7 @@ SparseMatrix<T> EigenSparseUtil<T>::toEigenSparse(SGSparseMatrix<T> sg_matrix)
 		return M;
 	}
 
+template class EigenSparseUtil<bool>;
 template class EigenSparseUtil<float64_t>;
 template class EigenSparseUtil<complex64_t>;
 }

--- a/src/shogun/mathematics/logdet/LogDetEstimator.cpp
+++ b/src/shogun/mathematics/logdet/LogDetEstimator.cpp
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #include <shogun/lib/common.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGMatrix.h>
@@ -92,9 +93,9 @@ SGVector<float64_t> CLogDetEstimator::sample(index_t num_estimates)
 	CDynamicObjectArray aggregators;
 	index_t num_trace_samples=m_trace_sampler->get_num_samples();
 
-	for (register index_t i=0; i<num_estimates; ++i)
+	for (index_t i=0; i<num_estimates; ++i)
 	{
-		for (register index_t j=0; j<num_trace_samples; ++j)
+		for (index_t j=0; j<num_trace_samples; ++j)
 		{
 			// get the trace sampler vector
 			SGVector<float64_t> s=m_trace_sampler->sample(j);

--- a/src/shogun/mathematics/logdet/LogDetEstimator.h
+++ b/src/shogun/mathematics/logdet/LogDetEstimator.h
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #ifndef LOG_DET_ESTIMATOR_H_
 #define LOG_DET_ESTIMATOR_H_
 

--- a/src/shogun/mathematics/logdet/NormalSampler.cpp
+++ b/src/shogun/mathematics/logdet/NormalSampler.cpp
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #include <shogun/lib/common.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/mathematics/Random.h>

--- a/src/shogun/mathematics/logdet/NormalSampler.h
+++ b/src/shogun/mathematics/logdet/NormalSampler.h
@@ -6,6 +6,7 @@
  * 
  * Written (W) 2013 Soumyajit De
  */
+
 #ifndef NORMAL_SAMPLER_H_
 #define NORMAL_SAMPLER_H_
 

--- a/src/shogun/mathematics/logdet/ProbingSampler.cpp
+++ b/src/shogun/mathematics/logdet/ProbingSampler.cpp
@@ -1,0 +1,205 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#include <shogun/lib/common.h>
+
+#ifdef HAVE_COLPACK
+#ifdef HAVE_EIGEN3
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGString.h>
+#include <shogun/base/Parameter.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/Random.h>
+#include <shogun/mathematics/logdet/SparseMatrixOperator.h>
+#include <shogun/mathematics/logdet/ProbingSampler.h>
+#include <ColPack/ColPackHeaders.h>
+
+using namespace Eigen;
+using namespace ColPack;
+
+namespace shogun
+{
+
+CProbingSampler::CProbingSampler() : CTraceSampler()
+{
+	init();
+
+	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+}
+
+CProbingSampler::CProbingSampler(
+	CSparseMatrixOperator<float64_t>* matrix_operator, int64_t power,
+	EOrderingVariant ordering, EColoringVariant coloring)
+	: CTraceSampler(matrix_operator->get_dimension())
+{
+	init();
+
+	m_power=power;
+	m_matrix_operator=matrix_operator;
+
+	std::string str_ordering;
+	switch(ordering)
+	{
+	case NATURAL:
+		str_ordering="NATURAL";
+		break;
+	case LARGEST_FIRST:
+		str_ordering="LARGEST_FIRST";
+		break;
+	case DYNAMIC_LARGEST_FIRST:
+		str_ordering="DYNAMIC_LARGEST_FIRST";
+		break;
+	case DISTANCE_TWO_LARGEST_FIRST:
+		str_ordering="DISTANCE_TWO_LARGEST_FIRST";
+		break;
+	case SMALLEST_LAST:
+		str_ordering="SMALLEST_LAST";
+		break;
+	case DISTANCE_TWO_SMALLEST_LAST:
+		str_ordering="DISTANCE_TWO_SMALLEST_LAST";
+		break;
+	case INCIDENCE_DEGREE:
+		str_ordering="INCIDENCE_DEGREE";
+		break;
+	case DISTANCE_TWO_INCIDENCE_DEGREE:
+		str_ordering="DISTANCE_TWO_INCIDENCE_DEGREE";
+		break;
+	case RANDOM:
+		str_ordering="RANDOM";
+		break;
+	}
+
+	std::string str_coloring;
+	switch(coloring)
+	{
+	case DISTANCE_ONE:
+		str_coloring="DISTANCE_ONE";
+		break;
+	case ACYCLIC:
+		str_coloring="ACYCLIC";
+		break;
+	case ACYCLIC_FOR_INDIRECT_RECOVERY:
+		str_coloring="ACYCLIC_FOR_INDIRECT_RECOVERY";
+		break;
+	case STAR:
+		str_coloring="STAR";
+		break;
+	case RESTRICTED_STAR:
+		str_coloring="RESTRICTED_STAR";
+		break;
+	case DISTANCE_TWO:
+		str_coloring="DISTANCE_TWO";
+		break;
+	}
+
+	m_ordering=SGString<char>(index_t(str_ordering.size()));
+	m_coloring=SGString<char>(index_t(str_coloring.size()));
+	memcpy(m_ordering.string, str_ordering.data(), str_ordering.size());
+	memcpy(m_coloring.string, str_coloring.data(), str_coloring.size());
+
+	SG_REF(m_matrix_operator);
+
+	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
+}
+
+void CProbingSampler::init()
+{
+	m_matrix_operator=NULL;
+	m_power=1;
+
+	SG_ADD(&m_probing_vector, "probing_vector", "the probing vector generated"
+		" from coloring", MS_NOT_AVAILABLE);
+
+	SG_ADD(&m_power, "matrix-power", "power of the sparse-matrix for coloring",
+		MS_NOT_AVAILABLE);
+
+	SG_ADD(&m_ordering, "ordering-variant", "ordering variant for coloring",
+		MS_NOT_AVAILABLE);
+
+	SG_ADD(&m_coloring, "coloring-variant", "coloring variant for coloring",
+		MS_NOT_AVAILABLE);
+
+	SG_ADD((CSGObject**)&m_matrix_operator, "matrix-operator",
+		"the sparse-matrix linear opeator for probing", MS_NOT_AVAILABLE);
+}
+
+CProbingSampler::~CProbingSampler()
+{
+	SG_UNREF(m_matrix_operator);
+
+	SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
+}
+
+SGVector<int32_t> CProbingSampler::get_probing_vector() const
+{
+	return m_probing_vector;
+}
+
+void CProbingSampler::precompute()
+{
+	// do coloring things here and save the probing vector
+	SparsityStructure* sp_str=m_matrix_operator->get_sparsity_structure(m_power);
+
+	GraphColoringInterface* Color
+		=new GraphColoringInterface(SRC_MEM_ADOLC, sp_str->m_ptr, sp_str->m_num_rows);
+
+	std::string ordering(m_ordering.string, m_ordering.slen);
+	std::string coloring(m_coloring.string, m_coloring.slen);
+	Color->Coloring(ordering, coloring);
+
+	std::vector<int32_t> vi_VertexColors;
+	Color->GetVertexColors(vi_VertexColors);
+
+	REQUIRE(vi_VertexColors.size()==static_cast<uint32_t>(m_dimension),
+		"dimension mismatch, %d vs %d!\n", vi_VertexColors.size(), m_dimension);
+
+	m_probing_vector=SGVector<int32_t>(vi_VertexColors.size());
+
+	for (std::vector<int32_t>::iterator it=vi_VertexColors.begin();
+		it!=vi_VertexColors.end(); it++)
+	{
+		index_t i=static_cast<index_t>(std::distance(vi_VertexColors.begin(), it));
+		m_probing_vector[i]=*it;
+	}
+
+	Map<VectorXi> probe(m_probing_vector.vector, m_probing_vector.vlen);
+	m_num_samples=probe.maxCoeff();
+
+	delete sp_str;
+	delete Color;
+}
+
+SGVector<float64_t> CProbingSampler::sample(index_t idx) const
+{
+	SGVector<float64_t> s(m_dimension);
+	s.set_const(0.0);
+	if (idx>=m_num_samples)
+		SG_WARNING("idx should be less than %d\n", m_num_samples)
+	else
+	{
+		for (index_t i=0; i<m_dimension; ++i)
+		{
+			if (m_probing_vector[i]==idx)
+			{
+				float64_t x=sg_rand->std_normal_distrib();
+				s[i]=(x>0)-(x<0);
+			}
+		}
+	}
+	return s;
+}
+
+}
+
+#endif // HAVE_EIGEN3
+#endif // HAVE_COLPACK

--- a/src/shogun/mathematics/logdet/ProbingSampler.h
+++ b/src/shogun/mathematics/logdet/ProbingSampler.h
@@ -1,0 +1,123 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#ifndef PROBING_SAMPLER_H_
+#define PROBING_SAMPLER_H_
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_COLPACK
+#ifdef HAVE_EIGEN3
+
+#include <shogun/mathematics/logdet/TraceSampler.h>
+
+namespace shogun
+{
+
+/** coloring order (see ColPack's GraphColoringInterface for details) */
+enum EOrderingVariant
+{
+	NATURAL=0,
+	LARGEST_FIRST,
+	DYNAMIC_LARGEST_FIRST,
+	DISTANCE_TWO_LARGEST_FIRST,
+	SMALLEST_LAST,
+	DISTANCE_TWO_SMALLEST_LAST,
+	INCIDENCE_DEGREE,
+	DISTANCE_TWO_INCIDENCE_DEGREE,
+	RANDOM
+};
+
+/** coloring variant (see ColPack's GraphColoringInterface for details) */
+enum EColoringVariant
+{
+	DISTANCE_ONE=0,
+	ACYCLIC,
+	ACYCLIC_FOR_INDIRECT_RECOVERY,
+	STAR,
+	RESTRICTED_STAR,
+	DISTANCE_TWO
+};
+
+template<class T> class SGVector;
+template<class T> class SGString;
+template<class T> class CSparseMatrixOperator;
+
+/** @brief Class that provides a sample method for probing vector using
+ * greedy graph coloring. It depends on an external library ColPack (used
+ * under GPL2+) for graph coloring related things.
+ */
+class CProbingSampler : public CTraceSampler
+{
+public:
+	/** default constructor */
+	CProbingSampler();
+
+	/** 
+	 * constructor 
+	 *
+	 * @param matrix_operator the sparse matrix operator
+	 * @param power the power of the sparse matrix operator whose
+	 * sparsity structure will be used for grpah coloring
+	 * @param ordering the ordering variant
+	 * @param coloring the coloring variant
+	 */
+	CProbingSampler(CSparseMatrixOperator<float64_t>* matrix_operator,
+		int64_t power=1, EOrderingVariant ordering=NATURAL,
+		EColoringVariant coloring=DISTANCE_ONE);
+
+	/** destructor */
+	virtual ~CProbingSampler();
+
+	/** @return the probing vector */
+	SGVector<int32_t> get_probing_vector() const;
+
+	/** 
+	 * method that generates the samples
+	 *
+	 * @param idx the index
+	 * @return the sample vector
+	 */
+	virtual SGVector<float64_t> sample(index_t idx) const;
+
+	/** precompute method that sets the num_samples of the base */
+	virtual void precompute();
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "ProbingSampler";
+	}
+
+private:
+	/** the matrix operator */
+	CSparseMatrixOperator<float64_t>* m_matrix_operator;
+
+	/** power of the matrix */
+	int64_t m_power;
+
+	/** probing vecotr */
+	SGVector<int32_t> m_probing_vector;
+
+	/** ordering variant */
+	SGString<char> m_ordering;
+
+	/** coloring variant */
+	SGString<char> m_coloring;
+
+	/** initialize with default values and register params */
+	void init();
+
+};
+
+}
+
+#endif // HAVE_EIGEN3
+#endif // HAVE_COLPACK
+#endif // PROBING_SAMPLER_H_

--- a/tests/unit/mathematics/logdet/ProbingSampler_unittest.cc
+++ b/tests/unit/mathematics/logdet/ProbingSampler_unittest.cc
@@ -1,0 +1,85 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Written (W) 2013 Soumyajit De
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_COLPACK
+#ifdef HAVE_EIGEN3
+
+#include <vector>
+#include <shogun/lib/SGSparseMatrix.h>
+#include <shogun/features/SparseFeatures.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/logdet/SparseMatrixOperator.h>
+#include <shogun/mathematics/logdet/ProbingSampler.h>
+#include <ColPack/ColPackHeaders.h>
+#include <gtest/gtest.h>
+
+using namespace std;
+using namespace shogun;
+using namespace Eigen;
+using namespace ColPack;
+
+TEST(ProbingSampler, get_probing_vector)
+{
+	const int32_t size=9;
+	const int32_t max_pow=10;
+
+	SGMatrix<float64_t> m(size, size);
+	m.set_const(0.0);
+	for (int32_t i=0; i<size; ++i)
+		m(i,i)=2.0;
+
+	for (int32_t i=0; i<size; i+=4)
+		m(i,size-1)=2.0;
+
+	for (int32_t i=0; i<size; i+=4)
+		m(size-1,i)=2.0;
+
+	CSparseFeatures<float64_t> feat(m);
+	SGSparseMatrix<float64_t> sm=feat.get_sparse_feature_matrix();
+	CSparseMatrixOperator<float64_t>* op
+		=new CSparseMatrixOperator<float64_t>(sm);
+	SG_REF(op);
+
+	// get the sparsity structure and use coloring to get probing
+	SparsityStructure* sp_str=op->get_sparsity_structure(max_pow);
+
+	GraphColoringInterface* Color=new GraphColoringInterface(SRC_MEM_ADOLC,
+		sp_str->m_ptr, sp_str->m_num_rows);
+	Color->Coloring("NATURAL", "DISTANCE_ONE");
+
+	vector<int32_t> vi_VertexColors;
+	Color->GetVertexColors(vi_VertexColors);
+
+	SGVector<int32_t> probing(vi_VertexColors.size());
+	for (vector<int32_t>::iterator it=vi_VertexColors.begin();
+		it!=vi_VertexColors.end(); it++)
+	{
+		probing[static_cast<int32_t>(distance(vi_VertexColors.begin(), it))]=*it;
+	}
+
+	// get the probing vector using probing sampler
+	CProbingSampler* sampler=new CProbingSampler(op, max_pow);
+	sampler->precompute();
+
+	SGVector<int32_t> sg_probing=sampler->get_probing_vector();
+
+	Map<VectorXi> eig_probing(probing.vector, probing.vlen);
+	Map<VectorXi> eig_sg_probing(sg_probing.vector, sg_probing.vlen);
+
+	// should be same
+	EXPECT_NEAR((eig_probing-eig_sg_probing).norm(), 0.0, 1E-15);
+
+	SG_UNREF(sampler);
+	SG_UNREF(op);
+	delete Color;
+}
+#endif // HAVE_EIGEN3
+#endif // HAVE_COLPACK


### PR DESCRIPTION
- added a struct SparsityStructure
- since we only need to use this structure for coloring, added a method get_sparsity_structure, which takes the power of matrix whose sparsity structure has to be used for coloring, then computes the matrix power in log(n) and returns the sparsity structure of the power instead of the whole matrix
- added a unit-test for this to make sure this matrix multiplication works same as normal multiplication
- added a probing sampler class which uses this method, and uses colpack to compute the probing vector
- added unit-test for this
