### PR TITLE
added random number generation to linalg

### DIFF
--- a/src/shogun/mathematics/linalg/internal/RandomMatrix.h
+++ b/src/shogun/mathematics/linalg/internal/RandomMatrix.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2014 Khaled Nasr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef RANDOMMATRIX_H_
+#define RANDOMMATRIX_H_
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_LINALG_LIB
+
+#include <shogun/mathematics/linalg/internal/RandomVector.h>
+
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/mathematics/Math.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUVector.h>
+#include <shogun/lib/GPUMatrix.h>
+#include <shogun/mathematics/linalg/internal/opencl_util.h>
+#endif
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+/** @brief A generic class which is specialized for different backends for 
+ * generating matrices that are filled with random numbers.
+ * 
+ * Supported scalar types are float32_t and float64_t
+ * 
+ * The default backend is the same as the one used by the Core module
+ */
+template <class T, Backend backend=linalg_traits<Core>::backend>
+class RandomMatrix
+{
+public:
+	/** Fills the matrix with unifromly-distributed random numbers in the 
+	 * range [min_value : max_value] 
+	 */
+	void generate_uniform(T min_value=0, T max_value=1);
+	
+	/** Fills the matrix with random numbers drawn from a normal distribution 
+	 * with a given mean and standard deviation
+	 */
+	void generate_gaussian(T mean=0, T std=1);
+};
+
+#ifdef HAVE_EIGEN3
+
+/** @brief Specialization of RandomMatrix for the EIGEN3 backend. The matrix 
+ * behaves like an SGMatrix and uses the random number generation methods of 
+ * CMath to generate its numbers
+ * 
+ * Supported scalar types are float32_t and float64_t
+ */
+template<> template <class T>
+class RandomMatrix<T, Backend::EIGEN3> : public SGMatrix<T>
+{
+public:
+	using SGMatrix<T>::SGMatrix;
+	
+	/** Fills the matrix with unifromly-distributed random numbers in the 
+	 * range [min_value : max_value] 
+	 */
+	void generate_uniform(T min_value=0, T max_value=1)
+	{
+		int32_t len = this->num_rows*this->num_cols;
+		for (int32_t i=0; i<len; i++)
+			this->matrix[i] = CMath::random(min_value, max_value);
+	}
+	
+	/** Fills the matrix with random numbers drawn from a normal distribution 
+	 * with mean mu and standard deviation std.
+	 */
+	void generate_gaussian(T mu=0, T std=1)
+	{
+		int32_t len = this->num_rows*this->num_cols;
+		for (int32_t i=0; i<len; i++)
+			this->matrix[i] = CMath::normal_random(mu, std);
+	}
+};
+
+#endif // HAVE_EIGEN3
+
+#ifdef HAVE_VIENNACL
+
+/** @brief Specialization of RandomMatrix for the VIENNACL backend. The matrix 
+ * behaves like a CGPUMatrix and stores its data on GPU memory. 
+ * 
+ * Supported scalar types are float32_t and float64_t
+ * 
+ * The uniform random number generation is based on the [MWC64X Random Number Generator]
+ * (http://cas.ee.ic.ac.uk/people/dt10/research/rngs-gpu-mwc64x.html) by 
+ * David B. Thomas.
+ * 
+ * The Gaussian random number generation is based on the polar form of the 
+ * [Box-Muller transform](http://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform#Polar_form).
+ */
+template<> template <class T>
+class RandomMatrix<T, Backend::VIENNACL> : public CGPUMatrix<T>
+{
+public:
+	using CGPUMatrix<T>::CGPUMatrix;
+	
+	/** Fills the matrix with unifromly-distributed random numbers in the 
+	 * range [min_value : max_value] 
+	 */
+	void generate_uniform(T min_value=0, T max_value=1)
+	{
+		if (states.vlen==0)
+			initialize_states();
+		
+		int32_t len = this->num_rows*this->num_cols;
+		
+		viennacl::ocl::kernel& kernel = 
+			RandomVector< T,Backend::VIENNACL>::generate_kernel_uniform();
+		kernel.global_work_size(0, implementation::ocl::align_to_multiple_1d(len));
+		
+		viennacl::ocl::enqueue(kernel(
+			this->vcl_matrix(), cl_int(len), cl_int(this->offset), 
+			states.vcl_vector(), min_value, max_value));
+	}
+	
+	/** Fills the matrix with random numbers drawn from a normal distribution 
+	 * with mean mu and standard deviation std.
+	 */
+	void generate_gaussian(T mu=0, T std=1)
+	{
+		if (states.vlen==0)
+			initialize_states();
+		
+		int32_t len = this->num_rows*this->num_cols;
+		
+		viennacl::ocl::kernel& kernel = 
+			RandomVector< T,Backend::VIENNACL>::generate_kernel_gaussian();
+		kernel.global_work_size(0, implementation::ocl::align_to_multiple_1d(len));
+		
+		viennacl::ocl::enqueue(kernel(
+			this->vcl_matrix(), cl_int(len), cl_int(this->offset), 
+			states.vcl_vector(), mu, std));
+	}
+	
+protected:
+	/** Initializes the states of the random number generators */
+	void initialize_states()
+	{
+		int32_t len = this->num_rows*this->num_cols;
+		SGVector<uint64_t> states_cpu(len);
+		
+		for (int32_t i=0; i<len; i++)
+			states_cpu[i] = CMath::random();
+		
+		states = states_cpu;
+	}
+	
+public:
+	/** A vector of length num_rows*num_cols that contains the states of each 
+	 * random number generator.
+	 */
+	CGPUVector<uint64_t> states;
+};
+
+#endif // HAVE_VIENNACL
+
+}
+
+}
+#endif // HAVE_LINALG_LIB
+
+#endif // RANDOMMATRIX_H_

