### PR TITLE
Move tokenize from CSVFile to StreamingAsciiFile.

### DIFF
--- a/src/shogun/io/CSVFile.cpp
+++ b/src/shogun/io/CSVFile.cpp
@@ -9,11 +9,11 @@
 
 #include <shogun/io/CSVFile.h>
 
+#include <shogun/io/SGIO.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/io/LineReader.h>
 #include <shogun/io/Parser.h>
 #include <shogun/lib/DelimiterTokenizer.h>
-#include <shogun/lib/v_array.h>
 
 using namespace shogun;
 
@@ -456,26 +456,3 @@ SET_STRING_LIST(floatmax_t)
 SET_STRING_LIST(int16_t)
 SET_STRING_LIST(uint16_t)
 #undef SET_STRING_LIST
-
-void CCSVFile::tokenize(char delim, substring s, v_array<substring>& ret)
-{
-	ret.erase();
-	char *last = s.start;
-	for (; s.start != s.end; s.start++)
-	{
-		if (*s.start == delim)
-		{
-			if (s.start != last)
-			{
-				substring temp = {last,s.start};
-				ret.push(temp);
-			}
-			last = s.start+1;
-		}
-	}
-	if (s.start != last)
-	{
-		substring final = {last, s.start};
-		ret.push(final);
-	}
-}

--- a/src/shogun/io/CSVFile.h
+++ b/src/shogun/io/CSVFile.h
@@ -20,10 +20,8 @@ namespace shogun
 class CDelimiterTokenizer;
 class CLineReader;
 class CParser;
-struct substring;
 template <class ST> class SGString;
 template <class T> class SGSparseVector;
-template <class T> class v_array;
 
 /** @brief Class CSVFile used to read data from comma-separated values (CSV)
  * files. See http://en.wikipedia.org/wiki/Comma-separated_values.
@@ -373,16 +371,6 @@ public:
 			const SGString<floatmax_t>* strings, int32_t num_str);
 	//@}
 #endif // #ifndef SWIG
-
-	/**
-	 * Split a given substring into an array of substrings
-	 * based on a specified delimiter
-	 *
-	 * @param delim delimiter to use
-	 * @param s substring to tokenize
-	 * @param ret array of substrings, returned
-	 */
-	static void tokenize(char delim, substring s, v_array<substring> &ret);
 
 	virtual const char* get_name() const { return "CSVFile"; }
 

--- a/src/shogun/io/streaming/StreamingAsciiFile.cpp
+++ b/src/shogun/io/streaming/StreamingAsciiFile.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <shogun/io/streaming/StreamingAsciiFile.h>
-#include <shogun/io/CSVFile.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/lib/SGSparseVector.h>
 #include <shogun/base/DynArray.h>
@@ -138,7 +137,7 @@ GET_VECTOR(get_longreal_vector, atoi, floatmax_t)
 																			\
 				substring example_string = {line, line + num_chars};		\
 																			\
-				CCSVFile::tokenize(m_delimiter, example_string, words);		\
+				tokenize(m_delimiter, example_string, words);				\
 																			\
 				len = words.index();										\
 				substring* feature_start = &words[0];						\
@@ -263,7 +262,7 @@ GET_VECTOR_AND_LABEL(get_longreal_vector_and_label, atoi, floatmax_t)
 																		\
 				substring example_string = {line, line + num_chars};	\
 																		\
-				CCSVFile::tokenize(m_delimiter, example_string, words);	\
+				tokenize(m_delimiter, example_string, words);			\
 																		\
 				label = SGIO::float_of_substring(words[0]);				\
 																		\
@@ -627,4 +626,26 @@ void CStreamingAsciiFile::append_item(
 void CStreamingAsciiFile::set_delimiter(char delimiter)
 {
 	m_delimiter = delimiter;
+}
+void CStreamingAsciiFile::tokenize(char delim, substring s, v_array<substring>& ret)
+{
+	ret.erase();
+	char *last = s.start;
+	for (; s.start != s.end; s.start++)
+	{
+		if (*s.start == delim)
+		{
+			if (s.start != last)
+			{
+				substring temp = {last,s.start};
+				ret.push(temp);
+			}
+			last = s.start+1;
+		}
+	}
+	if (s.start != last)
+	{
+		substring final = {last, s.start};
+		ret.push(final);
+	}
 }

--- a/src/shogun/io/streaming/StreamingAsciiFile.h
+++ b/src/shogun/io/streaming/StreamingAsciiFile.h
@@ -120,6 +120,17 @@ private:
 	 */
 	template <class T> void append_item(DynArray<T>* items, char* ptr_data, char* ptr_item);
 
+	/**
+	 * Split a given substring into an array of substrings
+	 * based on a specified delimiter
+	 *
+	 * @param delim delimiter to use
+	 * @param s substring to tokenize
+	 * @param ret array of substrings, returned
+	 */
+	void tokenize(char delim, substring s, v_array<substring> &ret);
+
+private:
 	/// Helper for parsing
 	v_array<substring> words;
 


### PR DESCRIPTION
This removes the dependency of StreamingAsciiFile on CSVFile.
