### PR TITLE
Various minor fixes in GPs framework

### DIFF
--- a/doc/ipython-notebooks/gaussian_process/gaussian_processes.ipynb
+++ b/doc/ipython-notebooks/gaussian_process/gaussian_processes.ipynb
@@ -20,10 +20,10 @@
      "level": 4,
      "metadata": {},
      "source": [
-      "By Heiko Strathmann - <a href=\"mailto:heiko.strathmann@gmail.com\">heiko.strathmann@gmail.com</a> - <a href=\"github.com/karlnapf\">github.com/karlnapf</a> - <a href=\"herrstrathmann.de\">herrstrathmann.de</a>.\n",
+      "By Heiko Strathmann - <a href=\"mailto:heiko.strathmann@gmail.com\">heiko.strathmann@gmail.com</a> - <a href=\"https://github.com/karlnapf\">github.com/karlnapf</a> - <a href=\"http://herrstrathmann.de\">herrstrathmann.de</a>.\n",
       "\n",
       "\n",
-      "Based on the GP framework of the <a href=\"http://www.google-melange.com/gsoc/project/google/gsoc2013/votjak/8001\">Google summer of code 2013 project</a> of Roman Voyjako - <a href=\"mailto:votjakovr@gmail.com\">votjakovr@gmail.com</a> - <a href=\"https://github.com/votjakovr\">https://github.com/votjakovr</a>, and the <a href=\"http://www.google-melange.com/gsoc/project/google/gsoc2013/votjak/8001\">Google summer of code 2012 project</a> of Jacob Walker - <a href=\"mailto:votjakovr@gmail.com\">votjakovr@gmail.com</a> - <a href=\"https://github.com/votjakovr\">https://github.com/votjakovr</a> "
+      "Based on the GP framework of the <a href=\"http://www.google-melange.com/gsoc/project/google/gsoc2013/votjak/8001\">Google summer of code 2013 project</a> of Roman Votyakov - <a href=\"mailto:votjakovr@gmail.com\">votjakovr@gmail.com</a> - <a href=\"https://github.com/votjakovr\">github.com/votjakovr</a>, and the <a href=\"http://www.google-melange.com/gsoc/project/google/gsoc2012/walke434/39001\">Google summer of code 2012 project</a> of Jacob Walker - <a href=\"mailto:walke434@gmail.com\">walke434@gmail.com</a> - <a href=\"https://github.com/puffin444\">github.com/puffin444</a> "
      ]
     },
     {

--- a/src/shogun/classifier/GaussianProcessBinaryClassification.cpp
+++ b/src/shogun/classifier/GaussianProcessBinaryClassification.cpp
@@ -69,7 +69,8 @@ bool CGaussianProcessBinaryClassification::train_machine(CFeatures* data)
 		m_method->set_features(data);
 
 	// perform inference
-	m_method->update();
+	if (m_method->update_parameter_hash())
+		m_method->update();
 
 	return true;
 }

--- a/src/shogun/machine/GaussianProcessMachine.cpp
+++ b/src/shogun/machine/GaussianProcessMachine.cpp
@@ -126,8 +126,6 @@ SGVector<float64_t> CGaussianProcessMachine::get_posterior_variances(
 	// compute Kss=Kss*scale^2
 	eigen_Kss*=CMath::sq(m_method->get_scale());
 
-	kernel->cleanup();
-
 	// compute kernel matrix: K(feat, data)*scale^2
 	kernel->init(feat, data);
 

--- a/src/shogun/machine/gp/EPInferenceMethod.cpp
+++ b/src/shogun/machine/gp/EPInferenceMethod.cpp
@@ -59,7 +59,7 @@ CEPInferenceMethod::~CEPInferenceMethod()
 
 void CEPInferenceMethod::init()
 {
-	m_max_sweep=8;
+	m_max_sweep=15;
 	m_min_sweep=2;
 	m_tol=1e-4;
 }
@@ -243,8 +243,12 @@ void CEPInferenceMethod::update()
 		update_negative_ml();
 	}
 
-	if (sweep==m_max_sweep)
-		SG_WARNING("Maximum number of sweeps reached")
+	if (sweep==m_max_sweep && CMath::abs(m_nlZ-nlZ_old)>m_tol)
+	{
+		SG_ERROR("Maximum number (%d) of sweeps reached, but tolerance (%f) was "
+				"not yet reached. You can manually set maximum number of sweeps "
+				"or tolerance to fix this problem.\n", m_max_sweep, m_tol);
+	}
 
 	// update vector alpha
 	update_alpha();

--- a/src/shogun/machine/gp/FITCInferenceMethod.cpp
+++ b/src/shogun/machine/gp/FITCInferenceMethod.cpp
@@ -157,12 +157,10 @@ void CFITCInferenceMethod::update_train_kernel()
 	CInferenceMethod::update_train_kernel();
 
 	// create kernel matrix for latent features
-	m_kernel->cleanup();
 	m_kernel->init(m_latent_features, m_latent_features);
 	m_kuu=m_kernel->get_kernel_matrix();
 
 	// create kernel matrix for latent and training features
-	m_kernel->cleanup();
 	m_kernel->init(m_latent_features, m_features);
 	m_ktru=m_kernel->get_kernel_matrix();
 }
@@ -457,8 +455,6 @@ SGVector<float64_t> CFITCInferenceMethod::get_derivative_wrt_kernel(
 			m_kernel->init(m_latent_features, m_features);
 			deriv_tru=m_kernel->get_parameter_gradient(param, i);
 		}
-
-		m_kernel->cleanup();
 
 		// create eigen representation of derivatives
 		Map<VectorXd> ddiagKi(deriv_trtr.vector, deriv_trtr.vlen);

--- a/src/shogun/machine/gp/InferenceMethod.cpp
+++ b/src/shogun/machine/gp/InferenceMethod.cpp
@@ -278,7 +278,6 @@ void CInferenceMethod::check_members() const
 
 void CInferenceMethod::update_train_kernel()
 {
-	m_kernel->cleanup();
 	m_kernel->init(m_features, m_features);
 	m_ktrtr=m_kernel->get_kernel_matrix();
 }

--- a/src/shogun/regression/GaussianProcessRegression.cpp
+++ b/src/shogun/regression/GaussianProcessRegression.cpp
@@ -103,7 +103,8 @@ bool CGaussianProcessRegression::train_machine(CFeatures* data)
 	}
 
 	// perform inference
-	m_method->update();
+	if (m_method->update_parameter_hash())
+		m_method->update();
 
 	return true;
 }


### PR DESCRIPTION
- Minor fixes in GPs notebook
- Removed unnecessary kernel->cleanup() calls
- Increased defauld maximum number of sweeps in EP (this also fixes warning in GPs notebook)
- Update hash of the parameters, when we call machine->train()
