### PR TITLE
Updated QuadraticTimeMMD with new formulas

### DIFF
--- a/examples/undocumented/python_modular/statistics_quadratic_time_mmd.py
+++ b/examples/undocumented/python_modular/statistics_quadratic_time_mmd.py
@@ -16,7 +16,7 @@ def statistics_quadratic_time_mmd (m,dim,difference):
 	from modshogun import MeanShiftDataGenerator
 	from modshogun import GaussianKernel, CustomKernel
 	from modshogun import QuadraticTimeMMD
-	from modshogun import PERMUTATION, MMD2_SPECTRUM, MMD2_GAMMA, BIASED, UNBIASED
+	from modshogun import PERMUTATION, MMD2_SPECTRUM, MMD2_GAMMA, BIASED, BIASED_DEPRECATED
 	from modshogun import Statistics, IntVector, RealVector, Math
 
 	# init seed for reproducability
@@ -59,7 +59,6 @@ def statistics_quadratic_time_mmd (m,dim,difference):
 	# using spectrum method. Use at least 250 samples from null.
 	# This is consistent but sometimes breaks, always monitor type I error.
 	# See tutorial for number of eigenvalues to use .
-	# Only works with BIASED statistic
 	mmd.set_statistic_type(BIASED);
 	mmd.set_null_approximation_method(MMD2_SPECTRUM);
 	mmd.set_num_eigenvalues_spectrum(3);
@@ -70,8 +69,8 @@ def statistics_quadratic_time_mmd (m,dim,difference):
 
 	# using gamma method. This is a quick hack, which works most of the time
 	# but is NOT guaranteed to. See tutorial for details.
-	# Only works with BIASED statistic
-	mmd.set_statistic_type(BIASED);
+	# Only works with BIASED_DEPRECATED statistic
+	mmd.set_statistic_type(BIASED_DEPRECATED);
 	mmd.set_null_approximation_method(MMD2_GAMMA);
 	p_value_gamma=mmd.perform_test();
 	# reject if p-value is smaller than test level
@@ -83,6 +82,7 @@ def statistics_quadratic_time_mmd (m,dim,difference):
 	# Also note that testing has to happen on
 	# difference data than kernel selection, but the linear time mmd does this
 	# implicitly and we used a fixed kernel here.
+	mmd.set_statistic_type(BIASED);
 	mmd.set_null_approximation_method(PERMUTATION);
 	mmd.set_num_null_samples(5);
 	num_trials=5;

--- a/src/shogun/statistics/HypothesisTest.cpp
+++ b/src/shogun/statistics/HypothesisTest.cpp
@@ -100,6 +100,7 @@ float64_t CHypothesisTest::compute_threshold(float64_t alpha)
 		SGVector<float64_t> values=sample_null();
 
 		/* return value of (1-alpha) quantile */
+		values.qsort();
 		result=values[index_t(CMath::floor(values.vlen*(1-alpha)))];
 	}
 	else

--- a/src/shogun/statistics/HypothesisTest.h
+++ b/src/shogun/statistics/HypothesisTest.h
@@ -47,7 +47,12 @@ enum EStatisticType
 /** enum for different method to approximate null-distibution */
 enum ENullApproximationMethod
 {
-	PERMUTATION, MMD2_SPECTRUM, MMD2_GAMMA, MMD1_GAUSSIAN, HSIC_GAMMA
+	PERMUTATION,
+	MMD2_SPECTRUM_DEPRECATED,
+	MMD2_SPECTRUM,
+	MMD2_GAMMA,
+	MMD1_GAUSSIAN,
+	HSIC_GAMMA
 };
 
 /** @brief Hypothesis test base class. Provides an interface for statistical

--- a/src/shogun/statistics/QuadraticTimeMMD.cpp
+++ b/src/shogun/statistics/QuadraticTimeMMD.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (w) 2012-2013 Heiko Strathmann
+ * Written (w) 2014 Soumyajit De
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,14 +31,17 @@
 
 #include <shogun/statistics/QuadraticTimeMMD.h>
 #include <shogun/features/Features.h>
+#include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/Statistics.h>
-#include <shogun/mathematics/eigen3.h>
 #include <shogun/kernel/Kernel.h>
 #include <shogun/kernel/CombinedKernel.h>
 #include <shogun/kernel/CustomKernel.h>
 
 using namespace shogun;
+
 #ifdef HAVE_EIGEN3
+#include <shogun/mathematics/eigen3.h>
+
 using namespace Eigen;
 #endif
 
@@ -85,107 +89,503 @@ void CQuadraticTimeMMD::init()
 	m_statistic_type=UNBIASED;
 }
 
-float64_t CQuadraticTimeMMD::compute_unbiased_statistic()
+SGVector<float64_t> CQuadraticTimeMMD::compute_unbiased_statistic_variance(
+		int m, int n)
 {
-	/* split computations into three terms from JLMR paper (see documentation )*/
-	index_t m=m_m;
-	index_t n=0;
+	SG_DEBUG("Entering!\n");
 
-	/* check if kernel is precomputed (custom kernel) */
-	if (m_kernel && m_kernel->get_kernel_type()==K_CUSTOM)
-		n=m_kernel->get_num_vec_lhs()-m;
-	else
-	{
-		REQUIRE(m_p_and_q, "The samples are not initialized!\n");
-		n=m_p_and_q->get_num_vectors()-m;
-	}
-
-	SG_DEBUG("Computing MMD_u with %d samples from p and %d samples from q\n",
-			m, n);
-
-	/* init kernel with features */
+	/* init kernel with features. NULL check is handled in compute_statistic */
 	m_kernel->init(m_p_and_q, m_p_and_q);
 
+	/* computing kernel values and their sums on the fly that are used both in
+	   computing statistic and variance */
+
+	/* the following matrix stores row-wise sum of kernel values k(X,X') in
+	   the first column and row-wise squared sum of kernel values k^2(X,X')
+	   in the second column. m entries in both column */
+	SGMatrix<float64_t> xx_sum_sq_sum_rowwise=m_kernel->
+		row_wise_sum_squared_sum_symmetric_block(0, m);
+
+	/* row-wise sum of kernel values k(Y,Y'), n entries */
+	SGVector<float64_t> yy_sum_rowwise=m_kernel->
+		row_wise_sum_symmetric_block(m, n);
+
+	/* row-wise and col-wise sum of kernel values k(X,Y), m+n entries
+	   first m entries are row-wise sum, rest n entries are col-wise sum */
+	SGVector<float64_t> xy_sum_rowcolwise=m_kernel->
+		row_col_wise_sum_block(0, m, m, n);
+
+	/* computing overall sum and squared sum from above for convenience */
+
+	SGVector<float64_t> xx_sum_rowwise(m);
+	std::copy(xx_sum_sq_sum_rowwise.matrix, xx_sum_sq_sum_rowwise.matrix+m,
+			xx_sum_rowwise.vector);
+
+	SGVector<float64_t> xy_sum_rowwise(m);
+	std::copy(xy_sum_rowcolwise.vector, xy_sum_rowcolwise.vector+m,
+			xy_sum_rowwise.vector);
+
+	SGVector<float64_t> xy_sum_colwise(n);
+	std::copy(xy_sum_rowcolwise.vector+m, xy_sum_rowcolwise.vector+m+n,
+			xy_sum_colwise.vector);
+
+	float64_t xx_sq_sum=0.0;
+	for (index_t i=0; i<xx_sum_sq_sum_rowwise.num_rows; i++)
+		xx_sq_sum+=xx_sum_sq_sum_rowwise(i, 1);
+
+	float64_t xx_sum=0.0;
+	for (index_t i=0; i<xx_sum_rowwise.vlen; i++)
+		xx_sum+=xx_sum_rowwise[i];
+
+	float64_t yy_sum=0.0;
+	for (index_t i=0; i<yy_sum_rowwise.vlen; i++)
+		yy_sum+=yy_sum_rowwise[i];
+
+	float64_t xy_sum=0.0;
+	for (index_t i=0; i<xy_sum_rowwise.vlen; i++)
+		xy_sum+=xy_sum_rowwise[i];
+
+	/* compute statistic */
+
+	/* split computations into three terms from JLMR paper (see documentation )*/
+
 	/* first term */
