### PR TITLE
added code to initialize cluster centers manually

### DIFF
--- a/src/shogun/clustering/KMeans.cpp
+++ b/src/shogun/clustering/KMeans.cpp
@@ -40,8 +40,24 @@ CKMeans::CKMeans(int32_t k_, CDistance* d)
 	set_distance(d);
 }
 
+CKMeans::CKMeans(int32_t k_i, CDistance* d_i, float64_t* centers_i )
+{
+	init();
+	k = k_i;
+	set_distance(d_i);
+	set_initial_centers(centers_i);
+}
+
 CKMeans::~CKMeans()
 {
+}
+
+bool CKMeans::set_initial_centers(float64_t* centers)
+{
+	//ASSERT(len == k*get_dimensions());
+	mus_initial = centers;
+	mus_set = true;
+	return true;	
 }
 
 bool CKMeans::train_machine(CFeatures* data)
@@ -63,7 +79,8 @@ bool CKMeans::train_machine(CFeatures* data)
 	for (int32_t i=0; i<num; i++)
 		Weights.vector[i]=1.0;
 
-	clustknb(false, NULL);
+	if(mus_set) clustknb(true, mus_initial);
+	else clustknb(false, NULL);
 
 	return true;
 }
@@ -242,12 +259,10 @@ void CKMeans::clustknb(bool use_old_mus, float64_t *mus_start)
 		ASSERT(mus_start)
 
 		/// set rhs to mus_start
-		rhs_mus->copy_feature_matrix(SGMatrix<float64_t>(mus_start,dimensions,k));
-		float64_t* p_dists=dists;
-
-		for(int32_t idx=0;idx<XSize;idx++,p_dists+=k)
-			distances_rhs(p_dists,0,k - 1,idx);
-		p_dists=NULL;
+		rhs_mus->copy_feature_matrix(SGMatrix<float64_t>(mus_start,dimensions,k,false));
+		for(int32_t idx=0;idx<XSize;idx++)
+			for(int32_t m=0;m<k;m++)
+				dists[k*idx+m] = distance->distance(idx,m);
 
 		for (i=0; i<XSize; i++)
 		{

--- a/src/shogun/clustering/KMeans.h
+++ b/src/shogun/clustering/KMeans.h
@@ -48,6 +48,13 @@ class CKMeans : public CDistanceMachine
 		 * @param d distance
 		 */
 		CKMeans(int32_t k, CDistance* d);
+
+		/** constructor for supplying initial centers
+		 * @param k_i parameter k
+		 * @param d_i distance
+		 * @param centers_i initial centers for KMeans algorithm
+		*/
+		CKMeans(int32_t k_i, CDistance* d_i, float64_t* centers_i );
 		virtual ~CKMeans();
 
 
@@ -118,6 +125,9 @@ class CKMeans : public CDistanceMachine
 		/** @return object name */
 		virtual const char* get_name() const { return "KMeans"; }
 
+		/* get the initial centers */
+		virtual bool set_initial_centers(float64_t* centers);
+
 	protected:
 		/** clustknb
 		 *
@@ -157,6 +167,8 @@ class CKMeans : public CDistanceMachine
 		/// radi of the clusters (size k)
 		SGVector<float64_t> R;
 
+		///initial centers supplied
+		float64_t* mus_initial;
 	private:
 		/* temporary variable for weighting over the train data */
 		SGVector<float64_t> Weights;
@@ -164,6 +176,8 @@ class CKMeans : public CDistanceMachine
 		/* temp variable for cluster centers */
 		SGMatrix<float64_t> mus;
 
+		/* flag to indicate if initial centers have been supplied */
+		bool mus_set;
 };
 }
 #endif


### PR DESCRIPTION
Added a constructor and a public function set_initial_centers both of which accept initial cluster centers in float64_t pointer form. two additional objects are also created float64_t\* mus_initial to store initial centers and a flag called mus_set. 
