### PR TITLE
added USE_REFERENCE_COUNTING check in CList unittests to prevent failure...

### DIFF
--- a/tests/unit/lib/List_unittest.cc
+++ b/tests/unit/lib/List_unittest.cc
@@ -33,6 +33,7 @@
 
 using namespace shogun;
 
+#ifdef USE_REFERENCE_COUNTING
 TEST(ListTest, contructor_ref_count_append_delete_data_true)
 {
 	// test reference counting of list
@@ -217,3 +218,4 @@ TEST(ListTest, get_first_element_ref_count_delete_data_false)
 	ASSERT_TRUE(data!=NULL); // dead pointer
 	ASSERT_TRUE(from_list==NULL);
 }
+#endif //USE_REFERENCE_COUNTING


### PR DESCRIPTION
... when refcounting not used