-	float64_t first=m_kernel->sum_symmetric_block(0, m);
-	first/=m*(m-1);
+	float64_t first=xx_sum/m/(m-1);
 
 	/* second term */
-	float64_t second=m_kernel->sum_symmetric_block(m, n);
-	second/=n*(n-1);
+	float64_t second=yy_sum/n/(n-1);
 
 	/* third term */
-	float64_t third=m_kernel->sum_block(0, m, m, n);
-	third*=2.0/m/n;
+	float64_t third=2.0*xy_sum/m/n;
 
+	float64_t statistic=first+second-third;
+
+	SG_INFO("Computed statistic!\n");
 	SG_DEBUG("first=%f, second=%f, third=%f\n", first, second, third);
 
-	float64_t mmd_u=first+second-third;
+	/* compute variance under null */
 
-	/* return m*MMD_u when m=n, (m+n)*MMD_u in general case */
-	if (m==n)
-		return m*mmd_u;
+	/* split computations into three terms (see documentation) */
 
-	return (m+n)*mmd_u;
+	/* first term */
+	float64_t kappa_0=CMath::sq(xx_sum/m/(m-1));
+
+	/* second term */
+	float64_t kappa_1=0.0;
+	for (index_t i=0; i<m; ++i)
+		kappa_1+=CMath::sq(xx_sum_rowwise[i]/(m-1));
+	kappa_1/=m;
+
+	/* third term */
+	float64_t kappa_2=xx_sq_sum/m/(m-1);
+
+	float64_t var_null=2*(kappa_0-2*kappa_1+kappa_2);
+
+	SG_INFO("Computed variance under null!\n");
+	SG_DEBUG("kappa_0=%f, kappa_1=%f, kappa_2=%f\n", kappa_0, kappa_1, kappa_2);
+
+	/* compute variance under alternative */
+
+	/* split computations into four terms (see documentation) */
+
+	/* first term */
+	float64_t alt_var_first=0.0;
+	for (index_t i=0; i<m; ++i)
+	{
+		// use row-wise sum from k(X,X') and k(X,Y) blocks
+		float64_t term=xx_sum_rowwise[i]/(m-1)-xy_sum_rowwise[i]/n;
+		alt_var_first+=CMath::sq(term);
+	}
+	alt_var_first/=m;
+
+	/* second term */
+	float64_t alt_var_second=CMath::sq(xx_sum/m/(m-1)-xy_sum/m/n);
+
+	/* third term */
+	float64_t alt_var_third=0.0;
+	for (index_t i=0; i<n; ++i)
+	{
+		// use row-wise sum from k(Y,Y') and col-wise sum from k(X,Y)
+		// blocks to simulate row-wise sum from k(Y,X) blocks
+		float64_t term=yy_sum_rowwise[i]/(n-1)-xy_sum_colwise[i]/m;
+		alt_var_third+=CMath::sq(term);
+	}
+	alt_var_third/=n;
+
+	/* fourth term */
+	float64_t alt_var_fourth=CMath::sq(yy_sum/n/(n-1)-xy_sum/m/n);
+
+	/* finally computing variance */
+	float64_t rho_x=float64_t(m)/(m+n);
+	float64_t rho_y=float64_t(n)/(m+n);
+
+	float64_t var_alt=4*rho_x*(alt_var_first-alt_var_second)+
+		4*rho_y*(alt_var_third-alt_var_fourth);
+
+	SG_INFO("Computed variance under alternative!\n");
+	SG_DEBUG("first=%f, second=%f, third=%f, fourth=%f\n", alt_var_first,
+			alt_var_second, alt_var_third, alt_var_fourth);
+
+	SGVector<float64_t> results(3);
+	results[0]=statistic;
+	results[1]=var_null;
+	results[2]=var_alt;
+
+	SG_DEBUG("Leaving!\n");
+
+	return results;
 }
 
