### PR TITLE
Proper naming of temp files in /tmp 

### DIFF
--- a/tests/unit/io/SerializationAscii_unittest.cc.jinja2
+++ b/tests/unit/io/SerializationAscii_unittest.cc.jinja2
@@ -21,7 +21,7 @@ TEST(SerializationAscii, {{class}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-ascii-" + class_name + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), PT_NOT_GENERIC);
 	ASSERT_TRUE(object != NULL);
@@ -63,7 +63,7 @@ TEST(SerializationAscii,{{class}}_{{type}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + "_{{type}}" + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-ascii-" + class_name + "_{{type}}" + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), {{type}});
 	ASSERT_TRUE(object != NULL);

--- a/tests/unit/io/SerializationHDF5_unittest.cc.jinja2
+++ b/tests/unit/io/SerializationHDF5_unittest.cc.jinja2
@@ -28,7 +28,7 @@ TEST(SerializationHDF5, {{class}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-hdfs-" + class_name + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), PT_NOT_GENERIC);
 	ASSERT_TRUE(object != NULL);
@@ -69,7 +69,7 @@ TEST(SerializationHDF5,{{class}}_{{type}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + "_{{type}}" + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-hdfs-" + class_name + "_{{type}}" + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), {{type}});
 	ASSERT_TRUE(object != NULL);

--- a/tests/unit/io/SerializationJSON_unittest.cc.jinja2
+++ b/tests/unit/io/SerializationJSON_unittest.cc.jinja2
@@ -24,7 +24,7 @@ TEST(SerializationJSON, {{class}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-json-" + class_name + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), PT_NOT_GENERIC);
 	ASSERT_TRUE(object != NULL);
@@ -66,7 +66,7 @@ TEST(SerializationJSON,{{class}}_{{type}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + "_{{type}}" + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-json-" + class_name + "_{{type}}" + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), {{type}});
 	ASSERT_TRUE(object != NULL);

--- a/tests/unit/io/SerializationXML_unittest.cc.jinja2
+++ b/tests/unit/io/SerializationXML_unittest.cc.jinja2
@@ -23,7 +23,7 @@ TEST(SerializationXML, {{class}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-xml-" + class_name + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), PT_NOT_GENERIC);
 	ASSERT_TRUE(object != NULL);
@@ -65,7 +65,7 @@ TEST(SerializationXML,{{class}}_{{type}})
 {% endif %}
 {
 	std::string class_name("{{class}}");
-	std::string file_template = "/tmp/" + class_name + "_{{type}}" + ".XXXXXX";
+	std::string file_template = "/tmp/shogun-unittest-serialization-xml-" + class_name + "_{{type}}" + ".XXXXXX";
 	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), {{type}});
 	ASSERT_TRUE(object != NULL);


### PR DESCRIPTION
This allows to identify stale serialization temp files.  For easier cleanup in /tmp.
