### PR TITLE
An optimised version of convolution (GSoC task)

### DIFF
--- a/src/shogun/mathematics/Convolve.cpp
+++ b/src/shogun/mathematics/Convolve.cpp
@@ -1,0 +1,132 @@
+#include <omp.h>
+#include <iostream>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <time.h>
+
+using namespace std;
+
+int MATSIZE = 0;
+int KERNELSIZE = 0;
+
+void convolve(double *matrix, double *kernel, double *target)
+{
+    /* 
+     * Some required values. To be used to refer to indices 
+     */
+    int fh = KERNELSIZE/2, sh = KERNELSIZE - fh;
+    double end;
+    int offsetij = KERNELSIZE - 1;
+    struct timespec t1, t2;
+
+    /* 
+     * Flip the kernel left-right and up-down.
+     * Reduces the number of addition operations 
+     * in indices.
+     */
+    double temp;
+    for(int i = 0; i < fh; i ++)
+        for(int j = 0; j < KERNELSIZE; j ++)
+        {
+            temp = kernel[i*KERNELSIZE + j];
+            kernel[i*KERNELSIZE + j] = kernel[(KERNELSIZE - i - 1)*KERNELSIZE + j];
+            kernel[(KERNELSIZE - i - 1)*KERNELSIZE + j] = temp;
+        }
+    for(int i = 0; i < KERNELSIZE; i ++)
+        for(int j = 0; j < fh; j ++)
+        {
+            temp = kernel[i*KERNELSIZE + j];
+            kernel[i*KERNELSIZE + j] = kernel[i*KERNELSIZE + KERNELSIZE - j - 1];
+            kernel[i*KERNELSIZE + KERNELSIZE - j - 1] = temp;
+        }
+
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+
+    /* 
+     * Parallelize
+     */
+#pragma omp parallel for schedule(dynamic) \
+    shared(matrix, kernel)
+    for(int x = fh; x < MATSIZE-sh+1; x ++)
+    {
+        /*
+         * The following assignment reduces KERNELSIZE*KERNELSIZE 
+         * addition operations per element in matrix.
+         */
+        double *thismatrix = matrix + x - fh;
+
+        for(int y = fh; y < MATSIZE-sh+1; y ++)
+        {
+            double sum = 0.0;
+            for(int i = 0; i < KERNELSIZE; i ++)
+            {
+                /*
+                 * offsety reduces KERNELSIZE more addition operations
+                 */
+                int offsety = i*MATSIZE + y - fh;
+
+                for(int j = 0; j < KERNELSIZE; j ++)
+                {
+                    sum += thismatrix[offsety + j] * kernel[i*KERNELSIZE + j];
+                }
+            }
+                            
+            /*
+             * Assign the result
+             */
+            target[x*MATSIZE + y] = sum;
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+    end = 1000.0*(t2.tv_sec - t1.tv_sec) + (t2.tv_nsec - t1.tv_nsec)*1.0/1000000;
+    cout << end << endl;
+
+    return;
+}
+
+
+int main(int argc, char *argv[])
+{
+    if(argc < 3)
+    {
+        cout << "Please specify MATSIZE and KERNELSIZE. ./a.out <MATSIZE> <KERNELSIZE>" << endl;
+        return 1;
+    }
+    MATSIZE = atoi(argv[1]);
+    KERNELSIZE = atoi(argv[2]);
+    double *mat = new double [MATSIZE*MATSIZE];
+    double *kernel = new double [KERNELSIZE*KERNELSIZE];
+    double *target = new double [MATSIZE*MATSIZE];
+    int i, j;
+
+    struct timespec t1, t2;
+    double start, end;
+
+    double sec;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    sec = t1.tv_sec;
+    srand(sec*sec);
+
+    /* 
+     * Assign random values
+     */
+    for(i = 0; i < MATSIZE*MATSIZE; i ++)
+    {
+        mat[i] = rand() % 10;
+    }
+    for(i = 0; i < KERNELSIZE*KERNELSIZE; i ++)
+    {
+        kernel[i] = rand()%10;
+    }
+
+    //memset(target, 0, sizeof(double)*MATSIZE*MATSIZE);
+    
+    convolve(mat, kernel, target);
+
+    delete mat;
+    delete target;
+    delete kernel;
+    return 0;
+}


### PR DESCRIPTION
An optimised implementation of the convolution operation in src/shogun/mathematics/Convolve.cpp. The function uses OpenMP for parallel computing, if a processor with multiple cores is being used. Compile using

```
c++ -o convolve convolve.cpp -g -lrt -fopenmp -O3
```

Test using 

```
./convolve <matrix-size> <kernel-size>
```

The program outputs a running time in milliseconds a matrix and kernel, both randomly initialized and conforming to the size given during execution. The matrix and kernel are always assumed to be square matrices. 

**Optimisations done**
1. Matrices are stored as contiguous memory blocks.
2. Use of multiple cores to perform computations: Since the computation at pixel (i, j) is independent of pixel (m, n) (m != i and n != j), computations can be distributed to several cores. 
3. Flipping the kernel horizontally and vertically before computing the convolution: Saves us several addition and multiplication operations which would be done refer to elements of the kernel. 
4. Pre-computing offsets to elements that would be involved in a computation: If we fix a pixel (x, y), an offset is computed which can be used to refer to the region around (x, y) directly, thus reducing the number of addition and multiplication operations required. 

**Results of tests**

Tabulated below are runtimes for several matrix and kernel sizes, compared between the optimised and non-optimised version. All times are in milliseconds. 

System information: Linux 3.2.0-60-generic, Ubuntu 12.04 64-bit, Intel(R) Core(TM) i3-2120 CPU @ 3.30GHz (quad core), 4 GB memory. 

| Matrix size | Kernel size | Runtime, with optimisations | Runtime, without optimisations |
| --- | --- | --- | --- |
| 10 | 2 | 0.062256 | 0.001485 |
| 10 | 4 | 0.055258 | 0.00115 |
| 10 | 8 | 0.054877 | 0.001431 |
| 100 | 2 | 0.10902 | 0.120909 |
| 100 | 4 | 0.140958 | 0.309394 |
| 100 | 8 | 0.248173 | 1.01533 |
| 100 | 16 | 0.683718 | 3.47518 |
| 100 | 32 | 1.63621 | 7.26863 |
| 100 | 64 | 2.07949 | 7.35253 |
| 1000 | 2 | 3.22446 | 6.1538 |
| 1000 | 4 | 8.22482 | 15.7314 |
| 1000 | 8 | 23.2947 | 55.5671 |
| 1000 | 16 | 87.6732 | 226.192 |
| 1000 | 32 | 328.684 | 875.173 |
| 1000 | 64 | 1382.11 | 3430.45 |
| 1000 | 128 | 4827.18 | 12065.5 |
| 1000 | 256 | 15185.1 | 35698.3 |
| 2000 | 2 | 12.9331 | 21.8078 |
| 2000 | 4 | 36.746 | 63.2698 |
| 2000 | 8 | 91.5461 | 224.739 |
| 2000 | 16 | 425.304 | 916.547 |
| 2000 | 32 | 1500.66 | 3612.84 |
| 2000 | 64 | 5505.56 | 14642.8 |
| 2000 | 128 | 19958.5 | 56051.6 |
| 2000 | 256 | 109162 | 192899 |
