### PR TITLE
Fixing potential colliding output files "out.txt" when runnning ctest -j4

### DIFF
--- a/examples/undocumented/cmdline_static/classifier_gmnpsvm.sg
+++ b/examples/undocumented/cmdline_static/classifier_gmnpsvm.sg
@@ -12,5 +12,5 @@ c 0.017
 train_classifier
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-classifier_gmnpsvm.txt = classify
+! rm out-classifier_gmnpsvm.txt

--- a/examples/undocumented/cmdline_static/classifier_gpbtsvm.sg
+++ b/examples/undocumented/cmdline_static/classifier_gpbtsvm.sg
@@ -12,5 +12,5 @@ c 0.017
 train_classifier
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-classifier_gpbtsvm.txt = classify
+! rm out-classifier_gpbtsvm.txt

--- a/examples/undocumented/cmdline_static/classifier_knn.sg
+++ b/examples/undocumented/cmdline_static/classifier_knn.sg
@@ -9,5 +9,5 @@ new_classifier KNN
 train_classifier 3
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-classifier_knn.txt = classify
+! rm out-classifier_knn.txt

--- a/examples/undocumented/cmdline_static/classifier_lda.sg
+++ b/examples/undocumented/cmdline_static/classifier_lda.sg
@@ -8,5 +8,5 @@ new_classifier LDA
 train_classifier
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-classifier_lda.txt = classify
+! rm out-classifier_lda.txt

--- a/examples/undocumented/cmdline_static/classifier_liblinear.sg
+++ b/examples/undocumented/cmdline_static/classifier_liblinear.sg
@@ -13,5 +13,5 @@ c 0.42
 train_classifier
 
 set_features TEST ../data/fm_test_sparsereal.dat
-out.txt = classify
-! rm out.txt
+out-classifier_liblinear.txt = classify
+! rm out-classifier_liblinear.txt

--- a/examples/undocumented/cmdline_static/classifier_libsvm.sg
+++ b/examples/undocumented/cmdline_static/classifier_libsvm.sg
@@ -8,10 +8,10 @@ new_classifier LIBSVM
 c 1
 
 train_classifier
-save_classifier libsvm.model
+save_classifier out-classifier_libsvm.model
 
-load_classifier libsvm.model LIBSVM
+load_classifier out-classifier_libsvm.model LIBSVM
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
-! rm libsvm.model
+out-classifier_libsvm.txt = classify
+! rm out-classifier_libsvm.txt
+! rm out-classifier_libsvm.model

--- a/examples/undocumented/cmdline_static/classifier_libsvmmulticlass.sg
+++ b/examples/undocumented/cmdline_static/classifier_libsvmmulticlass.sg
@@ -12,5 +12,5 @@ c 0.017
 train_classifier
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-classifier_libsvmmulticlass.txt = classify
+! rm out-classifier_libsvmmulticlass.txt

--- a/examples/undocumented/cmdline_static/classifier_libsvmoneclass.sg
+++ b/examples/undocumented/cmdline_static/classifier_libsvmoneclass.sg
@@ -12,5 +12,5 @@ c 0.017
 train_classifier
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-classifier_libsvmoneclass.txt = classify
+! rm out-classifier_libsvmoneclass.txt

--- a/examples/undocumented/cmdline_static/classifier_mpdsvm.sg
+++ b/examples/undocumented/cmdline_static/classifier_mpdsvm.sg
@@ -12,4 +12,5 @@ c 0.017
 train_classifier
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
+out-classifier_mpdsvm.txt = classify
+! rm out-classifier_mpdsvm.txt

--- a/examples/undocumented/cmdline_static/classifier_perceptron.sg
+++ b/examples/undocumented/cmdline_static/classifier_perceptron.sg
@@ -8,5 +8,5 @@ print Perceptron
 %train_classifier
 
 %set_features TEST fm_test_real
-%out.txt = classify
-
+%out-classifier_perceptron.txt = classify
+%! rm out-classifier_perceptron.txt

--- a/examples/undocumented/cmdline_static/classifier_svmlight.sg
+++ b/examples/undocumented/cmdline_static/classifier_svmlight.sg
@@ -13,8 +13,8 @@
 	train_classifier
 
 	set_features TEST ../data/fm_test_dna.dat DNA
-	out.txt = classify
-	! rm out.txt
+	out-classifier_svmlight.txt = classify
+	! rm out-classifier_svmlight.txt
 %catch
 %	print No support for SVMLight available.
 %end

--- a/examples/undocumented/cmdline_static/classifier_svmlin.sg
+++ b/examples/undocumented/cmdline_static/classifier_svmlin.sg
@@ -11,5 +11,5 @@ c 0.42
 train_classifier
 
 set_features TEST ../data/fm_test_sparsereal.dat
-out.txt = classify
-! rm out.txt
+out-classifier_svmlin.txt = classify
+! rm out-classifier_svmlin.txt

--- a/examples/undocumented/cmdline_static/classifier_svmocas.sg
+++ b/examples/undocumented/cmdline_static/classifier_svmocas.sg
@@ -11,5 +11,5 @@ c 0.42
 train_classifier
 
 set_features TEST ../data/fm_test_sparsereal.dat
-out.txt = classify
-! rm out.txt
+out-classifier_svmocas.txt = classify
+! rm out-classifier_svmocas.txt

--- a/examples/undocumented/cmdline_static/classifier_svmsgd.sg
+++ b/examples/undocumented/cmdline_static/classifier_svmsgd.sg
@@ -11,5 +11,5 @@ c 0.42
 train_classifier
 
 set_features TEST ../data/fm_test_sparsereal.dat
-out.txt = classify
-! rm out.txt
+out-classifier_svmsgd.txt = classify
+! rm out-classifier_svmsgd.txt

--- a/examples/undocumented/cmdline_static/mkl_multiclass.sg
+++ b/examples/undocumented/cmdline_static/mkl_multiclass.sg
@@ -28,5 +28,5 @@ c 1.2
 train_classifier
 
 
-out.txt = classify
-! rm out.txt
+out-mkl_multiclass.txt = classify
+! rm out-mkl_multiclass.txt

--- a/examples/undocumented/cmdline_static/regression_krr.sg
+++ b/examples/undocumented/cmdline_static/regression_krr.sg
@@ -10,5 +10,5 @@ c 0.017
 train_regression
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-regression_krr.txt = classify
+! rm out-regression_krr.txt

--- a/examples/undocumented/cmdline_static/regression_libsvr.sg
+++ b/examples/undocumented/cmdline_static/regression_libsvr.sg
@@ -10,5 +10,5 @@ c 0.017
 train_regression
 
 set_features TEST ../data/fm_test_real.dat
-out.txt = classify
-! rm out.txt
+out-regression_libsvr.txt = classify
+! rm out-regression_libsvr.txt

--- a/examples/undocumented/cmdline_static/regression_svrlight.sg
+++ b/examples/undocumented/cmdline_static/regression_svrlight.sg
@@ -12,8 +12,8 @@
 	train_regression
 
 	set_features TEST ../data/fm_test_real.dat
-	svrlight_out.txt = classify
-	! rm svrlight_out.txt
+	out-regression_svrlight.txt = classify
+	! rm out-regression_svrlight.txt
 %catch
 %	disp('No support for SVRLight available.')
 %end


### PR DESCRIPTION
The output name "out.txt" is used in many tests.  If they are run at the same time, tests will fail randomly.
