### PR TITLE
svm/OnlineLibLinear: Added learning of StreamingSparseFeatures

### DIFF
--- a/src/shogun/classifier/svm/OnlineLibLinear.h
+++ b/src/shogun/classifier/svm/OnlineLibLinear.h
@@ -6,6 +6,7 @@
  *
  * Written (W) 2007-2010 Soeren Sonnenburg
  * Written (W) 2011 Shashwat Lal Das
+ * Modifications (W) 2013 Thoralf Klein
  * Copyright (c) 2007-2009 The LIBLINEAR Project.
  * Copyright (C) 2007-2010 Fraunhofer Institute FIRST and Max-Planck-Society
  */
@@ -119,6 +120,8 @@ public:
 		 * @param label label of this example
 		 */
 		virtual void train_one(SGVector<float32_t> ex, float64_t label);
+
+		virtual void train_one(SGSparseVector<float32_t> ex, float64_t label);
 
 private:
 		/** Set up parameters */

--- a/src/shogun/features/streaming/StreamingSparseFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingSparseFeatures.cpp
@@ -5,6 +5,7 @@
  * (at your option) any later version.
  *
  * Written (W) 2011 Shashwat Lal Das
+ * Modifications (W) 2013 Thoralf Klein
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 #include <shogun/features/streaming/StreamingSparseFeatures.h>
@@ -45,6 +46,7 @@ T CStreamingSparseFeatures<T>::get_feature(int32_t index)
 template <class T>
 void CStreamingSparseFeatures<T>::reset_stream()
 {
+	SG_NOTIMPLEMENTED
 }
 
 template <class T>
@@ -54,30 +56,6 @@ int32_t CStreamingSparseFeatures<T>::set_num_features(int32_t num)
 	ASSERT(n<=num)
 	current_num_features=num;
 	return n;
-}
-
-template <class T>
-void CStreamingSparseFeatures<T>::expand_if_required(float32_t*& vec, int32_t &len)
-{
-	int32_t dim = get_dim_feature_space();
-	if (dim > len)
-	{
-		vec = SG_REALLOC(float32_t, vec, len, dim);
-		memset(&vec[len], 0, (dim-len) * sizeof(float32_t));
-		len = dim;
-	}
-}
-
-template <class T>
-void CStreamingSparseFeatures<T>::expand_if_required(float64_t*& vec, int32_t &len)
-{
-	int32_t dim = get_dim_feature_space();
-	if (dim > len)
-	{
-		vec = SG_REALLOC(float64_t, vec, len, dim);
-		memset(&vec[len], 0, (dim-len) * sizeof(float64_t));
-		len = dim;
-	}
 }
 
 template <class T>
@@ -110,11 +88,6 @@ template <class T>
 float64_t CStreamingSparseFeatures<T>::dense_dot(const float64_t* vec2, int32_t vec2_len)
 {
 	ASSERT(vec2)
-	if (vec2_len < current_num_features)
-	{
-		SG_ERROR("dimension of vec2 (=%d) does not match number of features (=%d)\n",
-			 vec2_len, current_num_features);
-	}
 
 	int32_t current_length = current_sgvector.num_feat_entries;
 	SGSparseVectorEntry<T>* current_vector = current_sgvector.features;
@@ -122,8 +95,11 @@ float64_t CStreamingSparseFeatures<T>::dense_dot(const float64_t* vec2, int32_t 
 	float64_t result=0;
 	if (current_vector)
 	{
-		for (int32_t i=0; i<current_length; i++)
-			result+=vec2[current_vector[i].feat_index]*current_vector[i].entry;
+		for (int32_t i=0; i<current_length; i++) {
+			if (current_vector[i].feat_index < vec2_len) {
+				result+=vec2[current_vector[i].feat_index]*current_vector[i].entry;
+			}
+		}
 	}
 
 	return result;
@@ -133,11 +109,6 @@ template <class T>
 float32_t CStreamingSparseFeatures<T>::dense_dot(const float32_t* vec2, int32_t vec2_len)
 {
 	ASSERT(vec2)
-	if (vec2_len < current_num_features)
-	{
-		SG_ERROR("dimension of vec2 (=%d) does not match number of features (=%d)\n",
-			 vec2_len, current_num_features);
-	}
 
 	int32_t current_length = current_sgvector.num_feat_entries;
 	SGSparseVectorEntry<T>* current_vector = current_sgvector.features;
@@ -145,8 +116,11 @@ float32_t CStreamingSparseFeatures<T>::dense_dot(const float32_t* vec2, int32_t 
 	float32_t result=0;
 	if (current_vector)
 	{
-		for (int32_t i=0; i<current_length; i++)
-			result+=vec2[current_vector[i].feat_index]*current_vector[i].entry;
+		for (int32_t i=0; i<current_length; i++) {
+			if (current_vector[i].feat_index < vec2_len) {
+				result+=vec2[current_vector[i].feat_index]*current_vector[i].entry;
+			}
+		}
 	}
 
 	return result;

--- a/src/shogun/features/streaming/StreamingSparseFeatures.h
+++ b/src/shogun/features/streaming/StreamingSparseFeatures.h
@@ -5,6 +5,7 @@
  * (at your option) any later version.
  *
  * Written (W) 2011 Shashwat Lal Das
+ * Modifications (W) 2013 Thoralf Klein
  * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
  */
 #ifndef _STREAMING_SPARSEFEATURES__H__
@@ -177,26 +178,6 @@ public:
 	 * @return dimensionality
 	 */
 	virtual int32_t get_dim_feature_space() const;
-
-	/**
-	 * Expand the vector passed so that it its length is equal to
-	 * the dimensionality of the features. The previous values are
-	 * kept intact through realloc, and the new ones are set to zero.
-	 *
-	 * @param vec float32_t* vector
-	 * @param len length of the vector
-	 */
-	virtual void expand_if_required(float32_t*& vec, int32_t &len);
-
-	/**
-	 * Expand the vector passed so that it its length is equal to
-	 * the dimensionality of the features. The previous values are
-	 * kept intact through realloc, and the new ones are set to zero.
-	 *
-	 * @param vec float64_t* vector
-	 * @param len length of the vector
-	 */
-	virtual void expand_if_required(float64_t*& vec, int32_t &len);
 
 	/**
 	 * Dot product taken with another StreamingDotFeatures object.


### PR DESCRIPTION
svm/OnlineLibLinear: Added learning of StreamingSparseFeatures
- Added method "train_one" for sparse vectors (a lot code duplication!  sorry!)
- "train_example" now consumes CStreamingDenseFeatures and CStreamingSparseFeatures
- Added bounds checking in CStreamingSparseFeatures<T>::dense_dot
  (allowing sparse dot-product with shorter weight vector)

Refactoring in StreamingSparseFeatures
- removed duplicate "expand_if_required" - already implemented in features
- avoided manual resizing of vectors using low-level stuff like realloc/memset/etc.
