### PR TITLE
StreamingHashedDocDotFeatures

### DIFF
--- a/src/shogun/converter/HashedDocConverter.cpp
+++ b/src/shogun/converter/HashedDocConverter.cpp
@@ -229,4 +229,15 @@ int32_t CHashedDocConverter::count_distinct_indices(CDynamicArray<uint32_t>& has
 	}
 	return num_nnz_features;	
 }
+
+void CHashedDocConverter::set_normalization(bool normalize)
+{
+	should_normalize = normalize;
+}
+
+void CHashedDocConverter::set_k_skip_n_grams(int32_t k, int32_t n)
+{
+	tokens_to_skip = k;
+	ngrams = n;
+}
 }

--- a/src/shogun/converter/HashedDocConverter.h
+++ b/src/shogun/converter/HashedDocConverter.h
@@ -94,6 +94,20 @@ public:
 	/** @return object name */
 	virtual const char* get_name() const;
 
+	/** specify whether hashed vector should be normalized or not
+	 *
+	 * @param normalize  whether to normalize
+	 */
+	void set_normalization(bool normalize);
+
+	/** Method used to specify the parameters for the quadratic
+	 * approach of k-skip n-grams. See class description for more 
+	 * details and an example.
+	 *
+	 * @param k the max number of allowed skips
+	 * @param n the max number of tokens to combine
+	 */
+	void set_k_skip_n_grams(int32_t k, int32_t n);
 protected:
 	
 	/** init */

--- a/src/shogun/features/HashedDocDotFeatures.h
+++ b/src/shogun/features/HashedDocDotFeatures.h
@@ -23,7 +23,7 @@ class CDotFeatures;
 class CHashedDocConverter;
 class CTokenizer;
 
