### PR TITLE
Remove LabelsFactory.to_structured in python modular example

### DIFF
--- a/examples/undocumented/python_modular/structure_factor_graph_model.py
+++ b/examples/undocumented/python_modular/structure_factor_graph_model.py
@@ -122,8 +122,7 @@ def structure_factor_graph_model(tr_samples = samples, tr_labels = labels, w = w
 	#print w_truth
 
 	# evaluation
-	eva_bmrm = bmrm.apply()
-	lbs_bmrm = LabelsFactory.to_structured(eva_bmrm)
+	lbs_bmrm = bmrm.apply()
 	acc_loss = 0.0
 	ave_loss = 0.0
 	for i in xrange(num_samples):


### PR DESCRIPTION
NO need to use this method to do the cast since it is already handled
in Machine.i
