### PR TITLE
add helper functions to StructuredOutputMachine

### DIFF
--- a/examples/undocumented/python_modular/structure_factor_graph_model.py
+++ b/examples/undocumented/python_modular/structure_factor_graph_model.py
@@ -95,9 +95,9 @@ samples, labels = gen_data(ftype_all, num_samples)
 parameter_list = [[samples,labels,w_all,ftype_all]]
 
 def structure_factor_graph_model(tr_samples = samples, tr_labels = labels, w = w_all, ftype = ftype_all):
+	from modshogun import SOSVMHelper, LabelsFactory
 	from modshogun import FactorGraphModel, MAPInference, TREE_MAX_PROD
-	from modshogun import DualLibQPBMSOSVM, LabelsFactory
-	from modshogun import StochasticSOSVM, SOSVMHelper
+	from modshogun import DualLibQPBMSOSVM, StochasticSOSVM
 
 	# create model
 	model = FactorGraphModel(tr_samples, tr_labels, TREE_MAX_PROD, False)
@@ -114,7 +114,7 @@ def structure_factor_graph_model(tr_samples = samples, tr_labels = labels, w = w
 
 	# --- training with BMRM ---
 	bmrm = DualLibQPBMSOSVM(model, tr_labels, 0.01)
-	bmrm.set_verbose(False)
+	#bmrm.set_verbose(True)
 	bmrm.train()
 	#print 'learned weights:'
 	#print bmrm.get_w()
@@ -135,16 +135,14 @@ def structure_factor_graph_model(tr_samples = samples, tr_labels = labels, w = w
 	#print('BMRM: Average training error is %.4f' % ave_loss)
 
 	# show primal objs and dual objs
-	from modshogun import BmrmStatistics
-	stats = bmrm.get_result()
-	Fps = stats.get_hist_Fp_vector()
-	Fds = stats.get_hist_Fd_vector()
-	#print Fps
-	#print Fds
-	#print Fps - Fds
+	#hbm = bmrm.get_helper()
+	#print hbm.get_primal_values()
+	#print hbm.get_eff_passes()
+	#print hbm.get_train_errors()
 
 	# --- training with SGD ---
-	sgd = StochasticSOSVM(model, tr_labels, True, True)
+	sgd = StochasticSOSVM(model, tr_labels)
+	#sgd.set_verbose(True)
 	sgd.set_lambda(0.01)
 	sgd.train()
 

--- a/examples/undocumented/python_modular/structure_mutliclass_bmrm.py
+++ b/examples/undocumented/python_modular/structure_mutliclass_bmrm.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import numpy as np
+
+def gen_data(num_classes,num_samples,dim):
+	np.random.seed(0)
+	covs = np.array([[[0., -1. ], [2.5,  .7]],
+			 [[3., -1.5], [1.2, .3]],
+			 [[ 2,  0  ], [ .0,  1.5 ]]])
+	X = np.r_[np.dot(np.random.randn(num_samples, dim), covs[0]) + np.array([0, 10]),
+		  np.dot(np.random.randn(num_samples, dim), covs[1]) + np.array([-10, -10]),
+		  np.dot(np.random.randn(num_samples, dim), covs[2]) + np.array([10, -10])];
+	Y = np.hstack((np.zeros(num_samples), np.ones(num_samples), 2*np.ones(num_samples)))
+	return X, Y
+
+# Number of classes
+M = 3
+# Number of samples of each class
+N = 50
+# Dimension of the data
+dim = 2
+
+traindat, label_traindat = gen_data(M,N,dim)
+
+parameter_list = [[traindat,label_traindat]]
+
+def structure_multiclass_bmrm(fm_train_real=traindat,label_train_multiclass=label_traindat):
+	from modshogun  import RealFeatures
+	from modshogun  import SOSVMHelper
+	from modshogun  import BMRM, PPBMRM, P3BMRM
+	from modshogun	import MulticlassModel, MulticlassSOLabels, DualLibQPBMSOSVM, RealNumber
+
+	labels = MulticlassSOLabels(label_train_multiclass)
+	features = RealFeatures(fm_train_real.T)
+
+	model = MulticlassModel(features, labels)
+	sosvm = DualLibQPBMSOSVM(model, labels, 1.0)
+
+	# BMRM
+	sosvm.set_solver(BMRM)
+	sosvm.set_verbose(True)
+	sosvm.train()
+
+	out = sosvm.apply()
+	count = 0
+	for i in xrange(out.get_num_labels()):
+		yi_pred = RealNumber.obtain_from_generic(out.get_label(i))
+		if yi_pred.value == label_train_multiclass[i]:
+			count = count + 1
+
+	#print("BMRM: Correct classification rate: %0.2f" % ( 100.0*count/out.get_num_labels() ))
+	#hp = sosvm.get_helper()
+	#print hp.get_primal_values()
+	#print hp.get_train_errors()
+
+	# PPBMRM
+	w = np.zeros(model.get_dim())
+	sosvm.set_w(w)
+	sosvm.set_solver(PPBMRM)
+	sosvm.set_verbose(True)
+	sosvm.train()
+
+	out = sosvm.apply()
+	count = 0
+	for i in xrange(out.get_num_labels()):
+		yi_pred = RealNumber.obtain_from_generic(out.get_label(i))
+		if yi_pred.value == label_train_multiclass[i]:
+			count = count + 1
+
+	#print("PPBMRM: Correct classification rate: %0.2f" % ( 100.0*count/out.get_num_labels() ))
+
+	# P3BMRM
+	w = np.zeros(model.get_dim())
+	sosvm.set_w(w)
+	sosvm.set_solver(P3BMRM)
+	sosvm.set_verbose(True)
+	sosvm.train()
+
+	out = sosvm.apply()
+	count = 0
+	for i in xrange(out.get_num_labels()):
+		yi_pred = RealNumber.obtain_from_generic(out.get_label(i))
+		if yi_pred.value == label_train_multiclass[i]:
+			count = count + 1
+
+	#print("P3BMRM: Correct classification rate: %0.2f" % ( 100.0*count/out.get_num_labels() ))
+
+if __name__=='__main__':
+	print('SO multiclass model with bundle methods')
+	structure_multiclass_bmrm(*parameter_list[0])

--- a/src/interfaces/modular/Structure.i
+++ b/src/interfaces/modular/Structure.i
@@ -21,9 +21,6 @@
 %rename(SegmentLoss) CSegmentLoss;
 %rename(IntronList) CIntronList;
 
-%rename(StructuredOutputMachine) CStructuredOutputMachine;
-%rename(LinearStructuredOutputMachine) CLinearStructuredOutputMachine;
-%rename(KernelStructuredOutputMachine) CKernelStructuredOutputMachine;
 %rename(StructuredModel) CStructuredModel;
 %rename(ResultSet) CResultSet;
 %rename(MulticlassModel) CMulticlassModel;
@@ -35,14 +32,6 @@
 %rename(StateModel) CStateModel;
 %rename(TwoStateModel) CTwoStateModel;
 %rename(DirectorStructuredModel) CDirectorStructuredModel;
-%rename(DualLibQPBMSOSVM) CDualLibQPBMSOSVM;
-
-#ifdef USE_MOSEK
-%rename(PrimalMosekSOSVM) CPrimalMosekSOSVM;
-#endif /* USE_MOSEK */
-
-%rename(SOSVMHelper) CSOSVMHelper;
-%rename(StochasticSOSVM) CStochasticSOSVM;
 
 %rename(FactorType) CFactorType;
 %rename(TableFactorType) CTableFactorType;
@@ -56,6 +45,18 @@
 %rename(MAPInference) CMAPInference;
 %rename(FactorGraphModel) CFactorGraphModel;
 
+%rename(SOSVMHelper) CSOSVMHelper;
+%rename(StructuredOutputMachine) CStructuredOutputMachine;
+%rename(LinearStructuredOutputMachine) CLinearStructuredOutputMachine;
+%rename(KernelStructuredOutputMachine) CKernelStructuredOutputMachine;
+%rename(DualLibQPBMSOSVM) CDualLibQPBMSOSVM;
+
+#ifdef USE_MOSEK
+%rename(PrimalMosekSOSVM) CPrimalMosekSOSVM;
+#endif /* USE_MOSEK */
+
+%rename(StochasticSOSVM) CStochasticSOSVM;
+
 /* Include Class Headers to make them visible from within the target language */
 %include <shogun/structure/PlifBase.h>
 %include <shogun/structure/Plif.h>
@@ -64,10 +65,6 @@
 %include <shogun/structure/PlifMatrix.h>
 %include <shogun/structure/IntronList.h>
 %include <shogun/structure/SegmentLoss.h>
-
-%include <shogun/machine/StructuredOutputMachine.h>
-%include <shogun/machine/LinearStructuredOutputMachine.h>
-%include <shogun/machine/KernelStructuredOutputMachine.h>
 
 %include <shogun/structure/BmrmStatistics.h>
 %include <shogun/structure/StructuredModel.h>
@@ -79,14 +76,6 @@
 %include <shogun/structure/StateModel.h>
 %include <shogun/structure/TwoStateModel.h>
 %include <shogun/structure/DirectorStructuredModel.h>
-%include <shogun/structure/DualLibQPBMSOSVM.h>
-
-#ifdef USE_MOSEK
-%include <shogun/structure/PrimalMosekSOSVM.h>
-#endif /* USE_MOSEK */
-
-%include <shogun/structure/SOSVMHelper.h>
-%include <shogun/structure/StochasticSOSVM.h>
 
 %include <shogun/structure/FactorType.h>
 %include <shogun/structure/Factor.h>
@@ -96,3 +85,16 @@
 %include <shogun/labels/FactorGraphLabels.h>
 %include <shogun/structure/MAPInference.h>
 %include <shogun/structure/FactorGraphModel.h>
+
+%include <shogun/structure/SOSVMHelper.h>
+%include <shogun/machine/StructuredOutputMachine.h>
+%include <shogun/machine/LinearStructuredOutputMachine.h>
+%include <shogun/machine/KernelStructuredOutputMachine.h>
+
+%include <shogun/structure/DualLibQPBMSOSVM.h>
+
+#ifdef USE_MOSEK
+%include <shogun/structure/PrimalMosekSOSVM.h>
+#endif /* USE_MOSEK */
+
+%include <shogun/structure/StochasticSOSVM.h>

--- a/src/interfaces/modular/Structure_includes.i
+++ b/src/interfaces/modular/Structure_includes.i
@@ -7,10 +7,6 @@
  #include <shogun/structure/IntronList.h>
  #include <shogun/structure/SegmentLoss.h>
 
- #include <shogun/machine/StructuredOutputMachine.h>
- #include <shogun/machine/LinearStructuredOutputMachine.h>
- #include <shogun/machine/KernelStructuredOutputMachine.h>
-
  #include <shogun/structure/BmrmStatistics.h>
  #include <shogun/structure/StructuredModel.h>
  #include <shogun/structure/MulticlassModel.h>
@@ -21,14 +17,6 @@
  #include <shogun/structure/StateModel.h>
  #include <shogun/structure/TwoStateModel.h>
  #include <shogun/structure/DirectorStructuredModel.h>
- #include <shogun/structure/DualLibQPBMSOSVM.h>
-
-#ifdef USE_MOSEK
- #include <shogun/structure/PrimalMosekSOSVM.h>
-#endif /* USE_MOSEK */
-
- #include <shogun/structure/SOSVMHelper.h>
- #include <shogun/structure/StochasticSOSVM.h>
 
  #include <shogun/structure/FactorType.h>
  #include <shogun/structure/Factor.h>
@@ -38,5 +26,18 @@
  #include <shogun/labels/FactorGraphLabels.h>
  #include <shogun/structure/MAPInference.h>
  #include <shogun/structure/FactorGraphModel.h>
+
+ #include <shogun/structure/SOSVMHelper.h>
+ #include <shogun/machine/StructuredOutputMachine.h>
+ #include <shogun/machine/LinearStructuredOutputMachine.h>
+ #include <shogun/machine/KernelStructuredOutputMachine.h>
+
+ #include <shogun/structure/DualLibQPBMSOSVM.h>
+
+#ifdef USE_MOSEK
+ #include <shogun/structure/PrimalMosekSOSVM.h>
+#endif /* USE_MOSEK */
+
+ #include <shogun/structure/StochasticSOSVM.h>
 %}
 

--- a/src/shogun/machine/StructuredOutputMachine.cpp
+++ b/src/shogun/machine/StructuredOutputMachine.cpp
@@ -4,6 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
+ * Written (W) 2013 Shell Hu
  * Written (W) 2013 Thoralf Klein
  * Written (W) 2012 Fernando José Iglesias García
  * Copyright (C) 2012 Fernando José Iglesias García
@@ -33,6 +34,7 @@ CStructuredOutputMachine::~CStructuredOutputMachine()
 {
 	SG_UNREF(m_model);
 	SG_UNREF(m_surrogate_loss);
+	SG_UNREF(m_helper);
 }
 
 void CStructuredOutputMachine::set_model(CStructuredModel* model)
@@ -52,6 +54,11 @@ void CStructuredOutputMachine::register_parameters()
 {
 	SG_ADD((CSGObject**)&m_model, "m_model", "Structured model", MS_NOT_AVAILABLE);
 	SG_ADD((CSGObject**)&m_surrogate_loss, "m_surrogate_loss", "Surrogate loss", MS_NOT_AVAILABLE);
+	SG_ADD(&m_verbose, "verbose", "Verbosity flag", MS_NOT_AVAILABLE);
+	SG_ADD((CSGObject**)&m_helper, "helper", "Training helper", MS_NOT_AVAILABLE);
+
+	m_verbose = false;
+	m_helper = NULL;
 }
 
 void CStructuredOutputMachine::set_labels(CLabels* lab)
@@ -171,4 +178,26 @@ float64_t CStructuredOutputMachine::risk(float64_t* subgrad, float64_t* W,
 			break;
 	}
 	return ret;
+}
+
+CSOSVMHelper* CStructuredOutputMachine::get_helper() const
+{
+	if (m_helper == NULL)
+	{
+		SG_ERROR("%s::get_helper(): no helper has been created!"
+			"Please set verbose before training!\n", get_name());
+	}
+
+	SG_REF(m_helper);
+	return m_helper;
+}
+
+void CStructuredOutputMachine::set_verbose(bool verbose) 
+{ 
+	m_verbose = verbose; 
+}
+
+bool CStructuredOutputMachine::get_verbose() const 
+{ 
+	return m_verbose; 
 }