-float64_t CQuadraticTimeMMD::compute_biased_statistic()
+SGVector<float64_t> CQuadraticTimeMMD::compute_biased_statistic_variance(int m, int n)
 {
-	/* split computations into three terms from JLMR paper (see documentation )*/
-	index_t m=m_m;
-	index_t n=0;
+	SG_DEBUG("Entering!\n");
 
-	/* check if kernel is precomputed (custom kernel) */
-	if (m_kernel && m_kernel->get_kernel_type()==K_CUSTOM)
-		n=m_kernel->get_num_vec_lhs()-m;
-	else
-	{
-		REQUIRE(m_p_and_q, "The samples are not initialized!\n");
-		n=m_p_and_q->get_num_vectors()-m;
-	}
-
-	SG_DEBUG("Computing MMD_b with %d samples from p and %d samples from q\n",
-			m, n);
-
-	/* init kernel with features */
+	/* init kernel with features. NULL check is handled in compute_statistic */
 	m_kernel->init(m_p_and_q, m_p_and_q);
 
+	/* computing kernel values and their sums on the fly that are used both in
+	   computing statistic and variance */
+
+	/* the following matrix stores row-wise sum of kernel values k(X,X') in
+	   the first column and row-wise squared sum of kernel values k^2(X,X')
+	   in the second column. m entries in both column */
+	SGMatrix<float64_t> xx_sum_sq_sum_rowwise=m_kernel->
+		row_wise_sum_squared_sum_symmetric_block(0, m, false);
+
+	/* row-wise sum of kernel values k(Y,Y'), n entries */
+	SGVector<float64_t> yy_sum_rowwise=m_kernel->
+		row_wise_sum_symmetric_block(m, n, false);
+
+	/* row-wise and col-wise sum of kernel values k(X,Y), m+n entries
+	   first m entries are row-wise sum, rest n entries are col-wise sum */
+	SGVector<float64_t> xy_sum_rowcolwise=m_kernel->
+		row_col_wise_sum_block(0, m, m, n);
+
+	/* computing overall sum and squared sum from above for convenience */
+
+	SGVector<float64_t> xx_sum_rowwise(m);
+	std::copy(xx_sum_sq_sum_rowwise.matrix, xx_sum_sq_sum_rowwise.matrix+m,
+			xx_sum_rowwise.vector);
+
+	SGVector<float64_t> xy_sum_rowwise(m);
+	std::copy(xy_sum_rowcolwise.vector, xy_sum_rowcolwise.vector+m,
+			xy_sum_rowwise.vector);
+
+	SGVector<float64_t> xy_sum_colwise(n);
+	std::copy(xy_sum_rowcolwise.vector+m, xy_sum_rowcolwise.vector+m+n,
+			xy_sum_colwise.vector);
+
+	float64_t xx_sq_sum=0.0;
+	for (index_t i=0; i<xx_sum_sq_sum_rowwise.num_rows; i++)
+		xx_sq_sum+=xx_sum_sq_sum_rowwise(i, 1);
+
+	float64_t xx_sum=0.0;
+	for (index_t i=0; i<xx_sum_rowwise.vlen; i++)
+		xx_sum+=xx_sum_rowwise[i];
+
+	float64_t yy_sum=0.0;
+	for (index_t i=0; i<yy_sum_rowwise.vlen; i++)
+		yy_sum+=yy_sum_rowwise[i];
+
+	float64_t xy_sum=0.0;
+	for (index_t i=0; i<xy_sum_rowwise.vlen; i++)
+		xy_sum+=xy_sum_rowwise[i];
+
+	/* compute statistic */
+
+	/* split computations into three terms from JLMR paper (see documentation )*/
+
 	/* first term */
-	float64_t first=m_kernel->sum_symmetric_block(0, m, false);
-	first/=m*m;
+	float64_t first=xx_sum/m/m;
 
 	/* second term */
-	float64_t second=m_kernel->sum_symmetric_block(m, n, false);
-	second/=n*n;
+	float64_t second=yy_sum/n/n;
 
 	/* third term */
-	float64_t third=m_kernel->sum_block(0, m, m, n);
-	third*=2.0/m/n;
+	float64_t third=2.0*xy_sum/m/n;
 
+	float64_t statistic=first+second-third;
+
+	SG_INFO("Computed statistic!\n");
 	SG_DEBUG("first=%f, second=%f, third=%f\n", first, second, third);
 
-	float64_t mmd_b=first+second-third;
+	/* compute variance under null */
 
-	/* return m*MMD_b when m=n, (m+n)*MMD_b in general case */
-	if (m==n)
-		return m*mmd_b;
+	/* split computations into three terms (see documentation) */
 
-	return (m+n)*mmd_b;
+	/* first term */
+	float64_t kappa_0=CMath::sq(xx_sum/m/m);
+
+	/* second term */
+	float64_t kappa_1=0.0;
+	for (index_t i=0; i<m; ++i)
+		kappa_1+=CMath::sq(xx_sum_rowwise[i]/m);
+	kappa_1/=m;
+
+	/* third term */
+	float64_t kappa_2=xx_sq_sum/m/m;
+
+	float64_t var_null=2*(kappa_0-2*kappa_1+kappa_2);
+
+	SG_INFO("Computed variance under null!\n");
+	SG_DEBUG("kappa_0=%f, kappa_1=%f, kappa_2=%f\n", kappa_0, kappa_1, kappa_2);
+
+	/* compute variance under alternative */
+
+	/* split computations into four terms (see documentation) */
+
+	/* first term */
+	float64_t alt_var_first=0.0;
+	for (index_t i=0; i<m; ++i)
+	{
+		// use row-wise sum from k(X,X') and k(X,Y) blocks
+		float64_t term=xx_sum_rowwise[i]/m-xy_sum_rowwise[i]/n;
+		alt_var_first+=CMath::sq(term);
+	}
+	alt_var_first/=m;
+
+	/* second term */
+	float64_t alt_var_second=CMath::sq(xx_sum/m/m-xy_sum/m/n);
+
+	/* third term */
+	float64_t alt_var_third=0.0;
+	for (index_t i=0; i<n; ++i)
+	{
+		// use row-wise sum from k(Y,Y') and col-wise sum from k(X,Y)
+		// blocks to simulate row-wise sum from k(Y,X) blocks
+		float64_t term=yy_sum_rowwise[i]/n-xy_sum_colwise[i]/m;
+		alt_var_third+=CMath::sq(term);
+	}
+	alt_var_third/=n;
+
+	/* fourth term */
+	float64_t alt_var_fourth=CMath::sq(yy_sum/n/n-xy_sum/m/n);
+
+	/* finally computing variance */
+	float64_t rho_x=float64_t(m)/(m+n);
+	float64_t rho_y=float64_t(n)/(m+n);
+
+	float64_t var_alt=4*rho_x*(alt_var_first-alt_var_second)+
+		4*rho_y*(alt_var_third-alt_var_fourth);
+
+	SG_INFO("Computed variance under alternative!\n");
+	SG_DEBUG("first=%f, second=%f, third=%f, fourth=%f\n", alt_var_first,
+			alt_var_second, alt_var_third, alt_var_fourth);
+
+	SGVector<float64_t> results(3);
+	results[0]=statistic;
+	results[1]=var_null;
+	results[2]=var_alt;
+
+	SG_DEBUG("Leaving!\n");
+
+	return results;
+}
+
+SGVector<float64_t> CQuadraticTimeMMD::compute_incomplete_statistic_variance(int n)
+{
+	SG_DEBUG("Entering!\n");
+
+	/* init kernel with features. NULL check is handled in compute_statistic */
+	m_kernel->init(m_p_and_q, m_p_and_q);
+
+	/* computing kernel values and their sums on the fly that are used both in
+	   computing statistic and variance */
+
+	/* the following matrix stores row-wise sum of kernel values k(X,X') in
+	   the first column and row-wise squared sum of kernel values k^2(X,X')
+	   in the second column. n entries in both column */
+	SGMatrix<float64_t> xx_sum_sq_sum_rowwise=m_kernel->
+		row_wise_sum_squared_sum_symmetric_block(0, n);
+
+	/* row-wise sum of kernel values k(Y,Y'), n entries */
+	SGVector<float64_t> yy_sum_rowwise=m_kernel->
+		row_wise_sum_symmetric_block(n, n);
+
+	/* row-wise and col-wise sum of kernel values k(X,Y), 2n entries
+	   first n entries are row-wise sum, rest n entries are col-wise sum */
+	SGVector<float64_t> xy_sum_rowcolwise=m_kernel->
+		row_col_wise_sum_block(0, n, n, n, true);
+
+	/* computing overall sum and squared sum from above for convenience */
+
+	SGVector<float64_t> xx_sum_rowwise(n);
+	std::copy(xx_sum_sq_sum_rowwise.matrix, xx_sum_sq_sum_rowwise.matrix+n,
+			xx_sum_rowwise.vector);
+
+	SGVector<float64_t> xy_sum_rowwise(n);
+	std::copy(xy_sum_rowcolwise.vector, xy_sum_rowcolwise.vector+n,
+			xy_sum_rowwise.vector);
+
+	SGVector<float64_t> xy_sum_colwise(n);
+	std::copy(xy_sum_rowcolwise.vector+n, xy_sum_rowcolwise.vector+2*n,
+			xy_sum_colwise.vector);
+
+	float64_t xx_sq_sum=0.0;
+	for (index_t i=0; i<xx_sum_sq_sum_rowwise.num_rows; i++)
+		xx_sq_sum+=xx_sum_sq_sum_rowwise(i, 1);
+
+	float64_t xx_sum=0.0;
+	for (index_t i=0; i<xx_sum_rowwise.vlen; i++)
+		xx_sum+=xx_sum_rowwise[i];
+
+	float64_t yy_sum=0.0;
+	for (index_t i=0; i<yy_sum_rowwise.vlen; i++)
+		yy_sum+=yy_sum_rowwise[i];
+
+	float64_t xy_sum=0.0;
+	for (index_t i=0; i<xy_sum_rowwise.vlen; i++)
+		xy_sum+=xy_sum_rowwise[i];
+
+	/* compute statistic */
+
+	/* split computations into three terms from JLMR paper (see documentation )*/
+
+	/* first term */
+	float64_t first=xx_sum/n/(n-1);
+
+	/* second term */
+	float64_t second=yy_sum/n/(n-1);
+
+	/* third term */
+	float64_t third=2.0*xy_sum/n/(n-1);
+
+	float64_t statistic=first+second-third;
+
+	SG_INFO("Computed statistic!\n");
+	SG_DEBUG("first=%f, second=%f, third=%f\n", first, second, third);
+
+	/* compute variance under null */
+
+	/* split computations into three terms (see documentation) */
+
+	/* first term */
+	float64_t kappa_0=CMath::sq(xx_sum/n/(n-1));
+
+	/* second term */
+	float64_t kappa_1=0.0;
+	for (index_t i=0; i<n; ++i)
+		kappa_1+=CMath::sq(xx_sum_rowwise[i]/(n-1));
+	kappa_1/=n;
+
+	/* third term */
+	float64_t kappa_2=xx_sq_sum/n/(n-1);
+
+	float64_t var_null=2*(kappa_0-2*kappa_1+kappa_2);
+
+	SG_INFO("Computed variance under null!\n");
+	SG_DEBUG("kappa_0=%f, kappa_1=%f, kappa_2=%f\n", kappa_0, kappa_1, kappa_2);
+
+	/* compute variance under alternative */
+
+	/* split computations into four terms (see documentation) */
+
+	/* first term */
+	float64_t alt_var_first=0.0;
+	for (index_t i=0; i<n; ++i)
+	{
+		// use row-wise sum from k(X,X') and k(X,Y) blocks
+		float64_t term=(xx_sum_rowwise[i]-xy_sum_rowwise[i])/(n-1);
+		alt_var_first+=CMath::sq(term);
+	}
+	alt_var_first/=n;
+
+	/* second term */
+	float64_t alt_var_second=CMath::sq(xx_sum/n/(n-1)-xy_sum/n/(n-1));
+
+	/* third term */
+	float64_t alt_var_third=0.0;
+	for (index_t i=0; i<n; ++i)
+	{
+		// use row-wise sum from k(Y,Y') and col-wise sum from k(X,Y)
+		// blocks to simulate row-wise sum from k(Y,X) blocks
+		float64_t term=(yy_sum_rowwise[i]-xy_sum_colwise[i])/(n-1);
+		alt_var_third+=CMath::sq(term);
+	}
+	alt_var_third/=n;
+
+	/* fourth term */
+	float64_t alt_var_fourth=CMath::sq(yy_sum/n/(n-1)-xy_sum/n/(n-1));
+
+	/* finally computing variance */
+	float64_t rho_x=0.5;
+	float64_t rho_y=0.5;
+
+	float64_t var_alt=4*rho_x*(alt_var_first-alt_var_second)+
+		4*rho_y*(alt_var_third-alt_var_fourth);
+
+	SG_INFO("Computed variance under alternative!\n");
+	SG_DEBUG("first=%f, second=%f, third=%f, fourth=%f\n", alt_var_first,
+			alt_var_second, alt_var_third, alt_var_fourth);
+
+	SGVector<float64_t> results(3);
+	results[0]=statistic;
+	results[1]=var_null;
+	results[2]=var_alt;
+
+	SG_DEBUG("Leaving!\n");
+
+	return results;
+}
+
+float64_t CQuadraticTimeMMD::compute_unbiased_statistic(int m, int n)
+{
+	return compute_unbiased_statistic_variance(m, n)[0];
+}
+
+float64_t CQuadraticTimeMMD::compute_biased_statistic(int m, int n)
+{
+	return compute_biased_statistic_variance(m, n)[0];
+}
+
+float64_t CQuadraticTimeMMD::compute_incomplete_statistic(int n)
+{
+	return compute_incomplete_statistic_variance(n)[0];
 }
 
 float64_t CQuadraticTimeMMD::compute_statistic()
 {
-	if (!m_kernel)
-		SG_ERROR("No kernel specified!\n")
+	REQUIRE(m_kernel, "No kernel specified!\n")
+
+	index_t m=m_m;
+	index_t n=0;
+
+	/* check if kernel is precomputed (custom kernel) */
+	if (m_kernel->get_kernel_type()==K_CUSTOM)
+		n=m_kernel->get_num_vec_lhs()-m;
+	else
+	{
+		REQUIRE(m_p_and_q, "The samples are not initialized!\n");
+		n=m_p_and_q->get_num_vectors()-m;
+	}
+
+	SG_DEBUG("Computing MMD with %d samples from p and %d samples from q!\n",
+			m, n);
 
 	float64_t result=0;
 	switch (m_statistic_type)
 	{
 	case UNBIASED:
-		result=compute_unbiased_statistic();
+		result=compute_unbiased_statistic(m, n);
+		result*=m*n/float64_t(m+n);
+		break;
+	case UNBIASED_DEPRECATED:
+		result=compute_unbiased_statistic(m, n);
+		result*=m==n ? m : (m+n);
 		break;
 	case BIASED:
-		result=compute_biased_statistic();
+		result=compute_biased_statistic(m, n);
+		result*=m*n/float64_t(m+n);
+		break;
+	case BIASED_DEPRECATED:
+		result=compute_biased_statistic(m, n);
+		result*=m==n? m : (m+n);
+		break;
+	case INCOMPLETE:
+		REQUIRE(m==n, "Only possible with equal number of samples from both"
+				"distribution!\n")
+		result=compute_incomplete_statistic(n);
+		result*=n/2;
 		break;
 	default:
 		SG_ERROR("Unknown statistic type!\n");
@@ -195,45 +595,72 @@ float64_t CQuadraticTimeMMD::compute_statistic()
 	return result;
 }
 
-float64_t CQuadraticTimeMMD::compute_p_value(float64_t statistic)
+SGVector<float64_t> CQuadraticTimeMMD::compute_variance()
 {
-	float64_t result=0;
+	REQUIRE(m_kernel, "No kernel specified!\n")
 
-	switch (m_null_approximation_method)
+	index_t m=m_m;
+	index_t n=0;
+
+	/* check if kernel is precomputed (custom kernel) */
+	if (m_kernel->get_kernel_type()==K_CUSTOM)
+		n=m_kernel->get_num_vec_lhs()-m;
+	else
 	{
-	case MMD2_SPECTRUM:
-	{
-#ifdef HAVE_EIGEN3
-		/* get samples from null-distribution and compute p-value of statistic */
-		SGVector<float64_t> null_samples=sample_null_spectrum(
-				m_num_samples_spectrum, m_num_eigenvalues_spectrum);
-		null_samples.qsort();
-		index_t pos=null_samples.find_position_to_insert(statistic);
-		result=1.0-((float64_t)pos)/null_samples.vlen;
-#else // HAVE_EIGEN3
-		SG_ERROR("Only possible if shogun is compiled with EIGEN3 enabled\n");
-#endif // HAVE_EIGEN3
-		break;
+		REQUIRE(m_p_and_q, "The samples are not initialized!\n");
+		n=m_p_and_q->get_num_vectors()-m;
 	}
 
-	case MMD2_GAMMA:
+	SG_DEBUG("Computing MMD with %d samples from p and %d samples from q!\n",
+			m, n);
+
+	SGVector<float64_t> result(2);
+	switch (m_statistic_type)
 	{
-		/* fit gamma and return cdf at statistic */
-		SGVector<float64_t> params=fit_null_gamma();
-		result=CStatistics::gamma_cdf(statistic, params[0], params[1]);
+	case UNBIASED:
+	case UNBIASED_DEPRECATED:
+	{
+		SGVector<float64_t> res=compute_unbiased_statistic_variance(m, n);
+		result[0]=res[1];
+		result[1]=res[2];
 		break;
 	}
-
+	case BIASED:
+	case BIASED_DEPRECATED:
+	{
+		SGVector<float64_t> res=compute_biased_statistic_variance(m, n);
+		result[0]=res[1];
+		result[1]=res[2];
+		break;
+	}
+	case INCOMPLETE:
+	{
+		REQUIRE(m==n, "Only possible with equal number of samples from both"
+				"distribution!\n")
+		SGVector<float64_t> res=compute_incomplete_statistic_variance(n);
+		result[0]=res[1];
+		result[1]=res[2];
+		break;
+	}
 	default:
-		result=CKernelTwoSampleTest::compute_p_value(statistic);
+		SG_ERROR("Unknown statistic type!\n");
 		break;
 	}
 
 	return result;
 }
 
-SGVector<float64_t> CQuadraticTimeMMD::compute_statistic(
-		bool multiple_kernels)
+float64_t CQuadraticTimeMMD::compute_variance_under_null()
+{
+	return compute_variance()[0];
+}
+
+float64_t CQuadraticTimeMMD::compute_variance_under_alternative()
+{
+	return compute_variance()[1];
+}
+
+SGVector<float64_t> CQuadraticTimeMMD::compute_statistic(bool multiple_kernels)
 {
 	SGVector<float64_t> mmds;
 	if (!multiple_kernels)
@@ -244,6 +671,7 @@ SGVector<float64_t> CQuadraticTimeMMD::compute_statistic(
 	}
 	else
 	{
+		REQUIRE(m_kernel, "No kernel specified!\n")
 		REQUIRE(m_kernel->get_kernel_type()==K_COMBINED,
 			"multiple kernels specified, but underlying kernel is not of type "
 			"K_COMBINED\n");
@@ -273,6 +701,103 @@ SGVector<float64_t> CQuadraticTimeMMD::compute_statistic(
 	return mmds;
 }
 
+SGMatrix<float64_t> CQuadraticTimeMMD::compute_variance(bool multiple_kernels)
+{
+	SGMatrix<float64_t> vars;
+	if (!multiple_kernels)
+	{
+		/* just one mmd result */
+		vars=SGMatrix<float64_t>(1, 2);
+		SGVector<float64_t> result=compute_variance();
+		vars(0, 0)=result[0];
+		vars(0, 1)=result[1];
+	}
+	else
+	{
+		REQUIRE(m_kernel, "No kernel specified!\n")
+		REQUIRE(m_kernel->get_kernel_type()==K_COMBINED,
+			"multiple kernels specified, but underlying kernel is not of type "
+			"K_COMBINED\n");
+
+		/* cast and allocate memory for results */
+		CCombinedKernel* combined=(CCombinedKernel*)m_kernel;
+		SG_REF(combined);
+		vars=SGMatrix<float64_t>(combined->get_num_subkernels(), 2);
+
+		/* iterate through all kernels and compute variance */
+		/* TODO this might be done in parallel */
+		for (index_t i=0; i<vars.num_rows; ++i)
+		{
+			CKernel* current=combined->get_kernel(i);
+			/* temporarily replace underlying kernel and compute variance */
+			m_kernel=current;
+			SGVector<float64_t> result=compute_variance();
+			vars(i, 0)=result[0];
+			vars(i, 1)=result[1];
+
+			SG_UNREF(current);
+		}
+
+		/* restore combined kernel */
+		m_kernel=combined;
+		SG_UNREF(combined);
+	}
+
+	return vars;
+}
+
+float64_t CQuadraticTimeMMD::compute_p_value(float64_t statistic)
+{
+	float64_t result=0;
+
+	switch (m_null_approximation_method)
+	{
+	case MMD2_SPECTRUM:
+	{
+#ifdef HAVE_EIGEN3
+		/* get samples from null-distribution and compute p-value of statistic */
+		SGVector<float64_t> null_samples=sample_null_spectrum(
+				m_num_samples_spectrum, m_num_eigenvalues_spectrum);
+		null_samples.qsort();
+		index_t pos=null_samples.find_position_to_insert(statistic);
+		result=1.0-((float64_t)pos)/null_samples.vlen;
+#else // HAVE_EIGEN3
+		SG_ERROR("Only possible if shogun is compiled with EIGEN3 enabled\n");
+#endif // HAVE_EIGEN3
+		break;
+	}
+
+	case MMD2_SPECTRUM_DEPRECATED:
+	{
+#ifdef HAVE_EIGEN3
+		/* get samples from null-distribution and compute p-value of statistic */
+		SGVector<float64_t> null_samples=sample_null_spectrum_DEPRECATED(
+				m_num_samples_spectrum, m_num_eigenvalues_spectrum);
+		null_samples.qsort();
+		index_t pos=null_samples.find_position_to_insert(statistic);
+		result=1.0-((float64_t)pos)/null_samples.vlen;
+#else // HAVE_EIGEN3
+		SG_ERROR("Only possible if shogun is compiled with EIGEN3 enabled\n");
+#endif // HAVE_EIGEN3
+		break;
+	}
+
+	case MMD2_GAMMA:
+	{
+		/* fit gamma and return cdf at statistic */
+		SGVector<float64_t> params=fit_null_gamma();
+		result=CStatistics::gamma_cdf(statistic, params[0], params[1]);
+		break;
+	}
+
+	default:
+		result=CKernelTwoSampleTest::compute_p_value(statistic);
+		break;
+	}
+
+	return result;
+}
+
 float64_t CQuadraticTimeMMD::compute_threshold(float64_t alpha)
 {
 	float64_t result=0;
@@ -284,6 +809,20 @@ float64_t CQuadraticTimeMMD::compute_threshold(float64_t alpha)
 #ifdef HAVE_EIGEN3
 		/* get samples from null-distribution and compute threshold */
 		SGVector<float64_t> null_samples=sample_null_spectrum(
+				m_num_samples_spectrum, m_num_eigenvalues_spectrum);
+		null_samples.qsort();
+		result=null_samples[index_t(CMath::floor(null_samples.vlen*(1-alpha)))];
+#else // HAVE_EIGEN3
+		SG_ERROR("Only possible if shogun is compiled with EIGEN3 enabled\n");
+#endif // HAVE_EIGEN3
+		break;
+	}
+
+	case MMD2_SPECTRUM_DEPRECATED:
+	{
+#ifdef HAVE_EIGEN3
+		/* get samples from null-distribution and compute threshold */
+		SGVector<float64_t> null_samples=sample_null_spectrum_DEPRECATED(
 				m_num_samples_spectrum, m_num_eigenvalues_spectrum);
 		null_samples.qsort();
 		result=null_samples[index_t(CMath::floor(null_samples.vlen*(1-alpha)))];
@@ -314,6 +853,85 @@ float64_t CQuadraticTimeMMD::compute_threshold(float64_t alpha)
 #ifdef HAVE_EIGEN3
 SGVector<float64_t> CQuadraticTimeMMD::sample_null_spectrum(index_t num_samples,
 		index_t num_eigenvalues)
+{
+	REQUIRE(m_kernel, "(%d, %d): No kernel set!\n", num_samples,
+			num_eigenvalues);
+	REQUIRE(m_kernel->get_kernel_type()==K_CUSTOM || m_p_and_q,
+			"(%d, %d): No features set and no custom kernel in use!\n",
+			num_samples, num_eigenvalues);
+
+	index_t m=m_m;
+	index_t n=0;
+
+	/* check if kernel is precomputed (custom kernel) */
+	if (m_kernel && m_kernel->get_kernel_type()==K_CUSTOM)
+		n=m_kernel->get_num_vec_lhs()-m;
+	else
+	{
+		REQUIRE(m_p_and_q, "The samples are not initialized!\n");
+		n=m_p_and_q->get_num_vectors()-m;
+	}
+
+	if (num_samples<=2)
+	{
+		SG_ERROR("Number of samples has to be at least 2, "
+				"better in the hundreds");
+	}
+
+	if (num_eigenvalues>m+n-1)
+		SG_ERROR("Number of Eigenvalues too large\n");
+
+	if (num_eigenvalues<1)
+		SG_ERROR("Number of Eigenvalues too small\n");
+
+	/* imaginary matrix K=[K KL; KL' L] (MATLAB notation)
+	 * K is matrix for XX, L is matrix for YY, KL is XY, LK is YX
+	 * works since X and Y are concatenated here */
+	m_kernel->init(m_p_and_q, m_p_and_q);
+	SGMatrix<float64_t> K=m_kernel->get_kernel_matrix();
+
+	/* center matrix K=H*K*H */
+	K.center();
+
+	/* compute eigenvalues and select num_eigenvalues largest ones */
+	Map<MatrixXd> c_kernel_matrix(K.matrix, K.num_rows, K.num_cols);
+	SelfAdjointEigenSolver<MatrixXd> eigen_solver(c_kernel_matrix);
+	REQUIRE(eigen_solver.info()==Eigen::Success,
+			"Eigendecomposition failed!\n");
+	index_t max_num_eigenvalues=eigen_solver.eigenvalues().rows();
+
+	/* finally, sample from null distribution */
+	SGVector<float64_t> null_samples(num_samples);
+	for (index_t i=0; i<num_samples; ++i)
+	{
+		null_samples[i]=0;
+		for (index_t j=0; j<num_eigenvalues; ++j)
+		{
+			float64_t z_j=CMath::randn_double();
+
+			SG_DEBUG("z_j=%f\n", z_j);
+
+			float64_t multiple=CMath::sq(z_j);
+
+			/* take largest EV, scale by 1/(m+n) on the fly and take abs value*/
+			float64_t eigenvalue_estimate=CMath::abs(1.0/(m+n)
+				*eigen_solver.eigenvalues()[max_num_eigenvalues-1-j]);
+
+			if (m_statistic_type==UNBIASED)
+				multiple-=1;
+
+			SG_DEBUG("multiple=%f, eigenvalue=%f\n", multiple,
+					eigenvalue_estimate);
+
+			null_samples[i]+=eigenvalue_estimate*multiple;
+		}
+	}
+
+	return null_samples;
+}
+
+SGVector<float64_t> CQuadraticTimeMMD::sample_null_spectrum_DEPRECATED(
+		index_t num_samples, index_t num_eigenvalues)
 {
 	REQUIRE(m_kernel, "(%d, %d): No kernel set!\n", num_samples,
 			num_eigenvalues);
@@ -393,7 +1011,7 @@ SGVector<float64_t> CQuadraticTimeMMD::sample_null_spectrum(index_t num_samples,
 			float64_t eigenvalue_estimate=CMath::abs(1.0/(m+n)
 				*eigen_solver.eigenvalues()[max_num_eigenvalues-1-j]);
 
-			if (m_statistic_type==UNBIASED)
+			if (m_statistic_type==UNBIASED_DEPRECATED)
 				multiple-=inv_rho_x_y;
 
 			SG_DEBUG("multiple=%f, eigenvalue=%f\n", multiple,
@@ -417,6 +1035,19 @@ SGVector<float64_t> CQuadraticTimeMMD::fit_null_gamma()
 	REQUIRE(m_kernel->get_kernel_type()==K_CUSTOM || m_p_and_q,
 			"No features set and no custom kernel in use!\n");
 
+	index_t n=0;
+
+	/* check if kernel is precomputed (custom kernel) */
+	if (m_kernel && m_kernel->get_kernel_type()==K_CUSTOM)
+		n=m_kernel->get_num_vec_lhs()-m_m;
+	else
+	{
+		REQUIRE(m_p_and_q, "The samples are not initialized!\n");
+		n=m_p_and_q->get_num_vectors()-m_m;
+	}
+	REQUIRE(m_m==n, "Only possible with equal number of samples "
+			"from both distribution!\n")
+
 	index_t num_data;
 	if (m_kernel->get_kernel_type()==K_CUSTOM)
 		num_data=m_kernel->get_num_vec_rhs();
@@ -427,11 +1058,11 @@ SGVector<float64_t> CQuadraticTimeMMD::fit_null_gamma()
 		SG_ERROR("Currently, only equal sample sizes are supported\n");
 
 	/* evtl. warn user not to use wrong statistic type */
-	if (m_statistic_type!=BIASED)
+	if (m_statistic_type!=BIASED_DEPRECATED)
 	{
 		SG_WARNING("Note: provided statistic has "
 				"to be BIASED. Please ensure that! To get rid of warning,"
-				"call %s::set_statistic_type(BIASED)\n", get_name());
+				"call %s::set_statistic_type(BIASED_DEPRECATED)\n", get_name());
 	}
 
 	/* imaginary matrix K=[K KL; KL' L] (MATLAB notation)

--- a/tests/unit/statistics/MMDKernelSelectionMax_unittest.cc
+++ b/tests/unit/statistics/MMDKernelSelectionMax_unittest.cc
@@ -74,6 +74,7 @@ TEST(MMDKernelSelectionMax,select_kernel_quadratic_time_mmd)
 	 * linear time mmd maxmmd selection. Do biased and unbiased m*MMD */
 
 	/* unbiased m*MMD */
+	mmd->set_statistic_type(UNBIASED_DEPRECATED);
 	SGVector<float64_t> measures=selection->compute_measures();
 	//measures.display_vector("unbiased mmd");
 //	unbiased_quad_mmds =
@@ -83,7 +84,7 @@ TEST(MMDKernelSelectionMax,select_kernel_quadratic_time_mmd)
 	EXPECT_LE(CMath::abs(measures[2]-0.000072802127661), 10E-15);
 
 	/* biased m*MMD */
-	mmd->set_statistic_type(BIASED);
+	mmd->set_statistic_type(BIASED_DEPRECATED);
 	measures=selection->compute_measures();
 	//measures.display_vector("biased mmd");
 //	biased_quad_mmds =

--- a/tests/unit/statistics/QuadraticTimeMMD_unittest.cc
+++ b/tests/unit/statistics/QuadraticTimeMMD_unittest.cc
@@ -59,6 +59,54 @@ TEST(QuadraticTimeMMD,test_quadratic_mmd_biased)
 	/* assert matlab result */
 	float64_t statistic=mmd->compute_statistic();
 	//SG_SPRINT("statistic=%f\n", statistic);
+	EXPECT_NEAR(statistic, 0.17882546486779649, 1E-15);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD,test_quadratic_mmd_biased_DEPRECATED)
+{
+	index_t m=8;
+	index_t d=3;
+	SGMatrix<float64_t> data(d,2*m);
+	for (index_t i=0; i<2*d*m; ++i)
+		data.matrix[i]=i;
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data.matrix[0]), sizeof(float64_t)*d*m);
+
+	SGMatrix<float64_t> data_q(d, m);
+	memcpy(&(data_q.matrix[0]), &(data.matrix[d*m]), sizeof(float64_t)*d*m);
+
+	/* normalise data */
+	float64_t max_p=data_p.max_single();
+	float64_t max_q=data_q.max_single();
+
+	for (index_t i=0; i<d*m; ++i)
+	{
+		data_p.matrix[i]/=max_p;
+		data_q.matrix[i]/=max_q;
+	}
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	float64_t sigma=2;
+	float64_t sq_sigma_twice=sigma*sigma*2;
+	CGaussianKernel* kernel=new CGaussianKernel(10, sq_sigma_twice);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+	mmd->set_statistic_type(BIASED_DEPRECATED);
+
+	/* assert matlab result */
+	float64_t statistic=mmd->compute_statistic();
+	//SG_SPRINT("statistic=%f\n", statistic);
 	EXPECT_NEAR(statistic, 0.357650929735592, 10E-15);
 
 	/* clean up */
@@ -107,8 +155,103 @@ TEST(QuadraticTimeMMD,test_quadratic_mmd_unbiased)
 	/* assert matlab result */
 	float64_t statistic=mmd->compute_statistic();
 	//SG_SPRINT("statistic=%f\n", statistic);
+	EXPECT_NEAR(statistic, 0.13440094336133723, 1E-15);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD,test_quadratic_mmd_unbiased_DEPRECATED)
+{
+	index_t m=8;
+	index_t d=3;
+	SGMatrix<float64_t> data(d,2*m);
+	for (index_t i=0; i<2*d*m; ++i)
+		data.matrix[i]=i;
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data.matrix[0]), sizeof(float64_t)*d*m);
+
+	SGMatrix<float64_t> data_q(d, m);
+	memcpy(&(data_q.matrix[0]), &(data.matrix[d*m]), sizeof(float64_t)*d*m);
+
+	/* normalise data */
+	float64_t max_p=data_p.max_single();
+	float64_t max_q=data_q.max_single();
+
+	for (index_t i=0; i<d*m; ++i)
+	{
+		data_p.matrix[i]/=max_p;
+		data_q.matrix[i]/=max_q;
+	}
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	float64_t sigma=2;
+	float64_t sq_sigma_twice=sigma*sigma*2;
+	CGaussianKernel* kernel=new CGaussianKernel(10, sq_sigma_twice);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+	mmd->set_statistic_type(UNBIASED_DEPRECATED);
+
+	/* assert matlab result */
+	float64_t statistic=mmd->compute_statistic();
+	//SG_SPRINT("statistic=%f\n", statistic);
 	float64_t difference=statistic-0.268801886722675;
 	EXPECT_LE(CMath::abs(difference), 10E-15);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD,test_quadratic_mmd_incomplete)
+{
+	index_t m=8;
+	index_t d=3;
+	SGMatrix<float64_t> data(d,2*m);
+	for (index_t i=0; i<2*d*m; ++i)
+		data.matrix[i]=i;
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data.matrix[0]), sizeof(float64_t)*d*m);
+
+	SGMatrix<float64_t> data_q(d, m);
+	memcpy(&(data_q.matrix[0]), &(data.matrix[d*m]), sizeof(float64_t)*d*m);
+
+	/* normalise data */
+	float64_t max_p=data_p.max_single();
+	float64_t max_q=data_q.max_single();
+
+	for (index_t i=0; i<d*m; ++i)
+	{
+		data_p.matrix[i]/=max_p;
+		data_q.matrix[i]/=max_q;
+	}
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	float64_t sigma=2;
+	float64_t sq_sigma_twice=sigma*sigma*2;
+	CGaussianKernel* kernel=new CGaussianKernel(10, sq_sigma_twice);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+	mmd->set_statistic_type(INCOMPLETE);
+
+	/* assert local machine computed result */
+	float64_t statistic=mmd->compute_statistic();
+	EXPECT_NEAR(statistic, 0.16743977201175841, 1E-15);
 
 	/* clean up */
 	SG_UNREF(mmd);
@@ -141,6 +284,43 @@ TEST(QuadraticTimeMMD, test_quadratic_mmd_unbiased_different_num_samples)
 	/* create MMD instance, convienience constructor */
 	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
 	mmd->set_statistic_type(UNBIASED);
+
+	/* assert python result at
+	 * https://github.com/lambday/shogun-hypothesis-testing/blob/master/mmd.py */
+	float64_t statistic=mmd->compute_statistic();
+	EXPECT_NEAR(statistic, -0.037500338130199401, 1E-9);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD, test_quadratic_mmd_unbiased_different_num_samples_DEPRECATED)
+{
+	const index_t m=5;
+	const index_t n=6;
+	const index_t d=1;
+	float64_t data[] = {0.61318059, -0.69222999, 0.94424411, -0.48769626,
+		-0.00709551,  0.35025598, 0.20741384, -0.63622519, -1.21315264,
+	   	-0.77349617, -0.42707091};
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data[0]), sizeof(float64_t)*m);
+
+	SGMatrix<float64_t> data_q(d, n);
+	memcpy(&(data_q.matrix[0]), &(data[m]), sizeof(float64_t)*n);
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	CGaussianKernel* kernel=new CGaussianKernel(10, 2);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+	mmd->set_statistic_type(UNBIASED_DEPRECATED);
 
 	/* assert python result at
 	 * https://github.com/lambday/shogun-hypothesis-testing/blob/master/mmd.py */