-/** This class can be used to provide on-the-fly vectorization of a document collection. 
+/** @brief This class can be used to provide on-the-fly vectorization of a document collection. 
  * Like in the standard Bag-of-Words representation, this class considers each document as a collection of tokens,
  * which are then hashed into a new feature space of a specified dimension.
  * This class is very flexible and allows the user to specify the tokenizer used to tokenize each document,

--- a/src/shogun/features/streaming/StreamingHashedDocDotFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingHashedDocDotFeatures.cpp
@@ -18,12 +18,12 @@ CStreamingHashedDocDotFeatures::CStreamingHashedDocDotFeatures(CStreamingFile* f
 	bool is_labelled, int32_t size,	CTokenizer* tzer, int32_t bits)
 : CStreamingDotFeatures()
 {
-	init(file, is_labelled, size, tzer, bits);
+	init(file, is_labelled, size, tzer, bits, true, 1, 0);
 }
 
 CStreamingHashedDocDotFeatures::CStreamingHashedDocDotFeatures() : CStreamingDotFeatures()
 {
-	init(NULL, false, 0, NULL, 0);
+	init(NULL, false, 0, NULL, 0, false, 1, 0);
 }
 
 CStreamingHashedDocDotFeatures::CStreamingHashedDocDotFeatures(
@@ -35,20 +35,20 @@ CStreamingHashedDocDotFeatures::CStreamingHashedDocDotFeatures(
 	bool is_labelled = (lab != NULL);
 	int32_t size=1024;
 
-	init(file, is_labelled, size, tzer, bits);
+	init(file, is_labelled, size, tzer, bits, true, 1, 0);
 	
 	parser.set_free_vectors_on_destruct(false);
 	seekable= true;
 }
 void CStreamingHashedDocDotFeatures::init(CStreamingFile* file, bool is_labelled,
-	int32_t size, CTokenizer* tzer, int32_t bits)
+	int32_t size, CTokenizer* tzer, int32_t bits, bool normalize, int32_t n_grams, int32_t skips)
 {
 	num_bits = bits;
 	tokenizer = tzer;
 	if (tokenizer)
 	{
 		SG_REF(tokenizer);
-		converter = new CHashedDocConverter(tzer, bits, false);
+		converter = new CHashedDocConverter(tzer, bits, normalize, n_grams, skips);
 	}
 	else
 		converter=NULL;
@@ -197,4 +197,14 @@ void CStreamingHashedDocDotFeatures::set_vector_and_label_reader()
 SGSparseVector<float64_t> CStreamingHashedDocDotFeatures::get_vector()
 {
 	return current_vector;
+}
+
+void CStreamingHashedDocDotFeatures::set_normalization(bool normalize)
+{
+	converter->set_normalization(normalize);
+}
+
+void CStreamingHashedDocDotFeatures::set_k_skip_n_grams(int32_t k, int32_t n)
+{
+	converter->set_k_skip_n_grams(k, n);
 }

--- a/tests/unit/features/StreamingHashedDocDotFeatures_unittest.cc
+++ b/tests/unit/features/StreamingHashedDocDotFeatures_unittest.cc
@@ -44,7 +44,7 @@ TEST(StreamingHashedDocFeaturesTest, example_reading)
 	tokenizer->delimiters['\''] = 1;
 	tokenizer->delimiters[','] = 1;
 
-	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, 5, false);
+	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, 5, true);
 	CStringFeatures<char>* doc_collection = new CStringFeatures<char>(list, RAWBYTE);
 	CStreamingHashedDocDotFeatures* feats = new CStreamingHashedDocDotFeatures(doc_collection,
 			tokenizer, 5);
@@ -103,7 +103,7 @@ TEST(StreamingHashedDocFeaturesTest, dot_tests)
 	tokenizer->delimiters['\''] = 1;
 	tokenizer->delimiters[','] = 1;
 
-	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, 5, false);
+	CHashedDocConverter* converter = new CHashedDocConverter(tokenizer, 5, true);
 	CStringFeatures<char>* doc_collection = new CStringFeatures<char>(list, RAWBYTE);
 	CStreamingHashedDocDotFeatures* feats = new CStreamingHashedDocDotFeatures(doc_collection,
 			tokenizer, 5);
@@ -111,7 +111,7 @@ TEST(StreamingHashedDocFeaturesTest, dot_tests)
 
 	SGVector<float32_t> dense_vec(32);
 	for (index_t j=0; j<32; j++)
-		dense_vec[j] = CMath::random();
+		dense_vec[j] = CMath::random(0.0, 1.0);
 
 	index_t i = 0;
 	while (feats->get_next_example())
@@ -125,7 +125,7 @@ TEST(StreamingHashedDocFeaturesTest, dot_tests)
 		for (index_t j=0; j<converted_doc.num_feat_entries; j++)
 			tmp_res += dense_vec[converted_doc.features[j].feat_index] * converted_doc.features[j].entry;
 
-		EXPECT_EQ(tmp_res, feats->dense_dot(dense_vec.vector, dense_vec.vlen));
+		EXPECT_NEAR(tmp_res, feats->dense_dot(dense_vec.vector, dense_vec.vlen), 1e-7);
 
 		/** Add to dense test */
 		SGSparseVector<float64_t> example = feats->get_vector();
@@ -140,11 +140,11 @@ TEST(StreamingHashedDocFeaturesTest, dot_tests)
 			if ( (sparse_idx < example.num_feat_entries) && 
 					(example.features[sparse_idx].feat_index == j) )
 			{
-				EXPECT_NEAR(dense_vec2[j], dense_vec[j] + example.features[sparse_idx].entry, 1e-10);
+				EXPECT_NEAR(dense_vec2[j], dense_vec[j] + example.features[sparse_idx].entry, 1e-7);
 				sparse_idx++;
 			}
 			else
-				EXPECT_NEAR(dense_vec2[j], dense_vec[j], 1e-10);
+				EXPECT_NEAR(dense_vec2[j], dense_vec[j], 1e-7);
 		}
 		
 		feats->release_example();


### PR DESCRIPTION
Added full functionality of HashedDocDotFeatures to this streaming version. Meaning added parameters for normalization and quadratic features to the constructor. Also made some changes to a unit-test ( issue #1648 ) that was failing at times, the float type isn't sufficient there so I changed to normalizing results and reduced accuracy of tests.
