### PR TITLE
Fixing leak in example libshogun/base_load_file_parameters.cpp

### DIFF
--- a/examples/undocumented/libshogun/base_load_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_file_parameters.cpp
@@ -210,12 +210,14 @@ void test_load_file_parameters()
 
 	/* ensure that its the same as of the instance */
 	current=file_loaded_number->get_element(0);
+	current->m_delete_data = true; // TODO: This shouldn't be necessary!
 	int32_t value_number=*((int32_t*)current->m_parameter);
 	SG_SPRINT("%i\n", value_number);
 	ASSERT(value_number=int_instance->m_number);
 
 	/* same for the vector */
 	current=file_loaded_vector->get_element(0);
+	current->m_delete_data = true; // TODO: This shouldn't be necessary!
 	int32_t* value_vector=*((int32_t**)current->m_parameter);
 	SGVector<int32_t>::display_vector(value_vector, int_instance->m_vector_length);
 	for (index_t i=0; i<int_instance->m_vector_length; ++i)
@@ -223,6 +225,7 @@ void test_load_file_parameters()
 
 	/* and for the matrix */
 	current=file_loaded_matrix->get_element(0);
+	current->m_delete_data = true; // TODO: This shouldn't be necessary!
 	int32_t* value_matrix=*((int32_t**)current->m_parameter);
 	SGMatrix<int32_t>::display_matrix(value_matrix, int_instance->m_matrix_rows,
 			int_instance->m_matrix_cols);
@@ -234,6 +237,7 @@ void test_load_file_parameters()
 
 	/* and for the feature object */
 	current=file_loaded_sgobject->get_element(0);
+	current->m_delete_data = true; // TODO: This shouldn't be necessary!
 	CDenseFeatures<int32_t>* features=
 			*((CDenseFeatures<int32_t>**)current->m_parameter);
 	SGMatrix<int32_t> feature_matrix_loaded=

--- a/src/shogun/base/Parameter.cpp
+++ b/src/shogun/base/Parameter.cpp
@@ -2035,7 +2035,7 @@ TParameter::new_cont(SGVector<index_t> dims)
 {
 	char* s=SG_MALLOC(char, 200);
 	m_datatype.to_string(s, 200);
-	SG_SDEBUG("entering TParameter::new_cont for \"%s\" of type %s with",
+	SG_SDEBUG("entering TParameter::new_cont for \"%s\" of type %s\n",
 			s, m_name ? m_name : "(nil)");
 	SG_FREE(s);
 	delete_cont();


### PR DESCRIPTION
@karlnapf - Hey Karl, please have a look why this is necessary.  Data is not freed automatically unless I set this hidden parameter.
