### PR TITLE
CMultilabelSOLabels class modified along with unit tests to remove memory leaks

### DIFF
--- a/src/shogun/structure/MultilabelSOLabels.cpp
+++ b/src/shogun/structure/MultilabelSOLabels.cpp
@@ -40,6 +40,10 @@ void CMultilabelSOLabels::init()
 {
 	SG_ADD((CSGObject **)&m_multilabel_labels, "multilabel_labels", "multilabel labels object",
 	       MS_NOT_AVAILABLE);
+	SG_ADD(&m_last_set_label, "last_set_label", "index of the last label added using add_label() method",
+	       MS_NOT_AVAILABLE);
+
+	m_last_set_label = 0;
 }
 
 CMultilabelSOLabels::~CMultilabelSOLabels()
@@ -91,6 +95,7 @@ bool CMultilabelSOLabels::set_label(int32_t j, CStructuredData * label)
 CStructuredData * CMultilabelSOLabels::get_label(int32_t j)
 {
 	CSparseMultilabel * slabel = new CSparseMultilabel(m_multilabel_labels->get_label(j));
+	SG_REF(slabel);
 	return (CStructuredData *)slabel;
 }
 
@@ -111,5 +116,14 @@ SGVector<float64_t> CMultilabelSOLabels::to_dense(CStructuredData * label,
 	SGVector<int32_t> slabel_data = slabel->get_data();
 	return CMultilabelLabels::to_dense<int32_t, float64_t>(&slabel_data,
 	                dense_dim, d_true, d_false);
+}
+
+void CMultilabelSOLabels::add_label(CStructuredData * label)
+{
+	REQUIRE(m_last_set_label >= 0 && m_last_set_label < get_num_labels(),
+	        "Only %d number of labels can be added.\n", get_num_labels());
+
+	set_label(m_last_set_label, label);
+	m_last_set_label++;
 }
 

--- a/src/shogun/structure/MultilabelSOLabels.h
+++ b/src/shogun/structure/MultilabelSOLabels.h
@@ -140,6 +140,13 @@ public:
 	 */
 	virtual bool set_label(int32_t j, CStructuredData * label);
 
+	/** add a new label to the vector of labels.
+	 * This method should be used when inserting labels for the first time.
+	 *
+	 * @param label sparse label to add
+	 */
+	virtual void add_label(CStructuredData * label);
+
 	/** get sparse assigment for j-th label
 	 *
 	 * @param j label index
@@ -174,6 +181,7 @@ public:
 
 private:
 	CMultilabelLabels * m_multilabel_labels;
+	int32_t m_last_set_label;
 
 private:
 	void init();

--- a/tests/unit/structure/MultilabelSOLabels_unittest.cc
+++ b/tests/unit/structure/MultilabelSOLabels_unittest.cc
@@ -50,15 +50,19 @@ TEST(MultilabelSOLabels, constructor_two_args)
 TEST(MultilabelSOLabels, set_sparse_label)
 {
 	CMultilabelSOLabels * ml = new CMultilabelSOLabels(1, 2);
+	SG_REF(ml);
 	ASSERT_TRUE(ml != NULL);
 
 	EXPECT_EQ(ml->get_num_labels(), 1);
 	EXPECT_EQ(ml->get_num_classes(), 2);
 
-	int lab[] = {0, 1};
-	ml->set_sparse_label(0, SGVector<int32_t>(lab, 2));
+	SGVector<int32_t> lab(2);
+	lab[0] = 0;
+	lab[1] = 1;
+	ml->set_sparse_label(0, lab);
 
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(ml->get_label(0));
+	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(
+	                                     ml->get_label(0));
 	SGVector<int32_t> slabel_data = slabel->get_data();
 
 	for (int i = 0; i < slabel_data.vlen; i++)
@@ -66,29 +70,37 @@ TEST(MultilabelSOLabels, set_sparse_label)
 		EXPECT_EQ(lab[i], slabel_data[i]);
 	}
 
+	SG_UNREF(slabel);
 	SG_UNREF(ml);
 }
 
 TEST(MultilabelSOLabels, set_label)
 {
 	CMultilabelSOLabels * ml = new CMultilabelSOLabels(1, 2);
-	ASSERT_TRUE(ml != NULL);
+	SG_REF(ml);
+	ASSERT(ml != NULL);
 
 	EXPECT_EQ(ml->get_num_labels(), 1);
 	EXPECT_EQ(ml->get_num_classes(), 2);
 
-	int lab[] = {0, 1};
-	CSparseMultilabel * slabel = new CSparseMultilabel(SGVector<int32_t>(lab, 2));
+	SGVector<int32_t> lab(2);
+	lab[0] = 0;
+	lab[1] = 1;
+	CSparseMultilabel * slabel = new CSparseMultilabel(lab);
+	SG_REF(slabel);
 	ml->set_label(0, slabel);
 
-	CSparseMultilabel * slabel_out = CSparseMultilabel::obtain_from_generic(ml->get_label(0));
+	CSparseMultilabel * slabel_out = CSparseMultilabel::obtain_from_generic(
+	                ml->get_label(0));
 	SGVector<int32_t> slabel_data = slabel_out->get_data();
 
-	for (int i = 0; i < slabel_data.vlen; i++)
+	for (index_t i = 0; i < slabel_data.vlen; i++)
 	{
 		EXPECT_EQ(lab[i], slabel_data[i]);
 	}
 
+	SG_UNREF(slabel);
+	SG_UNREF(slabel_out);
 	SG_UNREF(ml);
 }
 
@@ -124,6 +136,8 @@ TEST(MultilabelSOLabels, set_sparse_labels)
 		{
 			EXPECT_EQ(lab[j], slabel_data[j]);
 		}
+
+		SG_UNREF(slabel);
 	}
 
 	delete [] labels;
@@ -155,6 +169,7 @@ TEST(MultilabelSOLabels, to_dense)
 	{
 		CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(ml->get_label(0));
 		SGVector<float64_t> slabel_dense_data = CMultilabelSOLabels::to_dense(slabel, ml->get_num_classes(), 1, 0);
+		SG_UNREF(slabel);
 		EXPECT_EQ(slabel_dense_data.vlen, ml->get_num_classes());
 	}
 


### PR DESCRIPTION
Valgrind output for 
`valgrind --leak-check=full ./shogun-unit-test --gtest_filter=MultilabelSOLabels.*`
is : 

```
==4314== HEAP SUMMARY:
==4314==     in use at exit: 0 bytes in 0 blocks
==4314==   total heap usage: 55,562 allocs, 55,562 frees, 3,584,140 bytes allocated
==4314==
==4314== All heap blocks were freed -- no leaks are possible
==4314==
==4314== For counts of detected and suppressed errors, rerun with: -v
==4314== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 1 from 1)
```
