### PR TITLE
suggestion for output in case of failing integration test

### DIFF
--- a/tests/integration/python_modular/tester.py
+++ b/tests/integration/python_modular/tester.py
@@ -33,7 +33,17 @@ def compare(a, b, tolerance):
 		
 		# new, parameter framework based comparison up to tolerance
 		shogun_tolerance = 1e-5 if tolerance is None else tolerance
-		return a.equals(b, shogun_tolerance)			
+		result = a.equals(b, shogun_tolerance)
+		
+		# print debug output in case of failure
+		if not result:
+			print "Equals failed with debug output"
+			old_loglevel=a.io.get_loglevel()
+			a.io.set_loglevel(1)
+			a.equals(b, shogun_tolerance)
+			a.io.set_loglevel(old_loglevel)
+			
+		return result
 	elif type(a) in (tuple,list):
 		if len(a) != len(b): return False
 		for obj1, obj2 in zip(a,b):


### PR DESCRIPTION
Before, a failing test showed a diff of the ascii version of the objects.

Since we are using CSGObject::equals now, this is not possible anymore.
The method provides detailed information of what is going on via SG_DEBUG however.

An idea would be to first check whether equals returns false, and if it does, set the log-level to debug, and run the thing again. Then set the io-level back to old value.

@sonney2k @lisitsyn  @vigsterkr what do you think about this?

I think even better would be to just have the stack trace of the different parameter returned by equals in some way since this pollutes the output. But it is better than nothing for now
