### PR TITLE
Issue #1889 - comparison of SGVector

### DIFF
--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -387,15 +387,30 @@ void SGVector<T>::free_data()
 }
 
 template <>
-
 bool SGVector<float>::equals(SGVector<float>& other, float accuracy, bool tolerant)
 {
 	if(other.vlen != vlen)
 		return false ;
 
-	for(int i=0 ; i<other.vlen ; i++){
+	for(int i=0 ; i<other.vlen ; i++)
+	{
 		if(!CMath::fequals<float>(vector[i],other.vector[i] , accuracy, tolerant))
+		{
+			return false ;
+		}
+	}
+	return true ;
+}
 
+template <>
+bool SGVector<double>::equals(SGVector<double>& other, float accuracy, bool tolerant)
+{
+	if(other.vlen != vlen)
+		return false ;
+
+	for(int i=0 ; i<other.vlen ; i++)
+	{
+		if(!CMath::fequals<double>(vector[i],other.vector[i] , accuracy, tolerant))
 		{
 			return false ;
 		}
@@ -414,7 +429,6 @@ bool SGVector<T>::equals(SGVector<T>& other)
 		if (other.vector[i]!=vector[i])
 			return false;
 	}
-
 	return true;
 }
 

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -315,9 +315,9 @@ template<class T> class SGVector : public SGReferencedData
 		 * true otherwise
 		 */
 		bool equals(SGVector<T>& other);
+		bool equals(SGVector<double>& other, float accuracy, bool tolerant) ;
+		bool equals(SGVector<float>& other, float accuracy, bool tolerant) ;
 		
-		bool equals(SGVector<float>& other, float accuracy=0, bool tolerant=false) ;
-
 		/** permute vector */
 		static void permute_vector(SGVector<T> vec);
 

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -259,8 +259,7 @@ TEST(SGVectorTest,complex128_tests)
 	}
 }
 
-TEST(SGVectorTest,equals2_equal)
-
+TEST(SGVectorTest,equals_float_equal)
 {
 	SGVector<float> a(3);
 	SGVector<float> b(3);
@@ -273,7 +272,46 @@ TEST(SGVectorTest,equals2_equal)
 
 	EXPECT_TRUE(a.equals(b,0.2,true));
 }
+TEST(SGVectorTest,equals_double_equal)
+{
+	SGVector<double> a(3);
+	SGVector<double> b(3);
+	a[0]=0;
+	a[1]=1;
+	a[2]=2;
+	b[0]=0.1;
+	b[1]=1.01;
+	b[2]=2 ;
 
+	EXPECT_TRUE(a.equals(b,0.2,true));
+}
+
+TEST(SGVectorTest,equals_double_not_equal)
+{
+	SGVector<double> a(3);
+	SGVector<double> b(3);
+	a[0]=0;
+	a[1]=1;
+	a[2]=2;
+	b[0]=0.23;
+	b[1]=1.23;
+	b[2]=2.22 ;
+
+	EXPECT_FALSE(a.equals(b,0.2,true));
+}
+TEST(SGVectorTest,equals_float_not_equal)
+{
+	SGVector<float> a(3);
+	SGVector<float> b(3);
+	a[0]=0;
+	a[1]=1;
+	a[2]=2;
+	b[0]=0.23;
+	b[1]=1.23;
+	b[2]=2.22 ;
+
+	EXPECT_FALSE(a.equals(b,0.2,true));
+}
 
 TEST(SGVectorTest,equals_equal)
 {


### PR DESCRIPTION
just adds an other equals method specialized for float type to support comparison using the cmath::feqauals method if this is  efficient enough I can do the same for SGMatrix otherwise any guidelines are accepted . 
