### PR TITLE
Fix silly mistake in LMNN notebook

### DIFF
--- a/doc/ipython-notebooks/metric/LMNN.ipynb
+++ b/doc/ipython-notebooks/metric/LMNN.ipynb
@@ -203,8 +203,8 @@
       "lmnn = LMNN(features,labels,k)\n",
       "# set an initial transform as a start point of the optimization\n",
       "init_transform = numpy.eye(2)\n",
-      "lmnn.train(init_transform)\n",
-      "lmnn.set_maxiter(2000)"
+      "lmnn.set_maxiter(2000)\n",
+      "lmnn.train(init_transform)"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Set max_iter before training, not after...
