### PR TITLE
fixed python modular warnings for neuralnets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,7 @@
 		- Add Random Forests algorithm for ensemble learning using CART [Parijat Mazumdar] 
 		- Add Restricted Botlzmann Machines [Khaled Nasr]
 		- Add Stochastic Gradient Boosting algorithm for ensemble learning [Parijat Mazumdar]
+		- Add Deep contractive and denoising autoencoders [Khaled Nasr]
 	* Bugfixes:
 		- Fix reference counting bugs in CList when reference counting is on [Heiko Strathmann, Thoralf Klein, lambday]
 		- Fix memory problem in PCA::apply_to_feature_matrix [Parijat Mazumdar]

--- a/src/shogun/neuralnets/Autoencoder.h
+++ b/src/shogun/neuralnets/Autoencoder.h
@@ -42,10 +42,16 @@ namespace shogun
 {
 template <class T> class CDenseFeatures;
 
+/** @brief Determines the noise type for denoising autoencoders */
 enum EAENoiseType
 {
+	/** No noise is applied */
 	AENT_NONE=0,
+	
+	/** Each neuron in the input layer is randomly set to zero with some probability */
 	AENT_DROPOUT=1,
+	
+	/** Gaussian noise is added to neurons in the input layer */
 	AENT_GAUSSIAN=2
 };	
 
@@ -125,12 +131,12 @@ public:
 	 * with respect to its inputs, \f$ N \f$ is the batch size, and 
 	 * \f$ \lambda \f$ is the contraction coefficient. 
 	 * 
-	 * @param lambda Contraction coefficient
+	 * @param coeff Contraction coefficient
 	 */
-	virtual void set_contraction_coefficient(float64_t lambda)
+	virtual void set_contraction_coefficient(float64_t coeff)
 	{
-		m_contraction_coefficient = lambda;
-		get_layer(1)->contraction_coefficient = lambda;
+		m_contraction_coefficient = coeff;
+		get_layer(1)->contraction_coefficient = coeff;
 	}
 	
 	virtual ~CAutoencoder() {}

--- a/src/shogun/neuralnets/ConvolutionalFeatureMap.h
+++ b/src/shogun/neuralnets/ConvolutionalFeatureMap.h
@@ -39,10 +39,18 @@
 namespace shogun
 {
 
+/** @brief Determines the activation function for neurons in a convolutional 
+ * feature map
+ */
 enum EConvMapActivationFunction
 {
+	/** Identity activation function: \f$ f(x) = x \f$ */
 	CMAF_IDENTITY = 0,
+	
+	/** Logistic activation function: \f$ f(x) = \frac{1}{1+exp(-x)} \f$ */ 
 	CMAF_LOGISTIC = 1,
+	
+	/** Rectified linear activation function: \f$ f(x) = max(x,0) \f$ */
 	CMAF_RECTIFIED_LINEAR = 2
 };
 
@@ -121,9 +129,7 @@ public:
 	 * @param input_indices Indices of the layers that are connected to the map
 	 * as input
 	 * 
-	 * @param activations Matrix to store the activations in
-	 * 
-	 * @param parameters Vector in which the parameters gradients are to be 
+	 * @param parameter_gradients Vector in which the parameters gradients are to be 
 	 * stored
 	 */
 	void compute_gradients(SGVector<float64_t> parameters,

--- a/src/shogun/neuralnets/DeepAutoencoder.h
+++ b/src/shogun/neuralnets/DeepAutoencoder.h
@@ -106,8 +106,6 @@ public:
 	 * SGVector::set_const() method.
 	 * 
 	 * @param data Training examples
-	 * @param sigma Standard deviation of the gaussian used to initialize the 
-	 * parameters of each autoencoder
 	 */
 	virtual void pre_train(CFeatures* data);
 	

--- a/src/shogun/neuralnets/NeuralNetwork.h
+++ b/src/shogun/neuralnets/NeuralNetwork.h
@@ -221,6 +221,7 @@ public:
 	/** returns the number of neurons in the output layer */
 	int32_t get_num_outputs();
 	
+	/** Returns an array holding the network's layers */
 	CDynamicObjectArray* get_layers();
 	
 	virtual const char* get_name() const { return "NeuralNetwork";}
@@ -446,6 +447,9 @@ protected:
 	/** network's layers */
 	CDynamicObjectArray* m_layers;
 	
+	/** Describes the connections in the network: if there's a connection from
+	 * layer i to layer j then m_adj_matrix(i,j) = 1.
+	 */
 	SGMatrix<bool> m_adj_matrix;
 	
 	/** total number of parameters in the network */


### PR DESCRIPTION
Fixed the python modular [warnings](http://buildbot.shogun-toolbox.org/builders/deb3%20-%20modular_interfaces/builds/2401/steps/python%20modular/logs/warnings%20%2880%29) that are related to neuralnets, and updated the NEWS file.
