### PR TITLE
Increase default accuracy of gradient search and check parameters in unit test

### DIFF
--- a/src/shogun/modelselection/GradientModelSelection.cpp
+++ b/src/shogun/modelselection/GradientModelSelection.cpp
@@ -170,7 +170,7 @@ CGradientModelSelection::~CGradientModelSelection()
 void CGradientModelSelection::init()
 {
 	m_max_evaluations=1000;
-	m_grad_tolerance=1e-4;
+	m_grad_tolerance=1e-6;
 
 	SG_ADD(&m_grad_tolerance, "gradient_tolerance",	"Gradient tolerance",
 			MS_NOT_AVAILABLE);

--- a/tests/unit/modelselection/GradientModelSelection_unittest.cc
+++ b/tests/unit/modelselection/GradientModelSelection_unittest.cc
@@ -89,9 +89,19 @@ TEST(GradientModelSelection,select_model_exact_inference)
 	CParameterCombination* best_comb=grad_search->select_model(false);
 	best_comb->apply_to_machine(gpr);
 
-	// compare with result from GPML toolbox
+	// compare negative log marginal likelihood with result from GPML toolbox
 	float64_t nlZ=inf->get_negative_log_marginal_likelihood();
-	EXPECT_NEAR(nlZ, 5.862416, 1E-2);
+	EXPECT_NEAR(nlZ, 5.862416, 1E-6);
+
+	// get hyperparameters
+	float64_t scale=inf->get_scale();
+	float64_t width=kernel->get_width();
+	float64_t sigma=lik->get_sigma();
+
+	// compare hyperparameters with result from GPML toolbox
+	EXPECT_NEAR(scale, 0.833180109059697, 1E-2);
+	EXPECT_NEAR(width, 0.190931901479123, 1E-2);
+	EXPECT_NEAR(sigma, 4.25456324418582e-04, 1E-2);
 
 	// cleanup
 	SG_UNREF(grad_search);
@@ -157,7 +167,7 @@ TEST(GradientModelSelection,select_model_ep_inference)
 	CParameterCombination* best_comb=grad_search->select_model(false);
 	best_comb->apply_to_machine(gpc);
 
-	// compare with result from GPML toolbox
+	// compare negative log marginal likelihood with result from GPML toolbox
 	float64_t nlZ=inf->get_negative_log_marginal_likelihood();
 	EXPECT_NEAR(nlZ, 3.334009, 1E-3);
 


### PR DESCRIPTION
- checked parameters of CExactInferenceMethod (~50 gradient search steps vs ~550 in GPML)
- parameters of EP wasn't checked, since there are a very huge difference between different calls.

For example, best hyparameters from GPML for EP with the same initial data:

**first call**:

width =  10.7350381445812
scale =  135.740816464898

**the second one**:

width =  10.7333023367444
scale =  79.3076727325428

Probably we could compare things in log domain (but i'm not sure).
