### PR TITLE
Fixed initialization of DynArray in Parameter/ParameterMap to reduce memory footprint

### DIFF
--- a/src/shogun/base/DynArray.h
+++ b/src/shogun/base/DynArray.h
@@ -107,7 +107,7 @@ template <class T> class DynArray
 		 */
 		inline int32_t set_granularity(int32_t g)
 		{
-			g=CMath::max(g,128);
+			g=CMath::max(g,4);
 			this->resize_granularity = g;
 			return g;
 		}

--- a/src/shogun/base/Parameter.cpp
+++ b/src/shogun/base/Parameter.cpp
@@ -2739,9 +2739,12 @@ TParameter::load(CSerializableFile* file, const char* prefix)
 	return true;
 }
 
-Parameter::Parameter()
+/*
+  Initializing m_params(4) with small preallocation-sizes, because Parameter
+  will be constructed several times for EACH SGObject instance.
+ */
+Parameter::Parameter() : m_params(4)
 {
-	m_params.set_granularity(4);
 	SG_REF(sg_io);
 }
 

--- a/src/shogun/base/ParameterMap.cpp
+++ b/src/shogun/base/ParameterMap.cpp
@@ -227,11 +227,15 @@ bool ParameterMapElement::operator>(const ParameterMapElement& other) const
 	return *m_key>*other.m_key;
 }
 
+/*
+  Initializing m_map_elements(4), m_multi_map_elements(4) with small
+  preallocation-sizes, because ParameterMap will be constructed several
+  times for EACH SGObject instance.
+*/
 ParameterMap::ParameterMap()
+: m_map_elements(4), m_multi_map_elements(4)
 {
 	m_finalized=false;
-	m_map_elements.set_granularity(4);
-	m_multi_map_elements.set_granularity(4);
 }
 
 ParameterMap::~ParameterMap()


### PR DESCRIPTION
DynArray will be instanciated 5 times for each SGObject (via Parameter/ParameterMap)
which introduced a memory overhead of 5kb per instance.  With this commit, the overhead
should be reduced to 160 bytes.
