### PR TITLE
Changed travis.yml to not execute tests if compiling failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,10 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-script:
   - cmake -DENABLE_TESTING=ON -DBUNDLE_EIGEN=ON -DBUNDLE_JSON=ON -DBUNDLE_NLOPT=ON $CMAKE_OPTIONS ..
+script:
   - if [ -z "$CMAKE_OPTIONS" -o -n "$COVERALLS" ] ; then make -j 2 ; else make -j 4 ; fi
+after_script:
   - sudo make install
   - ctest --output-on-failure -j 2
 after_success:


### PR DESCRIPTION
According to 
- http://docs.travis-ci.com/user/build-lifecycle/#Breaking-the-Build
  Travis will execute all steps in the "script" section even if one of them fails.

In order to save time on travis, I changed the build config so that "script" only compiles and the testing is done in "script_after".  This should prevent the tests from being executed if the build failed.
