### PR TITLE
Get rid of empty temp directories cxx11_* in the cmake build dir.

### DIFF
--- a/cmake/CheckCXX11Features.cmake
+++ b/cmake/CheckCXX11Features.cmake
@@ -89,7 +89,7 @@ endif ()
 
 function(cxx11_check_feature FEATURE_NAME RESULT_VAR)
     if (NOT DEFINED ${RESULT_VAR})
-        set(_bindir "${CMAKE_CURRENT_BINARY_DIR}/cxx11_${FEATURE_NAME}")
+        set(_bindir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/CMakeTmp/cxx11_${FEATURE_NAME}")
 
         set(_SRCFILE_BASE ${CMAKE_CURRENT_LIST_DIR}/CheckCXX11Features/cxx11-test-${FEATURE_NAME})
         set(_LOG_NAME "\"${FEATURE_NAME}\"")


### PR DESCRIPTION
- added remove_recurse to "cxx11_check_feature"
- calling "cxx11_check_feature" on unused checks to remove the remaining directories

@vigsterkr: I think you're the one for reviewing this PR.
