### PR TITLE
SparseMatrixOperator memory leak fixed

### DIFF
--- a/src/shogun/mathematics/linalg/linop/SparseMatrixOperator.h
+++ b/src/shogun/mathematics/linalg/linop/SparseMatrixOperator.h
@@ -159,9 +159,8 @@ public:
 		typedef SGSparseVector<Scalar> vector;
 		typedef SGSparseVectorEntry<Scalar> entry;
 
-		SGSparseMatrix<Scalar> casted_m(m_operator.num_vectors, m_operator.num_features);
+		vector* rows=SG_MALLOC(vector, m_operator.num_vectors);
 
-		vector* rows=SG_MALLOC(vector, m_operator.num_features);
 		for (index_t i=0; i<m_operator.num_vectors; ++i)
 		{
 			entry* features=SG_MALLOC(entry, m_operator[i].num_feat_entries);
@@ -173,7 +172,11 @@ public:
 			rows[i].features=features;
 			rows[i].num_feat_entries=m_operator[i].num_feat_entries;
 		}
+
+		SGSparseMatrix<Scalar> casted_m;
 		casted_m.sparse_matrix=rows;
+		casted_m.num_vectors=m_operator.num_vectors;
+		casted_m.num_features= m_operator.num_features;
 
 		return new CSparseMatrixOperator<Scalar>(casted_m);
 	}


### PR DESCRIPTION
output from my machine

[rajkumar@cfdvs4-1 build]$ valgrind "--tool=memcheck" "--leak-check=yes" "--show-reachable=yes" ./tests/unit/shogun-unit-test "--gtest_filter=MatrixOperator.cast_sparse_double_complex"
==29168== Memcheck, a memory error detector
==29168== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==29168== Using Valgrind-3.9.0.SVN and LibVEX; rerun with -h for copyright info
==29168== Command: ./tests/unit/shogun-unit-test --gtest_filter=MatrixOperator.cast_sparse_double_complex
==29168== 
Note: Google Test filter = MatrixOperator.cast_sparse_double_complex
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from MatrixOperator
[ RUN      ] MatrixOperator.cast_sparse_double_complex
[       OK ] MatrixOperator.cast_sparse_double_complex (71 ms)
[----------] 1 test from MatrixOperator (78 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (124 ms total)
[  PASSED  ] 1 test.
==29168== 
==29168== HEAP SUMMARY:
==29168==     in use at exit: 0 bytes in 0 blocks
==29168==   total heap usage: 29,359 allocs, 29,359 frees, 1,973,483 bytes allocated
==29168== 
==29168== All heap blocks were freed -- no leaks are possible
==29168== 
==29168== For counts of detected and suppressed errors, rerun with: -v
==29168== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
