### PR TITLE
PCA class modified to restore feature vector using a projection

### DIFF
--- a/src/shogun/preprocessor/PCA.cpp
+++ b/src/shogun/preprocessor/PCA.cpp
@@ -349,6 +349,22 @@ SGVector<float64_t> CPCA::apply_to_feature_vector(SGVector<float64_t> vector)
 	return result;
 }
 
+SGVector<float64_t> CPCA::apply_inverse(SGVector<float64_t> vector)
+{
+	SGVector<float64_t> result = SGVector<float64_t>(m_transformation_matrix.num_rows);
+	Map<VectorXd> resultVec(result.vector, m_transformation_matrix.num_rows);
+	Map<VectorXd> inputVec(vector.vector, vector.vlen);
+
+	Map<VectorXd> mean(m_mean_vector.vector, m_mean_vector.vlen);
+	Map<MatrixXd> transformMat(m_transformation_matrix.matrix,
+		 m_transformation_matrix.num_rows, m_transformation_matrix.num_cols);
+
+	resultVec = transformMat*inputVec;
+	resultVec = resultVec+mean;
+
+	return result;
+}
+
 SGMatrix<float64_t> CPCA::get_transformation_matrix()
 {
 	return m_transformation_matrix;

--- a/src/shogun/preprocessor/PCA.h
+++ b/src/shogun/preprocessor/PCA.h
@@ -158,6 +158,12 @@ class CPCA: public CDimensionReductionPreprocessor
 		 */
 		virtual SGVector<float64_t> apply_to_feature_vector(SGVector<float64_t> vector);
 
+		/** Approximate reconstruction of the original data. \f$\mathbf{x}^n\f$ is given by : \f$ \tilde{\mathbf{x}}^n \approx m + \mathbf{E} \mathbf{y}^n \f$
+		 * @param vector feature vector
+		 * @return processed feature vector
+		 */
+		SGVector<float64_t> apply_inverse(SGVector<float64_t> vector);
+
 		/** get transformation matrix, i.e. eigenvectors (potentially scaled if
 		 * do_whitening is true)
 		 */


### PR DESCRIPTION
Hello,

I have changed the PCA class to restore a feature vector using a projection. Like we talked in the eigenfaces example.
