### PR TITLE
Fix memory leak due to SGVector::clone in KNN

### DIFF
--- a/src/shogun/multiclass/KNN.cpp
+++ b/src/shogun/multiclass/KNN.cpp
@@ -82,21 +82,20 @@ bool CKNN::train_machine(CFeatures* data)
 	}
 
 	SGVector<int32_t> lab=((CMulticlassLabels*) m_labels)->get_int_labels();
-	m_train_labels.vlen=lab.vlen;
-	m_train_labels.vector=SGVector<int32_t>::clone_vector(lab.vector, lab.vlen);
+	m_train_labels=lab.clone();
 	ASSERT(m_train_labels.vlen>0)
 
-	int32_t max_class=m_train_labels.vector[0];
-	int32_t min_class=m_train_labels.vector[0];
+	int32_t max_class=m_train_labels[0];
+	int32_t min_class=m_train_labels[0];
 
 	for (int32_t i=1; i<m_train_labels.vlen; i++)
 	{
-		max_class=CMath::max(max_class, m_train_labels.vector[i]);
-		min_class=CMath::min(min_class, m_train_labels.vector[i]);
+		max_class=CMath::max(max_class, m_train_labels[i]);
+		min_class=CMath::min(min_class, m_train_labels[i]);
 	}
 
 	for (int32_t i=0; i<m_train_labels.vlen; i++)
-		m_train_labels.vector[i]-=min_class;
+		m_train_labels[i]-=min_class;
 
 	m_min_label=min_class;
 	m_num_classes=max_class-min_class+1;


### PR DESCRIPTION
This fixes a little part of the leaks pointed out in #1797.
