### PR TITLE
Delete tests/integration/tests symlink.

### DIFF
--- a/tests/integration/tests
+++ b/tests/integration/tests
@@ -1,1 +1,0 @@
-../../data/testsuite/tests


### PR DESCRIPTION
It is outdated since the hierarchy now is testsuite/pythonX-tests.
