### PR TITLE
fixed issue #2445

### DIFF
--- a/src/shogun/kernel/CustomKernel.cpp
+++ b/src/shogun/kernel/CustomKernel.cpp
@@ -314,8 +314,9 @@ SGMatrix<float64_t> CCustomKernel::row_wise_sum_squared_sum_symmetric_block(
 	SGVector<float32_t> sum=rowwise_sum<Backend::EIGEN3>(block(kmatrix,
 				block_begin, block_begin, block_size, block_size), no_diag);
 
-	SGVector<float32_t> sq_sum=rowwise_sum<Backend::EIGEN3>(elementwise_square(block(kmatrix,
-					block_begin, block_begin, block_size, block_size)), no_diag);
+	SGVector<float32_t> sq_sum=rowwise_sum<Backend::EIGEN3>(
+		elementwise_square<Backend::EIGEN3>(block(kmatrix,
+		block_begin, block_begin, block_size, block_size)), no_diag);
 
 	for (index_t i=0; i<sum.vlen; ++i)
 		row_sum(i, 0)=sum[i];


### PR DESCRIPTION
@vigsterkr, @lambday found the problem in #2445: a call to elementwise_square on an SGMatrix block without specifying the backend (using the global backend). This causes no problems when the global backend is Eigen3, however, when the global backend is ViennaCL it doesn't compile because the viennacl implemnation of elementwise_square doesn't provide an overload for SGMatrix blocks. Fixed by explicitly specifying the backend the way it's done in the rest of CustomKernel.cpp
