### PR TITLE
Removing last memory warnings on buildbot (could not reproduce them locally)

### DIFF
--- a/configs/valgrind.supp
+++ b/configs/valgrind.supp
@@ -89,3 +89,31 @@
    obj:*/libhdf5.so.*
    fun:H5D_close
 }
+
+{
+   fscanf triggers "Conditional jump [...] on uninitialized values"
+   Memcheck:Cond
+   fun:__GI___strncasecmp_l
+   fun:____strtod_l_internal
+   fun:_IO_vfscanf
+   fun:fscanf
+   fun:*SerializableAsciiReader00*read_scalar_wrapped*
+}
+
+{
+   fscanf triggers "Uninitialized value of size 8"
+   Memcheck:Value8
+   fun:__GI___strncasecmp_l
+   fun:____strtod_l_internal
+   fun:_IO_vfscanf
+   fun:fscanf
+   fun:*SerializableAsciiReader00*read_scalar_wrapped*
+}
+
+{
+   strod triggers "Invalid read of size 8"
+   Memcheck:Addr8
+   fun:__GI___strncasecmp_l
+   fun:____strtod_l_internal
+   fun:*CParser*read_real*
+}


### PR DESCRIPTION
There are only a few warnings left on buildbot/memcheck.  In order to fix them, I tried to reproduce them locally.

None of the remaining warnings could be reproduced on my local SHOGUN machine (ubuntu 14.04). That's why I think it's not a problem within SHOGUN, but something related to the buildbot.  Therefore, I'm adding these suppressions to have a clean build as soon as GSoC starts.

@vigsterkr - I think you should have a look.  I'm not merging until you said that you agree. ;)