--- a/src/shogun/mathematics/linalg/internal/RandomVector.h
+++ b/src/shogun/mathematics/linalg/internal/RandomVector.h
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2014 Khaled Nasr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef RANDOMVECTOR_H_
+#define RANDOMVECTOR_H_
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_LINALG_LIB
+
+#include <shogun/lib/SGVector.h>
+#include <shogun/mathematics/Math.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUVector.h>
+#include <shogun/mathematics/linalg/internal/opencl_util.h>
+#endif
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+/** @brief A generic class which is specialized for different backends for 
+ * generating vectors that are filled with random numbers.
+ * 
+ * Supported scalar types are float32_t and float64_t
+ * 
+ * The default backend is the same as the one used by the Core module
+ */
+template <class T, Backend backend=linalg_traits<Core>::backend>
+class RandomVector
+{
+public:
+	/** Fills the vector with unifromly-distributed random numbers in the 
+	 * range [min_value : max_value] 
+	 */
+	void generate_uniform(T min_value=0, T max_value=1);
+	
+	/** Fills the vector with random numbers drawn from a normal distribution 
+	 * with a given mean and standard deviation
+	 */
+	void generate_gaussian(T mean=0, T std=1);
+};
+
+#ifdef HAVE_EIGEN3
+
+/** @brief Specialization of RandomVector for the EIGEN3 backend. The vector 
+ * behaves like an SGVector and uses the random number generation methods of 
+ * CMath to generate its numbers
+ * 
+ * Supported scalar types are float32_t and float64_t
+ */
+template<> template <class T>
+class RandomVector<T, Backend::EIGEN3> : public SGVector<T>
+{
+public:
+	using SGVector<T>::SGVector;
+	
+	/** Fills the vector with unifromly-distributed random numbers in the 
+	 * range [min_value : max_value] 
+	 */
+	void generate_uniform(T min_value=0, T max_value=1)
+	{
+		for (int32_t i=0; i<this->vlen; i++)
+			this->vector[i] = CMath::random(min_value, max_value);
+	}
+	
+	/** Fills the vector with random numbers drawn from a normal distribution 
+	 * with mean mu and standard deviation std.
+	 */
+	void generate_gaussian(T mu=0, T std=1)
+	{
+		for (int32_t i=0; i<this->vlen; i++)
+			this->vector[i] = CMath::normal_random(mu, std);
+	}
+};
+
+#endif // HAVE_EIGEN3
+
+#ifdef HAVE_VIENNACL
+
+/** @brief Specialization of RandomVector for the VIENNACL backend. The vector 
+ * behaves like a CGPUVector and stores its data on GPU memory. 
+ * 
+ * Supported scalar types are float32_t and float64_t
+ * 
+ * The uniform random number generation is based on the [MWC64X Random Number Generator]
+ * (http://cas.ee.ic.ac.uk/people/dt10/research/rngs-gpu-mwc64x.html) by 
+ * David B. Thomas.
+ * 
+ * The Gaussian random number generation is based on the polar form of the 
+ * [Box-Muller transform](http://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform#Polar_form).
+ */
+template<> template <class T>
+class RandomVector<T, Backend::VIENNACL> : public CGPUVector<T>
+{
+	template <class,Backend> friend class RandomMatrix;
+	
+public:
+	using CGPUVector<T>::CGPUVector;
+	
+	/** Fills the vector with unifromly-distributed random numbers in the 
+	 * range [min_value : max_value] 
+	 */
+	void generate_uniform(T min_value=0, T max_value=1)
+	{
+		if (states.vlen==0)
+			initialize_states();
+		
+		viennacl::ocl::kernel& kernel = generate_kernel_uniform();
+		kernel.global_work_size(0, implementation::ocl::align_to_multiple_1d(this->vlen));
+		
+		viennacl::ocl::enqueue(kernel(
+			this->vcl_vector(), cl_int(this->vlen), cl_int(this->offset), 
+			states.vcl_vector(), min_value, max_value));
+	}
+	
+	/** Fills the vector with random numbers drawn from a normal distribution 
+	 * with mean mu and standard deviation std.
+	 */
+	void generate_gaussian(T mu=0, T std=1)
+	{
+		if (states.vlen==0)
+			initialize_states();
+		
+		viennacl::ocl::kernel& kernel = generate_kernel_gaussian();
+		kernel.global_work_size(0, implementation::ocl::align_to_multiple_1d(this->vlen));
+		
+		viennacl::ocl::enqueue(kernel(
+			this->vcl_vector(), cl_int(this->vlen), cl_int(this->offset), 
+			states.vcl_vector(), mu, std));
+	}
+	
+protected:
+	/** Initializes the states of the random number generators */
+	void initialize_states()
+	{
+		SGVector<uint64_t> states_cpu(this->vlen);
+		
+		for (int32_t i=0; i<this->vlen; i++)
+			states_cpu[i] = CMath::random();
+		
+		states = states_cpu;
+	}
+	
+	/** Generates a kernel that draws samples from a uniform distribution. */
+	static viennacl::ocl::kernel& generate_kernel_uniform()
+	{
+		std::string kernel_name = "generate_random_uniform_" + 
+			implementation::ocl::get_type_string<T>();
+		
+		if (implementation::ocl::kernel_exists(kernel_name))
+			return implementation::ocl::get_kernel(kernel_name);
+		
+		std::string source = implementation::ocl::generate_kernel_preamble<T>(kernel_name);
+		
+		source.append(
+			R"(
+				inline uint MWC64X_step(__global ulong* state)
+				{
+					ulong s = *state;
+					uint c = s>>32, x = s&0xFFFFFFFF;
+					*state = x*((ulong)4294883355U) + c;
+					return x^c;
+				}
+				
+				__kernel void KERNEL_NAME(
+					__global DATATYPE* vec, int size, int offset,
+					__global ulong* states, DATATYPE min_value, DATATYPE max_value)
+				{
+					int i = get_global_id(0);
+					
+					if (i>=size)
+						return;
+					
+					uint x = MWC64X_step(states+i);
+					
+					DATATYPE s = (DATATYPE)(x)/0xFFFFFFFF;
+					
+					vec[i+offset] = s*(max_value-min_value) + min_value;
+				}
+			)"
+		);
+		
+		viennacl::ocl::kernel& kernel = 
+			implementation::ocl::compile_kernel(kernel_name, source);
+		
+		kernel.local_work_size(0, OCL_WORK_GROUP_SIZE_1D);
+		
+		return kernel;
+	}
+	
+	/** Generates a kernel that draws samples from a Gaussian distribution */
+	static viennacl::ocl::kernel& generate_kernel_gaussian()
+	{
+		std::string kernel_name = "generate_random_gaussian_" + 
+			implementation::ocl::get_type_string<T>();
+		
+		if (implementation::ocl::kernel_exists(kernel_name))
+			return implementation::ocl::get_kernel(kernel_name);
+		
+		std::string source = implementation::ocl::generate_kernel_preamble<T>(kernel_name);
+		
+		source.append(
+			R"(
+				inline DATATYPE MWC64X_step(__global ulong* state)
+				{
+					ulong s = *state;
+					uint c = s>>32, x = s&0xFFFFFFFF;
+					*state = x*((ulong)4294883355U) + c;
+					return (DATATYPE)(x^c)/0xFFFFFFFF;
+				}
+				
+				__kernel void KERNEL_NAME(
+					__global DATATYPE* vec, int size, int offset,
+					__global ulong* states, DATATYPE mean, DATATYPE std)
+				{
+					int i = get_global_id(0);
+					
+					if (i>=size)
+						return;
+					
+					DATATYPE u1, u2, s;
+					do
+					{
+						u1 = MWC64X_step(states+i) * 2 - 1;
+						u2 = MWC64X_step(states+i) * 2 - 1;
+						
+						s = u1*u1 + u2*u2;
+					} while ((s == 0) || (s >= 1));
+
+					DATATYPE sample = u1*sqrt(-2.0*log(s)/s);
+					
+					vec[i+offset] = sample*std + mean;
+				}
+			)"
+		);
+		
+		viennacl::ocl::kernel& kernel = 
+			implementation::ocl::compile_kernel(kernel_name, source);
+		
+		kernel.local_work_size(0, OCL_WORK_GROUP_SIZE_1D);
+		
+		return kernel;
+	}
+	
+public:
+	/** A vector of length vlen that contains the states of each random number 
+	 * generator.
+	 */
+	CGPUVector<uint64_t> states;
+};
+
+#endif // HAVE_VIENNACL
+
+}
+
+}
+#endif // HAVE_LINALG_LIB
+
+#endif // RANDOMVECTOR_H_

