### PR TITLE
added code to initialize cluster centers manually using SGVector

### DIFF
--- a/src/shogun/clustering/KMeans.cpp
+++ b/src/shogun/clustering/KMeans.cpp
@@ -40,7 +40,8 @@ CKMeans::CKMeans(int32_t k_, CDistance* d)
 	set_distance(d);
 }
 
-CKMeans::CKMeans(int32_t k_i, CDistance* d_i, float64_t* centers_i )
+CKMeans::CKMeans(int32_t k_i, CDistance* d_i, SGVector<float64_t> centers_i )
+: CDistanceMachine()
 {
 	init();
 	k = k_i;
@@ -52,11 +53,10 @@ CKMeans::~CKMeans()
 {
 }
 
-bool CKMeans::set_initial_centers(float64_t* centers)
+bool CKMeans::set_initial_centers(SGVector<float64_t> centers)
 {
 	//ASSERT(len == k*get_dimensions());
 	mus_initial = centers;
-	mus_set = true;
 	return true;	
 }
 
@@ -79,7 +79,7 @@ bool CKMeans::train_machine(CFeatures* data)
 	for (int32_t i=0; i<num; i++)
 		Weights.vector[i]=1.0;
 
-	if(mus_set) clustknb(true, mus_initial);
+	if(mus_initial.vlen>0) clustknb(true, mus_initial);
 	else clustknb(false, NULL);
 
 	return true;

--- a/src/shogun/clustering/KMeans.h
+++ b/src/shogun/clustering/KMeans.h
@@ -54,7 +54,7 @@ class CKMeans : public CDistanceMachine
 		 * @param d_i distance
 		 * @param centers_i initial centers for KMeans algorithm
 		*/
-		CKMeans(int32_t k_i, CDistance* d_i, float64_t* centers_i );
+		CKMeans(int32_t k_i, CDistance* d_i, SGVector<float64_t> centers_i );
 		virtual ~CKMeans();
 
 
@@ -126,7 +126,7 @@ class CKMeans : public CDistanceMachine
 		virtual const char* get_name() const { return "KMeans"; }
 
 		/* get the initial centers */
-		virtual bool set_initial_centers(float64_t* centers);
+		virtual bool set_initial_centers(SGVector<float64_t> centers);
 
 	protected:
 		/** clustknb
@@ -168,16 +168,13 @@ class CKMeans : public CDistanceMachine
 		SGVector<float64_t> R;
 
 		///initial centers supplied
-		float64_t* mus_initial;
+		SGVector<float64_t> mus_initial;
 	private:
 		/* temporary variable for weighting over the train data */
 		SGVector<float64_t> Weights;
 
 		/* temp variable for cluster centers */
 		SGMatrix<float64_t> mus;
-
-		/* flag to indicate if initial centers have been supplied */
-		bool mus_set;
 };
 }
 #endif


### PR DESCRIPTION
Added a constructor and a public function set_initial_centers both of which accept initial cluster centers in SGVector<float64_t> form. One additional SGVector<float64_t> object is also created mus_initial to store initial centers.
