### PR TITLE
refactored linalg's dot product

### DIFF
--- a/src/shogun/lib/GPUMatrix.h
+++ b/src/shogun/lib/GPUMatrix.h
@@ -66,6 +66,8 @@ template <class T> class CGPUMatrix
 	typedef viennacl::backend::mem_handle VCLMemoryArray;
 	
 public:
+	typedef T Scalar;
+	
 	/** Default Constructor */ 
 	CGPUMatrix();
 	

--- a/src/shogun/lib/GPUVector.h
+++ b/src/shogun/lib/GPUVector.h
@@ -66,6 +66,8 @@ template <class T> class CGPUVector
 	typedef viennacl::backend::mem_handle VCLMemoryArray;
 	
 public:
+	typedef T Scalar;
+	
 	/** Default Constructor */ 
 	CGPUVector();
 	

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -30,6 +30,8 @@ namespace shogun
 template<class T> class SGMatrix : public SGReferencedData
 {
 	public:
+		typedef T Scalar;
+		
 		/** default constructor */
 		SGMatrix();
 

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -34,6 +34,8 @@ namespace shogun
 template<class T> class SGVector : public SGReferencedData
 {
 	public:
+		typedef T Scalar;
+		
 		/** default constructor */
 		SGVector();
 

--- a/src/shogun/mathematics/linalg/internal/modules/Redux.h
+++ b/src/shogun/mathematics/linalg/internal/modules/Redux.h
@@ -44,84 +44,36 @@ namespace linalg
 
 /**
  * Wrapper method for internal implementation of vector dot-product that works
- * with generic vectors with first templated-argument as its value-type and
- * other (optional) templated-arguments of int type for compile time information
+ * with generic vectors.
  *
  * Uses globally set backend
  *
- * Suited for Shogun's SGVector, Eigen3's Vector etc
- *
  * @param a first vector
  * @param b second vector
  * @return the dot product of \f$\mathbf{a}\f$ and \f$\mathbf{b}\f$, represented
  * as \f$\sum_i a_i b_i\f$
  */
-template <template <class,int...> class Vector, class T, int... Info>
-T dot(Vector<T,Info...> a, Vector<T,Info...> b)
+template <class Vector>
+typename Vector::Scalar dot(const Vector& a, const Vector& b)
 {
-	return implementation::dot<int,linalg_traits<Redux>::backend,Vector,T,Info...>::compute(a, b);
+	return implementation::dot<linalg_traits<Redux>::backend,Vector>::compute(a, b);
 }
 
 /**
  * Wrapper method for internal implementation of vector dot-product that works
- * with generic vectors with first templated-argument as its value-type and
- * other (optional) templated-arguments of unsigned int type for compile time
- * information
- *
- * Uses globally set backend
- *
- * Suited for ViennaCL vectors
- *
- * @param a first vector
- * @param b second vector
- * @return the dot product of \f$\mathbf{a}\f$ and \f$\mathbf{b}\f$, represented
- * as \f$\sum_i a_i b_i\f$
- */
-template <template <class,unsigned int> class Vector, class T, unsigned int Info>
-T dot(Vector<T,Info> a, Vector<T,Info> b)
-{
-	return implementation::dot<unsigned int,linalg_traits<Redux>::backend,Vector,T,Info>::compute(a, b);
-}
-
-/**
- * Wrapper method for internal implementation of vector dot-product that works
- * with generic vectors with first templated-argument as its value-type and
- * other (optional) templated-arguments of int type for compile time information
+ * with generic vectors.
  *
  * Uses templated specified backend
  *
- * Suited for Shogun's SGVector, Eigen3's Vector etc
- *
  * @param a first vector
  * @param b second vector
  * @return the dot product of \f$\mathbf{a}\f$ and \f$\mathbf{b}\f$, represented
  * as \f$\sum_i a_i b_i\f$
  */
-template <Backend backend,template <class,int...> class Vector, class T, int... Info>
-T dot(Vector<T,Info...> a, Vector<T,Info...> b)
+template <Backend backend, class Vector>
+typename Vector::Scalar dot(const Vector& a, const Vector& b)
 {
-	return implementation::dot<int,backend,Vector,T,Info...>::compute(a, b);
-}
-
-/**
- * Wrapper method for internal implementation of vector dot-product that works
- * with generic vectors with first templated-argument as its value-type and
- * other (optional) templated-arguments of unsigned int type for compile time
- * information
- *
- * Uses templated specified backend
- *
- * Suited for ViennaCL vectors
- *
- * @param a first vector
- * @param b second vector
- * @return the dot product of \f$\mathbf{a}\f$ and \f$\mathbf{b}\f$, represented
- * as \f$\sum_i a_i b_i\f$
- */
-template <Backend backend,template <class,unsigned int> class Vector, class T, unsigned int Info>
-T dot(Vector<T,Info> a, Vector<T,Info> b)
-{
-	return implementation::dot<unsigned int,backend,Vector,T,Info>::compute(a, b);
+	return implementation::dot<backend,Vector>::compute(a, b);
 }
 
 /**

--- a/tests/unit/mathematics/linalg/DotProduct_unittest.cc
+++ b/tests/unit/mathematics/linalg/DotProduct_unittest.cc
@@ -46,7 +46,7 @@
 #endif // HAVE_EIGEN3
 
 #ifdef HAVE_VIENNACL
-#include <viennacl/vector.hpp>
+#include <shogun/lib/GPUVector.h>
 #endif // HAVE_VIENNACL
 
 using namespace shogun;
@@ -144,9 +144,9 @@ TEST(DotProduct, SGVector_explicit_viennacl_backend)
 TEST(DotProduct, ViennaCL_default_backend)
 {
 	const index_t size=10;
-	viennacl::vector<float32_t> a(size), b(size);
-	std::fill(a.begin(), a.end(), 1.0f);
-	std::fill(b.begin(), b.end(), 2.0f);
+	CGPUVector<float32_t> a(size), b(size);
+	a.set_const(1.0);
+	b.set_const(2.0);
 
 	EXPECT_NEAR(linalg::dot(a, b), 20.0, 1E-15);
 }
@@ -154,9 +154,9 @@ TEST(DotProduct, ViennaCL_default_backend)
 TEST(DotProduct, ViennaCL_explicit_viennacl_backend)
 {
 	const index_t size=10;
-	viennacl::vector<float32_t> a(size), b(size);
-	std::fill(a.begin(), a.end(), 1.0f);
-	std::fill(b.begin(), b.end(), 2.0f);
+	CGPUVector<float32_t> a(size), b(size);
+	a.set_const(1.0);
+	b.set_const(2.0);
 
 	float32_t result=linalg::dot<linalg::Backend::VIENNACL>(a, b);
 
@@ -167,9 +167,9 @@ TEST(DotProduct, ViennaCL_explicit_viennacl_backend)
 TEST(DotProduct, ViennaCL_explicit_eigen3_backend)
 {
 	const index_t size=10;
-	viennacl::vector<float32_t> a(size), b(size);
-	std::fill(a.begin(), a.end(), 1.0f);
-	std::fill(b.begin(), b.end(), 2.0f);
+	CGPUVector<float32_t> a(size), b(size);
+	a.set_const(1.0);
+	b.set_const(2.0);
 
 	float32_t result=linalg::dot<linalg::Backend::EIGEN3>(a, b);
 


### PR DESCRIPTION
- Changed the template for the implementation structs from `<class Info,enum Backend,template<class,Info...>class Vector,class T,Info... I>` to `<enum Backend, class Vector>`. This is simpler and works with any matrix type
- Eigen3 matrices are handled as described [here](http://eigen.tuxfamily.org/dox/TopicFunctionTakingEigenTypes.html). This makes the methods in the library work with any Eigen3 matrix type, including expressions.
- ViennaCL matrices are handled using CGPUVector/CGPUMatrix

@lambday, @karlnapf, @lisitsyn, please take a look. If you guys are okay with those changes, I'll change the rest of the library in the same manner.
