### PR TITLE
improve the  performance of softmax

### DIFF
--- a/src/shogun/machine/gp/SoftMaxLikelihood.h
+++ b/src/shogun/machine/gp/SoftMaxLikelihood.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The Shogun Machine Learning Toolbox
- * Written (w) 2014 Parijat Mazumdar
+ * Written (w) 2014 Parijat Mazumdar, Wu Lin
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The original implementation is using column vector times row vector, which is inefficient.
@karlnapf 
take a loot at this.