@@ -182,7 +362,154 @@ TEST(QuadraticTimeMMD, test_quadratic_mmd_biased_different_num_samples)
 	/* assert python result at
 	 * https://github.com/lambday/shogun-hypothesis-testing/blob/master/mmd.py */
 	float64_t statistic=mmd->compute_statistic();
+	EXPECT_NEAR(statistic, 0.54418915736201567, 1E-8);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD, test_quadratic_mmd_biased_different_num_samples_DEPRECATED)
+{
+	const index_t m=5;
+	const index_t n=6;
+	const index_t d=1;
+	float64_t data[] = {-0.47616889, -2.1767364, -0.04185537, -1.20787529,
+		1.94875193, -0.16695709, 2.51282666, -0.58116389, 1.52366887,
+		0.18985099, 0.76120258};
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data[0]), sizeof(float64_t)*m);
+
+	SGMatrix<float64_t> data_q(d, n);
+	memcpy(&(data_q.matrix[0]), &(data[m]), sizeof(float64_t)*n);
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	CGaussianKernel* kernel=new CGaussianKernel(10, 2);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+	mmd->set_statistic_type(BIASED_DEPRECATED);
+
+	/* assert python result at
+	 * https://github.com/lambday/shogun-hypothesis-testing/blob/master/mmd.py */
+	float64_t statistic=mmd->compute_statistic();
 	EXPECT_NEAR(statistic, 2.1948962593, 1E-8);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD,compute_variance_null)
