### PR TITLE
Fix broken CmdLineInterface (missing shogun/base/init.h)

### DIFF
--- a/src/interfaces/cmdline_static/CmdLineInterface.cpp
+++ b/src/interfaces/cmdline_static/CmdLineInterface.cpp
@@ -1,5 +1,6 @@
 #include "CmdLineInterface.h"
 
+#include <shogun/base/init.h>
 #include <shogun/lib/config.h>
 #include <shogun/lib/ShogunException.h>
 #include <shogun/io/SGIO.h>


### PR DESCRIPTION
Fixing #2049
