### PR TITLE
CMosek added variable bounds

### DIFF
--- a/src/shogun/structure/DirectorStructuredModel.cpp
+++ b/src/shogun/structure/DirectorStructuredModel.cpp
@@ -59,8 +59,8 @@ void CDirectorStructuredModel::init_primal_opt(
 		SGVector< float64_t > a,
 		SGMatrix< float64_t > B,
 		SGVector< float64_t > & b,
-		SGVector< float64_t > lb,
-		SGVector< float64_t > ub,
+		SGVector< float64_t > & lb,
+		SGVector< float64_t > & ub,
 		SGMatrix< float64_t > & C)
 {
 	SG_ERROR("Please implemement init_primal_opt(regularization,A,a,B,b,lb,ub,C) in your target language before use\n")

--- a/src/shogun/structure/DirectorStructuredModel.h
+++ b/src/shogun/structure/DirectorStructuredModel.h
@@ -102,7 +102,7 @@ IGNORE_IN_CLASSLIST class CDirectorStructuredModel : public CStructuredModel
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
-				SGVector< float64_t > lb, SGVector< float64_t > ub,
+				SGVector< float64_t > & lb, SGVector< float64_t > & ub,
 				SGMatrix < float64_t > & C);
 
 		/** @return name of SGSerializable */

--- a/src/shogun/structure/FactorGraphModel.cpp
+++ b/src/shogun/structure/FactorGraphModel.cpp
@@ -408,8 +408,8 @@ void CFactorGraphModel::init_primal_opt(
 		SGVector< float64_t > a,
 		SGMatrix< float64_t > B,
 		SGVector< float64_t > & b,
-		SGVector< float64_t > lb,
-		SGVector< float64_t > ub,
+		SGVector< float64_t > & lb,
+		SGVector< float64_t > & ub,
 		SGMatrix< float64_t > & C)
 {
 	C = SGMatrix< float64_t >::create_identity_matrix(get_dim(), regularization);

--- a/src/shogun/structure/FactorGraphModel.h
+++ b/src/shogun/structure/FactorGraphModel.h
@@ -152,7 +152,7 @@ public:
 			float64_t regularization,
 			SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 			SGMatrix< float64_t > B,  SGVector< float64_t > & b,
-			SGVector< float64_t > lb, SGVector< float64_t > ub,
+			SGVector< float64_t > & lb, SGVector< float64_t > & ub,
 			SGMatrix < float64_t >  & C);
 
 	/**

--- a/src/shogun/structure/HMSVMModel.cpp
+++ b/src/shogun/structure/HMSVMModel.cpp
@@ -358,8 +358,8 @@ void CHMSVMModel::init_primal_opt(
 		SGVector< float64_t > a,
 		SGMatrix< float64_t > B,
 		SGVector< float64_t > & b,
-		SGVector< float64_t > lb,
-		SGVector< float64_t > ub,
+		SGVector< float64_t > & lb,
+		SGVector< float64_t > & ub,
 		SGMatrix< float64_t > & C)
 {
 	// Shorthand for the number of free states (i.e. states for which parameters are learnt)

--- a/src/shogun/structure/HMSVMModel.h
+++ b/src/shogun/structure/HMSVMModel.h
@@ -107,7 +107,7 @@ class CHMSVMModel : public CStructuredModel
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
-				SGVector< float64_t > lb, SGVector< float64_t > ub,
+				SGVector< float64_t > & lb, SGVector< float64_t > & ub,
 				SGMatrix < float64_t > & C);
 
 		/**

--- a/src/shogun/structure/HashedMultilabelModel.cpp
+++ b/src/shogun/structure/HashedMultilabelModel.cpp
@@ -171,8 +171,8 @@ void CHashedMultilabelModel::init_primal_opt(
         SGVector<float64_t> a,
         SGMatrix<float64_t> B,
         SGVector<float64_t> &b,
-        SGVector<float64_t> lb,
-        SGVector<float64_t> ub,
+        SGVector<float64_t> &lb,
+        SGVector<float64_t> &ub,
         SGMatrix<float64_t> &C)
 {
 	C = SGMatrix<float64_t>::create_identity_matrix(get_dim(), regularization);

--- a/src/shogun/structure/HashedMultilabelModel.h
+++ b/src/shogun/structure/HashedMultilabelModel.h
@@ -128,8 +128,8 @@ public:
 	        SGVector<float64_t> a,
 	        SGMatrix<float64_t> B,
 	        SGVector<float64_t> &b,
-	        SGVector<float64_t> lb,
-	        SGVector<float64_t> ub,
+	        SGVector<float64_t> &lb,
+	        SGVector<float64_t> &ub,
 	        SGMatrix<float64_t> &C);
 
 	/** set seeds used for hashing features of *each* class

--- a/src/shogun/structure/MulticlassModel.cpp
+++ b/src/shogun/structure/MulticlassModel.cpp
@@ -158,8 +158,8 @@ void CMulticlassModel::init_primal_opt(
 		SGVector< float64_t > a,
 		SGMatrix< float64_t > B,
 		SGVector< float64_t > & b,
-		SGVector< float64_t > lb,
-		SGVector< float64_t > ub,
+		SGVector< float64_t > & lb,
+		SGVector< float64_t > & ub,
 		SGMatrix< float64_t > & C)
 {
 	C = SGMatrix< float64_t >::create_identity_matrix(get_dim(), regularization);

--- a/src/shogun/structure/MulticlassModel.h
+++ b/src/shogun/structure/MulticlassModel.h
@@ -104,7 +104,7 @@ class CMulticlassModel : public CStructuredModel
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
-				SGVector< float64_t > lb, SGVector< float64_t > ub,
+				SGVector< float64_t > & lb, SGVector< float64_t > & ub,
 				SGMatrix < float64_t > & C);
 
 		/** @return name of SGSerializable */

