### PR TITLE
prevents travis failure when mldata is in flaky state

### DIFF
--- a/examples/undocumented/libshogun/library_mldatahdf5.cpp
+++ b/examples/undocumented/libshogun/library_mldatahdf5.cpp
@@ -12,7 +12,17 @@ int main(int argc, char** argv)
 {
 	init_shogun_with_defaults();
 #if defined(HAVE_HDF5) && defined( HAVE_CURL)
-	CMLDataHDF5File* hdf = new CMLDataHDF5File((char *)"australian", "/data/data");
+	CMLDataHDF5File* hdf = NULL;
+	try
+	{
+		hdf = new CMLDataHDF5File((char *)"australian", "/data/data");
+	}
+	catch (ShogunException& e)
+	{
+		SG_UNREF(hdf);
+		exit_shogun();
+		return 0;
+	}
 	float64_t* mat=NULL;
 	int32_t num_feat;
 	int32_t num_vec;

--- a/src/shogun/io/MLDataHDF5File.cpp
+++ b/src/shogun/io/MLDataHDF5File.cpp
@@ -85,7 +85,7 @@ CMLDataHDF5File::CMLDataHDF5File(char* data_name,
 	h5file = H5Fopen(fname, H5F_ACC_RDONLY, H5P_DEFAULT);
 
 	if (h5file<0)
-		SG_SWARNING("Could not open data repository '%s'\n", data_name)
+		SG_ERROR("Could not open data repository '%s'\n", data_name)
 }
 
 CMLDataHDF5File::~CMLDataHDF5File()


### PR DESCRIPTION
- prevents travis failure when mldata is in flaky state. solves #1924