--- a/tests/unit/mathematics/linalg/RandomMatrix_unittest.cc
+++ b/tests/unit/mathematics/linalg/RandomMatrix_unittest.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2014 Khaled Nasr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_LINALG_LIB
+#include <shogun/mathematics/linalg/linalg.h>
+#include <shogun/mathematics/linalg/internal/RandomMatrix.h>
+#include <gtest/gtest.h>
+
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/mathematics/Math.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUMatrix.h>
+#endif // HAVE_VIENNACL
+
+using namespace shogun;
+
+#ifdef HAVE_EIGEN3
+
+/** Tests the uniform random number generator by computing the histogram of many
+ * samples and comparing it to the uniform histogram
+ */
+TEST(RandomMatrix, eigen3_backend_uniform)
+{
+	CMath::init_random(12345);
+	
+	const int32_t nrows = 1000;
+	const int32_t ncols = 100;
+	int32_t N = nrows*ncols;
+	
+	linalg::RandomMatrix<float64_t, linalg::Backend::EIGEN3> m(nrows,ncols);
+	
+	m.generate_uniform(0,10);
+	
+	SGVector<float64_t> histogram(10);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+		histogram[(int32_t)CMath::floor(m[i])] += 1.0/N;
+	
+	for (int32_t i=0; i<10; i++)
+		EXPECT_NEAR(0.1, histogram[i], 0.01);
+}
+
+/** Tests the gaussian random number generator by computing the histogram of many
+ * samples and comparing it to the gaussian histogram
+ */
+TEST(RandomMatrix, eigen3_backend_gaussian)
+{
+	CMath::init_random(12345);
+	
+	const int32_t nrows = 1000;
+	const int32_t ncols = 100;
+	int32_t N = nrows*ncols;
+	
+	linalg::RandomMatrix<float64_t, linalg::Backend::EIGEN3> m(nrows, ncols);
+	
+	m.generate_gaussian(7.5,2.0);
+	
+	SGVector<float64_t> histogram(15);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+	{
+		int32_t bin = CMath::floor(m[i]);
+		bin = CMath::clamp(bin,0,14);
+		histogram[bin] += 1.0/N;
+	}
+	float64_t ref[] = 
+	{
+		0.000575666203414724911,
+		0.00240208431540700094,
+		0.00924567323269862885,
+		0.027824832626936951,
+		0.0655995972867355476,
+		0.120974368891058739,
+		0.174654597118991506,
+		0.197418460258255213,
+		0.174654597118991506,
+		0.120974368891058739,
+		0.0655995972867355476,
+		0.027824832626936951,
+		0.00924567323269862885,
+		0.00240208431540700094,
+		0.000575666203414724911
+	};
+	
+	for (int32_t i=0; i<15; i++)
+		EXPECT_NEAR(1.0, histogram[i]/ref[i], 0.1);
+}
+#endif // HAVE_EIGEN3
+
+#ifdef HAVE_VIENNACL
+/** Tests the uniform random number generator by computing the histogram of many
+ * samples and comparing it to the uniform histogram
+ */
+TEST(RandomMatrix, viennacl_backend_uniform)
+{
+	CMath::init_random(100);
+	
+	const int32_t nrows = 1000;
+	const int32_t ncols = 100;
+	int32_t N = nrows*ncols;
+	
+	linalg::RandomMatrix<float64_t, linalg::Backend::VIENNACL> m(nrows, ncols);
+	
+	m.generate_uniform(0,10);
+	
+	SGMatrix<float64_t> m_cpu = m;
+	
+	SGVector<float64_t> histogram(10);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+		histogram[(int32_t)CMath::floor(m_cpu[i])] += 1.0/N;
+	
+	for (int32_t i=0; i<10; i++)
+		EXPECT_NEAR(0.1, histogram[i], 0.01);
+}
+
+/** Tests the gaussian random number generator by computing the histogram of many
+ * samples and comparing it to the gaussian histogram
+ */
+TEST(RandomMatrix, viennacl_backend_gaussian)
+{
+	CMath::init_random(100);
+	
+	const int32_t nrows = 1000;
+	const int32_t ncols = 100;
+	int32_t N = nrows*ncols;
+	
+	linalg::RandomMatrix<float64_t, linalg::Backend::VIENNACL> m(nrows, ncols);
+	
+	m.generate_gaussian(7.5,2.0);
+	
+	SGMatrix<float64_t> m_cpu = m;
+	
+	SGVector<float64_t> histogram(15);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+	{
+		int32_t bin = CMath::floor(m_cpu[i]);
+		bin = CMath::clamp(bin,0,14);
+		histogram[bin] += 1.0/N;
+	}
+	float64_t ref[] = 
+	{
+		0.000575666203414724911,
+		0.00240208431540700094,
+		0.00924567323269862885,
+		0.027824832626936951,
+		0.0655995972867355476,
+		0.120974368891058739,
+		0.174654597118991506,
+		0.197418460258255213,
+		0.174654597118991506,
+		0.120974368891058739,
+		0.0655995972867355476,
+		0.027824832626936951,
+		0.00924567323269862885,
+		0.00240208431540700094,
+		0.000575666203414724911
+	};
+	
+	for (int32_t i=0; i<15; i++)
+		EXPECT_NEAR(1.0, histogram[i]/ref[i], 0.1);
+}
+#endif // HAVE_VIENNACL
+
+#endif // HAVE_LINALG_LIB

