### PR TITLE
Fixed logical bug in DependenceMaximization

### DIFF
--- a/src/shogun/preprocessor/DependenceMaximization.cpp
+++ b/src/shogun/preprocessor/DependenceMaximization.cpp
@@ -133,8 +133,8 @@ CFeatures* CDependenceMaximization::remove_feats(CFeatures* features,
 
 	REQUIRE(m_num_remove>0, "Number or percentage of features to be removed is "
 			"not set! Please use set_num_remove() to set this!\n");
-	REQUIRE(m_policy==N_SMALLEST || m_policy==PERCENTILE_SMALLEST,
-			"Only N_SMALLEST and PERCENTILE_SMALLEST removal policy can work "
+	REQUIRE(m_policy==N_LARGEST || m_policy==PERCENTILE_LARGEST,
+			"Only N_LARGEST and PERCENTILE_LARGEST removal policy can work "
 			"with %s!\n", get_name());
 	REQUIRE(features, "Features is not intialized!\n");
 	REQUIRE(argsorted.vector, "The argsorted vector is not initialized!\n");
@@ -144,7 +144,7 @@ CFeatures* CDependenceMaximization::remove_feats(CFeatures* features,
 
 	// compute a threshold to remove for both the policies
 	index_t threshold=m_num_remove;
-	if (m_policy==PERCENTILE_SMALLEST)
+	if (m_policy==PERCENTILE_LARGEST)
 		threshold*=argsorted.vlen*0.01;
 
 	// make sure that the threshold is valid given the current number of feats
@@ -153,9 +153,9 @@ CFeatures* CDependenceMaximization::remove_feats(CFeatures* features,
 			"number for removal using set_num_remove() call",
 			threshold, argsorted.vlen);
 
-	// remove the lowest threshold rank holders by storing indices
+	// remove the highest rank holders by storing indices
 	SGVector<index_t> inds(argsorted.vlen-threshold);
-	memcpy(inds.vector, argsorted.vector+threshold, sizeof(index_t)*inds.vlen);
+	memcpy(inds.vector, argsorted.vector, sizeof(index_t)*inds.vlen);
 
 	// sorting the indices to get the original order
 	inds.qsort();
@@ -172,8 +172,8 @@ CFeatures* CDependenceMaximization::remove_feats(CFeatures* features,
 
 void CDependenceMaximization::set_policy(EFeatureRemovalPolicy policy)
 {
-	REQUIRE(policy==N_SMALLEST || policy==PERCENTILE_SMALLEST,
-			"Only N_SMALLEST and PERCENTILE_SMALLEST removal policy can work "
+	REQUIRE(policy==N_LARGEST || policy==PERCENTILE_LARGEST,
+			"Only N_LARGEST and PERCENTILE_LARGEST removal policy can work "
 			"with %s!\n", get_name());
 	m_policy=policy;
 }

--- a/src/shogun/preprocessor/DependenceMaximization.h
+++ b/src/shogun/preprocessor/DependenceMaximization.h
@@ -51,9 +51,12 @@ class CIndependenceTest;
  * 	\textbf{H}_0 : P\left(\mathbf{X}\setminus \mathbf{X}_i, \mathbf{Y}\right)
  *	=P\left(\mathbf{X}\setminus \mathbf{X}_i\right)P\left(\mathbf{Y}\right)
  * \f]
- * The test statistic is then used as a measure. Lowest measure signifies
- * lowest dependence. Therefore, lowest scoring features are removed. The
- * removal policy thus can only be ::N_SMALLEST and ::PERCENTILE_SMALLEST and
+ * The test statistic is then used as a measure which signifies the independence
+ * between the rest of the features and the labels - higher the value of the
+ * test statistic, greater the dependency between the rest of the features
+ * and the class labels, and therefore lesser significant the current feature
+ * becomes. Therefore, highest scoring features are removed. The removal policy
+ * thus can only be ::N_LARGEST and ::PERCENTILE_LARGEST and
  * it can be set via set_policy() call. remove_feats() method handles the
  * removal of features based on the specified policy.
  *
@@ -88,8 +91,8 @@ public:
 	/**
 	 * Method which handles the removal of features based on removal policy.
 	 * see documentation of CFeatureSelection. For dependence maximization
-	 * approach, the lowest scoring features are removed. Therefore, only
-	 * #m_policy can only be N_SMALLEST, PERCENTILE_SMALLEST. see set_policy()
+	 * approach, the highest scoring features are removed. Therefore, only
+	 * #m_policy can only be N_LARGEST, PERCENTILE_LARGEST. see set_policy()
 	 * method for specifying the exact policy
 	 *
 	 * @param features the features object from which specific features has

--- a/src/shogun/preprocessor/FeatureSelection.cpp
+++ b/src/shogun/preprocessor/FeatureSelection.cpp
@@ -59,7 +59,7 @@ void CFeatureSelection<ST>::init()
 
 	m_target_dim=0;
 	m_algorithm=BACKWARD_ELIMINATION;
-	m_policy=N_SMALLEST;
+	m_policy=N_LARGEST;
 	m_num_remove=1;
 	m_labels=NULL;
 }

--- a/tests/unit/preprocessor/BAHSIC_unittest.cc
+++ b/tests/unit/preprocessor/BAHSIC_unittest.cc
@@ -68,7 +68,7 @@ TEST(BAHSIC, apply)
 	fs->set_target_dim(target_dim);
 	fs->set_kernel_features(kernel_p);
 	fs->set_kernel_labels(kernel_q);
-	fs->set_policy(N_SMALLEST);
+	fs->set_policy(N_LARGEST);
 	fs->set_num_remove(dim-target_dim);
 	CFeatures* selected=fs->apply(feats);
 
@@ -81,10 +81,10 @@ TEST(BAHSIC, apply)
 
 	// ensure that selected feats are the same as computed in local machine
 	SGVector<index_t> inds(target_dim);
-	inds[0]=4;
-	inds[1]=5;
-	inds[2]=6;
-	inds[3]=7;
+	inds[0]=0;
+	inds[1]=1;
+	inds[2]=2;
+	inds[3]=3;
 
 	for (index_t i=0; i<target_dim; ++i)
 	{

--- a/tests/unit/preprocessor/FeatureSelection_unittest.cc
+++ b/tests/unit/preprocessor/FeatureSelection_unittest.cc
@@ -58,8 +58,9 @@ TEST(FeatureSelection, remove_feats)
 	CBAHSIC* fs=new CBAHSIC();
 	index_t target_dim=dim/2;
 	fs->set_num_remove(dim-target_dim);
+	fs->set_policy(N_LARGEST);
 
-	// create a dummy argsorted vector to remove first dim/2 features
+	// create a dummy argsorted vector to remove last dim/2 features
 	SGVector<index_t> argsorted(dim);
 	argsorted.range_fill();
 
@@ -70,7 +71,7 @@ TEST(FeatureSelection, remove_feats)
 	for (index_t i=0; i<target_dim; ++i)
 	{
 		for (index_t j=0; j<num_data; ++j)
-			EXPECT_NEAR(data(i+dim-target_dim, j), reduced_data(i, j), 1E-15);
+			EXPECT_NEAR(data(i, j), reduced_data(i, j), 1E-15);
 	}
 
 	SG_UNREF(reduced);


### PR DESCRIPTION
In dependence maximization based feature selection, the features
related to highest measure should be removed instead.
