### PR TITLE
Declaring method list_memory_allocs() "static" in header

### DIFF
--- a/src/shogun/base/SGRefObject.cpp
+++ b/src/shogun/base/SGRefObject.cpp
@@ -76,7 +76,7 @@ int32_t SGRefObject::unref()
 #include <shogun/lib/Map.h>
 extern CMap<void*, shogun::MemoryBlock>* sg_mallocs;
 
-static void SGRefObject::list_memory_allocs()
+void SGRefObject::list_memory_allocs()
 {
 	shogun::list_memory_allocs();
 }

--- a/src/shogun/base/SGRefObject.h
+++ b/src/shogun/base/SGRefObject.h
@@ -84,7 +84,7 @@ public:
 	virtual const char* get_name() const = 0;
 
 #ifdef TRACE_MEMORY_ALLOCS
-	void list_memory_allocs();
+	static void list_memory_allocs();
 #endif
 
 private:


### PR DESCRIPTION
This fixes building shogun with `-DTRACE_MEMORY_ALLOCS=ON`.

Travis won't see a difference, but it should fix buildbots nightly builds:
- http://buildbot.shogun-toolbox.org/builders/nightly_all/builds/691