--- a/tests/unit/mathematics/linalg/RandomVector_unittest.cc
+++ b/tests/unit/mathematics/linalg/RandomVector_unittest.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2014 Khaled Nasr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_LINALG_LIB
+#include <shogun/mathematics/linalg/linalg.h>
+#include <shogun/mathematics/linalg/internal/RandomVector.h>
+#include <gtest/gtest.h>
+
+#include <shogun/lib/SGVector.h>
+#include <shogun/mathematics/Math.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUVector.h>
+#endif // HAVE_VIENNACL
+
+using namespace shogun;
+
+#ifdef HAVE_EIGEN3
+
+/** Tests the uniform random number generator by computing the histogram of many
+ * samples and comparing it to the uniform histogram
+ */
+TEST(RandomVector, eigen3_backend_uniform)
+{
+	CMath::init_random(12345);
+	
+	const int32_t N = 100000;
+	
+	linalg::RandomVector<float64_t, linalg::Backend::EIGEN3> v(N);
+	
+	v.generate_uniform(0,10);
+	
+	SGVector<float64_t> histogram(10);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+		histogram[(int32_t)CMath::floor(v[i])] += 1.0/N;
+	
+	for (int32_t i=0; i<10; i++)
+		EXPECT_NEAR(0.1, histogram[i], 0.01);
+}
+
+/** Tests the gaussian random number generator by computing the histogram of many
+ * samples and comparing it to the gaussian histogram
+ */
+TEST(RandomVector, eigen3_backend_gaussian)
+{
+	CMath::init_random(12345);
+	
+	const int32_t N = 100000;
+	
+	linalg::RandomVector<float64_t, linalg::Backend::EIGEN3> v(N);
+	
+	v.generate_gaussian(7.5,2.0);
+	
+	SGVector<float64_t> histogram(15);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+	{
+		int32_t bin = CMath::floor(v[i]);
+		bin = CMath::clamp(bin,0,14);
+		histogram[bin] += 1.0/N;
+	}
+	float64_t ref[] = 
+	{
+		0.000575666203414724911,
+		0.00240208431540700094,
+		0.00924567323269862885,
+		0.027824832626936951,
+		0.0655995972867355476,
+		0.120974368891058739,
+		0.174654597118991506,
+		0.197418460258255213,
+		0.174654597118991506,
+		0.120974368891058739,
+		0.0655995972867355476,
+		0.027824832626936951,
+		0.00924567323269862885,
+		0.00240208431540700094,
+		0.000575666203414724911
+	};
+	
+	for (int32_t i=0; i<15; i++)
+		EXPECT_NEAR(1.0, histogram[i]/ref[i], 0.1);
+}
+#endif // HAVE_EIGEN3
+
+#ifdef HAVE_VIENNACL
+/** Tests the uniform random number generator by computing the histogram of many
+ * samples and comparing it to the uniform histogram
+ */
+TEST(RandomVector, viennacl_backend_uniform)
+{
+	CMath::init_random(100);
+	
+	const int32_t N = 100000;
+	
+	linalg::RandomVector<float64_t, linalg::Backend::VIENNACL> v(N);
+	
+	v.generate_uniform(0,10);
+	
+	SGVector<float64_t> v_cpu = v;
+	
+	SGVector<float64_t> histogram(10);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+		histogram[(int32_t)CMath::floor(v_cpu[i])] += 1.0/N;
+	
+	for (int32_t i=0; i<10; i++)
+		EXPECT_NEAR(0.1, histogram[i], 0.01);
+}
+
+/** Tests the gaussian random number generator by computing the histogram of many
+ * samples and comparing it to the gaussian histogram
+ */
+TEST(RandomVector, viennacl_backend_gaussian)
+{
+	CMath::init_random(100);
+	
+	const int32_t N = 100000;
+	
+	linalg::RandomVector<float64_t, linalg::Backend::VIENNACL> v(N);
+	
+	v.generate_gaussian(7.5,2.0);
+	
+	SGVector<float64_t> v_cpu = v;
+	
+	SGVector<float64_t> histogram(15);
+	histogram.zero();
+	
+	for (int32_t i=0; i<N; i++)
+	{
+		int32_t bin = CMath::floor(v_cpu[i]);
+		bin = CMath::clamp(bin,0,14);
+		histogram[bin] += 1.0/N;
+	}
+	float64_t ref[] = 
+	{
+		0.000575666203414724911,
+		0.00240208431540700094,
+		0.00924567323269862885,
+		0.027824832626936951,
+		0.0655995972867355476,
+		0.120974368891058739,
+		0.174654597118991506,
+		0.197418460258255213,
+		0.174654597118991506,
+		0.120974368891058739,
+		0.0655995972867355476,
+		0.027824832626936951,
+		0.00924567323269862885,
+		0.00240208431540700094,
+		0.000575666203414724911
+	};
+	
+	for (int32_t i=0; i<15; i++)
+		EXPECT_NEAR(1.0, histogram[i]/ref[i], 0.1);
+}
+#endif // HAVE_VIENNACL
+
+#endif // HAVE_LINALG_LIB


### PR DESCRIPTION
Added random number generation to linalg through 2 classes: RandomVector/RandomMatrix that offer methods to fill the vector/matrix with random (uniform or gaussian) data. 

The main point of this is that for the ViennaCL backend, the data is generated directly on the GPU, so that no CPU-GPU copies will be necessary.

@lisitsyn, @lambday, @karlnapf Please take a look.