--- a/src/shogun/machine/StructuredOutputMachine.h
+++ b/src/shogun/machine/StructuredOutputMachine.h
@@ -4,6 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
+ * Written (W) 2013 Shell Hu
  * Written (W) 2012 Fernando José Iglesias García
  * Copyright (C) 2012 Fernando José Iglesias García
  */
@@ -16,7 +17,7 @@
 #include <shogun/machine/Machine.h>
 #include <shogun/structure/StructuredModel.h>
 #include <shogun/loss/LossFunction.h>
-#include <shogun/structure/BmrmStatistics.h>
+#include <shogun/structure/SOSVMHelper.h>
 
 namespace shogun
 {
@@ -116,6 +117,23 @@ class CStructuredOutputMachine : public CMachine
 		virtual float64_t risk(float64_t* subgrad, float64_t* W, 
 				TMultipleCPinfo* info=0, EStructRiskType rtype = N_SLACK_MARGIN_RESCALING);
 
+		/** @return training progress helper */
+		CSOSVMHelper* get_helper() const; 
+
+		/** set verbose
+		 * NOTE that track verbose information including primal objectives, 
+		 * training errors and duality gaps will make the training 2x or 3x slower.
+		 *
+		 * @param verbose flag enabling/disabling verbose information
+		 */
+		void set_verbose(bool verbose);
+
+		/** get verbose
+		 *
+		 * @return Status of verbose flag (enabled/disabled)
+		 */
+		bool get_verbose() const;
+
 	protected:
 		/** n-slack formulation and margin rescaling
 		 *
@@ -195,6 +213,12 @@ class CStructuredOutputMachine : public CMachine
 		 * will be extended in the future
 		 */
 		CLossFunction* m_surrogate_loss;
+
+		/** the helper that records primal objectives, duality gaps etc */
+		CSOSVMHelper* m_helper;
+
+		/** verbose outputs and statistics */
+		bool m_verbose;
 
 }; /* class CStructuredOutputMachine */
 

