### PR TITLE
multitask: Include DotFeatures independent of HAVE_EIGEN3

### DIFF
--- a/src/shogun/transfer/multitask/MultitaskClusteredLogisticRegression.cpp
+++ b/src/shogun/transfer/multitask/MultitaskClusteredLogisticRegression.cpp
@@ -11,6 +11,8 @@
 #include <shogun/lib/malsar/malsar_clustered.h>
 #include <shogun/lib/malsar/malsar_options.h>
 #include <shogun/lib/SGVector.h>
+#include <shogun/features/DotFeatures.h>
+#include <shogun/lib/SGMatrix.h>
 
 namespace shogun
 {

--- a/src/shogun/transfer/multitask/MultitaskL12LogisticRegression.cpp
+++ b/src/shogun/transfer/multitask/MultitaskL12LogisticRegression.cpp
@@ -11,6 +11,7 @@
 #include <shogun/lib/malsar/malsar_joint_feature_learning.h>
 #include <shogun/lib/malsar/malsar_options.h>
 #include <shogun/lib/SGVector.h>
+#include <shogun/features/DotFeatures.h>
 
 namespace shogun
 {

--- a/src/shogun/transfer/multitask/MultitaskTraceLogisticRegression.cpp
+++ b/src/shogun/transfer/multitask/MultitaskTraceLogisticRegression.cpp
@@ -12,6 +12,7 @@
 #include <shogun/lib/malsar/malsar_options.h>
 #include <shogun/lib/IndexBlockGroup.h>
 #include <shogun/lib/SGVector.h>
+#include <shogun/features/DotFeatures.h>
 
 namespace shogun
 {


### PR DESCRIPTION
We missed including `DotFeatures` if `HAVE_EIGEN3` was not set.

Fixes issue #2043
