### PR TITLE
Fix leak in StreamingMMD that's probably caused by a CList bug.

### DIFF
--- a/src/shogun/statistics/StreamingMMD.cpp
+++ b/src/shogun/statistics/StreamingMMD.cpp
@@ -253,9 +253,15 @@ CList* CStreamingMMD::stream_data_blocks(index_t num_blocks,
 		SG_DEBUG("merging and premuting features!\n");
 
 		/* use the first element to merge rest of the data into */
-		CFeatures* merged=(CFeatures*)data->get_first_element();
+		CFeatures* merged_orig=(CFeatures*)data->get_first_element();
+		// TODO: There's a bug in CList: merged_orig->ref_count() == 2, but should be == 1!
 		data->delete_element();
-		merged=merged->create_merged_copy(data);
+		CFeatures* merged=merged_orig->create_merged_copy(data);
+
+		// TODO: UNREF to workaround get_first_element/CList bug
+		SG_UNREF(merged_orig);
+		// UNREF because delete_element() only shrinks list, but does not free data.
+		SG_UNREF(merged_orig);
 
 		/* get rid of unnecessary feature objects */
 		data->delete_all_elements();


### PR DESCRIPTION
This leak was a bit tricky to fix, because we apparently have a bug in CList (and/or the API has been used wrong).  Reference counters are too high after

```
o = new CSGObject(); // o->ref_count == 0
data->append_element(o); // o->ref_count == 1
o2 = data->get_first_element(); // o->ref_count == 2
data->delete_element(); // o->ref_count == 2
```

I think the problem is either in append_element or get_first_element, because SG_REF will be called when inserting to _and_ when getting an element from the list.

That's why we have to call SG_UNREF twice to properly free the memory.
