### PR TITLE
add graphviz plot for decision trees

### DIFF
--- a/examples/undocumented/python_modular/graphical/id3classifiertree_plot.py
+++ b/examples/undocumented/python_modular/graphical/id3classifiertree_plot.py
@@ -1,0 +1,25 @@
+from modshogun import *
+from numpy import array
+import pydot
+
+# create data
+train_data = array([[1.0, 2.0, 1.0, 3.0, 1.0, 3.0, 2.0, 2.0, 3.0, 1.0, 2.0, 2.0, 3.0, 1.0, 2.0],
+[2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 1.0],
+[3.0, 2.0, 3.0, 3.0, 3.0, 2.0, 2.0, 1.0, 3.0, 1.0, 2.0, 1.0, 3.0, 1.0, 2.0],
+[1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]])
+
+train_labels = array([1.0, 2.0, 1.0, 3.0, 1.0, 2.0, 2.0, 1.0, 3.0, 1.0, 2.0, 1.0, 3.0, 1.0, 2.0])
+
+# wrap features and labels into Shogun objects
+feats_train=RealFeatures(train_data)
+feats_labels=MulticlassLabels(train_labels)
+
+# ID3 Tree formation
+id3=ID3ClassifierTree()
+id3.set_labels(feats_labels)
+id3.train(feats_train)
+
+# ID3 Tree printing
+id3.export_to_graphviz_format()
+dot_graph = pydot.graph_from_dot_file('decision_tree.dot')
+dot_graph.write_pdf('decision_tree.pdf')

--- a/src/shogun/multiclass/tree/ID3ClassifierTree.h
+++ b/src/shogun/multiclass/tree/ID3ClassifierTree.h
@@ -112,7 +112,31 @@ public:
 	 */
 	bool prune_tree(CDenseFeatures<float64_t>* validation_data, CMulticlassLabels* validation_labels, float64_t epsilon=0.f);
 
+	/** print decision tree to a file in DOT format
+	 *
+	 * This function can be used to write the decision tree in a file. The tree is
+	 * written in DOT format which can be read by graphviz graph plotting tool. Once this
+	 * method is used to create the required dot file, the following command can be used
+	 * (in terminal) to visualize the decision tree in a pdf file :
+	 *
+	 * dot -Tpdf decision_tree.dot -o <output filename>.pdf
+	 * Alternatively pydot library can be used in python to render the tree in a pdf file
+	 *
+	 * @return true if successful 
+	 */
+	bool export_to_graphviz_format();
+
 protected:
+
+	/** prints node labels and tree edges in dot format for given subtree
+	 * aids export_to_graphviz_format method
+	 * 
+	 * @param file output file handle
+	 * @param root root of required subtree
+	 * @param index the identifying index number of the root
+	 * @return maximum index number among the nodes of the subtree
+	 */
+	int32_t print_subtree(FILE* file, node_t* root, int32_t index);
 	
 	/** train machine - build ID3 Tree from training data
 	 * @param data training data


### PR DESCRIPTION
- added methods to write decision tree into file in dot format
- added python_modular graphical example for the same

The pdf output of the python graphical example can be found [here](https://www.dropbox.com/s/qxby3349yxw3mmi/decision_tree.pdf). The dot file created can be found [here](https://gist.github.com/mazumdarparijat/11373739)  
