### PR TITLE
CG, COCG, CG-M solver fixed (log-det)

### DIFF
--- a/src/shogun/mathematics/logdet/CGMShiftedFamilySolver.cpp
+++ b/src/shogun/mathematics/logdet/CGMShiftedFamilySolver.cpp
@@ -133,23 +133,29 @@ SGVector<complex64_t> CCGMShiftedFamilySolver::solve_shifted_weighted(
 			break;
 
 		// compute the alpha parameter of CG_M
-		alpha=r_norm2/r_norm2_i;
+		alpha=r_norm2_i/r_norm2;
 
 		// update ||r||_{2}
 		r_norm2=r_norm2_i;
 
-		// update parameters
-		zeta_sh_old=zeta_sh_cur;
-		zeta_sh_cur=zeta_sh_new;
-		beta_old=beta;
-
 		// update direction
 		p=r+alpha*p;
 
-		compute_alpha_sh(zeta_sh_cur, zeta_sh_old, beta_sh, beta, alpha, alpha_sh);
+		compute_alpha_sh(zeta_sh_new, zeta_sh_cur, beta_sh, beta, alpha, alpha_sh);
 
 		for (index_t i=0; i<shifts.vlen; ++i)
-			p_sh.col(i)=zeta_sh_cur[i]*r+alpha_sh[i]*p_sh.col(i);
+		{		
+			p_sh.col(i)*=alpha_sh[i];
+			p_sh.col(i)+=zeta_sh_new[i]*r;
+		}
+
+		// update parameters
+		for (index_t i=0; i<shifts.vlen; ++i)
+		{
+			zeta_sh_old[i]=zeta_sh_cur[i];
+			zeta_sh_cur[i]=zeta_sh_new[i];
+		}
+		beta_old=beta;
 	}
 
 	if (it.succeeded(r))

