### PR TITLE
add streaming mmd, refactor linear time mmd

### DIFF
--- a/src/interfaces/modular/Statistics.i
+++ b/src/interfaces/modular/Statistics.i
@@ -12,6 +12,7 @@
 %rename(IndependenceTest) CIndependenceTest;
 %rename(TwoSampleTest) CTwoSampleTest;
 %rename(KernelTwoSampleTest) CKernelTwoSampleTest;
+%rename(StreamingMMD) CStreamingMMD;
 %rename(LinearTimeMMD) CLinearTimeMMD;
 %rename(QuadraticTimeMMD) CQuadraticTimeMMD;
 %rename(KernelIndependenceTest) CKernelIndependenceTest;
@@ -31,6 +32,7 @@
 %include <shogun/statistics/IndependenceTest.h>
 %include <shogun/statistics/TwoSampleTest.h>
 %include <shogun/statistics/KernelTwoSampleTest.h>
+%include <shogun/statistics/StreamingMMD.h>
 %include <shogun/statistics/LinearTimeMMD.h>
 %include <shogun/statistics/QuadraticTimeMMD.h>
 %include <shogun/statistics/KernelIndependenceTest.h>

--- a/src/interfaces/modular/Statistics_includes.i
+++ b/src/interfaces/modular/Statistics_includes.i
@@ -3,6 +3,7 @@
  #include <shogun/statistics/IndependenceTest.h>
  #include <shogun/statistics/TwoSampleTest.h>
  #include <shogun/statistics/KernelTwoSampleTest.h>
+ #include <shogun/statistics/StreamingMMD.h>
  #include <shogun/statistics/LinearTimeMMD.h>
  #include <shogun/statistics/QuadraticTimeMMD.h>
  #include <shogun/statistics/KernelIndependenceTest.h>

--- a/src/shogun/statistics/LinearTimeMMD.cpp
+++ b/src/shogun/statistics/LinearTimeMMD.cpp
@@ -1,10 +1,32 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2012-2013 Heiko Strathmann
+ * Written (w) 2014 Soumyajit De
+ * All rights reserved.
  *
- * Written (W) 2012-2013 Heiko Strathmann
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
  */
 
 #include <shogun/statistics/LinearTimeMMD.h>
@@ -19,50 +41,76 @@
 
 using namespace shogun;
 
-CLinearTimeMMD::CLinearTimeMMD() :
-		CKernelTwoSampleTest()
+CLinearTimeMMD::CLinearTimeMMD() : CStreamingMMD()
 {
-	init();
 }
 
 CLinearTimeMMD::CLinearTimeMMD(CKernel* kernel, CStreamingFeatures* p,
-		CStreamingFeatures* q, index_t m, index_t blocksize) :
-		CKernelTwoSampleTest(kernel, NULL, m)
+		CStreamingFeatures* q, index_t m, index_t blocksize)
+	: CStreamingMMD(kernel, p, q, m, blocksize)
 {
-	init();
-
-	m_streaming_p=p;
-	SG_REF(m_streaming_p);
-
-	m_streaming_q=q;
-	SG_REF(m_streaming_q);
-
-	m_blocksize=blocksize;
 }
 
 CLinearTimeMMD::~CLinearTimeMMD()
 {
-	SG_UNREF(m_streaming_p);
-	SG_UNREF(m_streaming_q);
-
-	/* m_kernel is SG_UNREFed in base desctructor */
 }
 