--- a/src/shogun/structure/DualLibQPBMSOSVM.cpp
+++ b/src/shogun/structure/DualLibQPBMSOSVM.cpp
@@ -69,7 +69,6 @@ void CDualLibQPBMSOSVM::init()
 	SG_ADD(&m_Tmax, "m_Tmax", "Parameter Tmax", MS_AVAILABLE);
 	SG_ADD(&m_cp_models, "m_cp_models", "Number of cutting plane models",
 			MS_AVAILABLE);
-	SG_ADD(&m_verbose, "m_verbose", "Verbosity flag", MS_NOT_AVAILABLE);
 
 	set_TolRel(0.001);
 	set_TolAbs(0.0);
@@ -80,7 +79,6 @@ void CDualLibQPBMSOSVM::init()
 	set_K(0.4);
 	set_Tmax(100);
 	set_cp_models(1);
-	set_verbose(false);
 	set_solver(BMRM);
 }
 
@@ -88,6 +86,15 @@ bool CDualLibQPBMSOSVM::train_machine(CFeatures* data)
 {
 	if (data)
 		set_features(data);
+
+	if (m_verbose)
+	{
+		if (m_helper != NULL)
+			SG_UNREF(m_helper);
+
+		m_helper = new CSOSVMHelper();
+		SG_REF(m_helper);
+	}
 
 	// Initialize the model for training
 	m_model->init_training();

--- a/src/shogun/structure/DualLibQPBMSOSVM.h
+++ b/src/shogun/structure/DualLibQPBMSOSVM.h
@@ -13,6 +13,7 @@
 
 #include <shogun/machine/LinearStructuredOutputMachine.h>
 #include <shogun/features/DotFeatures.h>
+#include <shogun/structure/BmrmStatistics.h>
 
 namespace shogun
 {
@@ -180,18 +181,6 @@ class CDualLibQPBMSOSVM : public CLinearStructuredOutputMachine
 		 */
 		inline uint32_t get_cp_models() { return m_cp_models; }
 
-		/** set verbose
-		 *
-		 * @param verbose 	Flag enabling/disabling screen output
-		 */
-		inline void set_verbose(bool verbose) { m_verbose=verbose; }
-
-		/** get verbose
-		 *
-		 * @return Status of screen output (enabled/disabled)
-		 */
-		inline bool get_verbose() { return m_verbose; }
-
 		/** get bmrm result
 		 *
 		 * @return Result returned from Bundle Method algorithm
@@ -267,9 +256,6 @@ class CDualLibQPBMSOSVM : public CLinearStructuredOutputMachine
 
 		/** number of cutting plane models */
 		uint32_t m_cp_models;
-
-		/** verbose */
-		bool m_verbose;
 
 		/** BMRM result */
 		BmrmStatistics m_result;

--- a/src/shogun/structure/SOSVMHelper.h
+++ b/src/shogun/structure/SOSVMHelper.h
@@ -81,7 +81,7 @@ public:
 	 * @param dual dual objective value
 	 * @param dgap duality gap
 	 */
-	void add_debug_info(float64_t primal, float64_t eff_pass, float64_t train_error, 
+	virtual void add_debug_info(float64_t primal, float64_t eff_pass, float64_t train_error, 
 		float64_t dual = -1, float64_t dgap = -1);
 
 	/** get primal objectives

--- a/src/shogun/structure/StochasticSOSVM.h
+++ b/src/shogun/structure/StochasticSOSVM.h
@@ -13,7 +13,6 @@
 
 #include <shogun/lib/SGVector.h>
 #include <shogun/machine/LinearStructuredOutputMachine.h>
-#include <shogun/structure/SOSVMHelper.h>
 
 namespace shogun
 {
@@ -40,11 +39,10 @@ public:
 	 * @param model structured model with application specific functions
 	 * @param labs structured labels
 	 * @param do_weighted_averaging whether mix w with previous average weights
-	 * @param debug whether compute debug information, such as primal value, duality gap etc.
+	 * @param verbose whether compute debug information, such as primal value, duality gap etc.
 	 */
 	CStochasticSOSVM(CStructuredModel* model, CStructuredLabels* labs, 
-		bool do_weighted_averaging = true,
-		bool debug = false);
+		bool do_weighted_averaging = true, bool verbose = false);
 
 	/** destructor */
 	~CStochasticSOSVM();
@@ -94,9 +92,6 @@ public:
 	 */
 	void set_rand_seed(uint32_t rand_seed);
 
-	/** @return training progress helper */
-	CSOSVMHelper* get_helper() const; 
-
 protected:
 	/** train primal SO-SVM
 	 *
@@ -116,20 +111,11 @@ private:
 	/** Number of passes through the data (default: 50) */
 	int32_t m_num_iter;
 
-	/** Whether to use weighted averaging of the iterates 
-	 * Recommended -- it made a big difference in test error in 
-	 * our experiments (default: 1)
-	 */
+	/** Whether to use weighted averaging of the iterates */
 	bool m_do_weighted_averaging;
 
 	/** random seed */
 	uint32_t m_rand_seed;
-
-	/** Whether to track the primal objective, dual objective, 
-	 * and training error, which makes the code about 3x
-	 * slower given the extra two passes through data (default: 0)
-	 */
-	bool m_debug;
 
 	/** If set to 0, the algorithm computes the objective after each full
 	 * pass trough the data. If in (0,100) logging happens at a
@@ -138,9 +124,6 @@ private:
 	 * costly the computations will be!
 	 */
 	int32_t m_debug_multiplier;
-
-	/** Primal objective, duality gap etc as the algorithm progresses */
-	CSOSVMHelper* m_progress;
 
 }; /* CStochasticSOSVM */
 


### PR DESCRIPTION
@uricamic @iglesias @sonney2k: I made tiny changes on the bundle methods for convex optimization (ncbm is not included here). There are 2 reasons for doing this: 1) without normalizing risk, the primal objectives are too large for the dual objectives, sometimes it's unrealistic to expect a zero duality gap in reasonable training time; 2) it is not convenient to compare with other solvers like SGD, which uses normalized loss/risk. However, I am not 100% sure what I changed are correct. Could you check the changes and think about potential issues?  
