### PR TITLE
Try if disable caching fixes python build errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-cache: apt
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
@karlnapf - reverting PR to check if caching caused the build breaks.