--- a/src/shogun/structure/MultilabelModel.cpp
+++ b/src/shogun/structure/MultilabelModel.cpp
@@ -218,8 +218,8 @@ void CMultilabelModel::init_primal_opt(
         SGVector<float64_t> a,
         SGMatrix<float64_t> B,
         SGVector<float64_t> &b,
-        SGVector<float64_t> lb,
-        SGVector<float64_t> ub,
+        SGVector<float64_t> &lb,
+        SGVector<float64_t> &ub,
         SGMatrix<float64_t> &C)
 {
 	C = SGMatrix<float64_t>::create_identity_matrix(get_dim(), regularization);

--- a/src/shogun/structure/MultilabelModel.h
+++ b/src/shogun/structure/MultilabelModel.h
@@ -104,8 +104,8 @@ public:
 	        SGVector<float64_t> a,
 	        SGMatrix<float64_t> B,
 	        SGVector<float64_t> &b,
-	        SGVector<float64_t> lb,
-	        SGVector<float64_t> ub,
+	        SGVector<float64_t> &lb,
+	        SGVector<float64_t> &ub,
 	        SGMatrix<float64_t> &C);
 
 	/** @return name of the SGSerializable */

--- a/src/shogun/structure/PrimalMosekSOSVM.h
+++ b/src/shogun/structure/PrimalMosekSOSVM.h
@@ -4,6 +4,7 @@
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
+ * Written (W) 2014 Shell Hu
  * Written (W) 2012 Fernando José Iglesias García
  * Copyright (C) 2012 Fernando José Iglesias García
  */
@@ -80,6 +81,16 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 		 */
 		void set_epsilon(float64_t epsilon);
 
+		/** set lower bounds
+		 * @param lb lower bounds
+		 */
+		void set_lower_bounds(SGVector< float64_t > lb);
+
+		/** set upper bounds
+		 * @param ub upper bounds
+		 */
+		void set_upper_bounds(SGVector< float64_t > ub);
+
 	protected:
 		/** train primal SO-SVM
 		 *
@@ -142,6 +153,12 @@ class CPrimalMosekSOSVM : public CLinearStructuredOutputMachine
 
 		/** epsilon */
 		float64_t m_epsilon;
+
+		/** lower bounds */
+		SGVector< float64_t > m_lb;
+
+		/** upper bounds */
+		SGVector< float64_t > m_ub;
 
 }; /* class CPrimalMosekSOSVM */
 