--- a/src/shogun/mathematics/logdet/ConjugateGradientSolver.cpp
+++ b/src/shogun/mathematics/logdet/ConjugateGradientSolver.cpp
@@ -94,7 +94,7 @@ SGVector<float64_t> CConjugateGradientSolver::solve(
 			break;
 
 		// compute the beta parameter of CG
-		float64_t beta=r_norm2/r_norm2_i;
+		float64_t beta=r_norm2_i/r_norm2;
 
 		// update direction, and ||r||_{2}
 		r_norm2=r_norm2_i;

--- a/src/shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.cpp
+++ b/src/shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.cpp
@@ -95,7 +95,7 @@ SGVector<complex64_t> CConjugateOrthogonalCGSolver::solve(
 			break;
 
 		// compute the beta parameter of CG
-		float64_t beta=r_norm2/r_norm2_i;
+		float64_t beta=r_norm2_i/r_norm2;
 
 		// update direction, and ||r||_{2}
 		r_norm2=r_norm2_i;

--- a/src/shogun/mathematics/logdet/IterativeShiftedLinearFamilySolver.cpp
+++ b/src/shogun/mathematics/logdet/IterativeShiftedLinearFamilySolver.cpp
@@ -30,8 +30,8 @@ CIterativeShiftedLinearFamilySolver<T, ST>::~CIterativeShiftedLinearFamilySolver
 
 template <class T, class ST>
 void CIterativeShiftedLinearFamilySolver<T, ST>::compute_zeta_sh_new(
-		SGVector<ST> zeta_sh_old, SGVector<ST> zeta_sh_cur, SGVector<ST> shifts,
-		T beta_old, T beta_cur, T alpha, SGVector<ST>& zeta_sh_new)
+		const SGVector<ST>& zeta_sh_old, const SGVector<ST>& zeta_sh_cur, const SGVector<ST>& shifts,
+		const T& beta_old, const T& beta_cur, const T& alpha, SGVector<ST>& zeta_sh_new)
 	{
 		// compute zeta_sh_new according to Jergerlehner, eq. 2.44
 		// [see IterativeShiftedLinearFamilySolver.h]
@@ -52,7 +52,7 @@ void CIterativeShiftedLinearFamilySolver<T, ST>::compute_zeta_sh_new(
 
 template <class T, class ST>
 void CIterativeShiftedLinearFamilySolver<T, ST>::compute_beta_sh(
-		SGVector<ST> zeta_sh_new, SGVector<ST> zeta_sh_cur, T beta_cur,
+		const SGVector<ST>& zeta_sh_new, const SGVector<ST>& zeta_sh_cur, const T& beta_cur,
 		SGVector<ST>& beta_sh_cur)
 	{
 		// compute beta_sh_cur according to Jergerlehner, eq. 2.42
@@ -72,15 +72,15 @@ void CIterativeShiftedLinearFamilySolver<T, ST>::compute_beta_sh(
 
 template <class T, class ST>
 void CIterativeShiftedLinearFamilySolver<T, ST>::compute_alpha_sh(
-		SGVector<ST> zeta_sh_cur, SGVector<ST> zeta_sh_old,
-		SGVector<ST> beta_sh, T beta, T alpha, SGVector<ST>& alpha_sh)
+		const SGVector<ST>& zeta_sh_cur, const SGVector<ST>& zeta_sh_old,
+		const SGVector<ST>& beta_sh_old, const T& beta_old, const T& alpha, SGVector<ST>& alpha_sh)
 	{
 		// compute alpha_sh_cur according to Jergerlehner, eq. 2.43
 		// [see IterativeShiftedLinearFamilySolver.h]
   	for (index_t i=0; i<alpha_sh.vlen; ++i)
 	  {
-			ST numer=alpha*zeta_sh_cur[i]*beta_sh[i];
-			ST denom=zeta_sh_old[i]*beta;
+			ST numer=alpha*zeta_sh_cur[i]*beta_sh_old[i];
+			ST denom=zeta_sh_old[i]*beta_old;
 
 			// handle division by zero
 			if (denom==static_cast<ST>(0.0))

--- a/src/shogun/mathematics/logdet/IterativeShiftedLinearFamilySolver.h
+++ b/src/shogun/mathematics/logdet/IterativeShiftedLinearFamilySolver.h
@@ -86,9 +86,9 @@ protected:
 	 * @param alpha \f$\alpha\f$ non-shifted
 	 * @param zeta_sh_new \f$\zeta^{\sigma}_{n+1}\f$ to be computed
 	 */
-	void compute_zeta_sh_new(SGVector<ST> zeta_sh_old,
-		SGVector<ST> zeta_sh_cur, SGVector<ST> shifts,
-		T beta_old, T beta_cur, T alpha, SGVector<ST>& zeta_sh_new);
+	void compute_zeta_sh_new(const SGVector<ST>& zeta_sh_old,
+		const SGVector<ST>& zeta_sh_cur, const SGVector<ST>& shifts,
+		const T& beta_old, const T& beta_cur, const T& alpha, SGVector<ST>& zeta_sh_new);
 
 	/**
 	 * compute \f$\beta^{\sigma}_{n}\f$ as \f$\beta_{n}\frac{\zeta^{\sigma}_{n+1}}
@@ -99,8 +99,8 @@ protected:
 	 * @param beta_cur \f$\beta_{n}\f$, non-shifted
 	 * @param beta_sh \f$\beta^{\sigma}_{n}\f$, to be computed
 	 */
-	void compute_beta_sh(SGVector<ST> zeta_sh_new,
-		SGVector<ST> zeta_sh_cur, T beta_cur, SGVector<ST>& beta_sh);
+	void compute_beta_sh(const SGVector<ST>& zeta_sh_new,
+		const SGVector<ST>& zeta_sh_cur, const T& beta_cur, SGVector<ST>& beta_sh);
 
 	/**
 	 * compute \f$alpha^{\sigma}_{n}\f$ as \f$\alpha_{n}\frac{\zeta^{\sigma}
@@ -108,14 +108,14 @@ protected:
 	 *
 	 * @param zeta_sh_cur \f$\zeta^{\sigma}_{n}\f$ shifted params
 	 * @param zeta_sh_old \f$\zeta^{\sigma}_{n-1}\f$ shifted params
-	 * @param beta_sh \f$\beta^{\sigma}_{n}\f$, shifted params
-	 * @param beta \f$\beta_{n}\f$, non-shifted
+	 * @param beta_sh_old \f$\beta^{\sigma}_{n-1}\f$, shifted params
+	 * @param beta_old \f$\beta_{n-1}\f$, non-shifted
 	 * @param alpha \f$\alpha_{n}\f$, non-shifted
 	 * @param alpha_sh \f$\alpha^{\sigma}_{n}\f$, to be computed
 	 */
-	void compute_alpha_sh(SGVector<ST> zeta_sh_cur,
-		SGVector<ST> zeta_sh_old, SGVector<ST> beta_sh,
-		T beta, T alpha, SGVector<ST>& alpha_sh);
+	void compute_alpha_sh(const SGVector<ST>& zeta_sh_cur,
+		const SGVector<ST>& zeta_sh_old, const SGVector<ST>& beta_sh_old,
+		const T& beta_old, const T& alpha, SGVector<ST>& alpha_sh);
 
 };
 

--- a/src/shogun/mathematics/logdet/IterativeSolverIterator.h
+++ b/src/shogun/mathematics/logdet/IterativeSolverIterator.h
@@ -82,7 +82,7 @@ public:
 		m_iter_info.residual_norm=residual.norm();
 
 		m_success=m_iter_info.residual_norm < m_tolerence;
-		return m_success || m_iter_info.iteration_count > m_max_iteration_limit;
+		return m_success || m_iter_info.iteration_count >= m_max_iteration_limit;
 	}
 
 	/** @return current iteration info */

--- a/tests/unit/mathematics/logdet/CGMShiftedFamilySolver_unittest.cc
+++ b/tests/unit/mathematics/logdet/CGMShiftedFamilySolver_unittest.cc
@@ -33,7 +33,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_noshift)
 
 	// diagonal Hermintian matrix
 	for (index_t i=0; i<size; ++i)
-		m(i,i)=i+1;
+		m(i,i)=CMath::pow(2, i);
 
 	// constant vector of the system
 	SGVector<float64_t> b(size);
@@ -56,7 +56,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_noshift)
 	Map<VectorXd> x_sh_map(x_sh.vector, x_sh.vlen);
 	Map<VectorXd> x_map(x.vector, x.vlen);
 
-	EXPECT_NEAR((x_sh_map-x_map).norm(), 0.0, 1E-14);
+	EXPECT_NEAR((x_sh_map-x_map).norm(), 0.0, 1E-15);
 
 	SG_UNREF(A);
 }
@@ -69,14 +69,14 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_real_shift)
 
 	// diagonal Hermintian matrix
 	for (index_t i=0; i<size; ++i)