+{
+	index_t m=8;
+	index_t d=3;
+	SGMatrix<float64_t> data(d,2*m);
+	for (index_t i=0; i<2*d*m; ++i)
+		data.matrix[i]=i;
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data.matrix[0]), sizeof(float64_t)*d*m);
+
+	SGMatrix<float64_t> data_q(d, m);
+	memcpy(&(data_q.matrix[0]), &(data.matrix[d*m]), sizeof(float64_t)*d*m);
+
+	/* normalise data */
+	float64_t max_p=data_p.max_single();
+	float64_t max_q=data_q.max_single();
+
+	for (index_t i=0; i<d*m; ++i)
+	{
+		data_p.matrix[i]/=max_p;
+		data_q.matrix[i]/=max_q;
+	}
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	float64_t sigma=2;
+	float64_t sq_sigma_twice=sigma*sigma*2;
+	CGaussianKernel* kernel=new CGaussianKernel(10, sq_sigma_twice);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+
+	/* assert local machine computed result */
+	mmd->set_statistic_type(UNBIASED);
+	float64_t var=mmd->compute_variance_under_null();
+	EXPECT_NEAR(var, 0.0064888052500351456, 1E-15);
+
+	mmd->set_statistic_type(BIASED);
+	var=mmd->compute_variance_under_null();
+	EXPECT_NEAR(var, 0.0071464012090942663, 1E-15);
+
+	mmd->set_statistic_type(INCOMPLETE);
+	var=mmd->compute_variance_under_null();
+	EXPECT_NEAR(var, 0.0064888052500342575, 1E-15);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(features_p);
+	SG_UNREF(features_q);
+}
+
+TEST(QuadraticTimeMMD,compute_variance_alternative)
+{
+	index_t m=8;
+	index_t d=3;
+	SGMatrix<float64_t> data(d,2*m);
+	for (index_t i=0; i<2*d*m; ++i)
+		data.matrix[i]=i;
+
+	/* create data matrix for each features (appended is not supported) */
+	SGMatrix<float64_t> data_p(d, m);
+	memcpy(&(data_p.matrix[0]), &(data.matrix[0]), sizeof(float64_t)*d*m);
+
+	SGMatrix<float64_t> data_q(d, m);
+	memcpy(&(data_q.matrix[0]), &(data.matrix[d*m]), sizeof(float64_t)*d*m);
+
+	/* normalise data */
+	float64_t max_p=data_p.max_single();
+	float64_t max_q=data_q.max_single();
+
+	for (index_t i=0; i<d*m; ++i)
+	{
+		data_p.matrix[i]/=max_p;
+		data_q.matrix[i]/=max_q;
+	}
+
+	CDenseFeatures<float64_t>* features_p=new CDenseFeatures<float64_t>(data_p);
+	CDenseFeatures<float64_t>* features_q=new CDenseFeatures<float64_t>(data_q);
+
+	/* shoguns kernel width is different */
+	float64_t sigma=2;
+	float64_t sq_sigma_twice=sigma*sigma*2;
+	CGaussianKernel* kernel=new CGaussianKernel(10, sq_sigma_twice);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, features_p, features_q);
+
+	/* assert local machine computed result */
+	mmd->set_statistic_type(UNBIASED);
+	float64_t var=mmd->compute_variance_under_alternative();
+	EXPECT_NEAR(var, 0.0065377436264417842, 1E-15);
+
+	mmd->set_statistic_type(BIASED);
+	var=mmd->compute_variance_under_alternative();
+	EXPECT_NEAR(var, 0.0065069769045954847, 1E-15);
+
+	mmd->set_statistic_type(INCOMPLETE);
+	var=mmd->compute_variance_under_alternative();
+	EXPECT_NEAR(var, 0.0080742069013913682, 1E-15);
 
 	/* clean up */
 	SG_UNREF(mmd);
