### PR TITLE
old opencv version error handled

### DIFF
--- a/doc/ipython-notebooks/computer_vision/ANPR.ipynb
+++ b/doc/ipython-notebooks/computer_vision/ANPR.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:cc0b08cfea73e7ed00c4dbff09140f93a120aff36125e39aa25266b6e45fa90c"
+  "signature": "sha256:695bf4bd5be14f959383710a81ba9f5f8298f5b7eef1a2d99713b526e8247965"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -121,13 +121,15 @@
       "    import cv2\n",
       "except ImportError:\n",
       "    print \"You must have OpenCV installed\"\n",
+      "    exit(1)\n",
       "\n",
       "#check the OpenCV version\n",
       "try:\n",
       "    v=cv2.__version__\n",
       "    assert (tuple(map(int,v.split(\".\")))>(2,4,3))\n",
-      "except AssertionError:\n",
+      "except (AssertionError, ValueError):\n",
       "    print \"Install newer version of OpenCV than 2.4.3, i.e from 2.4.4\"\n",
+      "    exit(1)\n",
       "\n",
       "import matplotlib.pyplot as plt\n",
       "import numpy as np\n",
@@ -499,7 +501,8 @@
       "try:\n",
       "    assert (len(validated_masklist)!=0)\n",
       "except AssertionError:\n",
-      "    print \"No valid masks could be generated\""
+      "    print \"No valid masks could be generated\"\n",
+      "    exit(1)"
      ],
      "language": "python",
      "metadata": {},
@@ -781,7 +784,8 @@
       "try:\n",
       "    assert (len(segmentation_output)!=0)\n",
       "except AssertionError:\n",
-      "    print \"SVM couldn't find a single License Plate here. Restart to crosscheck!The current framework is closing\""
+      "    print \"SVM couldn't find a single License Plate here. Restart to crosscheck!The current framework is closing\"\n",
+      "    exit(1)"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
OpenCV before 2.4.0 used subversion. This causes the cv2.**version**() to return `$Rev: 4557 $` which is a subversion revision reference. 
