### PR TITLE
memory leak fixed

### DIFF
--- a/tests/unit/multiclass/tree/ID3ClassifierTree_unittest.cc
+++ b/tests/unit/multiclass/tree/ID3ClassifierTree_unittest.cc
@@ -318,4 +318,5 @@ TEST(ID3ClassifierTree, tree_prune)
 	SG_UNREF(test_features);
 	SG_UNREF(validation_lab);
 	SG_UNREF(result);
+	SG_UNREF(id3tree);
 }


### PR DESCRIPTION
- fixed memory leak in ID3ClassifierTree_unittest.cc