@@ -237,6 +564,63 @@ TEST(QuadraticTimeMMD, null_approximation_spectrum_different_num_samples)
 	/* compute p-value using spectrum approximation for null distribution and
 	 * assert against local machine computed result */
 	mmd->set_statistic_type(UNBIASED);
+	p_value_spectrum=mmd->perform_test();
+	EXPECT_NEAR(p_value_spectrum, 0.004, 1E-10);
+
+	/* clean up */
+	SG_UNREF(mmd);
+	SG_UNREF(feat_p);
+	SG_UNREF(feat_q);
+	SG_UNREF(gen_p);
+	SG_UNREF(gen_q);
+}
+
+TEST(QuadraticTimeMMD, null_approximation_spectrum_different_num_samples_DEPRECATED)
+{
+	const index_t m=20;
+	const index_t n=30;
+	const index_t dim=3;
+
+	/* use fixed seed */
+	sg_rand->set_seed(12345);
+
+	float64_t difference=0.5;
+
+	/* streaming data generator for mean shift distributions */
+	CMeanShiftDataGenerator* gen_p=new CMeanShiftDataGenerator(0, dim, 0);
+	CMeanShiftDataGenerator* gen_q=new CMeanShiftDataGenerator(difference, dim, 0);
+
+	/* stream some data from generator */
+	CFeatures* feat_p=gen_p->get_streamed_features(m);
+	CFeatures* feat_q=gen_q->get_streamed_features(n);
+
+	/* shoguns kernel width is different */
+	float64_t sigma=2;
+	float64_t sq_sigma_twice=sigma*sigma*2;
+	CGaussianKernel* kernel=new CGaussianKernel(10, sq_sigma_twice);
+
+	/* create MMD instance, convienience constructor */
+	CQuadraticTimeMMD* mmd=new CQuadraticTimeMMD(kernel, feat_p, feat_q);
+
+	index_t num_null_samples=250;
+	index_t num_eigenvalues=10;
+	mmd->set_num_samples_spectrum(num_null_samples);
+	mmd->set_null_approximation_method(MMD2_SPECTRUM_DEPRECATED);
+	mmd->set_num_eigenvalues_spectrum(num_eigenvalues);
+
+	/* biased case */
+
+	/* compute p-value using spectrum approximation for null distribution and
+	 * assert against local machine computed result */
+	mmd->set_statistic_type(BIASED_DEPRECATED);
+	float64_t p_value_spectrum=mmd->perform_test();
+	EXPECT_NEAR(p_value_spectrum, 0.0, 1E-10);
+
+	/* unbiased case */
+
+	/* compute p-value using spectrum approximation for null distribution and
+	 * assert against local machine computed result */
+	mmd->set_statistic_type(UNBIASED_DEPRECATED);
 	p_value_spectrum=mmd->perform_test();
 	EXPECT_NEAR(p_value_spectrum, 0.004, 1E-10);
 
@@ -307,7 +691,6 @@ TEST(QuadraticTimeMMD,test_quadratic_mmd_precomputed_kernel)
 	CCustomKernel* precomputed_kernel=new CCustomKernel(kernel);
 	SG_UNREF(mmd);
 	mmd=new CQuadraticTimeMMD(precomputed_kernel, p_and_q, m);
-	mmd->set_statistic_type(UNBIASED);
 	mmd->set_num_null_samples(10);
 	sg_rand->set_seed(12345);
 	null_samples=mmd->sample_null();
@@ -325,7 +708,7 @@ TEST(QuadraticTimeMMD,test_quadratic_mmd_precomputed_kernel)
 }
 
 #ifdef HAVE_EIGEN3
-TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel)
+TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel_DEPRECATED)
 {
 	/* number of examples kept low in order to make things fast */
 	index_t m=20;
@@ -363,13 +746,13 @@ TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel)
 	float64_t alpha=0.05;
 
 	mmd->set_null_approximation_method(PERMUTATION);
-	mmd->set_statistic_type(BIASED);
+	mmd->set_statistic_type(BIASED_DEPRECATED);
 	mmd->set_num_null_samples(3);
 	mmd->set_num_eigenvalues_spectrum(3);
 	mmd->set_num_samples_spectrum(250);
 
 	mmd2->set_null_approximation_method(PERMUTATION);
-	mmd2->set_statistic_type(BIASED);
+	mmd2->set_statistic_type(BIASED_DEPRECATED);
 	mmd2->set_num_null_samples(3);
 	mmd2->set_num_eigenvalues_spectrum(3);
 	mmd2->set_num_samples_spectrum(250);
@@ -395,7 +778,7 @@ TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel)
 		float64_t type_I_mmds=mmd->compute_statistic();
 		mmd->set_null_approximation_method(PERMUTATION);
 		float64_t type_I_threshs_boot=mmd->compute_threshold(alpha);
-		mmd->set_null_approximation_method(MMD2_SPECTRUM);
+		mmd->set_null_approximation_method(MMD2_SPECTRUM_DEPRECATED);
 		float64_t type_I_threshs_spectrum=mmd->compute_threshold(alpha);
 		mmd->set_null_approximation_method(MMD2_GAMMA);
 		float64_t type_I_threshs_gamma=mmd->compute_threshold(alpha);
