### PR TITLE
Fix set_features for every machine in LinearMulticlassMachine

### DIFF
--- a/src/shogun/machine/LinearMulticlassMachine.h
+++ b/src/shogun/machine/LinearMulticlassMachine.h
@@ -69,6 +69,9 @@ class CLinearMulticlassMachine : public CMulticlassMachine
 			SG_REF(f);
 			SG_UNREF(m_features);
 			m_features = f;
+
+			for (index_t i=0; i<m_machines->get_num_elements(); i++)
+				((CLinearMachine* )m_machines->get_element(i))->set_features(f);
 		}
 
 		/** get features


### PR DESCRIPTION
I've spotted something that could be a bug. When I called set_features(NULL) on my multiclass svm to clear the data, I could still see the features in the serialized file. Looking into it led me to realize that the features remained on the different machines that were trained.
Here is output w/ and w/o my change : https://gist.github.com/van51/6522455 .
Let me know if this was intended or if it should be tackled in a different way. 