--- a/src/shogun/structure/StructuredModel.cpp
+++ b/src/shogun/structure/StructuredModel.cpp
@@ -69,8 +69,8 @@ void CStructuredModel::init_primal_opt(
 		SGVector< float64_t > a,
 		SGMatrix< float64_t > B,
 		SGVector< float64_t > & b,
-		SGVector< float64_t > lb,
-		SGVector< float64_t > ub,
+		SGVector< float64_t > & lb,
+		SGVector< float64_t > & ub,
 		SGMatrix< float64_t > & C)
 {
 	SG_ERROR("init_primal_opt is not implemented for %s!\n", get_name())

--- a/src/shogun/structure/StructuredModel.h
+++ b/src/shogun/structure/StructuredModel.h
@@ -129,7 +129,7 @@ class CStructuredModel : public CSGObject
 				float64_t regularization,
 				SGMatrix< float64_t > & A,  SGVector< float64_t > a,
 				SGMatrix< float64_t > B,  SGVector< float64_t > & b,
-				SGVector< float64_t > lb, SGVector< float64_t > ub,
+				SGVector< float64_t > & lb, SGVector< float64_t > & ub,
 				SGMatrix < float64_t >  & C);
 
 		/**

--- a/tests/unit/structure/PrimalMosekSOSVM_unittest.cc
+++ b/tests/unit/structure/PrimalMosekSOSVM_unittest.cc
@@ -1,0 +1,163 @@
+#include <shogun/io/SGIO.h>
+#include <shogun/lib/common.h>
+#include <shogun/lib/SGVector.h>
+
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/Mosek.h>
+#include <shogun/structure/FactorType.h>
+#include <shogun/structure/MAPInference.h>
+#include <shogun/structure/FactorGraphModel.h>
+#include <shogun/features/FactorGraphFeatures.h>
+#include <shogun/labels/FactorGraphLabels.h>
+#include <shogun/structure/PrimalMosekSOSVM.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+#ifdef USE_MOSEK
+TEST(PrimalMosekSOSVM, mosek_init_sosvm_w_bounds)
+{
+	int32_t num_samples = 10;
+	CMath::init_random(17);
+
+	// define factor type
+	SGVector<int32_t> card(2);
+	card[0] = 2;
+	card[1] = 2;
+	SGVector<float64_t> w(8);
+	w[0] = 0.3; // 0,0
+	w[1] = 0.5; // 0,0
+	w[2] = 1.0; // 1,0
+	w[3] = 0.2; // 1,0
+	w[4] = 0.05; // 0,1
+	w[5] = 0.6; // 0,1
+	w[6] = -0.2; // 1,1
+	w[7] = 0.75; // 1,1
+	int32_t tid = 0;
+	CTableFactorType* factortype = new CTableFactorType(tid, card, w);
+	SG_REF(factortype);
+
+	// create features and labels
+	CFactorGraphFeatures* instances = new CFactorGraphFeatures(num_samples);
+	SG_REF(instances);
+	CFactorGraphLabels* labels = new CFactorGraphLabels(num_samples);
+	SG_REF(labels);
+
+	for (int32_t n = 0; n < num_samples; ++n)
+	{
+		// factor graph
+		SGVector<int32_t> vc(3);
+		SGVector<int32_t>::fill_vector(vc.vector, vc.vlen, 2);
+
+		CFactorGraph* fg = new CFactorGraph(vc);
+
+		// add factors
+		SGVector<float64_t> data1(2);
+		data1[0] = 2.0 * CMath::random(0.0, 1.0) - 1.0;
+		data1[1] = 2.0 * CMath::random(0.0, 1.0) - 1.0;
+		SGVector<int32_t> var_index1(2);
+		var_index1[0] = 0;
+		var_index1[1] = 1;
+		CFactor* fac1 = new CFactor(factortype, var_index1, data1);
+		fg->add_factor(fac1);
+
+		SGVector<float64_t> data2(2);
+		data2[0] = 2.0 * CMath::random(0.0, 1.0) - 1.0;
+		data2[1] = 2.0 * CMath::random(0.0, 1.0) - 1.0;
+		SGVector<int32_t> var_index2(2);
+		var_index2[0] = 1;
+		var_index2[1] = 2;
+		CFactor* fac2 = new CFactor(factortype, var_index2, data2);
+		fg->add_factor(fac2);
+
+		// add factor graph instance
+		instances->add_sample(fg);
+
+		fg->connect_components();
+		fg->compute_energies();
+
+		CMAPInference infer_met(fg, TREE_MAX_PROD);
+		infer_met.inference();
+
+		CFactorGraphObservation* fg_observ = infer_met.get_structured_outputs();
+
+		// add ground truth states
+		labels->add_label(fg_observ);
+		SG_UNREF(fg_observ);
+	}
+
+	CFactorGraphModel* model = new CFactorGraphModel(instances, labels, TREE_MAX_PROD, false);
+	SG_REF(model);
+
+	// initialize model parameters
+	SGVector<float64_t> w_truth = w.clone();
+	w.zero();
+	factortype->set_w(w);
+	model->add_factor_type(factortype);
+
+	// create dummy primal mosek solver and check w's bounds
+	CPrimalMosekSOSVM* primcp = new CPrimalMosekSOSVM(model, labels);
+	SG_REF(primcp);
+	primcp->set_regularization(0.01); // TODO: check 1000
+
+	SGVector< float64_t > lb(w.vlen);
+	SGVector< float64_t > ub(w.vlen);
+
+	// ranged case
+	SGVector< float64_t >::fill_vector(ub.vector, ub.vlen, 10);
+	SGVector< float64_t >::fill_vector(lb.vector, ub.vlen, -10);
+	primcp->set_lower_bounds(lb);
+	primcp->set_upper_bounds(ub);
+	primcp->train();
+	w = primcp->get_w();
+
+	//w = dummy_mosek_sosvm(model, lb, ub, 0);
+	for (int32_t i = 0; i < w.vlen; i++)
+	{
+		EXPECT_LE(w[i], ub[i]);
+		EXPECT_GE(w[i], lb[i]);
+	}
+
+	// fixed case
+	lb.zero();
+	ub.zero();
+	primcp->set_lower_bounds(lb);
+	primcp->set_upper_bounds(ub);
+	primcp->train();
+	w = primcp->get_w();
+
+	//w = dummy_mosek_sosvm(model, lb, ub, 0);
+	for (int32_t i = 0; i < w.vlen; i++)
+		EXPECT_NEAR(w[i], ub[i], 1e-10);
+
+	// lb case
+	lb.zero();
+	SGVector< float64_t >::fill_vector(ub.vector, ub.vlen, +CMath::INFTY);
+	primcp->set_lower_bounds(lb);
+	primcp->set_upper_bounds(ub);
+	primcp->train();
+	w = primcp->get_w();
+
+	//w = dummy_mosek_sosvm(model, lb, ub, 0);
+	for (int32_t i = 0; i < w.vlen; i++)
+		EXPECT_GE(w[i], lb[i]);
+
+	// ub case
+	ub.zero();
+	SGVector< float64_t >::fill_vector(lb.vector, lb.vlen, -CMath::INFTY);
+	primcp->set_lower_bounds(lb);
+	primcp->set_upper_bounds(ub);
+	primcp->train();
+	w = primcp->get_w();
+
+	//w = dummy_mosek_sosvm(model, lb, ub, 0);
+	for (int32_t i = 0; i < w.vlen; i++)
+		EXPECT_LE(w[i], ub[i]);
+
+	SG_UNREF(primcp);
+	SG_UNREF(model);
+	SG_UNREF(labels);
+	SG_UNREF(instances);
+	SG_UNREF(factortype);
+}
+#endif


### PR DESCRIPTION
Hey @iglesias I made changes in Mosek.cpp for adding bounds on variables. Unfortunately, I have to touch many files to make the arguments consistent. Could you review the little patch for me? 

I am not sure we want to add unit-test for Mosek related class. But I am pretty sure these changes make sense. I have tested them on my own computer. BTW, I think @Jiaolong will test this part of code in his GraphCut inference thoroughly. 