@@ -404,7 +787,7 @@ TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel)
 		float64_t type_II_mmds=mmd->compute_statistic();
 		mmd->set_null_approximation_method(PERMUTATION);
 		float64_t type_II_threshs_boot=mmd->compute_threshold(alpha);
-		mmd->set_null_approximation_method(MMD2_SPECTRUM);
+		mmd->set_null_approximation_method(MMD2_SPECTRUM_DEPRECATED);
 		float64_t type_II_threshs_spectrum=mmd->compute_threshold(alpha);
 		mmd->set_null_approximation_method(MMD2_GAMMA);
 		float64_t type_II_threshs_gamma=mmd->compute_threshold(alpha);
@@ -419,7 +802,7 @@ TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel)
 		float64_t type_I_mmds_pre=mmd2->compute_statistic();
 		mmd2->set_null_approximation_method(PERMUTATION);
 		float64_t type_I_threshs_boot_pre=mmd2->compute_threshold(alpha);
-		mmd2->set_null_approximation_method(MMD2_SPECTRUM);
+		mmd2->set_null_approximation_method(MMD2_SPECTRUM_DEPRECATED);
 		float64_t type_I_threshs_spectrum_pre=mmd2->compute_threshold(alpha);
 		mmd2->set_null_approximation_method(MMD2_GAMMA);
 		float64_t type_I_threshs_gamma_pre=mmd2->compute_threshold(alpha);
@@ -429,7 +812,7 @@ TEST(QuadraticTimeMMD,custom_kernel_vs_normal_kernel)
 		float64_t type_II_mmds_pre=mmd2->compute_statistic();
 		mmd2->set_null_approximation_method(PERMUTATION);
 		float64_t type_II_threshs_boot_pre=mmd2->compute_threshold(alpha);
-		mmd2->set_null_approximation_method(MMD2_SPECTRUM);
+		mmd2->set_null_approximation_method(MMD2_SPECTRUM_DEPRECATED);
 		float64_t type_II_threshs_spectrum_pre=mmd2->compute_threshold(alpha);
 		mmd2->set_null_approximation_method(MMD2_GAMMA);
 		float64_t type_II_threshs_gamma_pre=mmd2->compute_threshold(alpha);


### PR DESCRIPTION
The previous implementation is also kept alongside with the new
implementation as DEPRECATED versions.

The changes are
- compute_statistic method now returns m_n/(m+n)_MMD^2 estimate.
- An incomplete estimate of statistic is made available.
- Previous results work if statistic type is set as BIASED_DEPRECATED,
  UNBIASED_DEPRECATED which returns (m+n)_MMD^2 in general case and
  m_MMD^2 when m equals n.
- Spectral estimate of null samples returns m_n/(m+n)_Null-samples now
  Previous method works with MMD2_SPECTRUM_DEPRECATED enum.
- Estimate of variance of asymptotic distribution of the statistic is
  computed along with computing statistic to avoid recomputing the
  kernel. Variance under null and alternative are computed separately.
- Similar to compute_statistic, compute_variance works with multiple
  kernels as well.
