### PR TITLE
CEMMixtureModel removing log_sum_exp redudancy

### DIFF
--- a/src/shogun/distributions/EMMixtureModel.cpp
+++ b/src/shogun/distributions/EMMixtureModel.cpp
@@ -56,7 +56,7 @@ float64_t CEMMixtureModel::expectation_step()
 			SG_UNREF(jth_component);
 		};
 
-		float64_t normalize=log_sum_exp(alpha_ij);
+		float64_t normalize=CMath::log_sum_exp(alpha_ij);
 		log_likelihood+=normalize;
 
 		// fill row of alpha
@@ -90,37 +90,4 @@ void CEMMixtureModel::maximization_step()
 	// update weights - normalization
 	for (int32_t j=0;j<data.alpha.num_cols;j++)
 		data.weights[j]/=sum_weights;
-}
-
-float64_t CEMMixtureModel::log_sum_exp(SGVector<float64_t> values)
-{
-	REQUIRE(values.vlen>0,"number of values supplied is 0\n")
-	REQUIRE(values.vector, "Values are empty\n");
-
-	/* find max element index */
-	index_t max_index=0;
-	float64_t X0=values[0];
-
-	for (index_t i=1; i<values.vlen; ++i)
-	{
-		if (values[i]>X0)
-		{
-			X0=values[i];
-			max_index=i;
-		}
-	}
-
-	/* remove element from vector copy and compute log sum exp */
-	SGVector<float64_t> values_without_X0(values.vlen-1);
-	index_t to_idx=0;
-	for (index_t from_idx=0; from_idx<values.vlen; ++from_idx)
-	{
-		if (from_idx!=max_index)
-		{
-			values_without_X0[to_idx]=exp(values[from_idx]-X0);
-			to_idx++;
-		}
-	}
-
-	return X0+log(SGVector<float64_t>::sum(values_without_X0)+1);
 }

--- a/src/shogun/distributions/EMMixtureModel.h
+++ b/src/shogun/distributions/EMMixtureModel.h
@@ -61,14 +61,6 @@ class CEMMixtureModel : public CEMBase<MixModelData>
 
 		/** maximization step */
 		virtual void maximization_step();
-
-	private:
-		/** log sum exp trick
-		 *
-		 * @param log_values vector of logarithmic values on which log_sum_exp trick has to be applied
-		 * @return log_sum_exp of the supplied log_values
-		 */
-		float64_t log_sum_exp(SGVector<float64_t> log_values);
 };
 } /* shogun */
 #endif /* _EMMIXTUREMODEL_H__ */

--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -762,6 +762,7 @@ class CMath : public CSGObject
 		static T log_sum_exp(SGVector<T> values)
 		{
 			REQUIRE(values.vector, "Values are empty");
+			REQUIRE(values.vlen>0,"number of values supplied is 0\n");
 
 			/* find minimum element index */
 			index_t min_index=0;


### PR DESCRIPTION
This is my patch for addressing the issue #2559 
