### PR TITLE
Fixing data path in python modular examples.

### DIFF
--- a/examples/undocumented/python_modular/mathematics_linsolver_cg.py
+++ b/examples/undocumented/python_modular/mathematics_linsolver_cg.py
@@ -4,7 +4,7 @@ from numpy import *
 from scipy.io import mmread
 
 # Loading an example sparse matrix of dimension 479x479, real, unsymmetric
-mtx=mmread('../data/../logdet/west0479.mtx.gz')
+mtx=mmread('../../../data/logdet/west0479.mtx.gz')
 
 parameter_list=[[mtx,6000,10]]
 

--- a/examples/undocumented/python_modular/mathematics_logdet.py
+++ b/examples/undocumented/python_modular/mathematics_logdet.py
@@ -4,7 +4,7 @@ from numpy import *
 from scipy.io import mmread
 
 # Loading an example sparse matrix of dimension 479x479, real, unsymmetric
-mtx=mmread('../data/../logdet/west0479.mtx.gz')
+mtx=mmread('../../../data/logdet/west0479.mtx.gz')
 
 parameter_list=[[mtx,100,60,1]]
 


### PR DESCRIPTION
Working directory of test was: shogun/examples/undocumented/python_modular
Data files are in: shogun/data/logdet/
