### PR TITLE
fixed memory leak in graph cut unit test

### DIFF
--- a/src/shogun/structure/GraphCut.cpp
+++ b/src/shogun/structure/GraphCut.cpp
@@ -63,7 +63,6 @@ void CGraphCut::init()
 	for (int32_t i = 0; i < facs->get_num_elements(); i++)
 	{
 		CFactor* fac = dynamic_cast<CFactor*>(facs->get_element(i));
-		SG_REF(fac);
 		
 		int32_t num_vars = fac->get_num_vars();
 		


### PR DESCRIPTION
@tklein23
This PR is for fixing the [GraphCut_unittest memory leak issue](http://buildbot.shogun-toolbox.org/memcheck/20140625-2038.html)

Thanks @hushell for the discussion in IRC.