-		m(i,i)=i+1;
+		m(i,i)=CMath::pow(2, i);
 
 	// constant vector of the system
 	SGVector<float64_t> b(size);
-	b.set_const(0.5);
+	b.set_const(1.0);
 
 	// shifts
-	float64_t shift=0.01;
+	float64_t shift=100;
 
 	SGVector<complex64_t> shifts(1);
 	shifts.set_const(shift);
@@ -111,7 +111,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_real_shift)
 	Map<VectorXcd> x_sh_map(x_sh.vector, x_sh.vlen);
 	Map<VectorXd> x_map(x.vector, x.vlen);
 
-	EXPECT_NEAR((x_sh_map-x_map.cast<complex64_t>()).norm(), 0.0, 0.01);
+	EXPECT_NEAR((x_sh_map-x_map.cast<complex64_t>()).norm(), 0.0, 1E-7);
 
 	SG_UNREF(A);
 }
@@ -124,14 +124,14 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_complex_shift)
 
 	// diagonal Hermintian matrix
 	for (index_t i=0; i<size; ++i)
-		m(i,i)=i+1;
+		m(i,i)=CMath::pow(2, i);
 
 	// constant vector of the system
 	SGVector<float64_t> b(size);
 	b.set_const(0.5);
 
 	// shifts
