### PR TITLE
Fix converter_jade_bss example

### DIFF
--- a/examples/undocumented/libshogun/converter_jade_bss.cpp
+++ b/examples/undocumented/libshogun/converter_jade_bss.cpp
@@ -11,12 +11,14 @@
 
 #include <shogun/base/init.h>
 #include <shogun/lib/common.h>
-#include <shogun/features/DenseFeatures.h>
 
 #include <iostream>
 
+using namespace shogun;
+
 #ifdef HAVE_EIGEN3
 
+#include <shogun/features/DenseFeatures.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/eigen3.h>
 
@@ -24,7 +26,6 @@
 #include <shogun/evaluation/ica/PermutationMatrix.h>
 #include <shogun/evaluation/ica/AmariIndex.h>
 
-using namespace shogun;
 using namespace Eigen;
 
 void test()
@@ -99,15 +100,16 @@ void test()
 	return;
 }
 
+#endif // HAVE_EIGEN3
+
 int main(int argc, char ** argv)
 {
 	init_shogun_with_defaults();
 
+#ifdef HAVE_EIGEN3
 	test();
-
+#endif // HAVE_EIGEN3
 	exit_shogun();
 
 	return 0;
 }
-
-#endif //HAVE_EIGEN3


### PR DESCRIPTION
I don't have the Eigen3 on my local machine. 
So, before this patch I got:

/usr/lib/gcc/x86_64-linux-gnu/4.7/../../../x86_64-linux-gnu/crt1.o: In function '_start':
(.text+0x20): undefined reference to 'main'
collect2: error: ld returned 1 exit status
make[2]: **\* [examples/undocumented/libshogun/converter_jade_bss] Error 1
make[1]: **\* [examples/undocumented/libshogun/CMakeFiles/converter_jade_bss.dir/all] Error 2
