### PR TITLE
Update RInterface : correction of 'number of arguments' bug

### DIFF
--- a/src/interfaces/r_static/RInterface.cpp
+++ b/src/interfaces/r_static/RInterface.cpp
@@ -700,9 +700,9 @@ void R_init_sg(DllInfo *info)
    R_FortranMethodDef fortranMethods[] = { {NULL, NULL, 0} };
    
 #ifdef HAVE_ELWMS
-   R_ExternalMethodDef externalMethods[] = { {"elwms", (void*(*)()) &Rsg, 1}, {NULL, NULL, 0} };
+   R_ExternalMethodDef externalMethods[] = { {"elwms", (void*(*)()) &Rsg, -1}, {NULL, NULL, 0} };
 #else
-   R_ExternalMethodDef externalMethods[] = { {"sg", (void*(*)()) &Rsg, 1}, {NULL, NULL, 0} };
+   R_ExternalMethodDef externalMethods[] = { {"sg", (void*(*)()) &Rsg, -1}, {NULL, NULL, 0} };
 #endif
    R_CallMethodDef callMethods[] = { {NULL, NULL, 0} };
 


### PR DESCRIPTION
Since R3.0 the number of arguments of External calls is checked for each call. sg has an unfixed number of argument. Fixing the number of arguments to -1 in the registration allows to disable that check.