-	complex64_t shift(0.0, 0.01);
+	complex64_t shift(0.0, 100.0);
 
 	SGVector<complex64_t> shifts(1);
 	shifts.set_const(shift);
@@ -148,7 +148,6 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_complex_shift)
 
 	// Solve with CG_M
 	CCGMShiftedFamilySolver cg_m_linear_solver;
-	cg_m_linear_solver.set_iteration_limit(10000);
 	SGVector<complex64_t> x_sh
 		=cg_m_linear_solver.solve_shifted_weighted(A, b, shifts, weights);
 
@@ -167,7 +166,7 @@ TEST(CGMShiftedFamilySolver, solve_shifted_weight_complex_shift)
 	Map<VectorXcd> x_sh_map(x_sh.vector, x_sh.vlen);
 	Map<VectorXcd> x_map(x.vector, x.vlen);
 
-	EXPECT_NEAR((x_sh_map-x_map).norm(), 0.0, 0.13);
+	EXPECT_NEAR((x_sh_map-x_map).norm(), 0.0, 1E-15);
 
 	SG_UNREF(A);
 	SG_UNREF(B);

--- a/tests/unit/mathematics/logdet/LogDetEstimator_unittest.cc
+++ b/tests/unit/mathematics/logdet/LogDetEstimator_unittest.cc
@@ -22,12 +22,13 @@
 #include <shogun/mathematics/logdet/SparseMatrixOperator.h>
 #include <shogun/mathematics/logdet/DenseMatrixExactLog.h>
 #include <shogun/mathematics/logdet/LogRationalApproximationIndividual.h>
+#include <shogun/mathematics/logdet/LogRationalApproximationCGM.h>
 #include <shogun/mathematics/logdet/NormalSampler.h>
 #include <shogun/mathematics/logdet/ProbingSampler.h>
 #include <shogun/mathematics/logdet/DirectEigenSolver.h>
 #include <shogun/mathematics/logdet/LanczosEigenSolver.h>
 #include <shogun/mathematics/logdet/DirectLinearSolverComplex.h>
-#include <shogun/mathematics/logdet/ConjugateOrthogonalCGSolver.h>
+#include <shogun/mathematics/logdet/CGMShiftedFamilySolver.h>
 #include <shogun/mathematics/logdet/LogDetEstimator.h>
 #include <shogun/lib/computation/job/ScalarResult.h>
 #include <shogun/lib/computation/engine/SerialComputationEngine.h>
@@ -208,6 +209,88 @@ TEST(LogDetEstimator, sample_ratapp_probing_sampler)
 	SG_UNREF(op_func);
 	SG_UNREF(op);
 	SG_UNREF(opd);
