### PR TITLE
Trying to speed-up travis build through "cache: apt"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+cache: apt
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
Downloading apt-packages takes more than half of the build time.  Lets try to change this.
