### PR TITLE
prevent failure in class_list.cpp when LAPACK is not present

### DIFF
--- a/src/shogun/statistics/MMDKernelSelectionCombMaxL2.h
+++ b/src/shogun/statistics/MMDKernelSelectionCombMaxL2.h
@@ -68,6 +68,11 @@ public:
 	 * used for testing/evaluation!
 	 */
 	virtual SGVector<float64_t> compute_measures();
+#else
+	/** In absense of LAPACK this method is pure virtual. Required to put this
+	 * here in order to prevent failure in class_list.cpp when LAPACK is absent
+	 */
+	virtual SGVector<float64_t> compute_measures()=0;
 #endif
 
 	/** @return name of the SGSerializable */

--- a/src/shogun/statistics/MMDKernelSelectionCombOpt.h
+++ b/src/shogun/statistics/MMDKernelSelectionCombOpt.h
@@ -73,6 +73,11 @@ public:
 	 * used for testing/evaluation!
 	 */
 	virtual SGVector<float64_t> compute_measures();
+#else
+	/** In absense of LAPACK this method is pure virtual. Required to put this
+	 * here in order to prevent failure in class_list.cpp when LAPACK is absent
+	 */
+	virtual SGVector<float64_t> compute_measures()=0;
 #endif
 
 	/** @return name of the SGSerializable */


### PR DESCRIPTION
Introduced by PR #2292 which causes class_list.cpp to fail due to incorrectly considering CMMDKernelSelectionCombOpt and CMMDKernelSelectionCombMaxL2 as non-abstract classes in absence of LAPACK. Caught [here](http://buildbot.shogun-toolbox.org/builders/bsd1%20-%20libshogun/builds/2339/steps/compile/logs/stdio).