+	SG_UNREF(e);
+}
+
+TEST(LogDetEstimator, sample_ratapp_probing_sampler_cgm)
+{
+	CSerialComputationEngine* e=new CSerialComputationEngine;
+	SG_REF(e);
+	
+	const index_t size=16;
+	SGMatrix<float64_t> mat(size, size);
+	mat.set_const(0.0);
+	for (index_t i=0; i<size; ++i)
+	{
+		float64_t value=CMath::abs(sg_rand->std_normal_distrib())*1000;
+		mat(i,i)=value<1.0?10.0:value;
+	}
+
+	mat(0,5)=mat(5,0)=1.0;
+	mat(0,7)=mat(7,0)=1.0;
+	mat(0,11)=mat(11,0)=1.0;
+	mat(1,8)=mat(8,1)=1.0;
+	mat(1,10)=mat(10,1)=1.0;
+	mat(1,11)=mat(11,1)=1.0;
+	mat(1,12)=mat(12,1)=1.0;
+	mat(2,8)=mat(8,2)=1.0;
+	mat(2,11)=mat(11,2)=1.0;
+	mat(2,13)=mat(13,2)=1.0;
+	mat(2,14)=mat(14,2)=1.0;
+	mat(3,8)=mat(8,3)=1.0;
+	mat(3,12)=mat(12,3)=1.0;
+	mat(3,15)=mat(15,3)=1.0;
+	mat(4,8)=mat(8,4)=1.0;
+	mat(4,14)=mat(14,4)=1.0;
+	mat(4,15)=mat(15,4)=1.0;
+	mat(5,11)=mat(11,5)=1.0;
+	mat(5,10)=mat(10,5)=1.0;
+	mat(6,10)=mat(10,6)=1.0;
+	mat(6,12)=mat(12,6)=1.0;
+	mat(7,11)=mat(11,7)=1.0;
+	mat(7,13)=mat(13,7)=1.0;
+	mat(8,11)=mat(11,8)=1.0;
+	mat(8,15)=mat(15,8)=1.0;
+	mat(9,13)=mat(13,9)=1.0;
+	mat(9,14)=mat(14,9)=1.0;
+
+	float64_t actual_result=CStatistics::log_det(mat);
+
+	CSparseFeatures<float64_t> feat(mat);
+	SGSparseMatrix<float64_t> sm=feat.get_sparse_feature_matrix();
+
+	CSparseMatrixOperator<float64_t>* op=new CSparseMatrixOperator<float64_t>(sm);
+	SG_REF(op);
+
+	CLanczosEigenSolver* eig_solver=new CLanczosEigenSolver(op);
+	SG_REF(eig_solver);
+
+	CCGMShiftedFamilySolver* linear_solver=new CCGMShiftedFamilySolver();
+	SG_REF(linear_solver);
+
+	CLogRationalApproximationCGM *op_func
+		=new CLogRationalApproximationCGM(op, e, eig_solver, linear_solver, 20);
+	SG_REF(op_func);
+
+	CProbingSampler* trace_sampler=new CProbingSampler(op, 1, NATURAL, DISTANCE_TWO);
+	SG_REF(trace_sampler);
+
+	CLogDetEstimator estimator(trace_sampler, op_func, e);
+	const index_t num_estimates=10;
+	SGVector<float64_t> estimates=estimator.sample(num_estimates);
+
+	float64_t result=0.0;
+	for (index_t i=0; i<num_estimates; ++i)
+		result+=estimates[i];
+	result/=num_estimates;
+
+	EXPECT_NEAR(result, actual_result, 1E-3);
+
+	SG_UNREF(trace_sampler);
+	SG_UNREF(eig_solver);
+	SG_UNREF(linear_solver);
+	SG_UNREF(op_func);
+	SG_UNREF(op);
 	SG_UNREF(e);
 }
 #endif // HAVE_COLPACK

--- a/tests/unit/mathematics/logdet/RationalApproximation_unittest.cc
+++ b/tests/unit/mathematics/logdet/RationalApproximation_unittest.cc
@@ -233,8 +233,6 @@ TEST(RationalApproximation, compare_direct_vs_cocg_accuracy)
 
 	CConjugateOrthogonalCGSolver *sparse_solver
 		=new CConjugateOrthogonalCGSolver();
-	sparse_solver->set_absolute_tolerence(0.001);
-	sparse_solver->set_iteration_limit(500);
 
 	CLogRationalApproximationIndividual *op_func
 		=new CLogRationalApproximationIndividual(
@@ -278,7 +276,7 @@ TEST(RationalApproximation, compare_direct_vs_cocg_accuracy)
 		Map<VectorXcd> map_xd(xd.vector, xd.vlen);
 		Map<VectorXcd> map_xs(xs.vector, xs.vlen);
 
-		EXPECT_NEAR((map_xd-map_xs).norm(), 0.0, 0.001);
+		EXPECT_NEAR((map_xd-map_xs).norm(), 0.0, 0.01);
 
 		SG_UNREF(shifted_dense);
 		SG_UNREF(shifted_sparse);


### PR DESCRIPTION
- also added a new unit-test in LogDetEstimator that uses this CG-M solver for computing log-det.