-void CLinearTimeMMD::init()
+void CLinearTimeMMD::compute_squared_mmd(CKernel* kernel, CList* data,
+		SGVector<float64_t>& current, SGVector<float64_t>& pp,
+		SGVector<float64_t>& qq, SGVector<float64_t>& pq,
+		SGVector<float64_t>& qp, index_t num_this_run)
 {
-	SG_ADD((CSGObject**)&m_streaming_p, "streaming_p", "Streaming features p",
-				MS_NOT_AVAILABLE);
-	SG_ADD((CSGObject**)&m_streaming_q, "streaming_q", "Streaming features p",
-				MS_NOT_AVAILABLE);
-	SG_ADD(&m_blocksize, "blocksize", "Number of elements processed at once",
-				MS_NOT_AVAILABLE);
-	SG_ADD(&m_simulate_h0, "simulate_h0", "Whether p and q are mixed",
-				MS_NOT_AVAILABLE);
+	SG_DEBUG("entering!\n");
 
-	m_streaming_p=NULL;
-	m_streaming_q=NULL;
-	m_blocksize=10000;
-	m_simulate_h0=false;
+	REQUIRE(data->get_num_elements()==4, "Wrong number of blocks!\n");
+
+	/* cast is safe the list is passed inside the class
+	 * features will be SG_REF'ed once again by these get methods */
+	CFeatures* p1=(CFeatures*)data->get_first_element();
+	CFeatures* p2=(CFeatures*)data->get_next_element();
+	CFeatures* q1=(CFeatures*)data->get_next_element();
+	CFeatures* q2=(CFeatures*)data->get_next_element();
+
+	SG_DEBUG("computing MMD values for current kernel!\n");
+
+	/* compute kernel matrix diagonals */
+	kernel->init(p1, p2);
+	kernel->get_kernel_diagonal(pp);
+
+	kernel->init(q1, q2);
+	kernel->get_kernel_diagonal(qq);
+
+	kernel->init(p1, q2);
+	kernel->get_kernel_diagonal(pq);
+
+	kernel->init(q1, p2);
+	kernel->get_kernel_diagonal(qp);
+
+	/* cleanup */
+	SG_UNREF(p1);
+	SG_UNREF(p2);
+	SG_UNREF(q1);
+	SG_UNREF(q2);
+
+	/* compute sum of current h terms for current kernel */
+
+	for (index_t i=0; i<num_this_run; ++i)
+		current[i]=pp[i]+qq[i]-pq[i]-qp[i];
+
+	SG_DEBUG("leaving!\n");
+}
+
+SGVector<float64_t> CLinearTimeMMD::compute_squared_mmd(CKernel* kernel,
+		CList* data, index_t num_this_run)
+{
+	/* wrapper method used for convenience for using preallocated memory */
+	SGVector<float64_t> current(num_this_run);
+	SGVector<float64_t> pp(num_this_run);
+	SGVector<float64_t> qq(num_this_run);
+	SGVector<float64_t> pq(num_this_run);
+	SGVector<float64_t> qp(num_this_run);
+	compute_squared_mmd(kernel, data, current, pp, qq, pq, qp, num_this_run);
+	return current;
 }
 
 void CLinearTimeMMD::compute_statistic_and_variance(
@@ -113,7 +161,6 @@ void CLinearTimeMMD::compute_statistic_and_variance(
 			 variance.vlen, num_kernels);
 
 	/* temp variable in the algorithm */
-	float64_t current;
 	float64_t delta;
 
 	/* initialise statistic and variance since they are cumulative */
@@ -134,56 +181,8 @@ void CLinearTimeMMD::compute_statistic_and_variance(
 		SG_DEBUG("processing %d more examples. %d so far processed. Blocksize "
 				"is %d\n", num_this_run, num_examples_processed, m_blocksize);
 
-		/* stream data from both distributions */
-		CFeatures* p1=m_streaming_p->get_streamed_features(num_this_run);
-		CFeatures* p2=m_streaming_p->get_streamed_features(num_this_run);
-		CFeatures* q1=m_streaming_q->get_streamed_features(num_this_run);
-		CFeatures* q2=m_streaming_q->get_streamed_features(num_this_run);
-
-		/* check whether h0 should be simulated and permute if so */
-		if (m_simulate_h0)
-		{
-			/* create merged copy of all feature instances to permute */
-			CList* list=new CList();
-			list->append_element(p2);
-			list->append_element(q1);
-			list->append_element(q2);
-			CFeatures* merged=p1->create_merged_copy(list);
-			SG_UNREF(list);
-
-			/* permute */
-			SGVector<index_t> inds(merged->get_num_vectors());
-			inds.range_fill();
-			inds.permute();
-			merged->add_subset(inds);
-
-			/* copy back, replacing old features */
-			SG_UNREF(p1);
-			SG_UNREF(p2);
-			SG_UNREF(q1);
-			SG_UNREF(q2);
-
-			SGVector<index_t> copy(num_this_run);
-			copy.range_fill();
-			p1=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			p2=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			q1=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			q2=merged->copy_subset(copy);
-
-			/* clean up and note that copy_subset does a SG_REF */
-			SG_UNREF(merged);
-		}
-		else
-		{
-			/* reference produced features (only if copy_subset was not used) */
-			SG_REF(p1);
-			SG_REF(p2);
-			SG_REF(q1);
-			SG_REF(q2);
-		}
+		/* stream 2 data blocks from each distribution */
+		CList* data=stream_data_blocks(2, num_this_run);
 
 		/* if multiple kernels are used, compute all of them on streamed data,
 		 * if multiple kernels flag is false, the above loop will be executed
@@ -193,40 +192,29 @@ void CLinearTimeMMD::compute_statistic_and_variance(
 			SG_DEBUG("using multiple kernels\n");
 
 		/* iterate through all kernels for this data */
+
 		for (index_t i=0; i<num_kernels; ++i)
 		{
 			/* if multiple kernels should be computed, set next kernel */
 			if (multiple_kernels)
 				kernel=((CCombinedKernel*)m_kernel)->get_kernel(i);
 
-			/* compute kernel matrix diagonals */
-			kernel->init(p1, p2);
-			SGVector<float64_t> pp=kernel->get_kernel_diagonal();
-
-			kernel->init(q1, q2);
-			SGVector<float64_t> qq=kernel->get_kernel_diagonal();
-
-			kernel->init(p1, q2);
-			SGVector<float64_t> pq=kernel->get_kernel_diagonal();
-
-			kernel->init(q1, p2);
-			SGVector<float64_t> qp=kernel->get_kernel_diagonal();
+			/* compute linear time MMD values */
+			SGVector<float64_t> current=compute_squared_mmd(kernel, data,
+					num_this_run);
 
 			/* single variances for all kernels. Update mean and variance
 			 * using Knuth's online variance algorithm.
 			 * C.f. for example Wikipedia */
 			for (index_t j=0; j<num_this_run; ++j)
 			{
-				/* compute sum of current h terms for current kernel */
-				current=pp[j]+qq[j]-pq[j]-qp[j];
-
 				/* D. Knuth's online variance algorithm for current kernel */
-				delta=current-statistic[i];
+				delta=current[j]-statistic[i];
 				statistic[i]+=delta/term_counters[i]++;
-				variance[i]+=delta*(current-statistic[i]);
+				variance[i]+=delta*(current[j]-statistic[i]);
 
 				SG_DEBUG("burst: current=%f, delta=%f, statistic=%f, "
-						"variance=%f, kernel_idx=%d\n", current, delta,
+						"variance=%f, kernel_idx=%d\n", current[j], delta,
 						statistic[i], variance[i], i);
 			}
 
@@ -234,11 +222,8 @@ void CLinearTimeMMD::compute_statistic_and_variance(
 				SG_UNREF(kernel);
 		}
 
-		/* clean up streamed data */
-		SG_UNREF(p1);
-		SG_UNREF(p2);
-		SG_UNREF(q1);
-		SG_UNREF(q2);
+		/* clean up streamed data, this frees the feature objects  */
+		SG_UNREF(data);
 
 		/* add number of processed examples for this run */
 		num_examples_processed+=num_this_run;
@@ -340,80 +325,36 @@ void CLinearTimeMMD::compute_statistic_and_Q(
 		SG_DEBUG("processing %d more examples. %d so far processed. Blocksize "
 				"is %d\n", num_this_run, num_examples_processed, m_blocksize);
 
-		/* stream data from both distributions */
-		CFeatures* p1a=m_streaming_p->get_streamed_features(num_this_run);
-		CFeatures* p1b=m_streaming_p->get_streamed_features(num_this_run);
-		CFeatures* p2a=m_streaming_p->get_streamed_features(num_this_run);
-		CFeatures* p2b=m_streaming_p->get_streamed_features(num_this_run);
-		CFeatures* q1a=m_streaming_q->get_streamed_features(num_this_run);
-		CFeatures* q1b=m_streaming_q->get_streamed_features(num_this_run);
-		CFeatures* q2a=m_streaming_q->get_streamed_features(num_this_run);
-		CFeatures* q2b=m_streaming_q->get_streamed_features(num_this_run);
+		/* stream 4 data blocks from each distribution */
+		CList* data=stream_data_blocks(4, num_this_run);
 
-		/* check whether h0 should be simulated and permute if so */
-		if (m_simulate_h0)
+		/* create two sets of data, a and b, from alternative blocks */
+		CList* data_a=new CList(true);
+		CList* data_b=new CList(true);
+
+		/* take care of refcounts */
+		int32_t num_elements=data->get_num_elements();
+		CFeatures* current=(CFeatures*)data->get_first_element();
+		data_a->append_element(current);
+		SG_UNREF(current);
+		current=(CFeatures*)data->get_next_element();
+		data_b->append_element(current);
+		SG_UNREF(current);
+		num_elements-=2;
+		/* loop counter is safe since num_elements can only be even */
+		while (num_elements)
 		{
-			/* create merged copy of all feature instances to permute */
-			CList* list=new CList();
-			list->append_element(p1b);
-			list->append_element(p2a);
-			list->append_element(p2b);
-			list->append_element(q1a);
-			list->append_element(q1b);
-			list->append_element(q2a);
-			list->append_element(q2b);
-			CFeatures* merged=p1a->create_merged_copy(list);
-			SG_UNREF(list);
-
-			/* permute */
-			SGVector<index_t> inds(merged->get_num_vectors());
-			inds.range_fill();
-			inds.permute();
-			merged->add_subset(inds);
-
-			/* copy back, replacing old features */
-			SG_UNREF(p1a);
-			SG_UNREF(p1b);
-			SG_UNREF(p2a);
-			SG_UNREF(p2b);
-			SG_UNREF(q1a);
-			SG_UNREF(q1b);
-			SG_UNREF(q2a);
-			SG_UNREF(q2b);
-
-			SGVector<index_t> copy(num_this_run);
-			copy.range_fill();
-			p1a=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			p1b=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			p2a=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			p2b=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			q1a=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			q1b=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			q2a=merged->copy_subset(copy);
-			copy.add(num_this_run);
-			q2b=merged->copy_subset(copy);
-
-			/* clean up and note that copy_subset does a SG_REF */
-			SG_UNREF(merged);
+			current=(CFeatures*)data->get_next_element();
+			data_a->append_element(current);
+			SG_UNREF(current);
+			current=(CFeatures*)data->get_next_element();
+			data_b->append_element(current);
+			SG_UNREF(current);
+			num_elements-=2;
 		}
-		else
-		{
-			/* reference the produced features (only if copy subset was not used) */
-			SG_REF(p1a);
-			SG_REF(p1b);
-			SG_REF(p2a);
-			SG_REF(p2b);
-			SG_REF(q1a);
-			SG_REF(q1b);
-			SG_REF(q2a);
-			SG_REF(q2b);
-		}
+		/* safely unref previous list of data, decreases refcounts of features
+		 * but doesn't delete them */
+		SG_UNREF(data);
 
 		/* now for each of these streamed data instances, iterate through all
 		 * kernels and update Q matrix while also computing MMD statistic */
@@ -433,32 +374,15 @@ void CLinearTimeMMD::compute_statistic_and_Q(
 		for (index_t i=0; i<num_kernels; ++i)
 		{
 			/* compute all necessary 8 h-vectors for this burst.
-			 * h_delta-terms for each kernel, expression 7 of NIPS paper
-			 * first kernel */
+			 * h_delta-terms for each kernel, expression 7 of NIPS paper */
 
 			/* first kernel, a-part */
-			kernel_i->init(p1a, p2a);
-			pp=kernel_i->get_kernel_diagonal(pp);
-			kernel_i->init(q1a, q2a);
-			qq=kernel_i->get_kernel_diagonal(qq);
-			kernel_i->init(p1a, q2a);
-			pq=kernel_i->get_kernel_diagonal(pq);
-			kernel_i->init(q1a, p2a);
-			qp=kernel_i->get_kernel_diagonal(qp);
-			for (index_t it=0; it<num_this_run; ++it)
-				h_i_a[it]=pp[it]+qq[it]-pq[it]-qp[it];
+			compute_squared_mmd(kernel_i, data_a, h_i_a, pp, qq, pq, qp,
+					num_this_run);
 
 			/* first kernel, b-part */
-			kernel_i->init(p1b, p2b);
-			pp=kernel_i->get_kernel_diagonal(pp);
-			kernel_i->init(q1b, q2b);
-			qq=kernel_i->get_kernel_diagonal(qq);
-			kernel_i->init(p1b, q2b);
-			pq=kernel_i->get_kernel_diagonal(pq);
-			kernel_i->init(q1b, p2b);
-			qp=kernel_i->get_kernel_diagonal(qp);
-			for (index_t it=0; it<num_this_run; ++it)
-				h_i_b[it]=pp[it]+qq[it]-pq[it]-qp[it];
+			compute_squared_mmd(kernel_i, data_b, h_i_b, pp, qq, pq, qp,
+					num_this_run);
 
 			/* iterate through j, but use symmetry in order to save half of the
 			 * computations */
@@ -466,32 +390,15 @@ void CLinearTimeMMD::compute_statistic_and_Q(
 			for (index_t j=0; j<=i; ++j)
 			{
 				/* compute all necessary 8 h-vectors for this burst.
-				 * h_delta-terms for each kernel, expression 7 of NIPS paper
-				 * second kernel */
+				 * h_delta-terms for each kernel, expression 7 of NIPS paper */
 
 				/* second kernel, a-part */
-				kernel_j->init(p1a, p2a);
-				pp=kernel_j->get_kernel_diagonal(pp);
-				kernel_j->init(q1a, q2a);
-				qq=kernel_j->get_kernel_diagonal(qq);
-				kernel_j->init(p1a, q2a);
-				pq=kernel_j->get_kernel_diagonal(pq);
-				kernel_j->init(q1a, p2a);
-				qp=kernel_j->get_kernel_diagonal(qp);
-				for (index_t it=0; it<num_this_run; ++it)
-					h_j_a[it]=pp[it]+qq[it]-pq[it]-qp[it];
+				compute_squared_mmd(kernel_j, data_a, h_j_a, pp, qq, pq, qp,
+						num_this_run);
 
 				/* second kernel, b-part */
-				kernel_j->init(p1b, p2b);
-				pp=kernel_j->get_kernel_diagonal(pp);
-				kernel_j->init(q1b, q2b);
-				qq=kernel_j->get_kernel_diagonal(qq);
-				kernel_j->init(p1b, q2b);
-				pq=kernel_j->get_kernel_diagonal(pq);
-				kernel_j->init(q1b, p2b);
-				qp=kernel_j->get_kernel_diagonal(qp);
-				for (index_t it=0; it<num_this_run; ++it)
-					h_j_b[it]=pp[it]+qq[it]-pq[it]-qp[it];
+				compute_squared_mmd(kernel_j, data_b, h_j_b, pp, qq, pq, qp,
+						num_this_run);
 
 				float64_t term;
 				for (index_t it=0; it<num_this_run; ++it)
@@ -532,14 +439,8 @@ void CLinearTimeMMD::compute_statistic_and_Q(
 		}
 
 		/* clean up streamed data */
-		SG_UNREF(p1a);
-		SG_UNREF(p1b);
-		SG_UNREF(p2a);
-		SG_UNREF(p2b);
-		SG_UNREF(q1a);
-		SG_UNREF(q1b);
-		SG_UNREF(q2a);
-		SG_UNREF(q2b);
+		SG_UNREF(data_a);
+		SG_UNREF(data_b);
 
 		/* add number of processed examples for this run */
 		num_examples_processed+=num_this_run;
@@ -553,166 +454,5 @@ void CLinearTimeMMD::compute_statistic_and_Q(
 			num_examples_processed);
 
 	SG_DEBUG("leaving!\n")
-}
-
-float64_t CLinearTimeMMD::compute_statistic()
-{
-	/* use wrapper method and compute for single kernel */
-	SGVector<float64_t> statistic;
-	SGVector<float64_t> variance;
-	compute_statistic_and_variance(statistic, variance, false);
-
-	return statistic[0];
-}
-
-SGVector<float64_t> CLinearTimeMMD::compute_statistic(
-		bool multiple_kernels)
-{
-	/* make sure multiple_kernels flag is used only with a combined kernel */
-	REQUIRE(!multiple_kernels || m_kernel->get_kernel_type()==K_COMBINED,
-			"multiple kernels specified, but underlying kernel is not of type "
-			"K_COMBINED\n");
-
-	SGVector<float64_t> statistic;
-	SGVector<float64_t> variance;
-	compute_statistic_and_variance(statistic, variance, multiple_kernels);
-
-	return statistic;
-}
-
-float64_t CLinearTimeMMD::compute_variance_estimate()
-{
-	/* use wrapper method and compute for single kernel */
-	SGVector<float64_t> statistic;
-	SGVector<float64_t> variance;
-	compute_statistic_and_variance(statistic, variance, false);
-
-	return variance[0];
-}
-
-float64_t CLinearTimeMMD::compute_p_value(float64_t statistic)
-{
-	float64_t result=0;
-
-	switch (m_null_approximation_method)
-	{
-	case MMD1_GAUSSIAN:
-		{
-			/* compute variance and use to estimate Gaussian distribution */
-			float64_t std_dev=CMath::sqrt(compute_variance_estimate());
-			result=1.0-CStatistics::normal_cdf(statistic, std_dev);
-		}
-		break;
-
-	default:
-		/* sampling null is handled here */
-		result=CKernelTwoSampleTest::compute_p_value(statistic);
-		break;
-	}
-
-	return result;
-}
-
-float64_t CLinearTimeMMD::compute_threshold(float64_t alpha)
-{
-	float64_t result=0;
-
-	switch (m_null_approximation_method)
-	{
-	case MMD1_GAUSSIAN:
-		{
-			/* compute variance and use to estimate Gaussian distribution */
-			float64_t std_dev=CMath::sqrt(compute_variance_estimate());
-			result=1.0-CStatistics::inverse_normal_cdf(1-alpha, 0, std_dev);
-		}
-		break;
-
-	default:
-		/* sampling null is handled here */
-		result=CKernelTwoSampleTest::compute_threshold(alpha);
-		break;
-	}
-
-	return result;
-}
-
-float64_t CLinearTimeMMD::perform_test()
-{
-	float64_t result=0;
-
-	switch (m_null_approximation_method)
-	{
-	case MMD1_GAUSSIAN:
-		{
-			/* compute variance and use to estimate Gaussian distribution, use
-			 * wrapper method and compute for single kernel */
-			SGVector<float64_t> statistic;
-			SGVector<float64_t> variance;
-			compute_statistic_and_variance(statistic, variance, false);
-
-			/* estimate Gaussian distribution */
-			result=1.0-CStatistics::normal_cdf(statistic[0],
-					CMath::sqrt(variance[0]));
-		}
-		break;
-
-	default:
-		/* sampling null can be done separately in superclass */
-		result=CHypothesisTest::perform_test();
-		break;
-	}
-
-	return result;
-}
-
-SGVector<float64_t> CLinearTimeMMD::sample_null()
-{
-	SGVector<float64_t> samples(m_num_null_samples);
-
-	/* instead of permutating samples, just samples new data all the time. */
-	CStreamingFeatures* p=m_streaming_p;
-	CStreamingFeatures* q=m_streaming_q;
-	SG_REF(p);
-	SG_REF(q);
-
-	bool old=m_simulate_h0;
-	set_simulate_h0(true);
-	for (index_t i=0; i<m_num_null_samples; ++i)
-	{
-		/* compute statistic for this permutation of mixed samples */
-		samples[i]=compute_statistic();
-	}
-	set_simulate_h0(old);
-	m_streaming_p=p;
-	m_streaming_q=q;
-	SG_UNREF(p);
-	SG_UNREF(q);
-
-	return samples;
-}
-
-void CLinearTimeMMD::set_p_and_q(CFeatures* p_and_q)
-{
-	SG_ERROR("Method not implemented since linear time mmd is based on "
-			"streaming features\n");
-}
-
-CFeatures* CLinearTimeMMD::get_p_and_q()
-{
-	SG_ERROR("Method not implemented since linear time mmd is based on "
-			"streaming features\n");
-	return NULL;
-}
-
-CStreamingFeatures* CLinearTimeMMD::get_streaming_p()
-{
-	SG_REF(m_streaming_p);
-	return m_streaming_p;
-}
-
-CStreamingFeatures* CLinearTimeMMD::get_streaming_q()
-{
-	SG_REF(m_streaming_q);
-	return m_streaming_q;
 }
 

--- a/src/shogun/statistics/LinearTimeMMD.h
+++ b/src/shogun/statistics/LinearTimeMMD.h
@@ -1,18 +1,38 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2012-2013 Heiko Strathmann
+ * Written (w) 2014 Soumyajit De
+ * All rights reserved.
  *
- * Written (W) 2012-2013 Heiko Strathmann
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
  */
 
-#ifndef __LINEARTIMEMMD_H_
-#define __LINEARTIMEMMD_H_
+#ifndef LINEAR_TIME_MMD_H_
+#define LINEAR_TIME_MMD_H_
 
-#include <shogun/statistics/KernelTwoSampleTest.h>
-#include <shogun/kernel/Kernel.h>
-#include <shogun/lib/external/libqp.h>
+#include <shogun/statistics/StreamingMMD.h>
 
 namespace shogun
 {
@@ -21,23 +41,10 @@ class CStreamingFeatures;
 class CFeatures;
 
 /** @brief This class implements the linear time Maximum Mean Statistic as
- * described in [1]. This statistic is in particular suitable for streaming
- * data. Therefore, only streaming features may be passed. To process other
- * feature types, construct streaming features from these (see constructor
- * documentations). A blocksize has to be specified that determines how many
- * examples are processed at once. This should be set as large as available
- * memory allows to ensure faster computations.
- *
- * The MMD is the distance of two probability distributions \f$p\f$ and \f$q\f$
- * in a RKHS.
- * \f[
- * \text{MMD}[\mathcal{F},p,q]^2=\textbf{E}_{x,x'}\left[ k(x,x')\right]-
- * 2\textbf{E}_{x,y}\left[ k(x,y)\right]
- * +\textbf{E}_{y,y'}\left[ k(y,y')\right]=||\mu_p - \mu_q||^2_\mathcal{F}
- * \f]
+ * described in [1] for streaming data (see CStreamingMMD for description).
  *
  * Given two sets of samples \f$\{x_i\}_{i=1}^m\sim p\f$ and
- * \f$\{y_i\}_{i=1}^n\sim q\f$
+ * \f$\{y_i\}_{i=1}^m\sim q\f$
  * the (unbiased) statistic is computed as
  * \f[
  * \text{MMD}_l^2[\mathcal{F},X,Y]=\frac{1}{m_2}\sum_{i=1}^{m_2}
@@ -50,37 +57,21 @@ class CFeatures;
  * \f]
  * and \f$ m_2=\lfloor\frac{m}{2} \rfloor\f$.
  *
- * Along with the statistic comes a method to compute a p-value based on a
- * Gaussian approximation of the null-distribution which is also possible in
- * linear time and constant space. Sampling from null is also possible (no
- * permutations but new examples will be used here).
- * If unsure which one to use, sampling with 250 iterations always is
- * correct (but slow). When the sample size is large (>1000) at least,
- * the Gaussian approximation is an accurate and much faster choice.
- *
- * To choose, use set_null_approximation_method() and choose from
- *
- * MMD1_GAUSSIAN: Approximates the null-distribution with a Gaussian. Only use
- * from at least 1000 samples. If using, check if type I error equals the
- * desired value.
- *
- * PERMUTATION: For permuting available samples to sample null-distribution
- *
- * For kernel selection see CMMDKernelSelection.
- *
- * [1]: Gretton, A., Borgwardt, K. M., Rasch, M. J., Schoelkopf, B., & Smola, A. (2012).
- * A Kernel Two-Sample Test. Journal of Machine Learning Research, 13, 671-721.
+ * [1]: Gretton, A., Borgwardt, K. M., Rasch, M. J., Schoelkopf, B.,
+ * & Smola, A. (2012). A Kernel Two-Sample Test. Journal of Machine Learning
+ * Research, 13, 671-721.
  */
-class CLinearTimeMMD: public CKernelTwoSampleTest
+class CLinearTimeMMD: public CStreamingMMD
 {
 public:
+	/** default constructor */
 	CLinearTimeMMD();
 
 	/** Constructor.
 	 * @param kernel kernel to use
 	 * @param p streaming features p to use
 	 * @param q streaming features q to use
-	 * @param m index of first sample of q
+	 * @param m number of samples from each distribution
 	 * @param blocksize size of examples that are processed at once when
 	 * computing statistic/threshold. If larger than m/2, all examples will be
 	 * processed at once. Memory consumption increased linearly in the
@@ -89,83 +80,10 @@ public:
 	CLinearTimeMMD(CKernel* kernel, CStreamingFeatures* p,
 			CStreamingFeatures* q, index_t m, index_t blocksize=10000);
 
+	/** destructor */
 	virtual ~CLinearTimeMMD();
 
-	/** Computes the squared linear time MMD for the current data. This is an
-	 * unbiased estimate.
-	 *
-	 * Note that the underlying streaming feature parser has to be started
-	 * before this is called. Otherwise deadlock.
-	 *
-	 * @return squared linear time MMD
-	 */
-	virtual float64_t compute_statistic();
-
-	/** Same as compute_statistic(), but with the possibility to perform on
-	 * multiple kernels at once
-	 *
-	 * @param multiple_kernels if true, and underlying kernel is K_COMBINED,
-	 * method will be executed on all subkernels on the same data
-	 * @return vector of results for subkernels
-	 */
-	virtual SGVector<float64_t> compute_statistic(bool multiple_kernels);
-
-	/** computes a p-value based on current method for approximating the
-	 * null-distribution. The p-value is the 1-p quantile of the null-
-	 * distribution where the given statistic lies in.
-	 *
-	 * The method for computing the p-value can be set via
-	 * set_null_approximation_method().
-	 * Since the null- distribution is normal, a Gaussian approximation
-	 * is available.
-	 *
-	 * @param statistic statistic value to compute the p-value for
-	 * @return p-value parameter statistic is the (1-p) percentile of the
-	 * null distribution
-	 */
-	virtual float64_t compute_p_value(float64_t statistic);
-
-	/** Performs the complete two-sample test on current data and returns a
-	 * p-value.
-	 *
-	 * In case null distribution should be estimated with MMD1_GAUSSIAN,
-	 * statistic and p-value are computed in the same loop, which is more
-	 * efficient than first computing statistic and then computung p-values.
-	 *
-	 * In case of sampling null, superclass method is called.
-	 *
-	 * The method for computing the p-value can be set via
-	 * set_null_approximation_method().
-	 *
-	 * @return p-value such that computed statistic is the (1-p) quantile
-	 * of the estimated null distribution
-	 */
-	virtual float64_t perform_test();
-
-	/** computes a threshold based on current method for approximating the
-	 * null-distribution. The threshold is the value that a statistic has
-	 * to have in ordner to reject the null-hypothesis.
-	 *
-	 * The method for computing the p-value can be set via
-	 * set_null_approximation_method().
-	 * Since the null- distribution is normal, a Gaussian approximation
-	 * is available.
-	 *
-	 * @param alpha test level to reject null-hypothesis
-	 * @return threshold for statistics to reject null-hypothesis
-	 */
-	virtual float64_t compute_threshold(float64_t alpha);
-
-	/** computes a linear time estimate of the variance of the squared linear
-	 * time mmd, which may be used for an approximation of the null-distribution
-	 * The value is the variance of the vector of which the linear time MMD is
-	 * the mean.
-	 *
-	 * @return variance estimate
-	 */
-	virtual float64_t compute_variance_estimate();
-
-	/** Computes MMD and a linear time variance estimate.
+	/** Computes squared MMD and a variance estimate, in linear time.
 	 * If multiple_kernels is set to true, each subkernel is evaluated on the
 	 * same data.
 	 *
@@ -194,74 +112,45 @@ public:
 	virtual void compute_statistic_and_Q(
 			SGVector<float64_t>& statistic, SGMatrix<float64_t>& Q);
 
-	/** Mimics sampling null for the linear time MMD. However, samples are not
-	 * permutated but constantly streamed and then merged. Usually, this is not
-	 * necessary since there is the Gaussian approximation for the null
-	 * distribution. However, in certain cases this may fail and sampling the
-	 * null distribution might be numerically more stable.
-	 * Ovewrite superclass method that merges samples.
-	 *
-	 * @return vector of all statistics
-	 */
-	virtual SGVector<float64_t> sample_null();
-
-	/** Setter for the blocksize of examples to be processed at once
-	 * @param blocksize new blocksize to use
-	 */
-	void set_blocksize(index_t blocksize) { m_blocksize=blocksize; }
-
-	/** Not implemented for linear time MMD since it uses streaming feautres */
-	virtual void set_p_and_q(CFeatures* p_and_q);
-
-	/** Not implemented for linear time MMD since it uses streaming feautres */
-	virtual CFeatures* get_p_and_q();
-
-	/** Getter for streaming features of p distribution.
-	 * @return streaming features object for p distribution, SG_REF'ed
-	 */
-	virtual CStreamingFeatures* get_streaming_p();
-
-	/** Getter for streaming features of q distribution.
-	 * @return streaming features object for q distribution, SG_REF'ed
-	 */
-	virtual CStreamingFeatures* get_streaming_q();
-
 	/** returns the statistic type of this test statistic */
 	virtual EStatisticType get_statistic_type() const
 	{
 		return S_LINEAR_TIME_MMD;
 	}
 
-	/** @param simulate_h0 if true, samples from p and q will be mixed and
-	 * permuted
-	 */
-	inline void set_simulate_h0(bool simulate_h0) { m_simulate_h0=simulate_h0; }
-
-
+	/** @return the class name */
 	virtual const char* get_name() const
 	{
 		return "LinearTimeMMD";
 	}
 
-private:
-	void init();
-
 protected:
-	/** Streaming feature objects that are used instead of merged samples */
-	CStreamingFeatures* m_streaming_p;
+	/** method that computes the squared MMD in linear time (see class
+	 * description for the equation)
+	 *
+	 * @param kernel the kernel to be used for computing MMD. This will be
+	 * useful when multiple kernels are used
+	 * @param data the list of data on which kernels are computed. The order
+	 * of data in the list is \f$x,x',\cdots\sim p\f$ followed by
+	 * \f$y,y',\cdots\sim q\f$. It is assumed that detele_data flag is set
+	 * inside the list
+	 * @param num_this_run number of data points in current blocks
+	 * @return the MMD values (the h-vectors)
+	 */
+	 virtual SGVector<float64_t> compute_squared_mmd(CKernel* kernel,
+			 CList* data, index_t num_this_run);
 
-	/** Streaming feature objects that are used instead of merged samples*/
-	CStreamingFeatures* m_streaming_q;
+private:
+	/** helper method, same as compute_squared_mmd with an option to use
+	 * preallocated memory for faster processing */
+	void compute_squared_mmd(CKernel* kernel, CList* data,
+			SGVector<float64_t>& current, SGVector<float64_t>& pp,
+			SGVector<float64_t>& qq, SGVector<float64_t>& pq,
+			SGVector<float64_t>& qp, index_t num_this_run);
 
-	/** Number of examples processed at once, i.e. in one burst */
-	index_t m_blocksize;
-
-	/** If this is true, samples will be mixed between p and q in any method
-	 * that computes the statistic */
-	bool m_simulate_h0;
 };
 
 }
 
-#endif /* __LINEARTIMEMMD_H_ */
+#endif /* LINEAR_TIME_MMD_H_ */
 

--- a/src/shogun/statistics/StreamingMMD.cpp
+++ b/src/shogun/statistics/StreamingMMD.cpp
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2012-2013 Heiko Strathmann
+ * Written (w) 2014 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/statistics/StreamingMMD.h>
+#include <shogun/features/Features.h>
+#include <shogun/features/streaming/StreamingFeatures.h>
+#include <shogun/mathematics/Statistics.h>
+#include <shogun/lib/List.h>
+
+using namespace shogun;
+
+CStreamingMMD::CStreamingMMD() : CKernelTwoSampleTest()
+{
+	init();
+}
+
+CStreamingMMD::CStreamingMMD(CKernel* kernel, CStreamingFeatures* p,
+		CStreamingFeatures* q, index_t m, index_t blocksize) :
+		CKernelTwoSampleTest(kernel, NULL, m)
+{
+	init();
+
+	m_streaming_p=p;
+	SG_REF(m_streaming_p);
+
+	m_streaming_q=q;
+	SG_REF(m_streaming_q);
+
+	m_blocksize=blocksize;
+}
+
+CStreamingMMD::~CStreamingMMD()
+{
+	SG_UNREF(m_streaming_p);
+	SG_UNREF(m_streaming_q);
+
+	/* m_kernel is SG_UNREFed in base desctructor */
+}
+
+void CStreamingMMD::init()
+{
+	SG_ADD((CSGObject**)&m_streaming_p, "streaming_p", "Streaming features p",
+				MS_NOT_AVAILABLE);
+	SG_ADD((CSGObject**)&m_streaming_q, "streaming_q", "Streaming features p",
+				MS_NOT_AVAILABLE);
+	SG_ADD(&m_blocksize, "blocksize", "Number of elements processed at once",
+				MS_NOT_AVAILABLE);
+	SG_ADD(&m_simulate_h0, "simulate_h0", "Whether p and q are mixed",
+				MS_NOT_AVAILABLE);
+
+	m_streaming_p=NULL;
+	m_streaming_q=NULL;
+	m_blocksize=10000;
+	m_simulate_h0=false;
+}
+
+float64_t CStreamingMMD::compute_statistic()
+{
+	/* use wrapper method and compute for single kernel */
+	SGVector<float64_t> statistic;
+	SGVector<float64_t> variance;
+	compute_statistic_and_variance(statistic, variance, false);
+
+	return statistic[0];
+}
+
+SGVector<float64_t> CStreamingMMD::compute_statistic(bool multiple_kernels)
+{
+	/* make sure multiple_kernels flag is used only with a combined kernel */
+	REQUIRE(!multiple_kernels || m_kernel->get_kernel_type()==K_COMBINED,
+			"multiple kernels specified, but underlying kernel is not of type "
+			"K_COMBINED\n");
+
+	SGVector<float64_t> statistic;
+	SGVector<float64_t> variance;
+	compute_statistic_and_variance(statistic, variance, multiple_kernels);
+
+	return statistic;
+}
+
+float64_t CStreamingMMD::compute_variance_estimate()
+{
+	/* use wrapper method and compute for single kernel */
+	SGVector<float64_t> statistic;
+	SGVector<float64_t> variance;
+	compute_statistic_and_variance(statistic, variance, false);
+
+	return variance[0];
+}
+
+float64_t CStreamingMMD::compute_p_value(float64_t statistic)
+{
+	float64_t result=0;
+
+	switch (m_null_approximation_method)
+	{
+	case MMD1_GAUSSIAN:
+		{
+			/* compute variance and use to estimate Gaussian distribution */
+			float64_t std_dev=CMath::sqrt(compute_variance_estimate());
+			result=1.0-CStatistics::normal_cdf(statistic, std_dev);
+		}
+		break;
+
+	default:
+		/* sampling null is handled here */
+		result=CKernelTwoSampleTest::compute_p_value(statistic);
+		break;
+	}
+
+	return result;
+}
+
+float64_t CStreamingMMD::compute_threshold(float64_t alpha)
+{
+	float64_t result=0;
+
+	switch (m_null_approximation_method)
+	{
+	case MMD1_GAUSSIAN:
+		{
+			/* compute variance and use to estimate Gaussian distribution */
+			float64_t std_dev=CMath::sqrt(compute_variance_estimate());
+			result=1.0-CStatistics::inverse_normal_cdf(1-alpha, 0, std_dev);
+		}
+		break;
+
+	default:
+		/* sampling null is handled here */
+		result=CKernelTwoSampleTest::compute_threshold(alpha);
+		break;
+	}
+
+	return result;
+}
+
+float64_t CStreamingMMD::perform_test()
+{
+	float64_t result=0;
+
+	switch (m_null_approximation_method)
+	{
+	case MMD1_GAUSSIAN:
+		{
+			/* compute variance and use to estimate Gaussian distribution, use
+			 * wrapper method and compute for single kernel */
+			SGVector<float64_t> statistic;
+			SGVector<float64_t> variance;
+			compute_statistic_and_variance(statistic, variance, false);
+
+			/* estimate Gaussian distribution */
+			result=1.0-CStatistics::normal_cdf(statistic[0],
+					CMath::sqrt(variance[0]));
+		}
+		break;
+
+	default:
+		/* sampling null can be done separately in superclass */
+		result=CHypothesisTest::perform_test();
+		break;
+	}
+
+	return result;
+}
+
+SGVector<float64_t> CStreamingMMD::sample_null()
+{
+	SGVector<float64_t> samples(m_num_null_samples);
+
+	/* instead of permutating samples, just samples new data all the time. */
+	CStreamingFeatures* p=m_streaming_p;
+	CStreamingFeatures* q=m_streaming_q;
+	SG_REF(p);
+	SG_REF(q);
+
+	bool old=m_simulate_h0;
+	set_simulate_h0(true);
+	for (index_t i=0; i<m_num_null_samples; ++i)
+	{
+		/* compute statistic for this permutation of mixed samples */
+		samples[i]=compute_statistic();
+	}
+	set_simulate_h0(old);
+	m_streaming_p=p;
+	m_streaming_q=q;
+	SG_UNREF(p);
+	SG_UNREF(q);
+
+	return samples;
+}
+
+CList* CStreamingMMD::stream_data_blocks(index_t num_blocks,
+		index_t num_this_run)
+{
+	SG_DEBUG("entering!\n");
+
+	/* the list of blocks of data to be returned, turning delete_data flag
+	 * on which SG_REFs the elements when appended or returned. */
+	CList* data=new CList(true);
+
+	SG_DEBUG("streaming %d blocks from p of blocksize %d!\n", num_blocks,
+			num_this_run);
+
+	/* stream data from p num_blocks of time*/
+	for (index_t i=0; i<num_blocks; ++i)
+	{
+		CFeatures* block=m_streaming_p->get_streamed_features(num_this_run);
+		data->append_element(block);
+	}
+
+	SG_DEBUG("streaming %d blocks from q of blocksize %d!\n", num_blocks,
+			num_this_run);
+
+	/* stream data from q num_blocks of time*/
+	for (index_t i=0; i<num_blocks; ++i)
+	{
+		CFeatures* block=m_streaming_q->get_streamed_features(num_this_run);
+		data->append_element(block);
+	}
+
+	/* check whether h0 should be simulated and permute if so */
+	if (m_simulate_h0)
+	{
+		/* create merged copy of all feature instances to permute */
+		SG_DEBUG("merging and premuting features!\n");
+
+		/* use the first element to merge rest of the data into */
+		CFeatures* merged=(CFeatures*)data->get_first_element();
+		data->delete_element();
+		merged=merged->create_merged_copy(data);
+
+		/* get rid of unnecessary feature objects */
+		data->delete_all_elements();
+
+		/* permute */
+		SGVector<index_t> inds(merged->get_num_vectors());
+		inds.range_fill();
+		inds.permute();
+		merged->add_subset(inds);
+
+		/* copy back */
+		SGVector<index_t> copy(num_this_run);
+		copy.range_fill();
+		for (index_t i=0; i<2*num_blocks; ++i)
+		{
+			CFeatures* current=merged->copy_subset(copy);
+			data->append_element(current);
+			/* SG_UNREF'ing since copy_subset does a SG_REF, this is
+			 * safe since the object is already SG_REF'ed inside the list */
+			SG_UNREF(current);
+
+			if (i<2*num_blocks-1)
+				copy.add(num_this_run);
+		}
+
+		/* clean up */
+		SG_UNREF(merged);
+	}
+
+	SG_REF(data);
+
+	SG_DEBUG("leaving!\n");
+	return data;
+}
+
+void CStreamingMMD::set_p_and_q(CFeatures* p_and_q)
+{
+	SG_ERROR("Method not implemented since linear time mmd is based on "
+			"streaming features\n");
+}
+
+CFeatures* CStreamingMMD::get_p_and_q()
+{
+	SG_ERROR("Method not implemented since linear time mmd is based on "
+			"streaming features\n");
+	return NULL;
+}
+
+CStreamingFeatures* CStreamingMMD::get_streaming_p()
+{
+	SG_REF(m_streaming_p);
+	return m_streaming_p;
+}
+
+CStreamingFeatures* CStreamingMMD::get_streaming_q()
+{
+	SG_REF(m_streaming_q);
+	return m_streaming_q;
+}
+

--- a/src/shogun/statistics/StreamingMMD.h
+++ b/src/shogun/statistics/StreamingMMD.h
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2012-2013 Heiko Strathmann
+ * Written (w) 2014 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef STREAMING_MMD_H_
+#define STREAMING_MMD_H_
+
+#include <shogun/statistics/KernelTwoSampleTest.h>
+
+namespace shogun
+{
+
+class CStreamingFeatures;
+class CFeatures;
+
+/** @brief Abstract base class that provides an interface for performing kernel
+ * two-sample test on streaming data using Maximum Mean Discrepancy (MMD) as
+ * the test statistic. The MMD is the distance of two probability distributions
+ * \f$p\f$ and \f$q\f$ in a RKHS (see [1] for formal description).
+ *
+ * \f[
+ * \text{MMD}[\mathcal{F},p,q]^2=\textbf{E}_{x,x'}\left[ k(x,x')\right]-
+ * 2\textbf{E}_{x,y}\left[ k(x,y)\right]
+ * +\textbf{E}_{y,y'}\left[ k(y,y')\right]=||\mu_p - \mu_q||^2_\mathcal{F}
+ * \f]
+ *
+ * where \f$x,x'\sim p\f$ and \f$y,y'\sim q\f$. The data has to be provided as
+ * streaming features, which are processed in blocks for a given blocksize.
+ * The blocksize determines how many examples are processed at once. A method
+ * for getting a specified number of blocks of data is provided which can
+ * optionally merge and permute the data within the current burst. The exact
+ * computation of kernel functions for MMD computation is abstract and has to
+ * be defined by its subclasses, which should return a vector of function
+ * values. Please note that for streaming MMD, the number of data points from
+ * both the distributions has to be equal.
+ *
+ * Along with the statistic comes a method to compute a p-value based on a
+ * Gaussian approximation of the null-distribution which is possible in
+ * linear time and constant space. Sampling from null is also possible (no
+ * permutations but new examples will be used here).
+ * If unsure which one to use, sampling with 250 iterations always is
+ * correct (but slow). When the sample size is large (>1000) at least,
+ * the Gaussian approximation is an accurate and much faster choice.
+ *
+ * To choose, use set_null_approximation_method() and choose from
+ *
+ * MMD1_GAUSSIAN: Approximates the null-distribution with a Gaussian. Only use
+ * from at least 1000 samples. If using, check if type I error equals the
+ * desired value.
+ *
+ * PERMUTATION: For permuting available samples to sample null-distribution.
+ *
+ * For kernel selection see CMMDKernelSelection.
+ *
+ * [1]: Gretton, A., Borgwardt, K. M., Rasch, M. J., Schoelkopf, B., &
+ * Smola, A. (2012). A Kernel Two-Sample Test. Journal of Machine Learning
+ * Research, 13, 671-721.
+ */
+class CStreamingMMD: public CKernelTwoSampleTest
+{
+public:
+	/** default constructor */
+	CStreamingMMD();
+
+	/** constructor.
+	 *
+	 * @param kernel kernel to use
+	 * @param p streaming features p to use
+	 * @param q streaming features q to use
+	 * @param m number of samples from each distribution
+	 * @param blocksize size of examples that are processed at once when
+	 * computing statistic/threshold.
+	 */
+	CStreamingMMD(CKernel* kernel, CStreamingFeatures* p,
+			CStreamingFeatures* q, index_t m, index_t blocksize=10000);
+
+	/** destructor */
+	virtual ~CStreamingMMD();
+
+	/** Computes the squared MMD for the current data. This is an unbiased
+	 * estimate. This method relies on compute_statistic_and_variance which
+	 * has to be defined in the subclasses
+	 *
+	 * Note that the underlying streaming feature parser has to be started
+	 * before this is called. Otherwise deadlock.
+	 *
+	 * @return squared MMD
+	 */
+	virtual float64_t compute_statistic();
+
+	/** Same as compute_statistic(), but with the possibility to perform on
+	 * multiple kernels at once
+	 *
+	 * @param multiple_kernels if true, and underlying kernel is K_COMBINED,
+	 * method will be executed on all subkernels on the same data
+	 * @return vector of results for subkernels
+	 */
+	virtual SGVector<float64_t> compute_statistic(bool multiple_kernels);
+
+	/** computes a p-value based on current method for approximating the
+	 * null-distribution. The p-value is the 1-p quantile of the null-
+	 * distribution where the given statistic lies in.
+	 *
+	 * The method for computing the p-value can be set via
+	 * set_null_approximation_method().
+	 * Since the null- distribution is normal, a Gaussian approximation
+	 * is available.
+	 *
+	 * @param statistic statistic value to compute the p-value for
+	 * @return p-value parameter statistic is the (1-p) percentile of the
+	 * null distribution
+	 */
+	virtual float64_t compute_p_value(float64_t statistic);
+
+	/** Performs the complete two-sample test on current data and returns a
+	 * p-value.
+	 *
+	 * In case null distribution should be estimated with MMD1_GAUSSIAN,
+	 * statistic and p-value are computed in the same loop, which is more
+	 * efficient than first computing statistic and then computung p-values.
+	 *
+	 * In case of sampling null, superclass method is called.
+	 *
+	 * The method for computing the p-value can be set via
+	 * set_null_approximation_method().
+	 *
+	 * @return p-value such that computed statistic is the (1-p) quantile
+	 * of the estimated null distribution
+	 */
+	virtual float64_t perform_test();
+
+	/** computes a threshold based on current method for approximating the
+	 * null-distribution. The threshold is the value that a statistic has
+	 * to have in ordner to reject the null-hypothesis.
+	 *
+	 * The method for computing the p-value can be set via
+	 * set_null_approximation_method().
+	 * Since the null- distribution is normal, a Gaussian approximation
+	 * is available.
+	 *
+	 * @param alpha test level to reject null-hypothesis
+	 * @return threshold for statistics to reject null-hypothesis
+	 */
+	virtual float64_t compute_threshold(float64_t alpha);
+
+	/** computes a linear time estimate of the variance of the squared mmd,
+	 * which may be used for an approximation of the null-distribution
+	 * The value is the variance of the vector of which the MMD is the mean.
+	 *
+	 * @return variance estimate
+	 */
+	virtual float64_t compute_variance_estimate();
+
+	/** Abstract method that computes MMD and a linear time variance estimate.
+	 * If multiple_kernels is set to true, each subkernel is evaluated on the
+	 * same data.
+	 *
+	 * @param statistic return parameter for statistic, vector with entry for
+	 * each kernel. May be allocated before but doesn not have to be
+	 *
+	 * @param variance return parameter for statistic, vector with entry for
+	 * each kernel. May be allocated before but doesn not have to be
+	 *
+	 * @param multiple_kernels optional flag, if set to true, it is assumed that
+	 * the underlying kernel is of type K_COMBINED. Then, the MMD is computed on
+	 * all subkernel separately rather than computing it on the combination.
+	 * This is used by kernel selection strategies that need to evaluate
+	 * multiple kernels on the same data. Since the linear time MMD works on
+	 * streaming data, one cannot simply compute MMD, change kernel since data
+	 * would be different for every kernel.
+	 */
+	virtual void compute_statistic_and_variance(
+			SGVector<float64_t>& statistic, SGVector<float64_t>& variance,
+			bool multiple_kernels=false)=0;
+
+	/** Same as compute_statistic_and_variance, but computes a linear time
+	 * estimate of the covariance of the multiple-kernel-MMD.
+	 * See [1] for details.
+	 */
+	virtual void compute_statistic_and_Q(
+			SGVector<float64_t>& statistic, SGMatrix<float64_t>& Q)=0;
+
+	/** Mimics sampling null for MMD. However, samples are not permutated but
+	 * constantly streamed and then merged. Usually, this is not necessary
+	 * since there is the Gaussian approximation for the null distribution.
+	 * However, in certain cases this may fail and sampling the null
+	 * distribution might be numerically more stable. Ovewrite superclass
+	 * method that merges samples.
+	 *
+	 * @return vector of all statistics
+	 */
+	virtual SGVector<float64_t> sample_null();
+
+	/** Setter for the blocksize of examples to be processed at once
+	 * @param blocksize new blocksize to use
+	 */
+	void set_blocksize(index_t blocksize)
+	{
+		m_blocksize=blocksize;
+	}
+
+	/** Streams num_blocks data from each distribution with blocks of size
+	 * num_this_run. If m_simulate_h0 is set, it merges the blocks together,
+	 * shuffles and redistributes between the blocks.
+	 *
+	 * @param num_blocks number of blocks to be streamed from each distribution
+	 * @param num_this_run number of data points to be streamed for one block
+	 * @return an ordered list of blocks of data. The order in the
+	 * list is \f$x,x',\cdots\sim p\f$ followed by \f$y,y',\cdots\sim q\f$.
+	 * The features inside the list are SG_REF'ed and delete_data is set in the
+	 * list, which will destroy the at CList's destructor call
+	 */
+	CList* stream_data_blocks(index_t num_blocks, index_t num_this_run);
+
+	/** Not implemented for streaming MMD since it uses streaming feautres */
+	virtual void set_p_and_q(CFeatures* p_and_q);
+
+	/** Not implemented for streaming MMD since it uses streaming feautres */
+	virtual CFeatures* get_p_and_q();
+
+	/** Getter for streaming features of p distribution.
+	 * @return streaming features object for p distribution, SG_REF'ed
+	 */
+	virtual CStreamingFeatures* get_streaming_p();
+
+	/** Getter for streaming features of q distribution.
+	 * @return streaming features object for q distribution, SG_REF'ed
+	 */
+	virtual CStreamingFeatures* get_streaming_q();
+
+	/** @param simulate_h0 if true, samples from p and q will be mixed and
+	 * permuted
+	 */
+	inline void set_simulate_h0(bool simulate_h0)
+	{
+		m_simulate_h0=simulate_h0;
+	}
+
+	/** @return the class name */
+	virtual const char* get_name() const
+	{
+		return "StreamingMMD";
+	}
+
+protected:
+	/** abstract method that computes the squared MMD
+	 *
+	 * @param kernel the kernel to be used for computing MMD. This will be
+	 * useful when multiple kernels are used
+	 * @param data the list of data on which kernels are computed. The order
+	 * of data in the list is \f$x,x',\cdots\sim p\f$ followed by
+	 * \f$y,y',\cdots\sim q\f$. It is assumed that detele_data flag is set
+	 * inside the list
+	 * @param num_this_run number of data points in current blocks
+	 * @return the MMD values
+	 */
+	virtual SGVector<float64_t> compute_squared_mmd(CKernel* kernel,
+			CList* data, index_t num_this_run)=0;
+
+	/** Streaming feature objects that are used instead of merged samples */
+	CStreamingFeatures* m_streaming_p;
+
+	/** Streaming feature objects that are used instead of merged samples*/
+	CStreamingFeatures* m_streaming_q;
+
+	/** Number of examples processed at once, i.e. in one burst */
+	index_t m_blocksize;
+
+	/** If this is true, samples will be mixed between p and q in any method
+	 * that computes the statistic */
+	bool m_simulate_h0;
+
+private:
+	/** register parameters and initialize with defaults */
+	void init();
+};
+
+}
+
+#endif /* STREAMING_MMD_H_ */
+


### PR DESCRIPTION
@karlnapf Please have a look at this class structure. Added a base class CStreamingMMD to make things easier for CLinearTimeMMD and CBTestMMD and refactored CLinearTimeMMD. Gaussian approximation and multiple kernel stuff readily works for both, and moved the parts common to both inside the base. It provides a method for stream data blocks and an interface for computing squared MMD which is to be defined by the subclasses.

Tested all existing unit-tests and integration tests and locally everything seems to work as before.
