### PR TITLE
Remove a bunch of math methods in SGVector.

### DIFF
--- a/src/shogun/classifier/GaussianProcessClassification.cpp
+++ b/src/shogun/classifier/GaussianProcessClassification.cpp
@@ -40,6 +40,7 @@
 #ifdef HAVE_EIGEN3
 
 #include <shogun/classifier/GaussianProcessClassification.h>
+#include <shogun/mathematics/Math.h>
 
 using namespace shogun;
 
@@ -80,7 +81,7 @@ CMulticlassLabels* CGaussianProcessClassification::apply_multiclass(CFeatures* d
 	SGVector<float64_t> mean=get_mean_vector(data);
 	const index_t C=mean.vlen/n;
 	SGVector<index_t> lab(n);
-	for(index_t idx=0; idx<n; idx++)
+	for (index_t idx=0; idx<n; idx++)
 	{
 		int32_t cate=SGVector<float64_t>::arg_max(mean.vector+idx*C, 1, C);
 		lab[idx]=cate;
@@ -200,7 +201,8 @@ SGVector<float64_t> CGaussianProcessClassification::get_probabilities(
 	SG_UNREF(lik);
 
 	// evaluate probabilities
-	p.exp();
+	for (index_t idx=0; idx<p.vlen; idx++)
+		p[idx]=CMath::exp(p[idx]);
 
 	return p;
 }

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -1193,78 +1193,6 @@ void SGVector<complex128_t>::save(CFile* saver)
 	SG_SERROR("SGVector::save():: Not supported for complex128_t\n");
 }
 
-
-#define MATHOP(op)								\
-template <class T> void SGVector<T>::op()		\
-{												\
-	for (int32_t i=0; i<vlen; i++)				\
-		vector[i]=(T) CMath::op((double) vector[i]);		\
-}
-
-MATHOP(abs)
-MATHOP(acos)
-MATHOP(asin)
-MATHOP(atan)
-MATHOP(cos)
-MATHOP(cosh)
-MATHOP(exp)
-MATHOP(log)
-MATHOP(log10)
-MATHOP(sin)
-MATHOP(sinh)
-MATHOP(sqrt)
-MATHOP(tan)
-MATHOP(tanh)
-#undef MATHOP
-
-#define COMPLEX128_MATHOP(op)								\
-template <>\
-void SGVector<complex128_t>::op()		\
-{												\
-	for (int32_t i=0; i<vlen; i++)				\
-		vector[i]=complex128_t(CMath::op(vector[i]));		\
-}
-
-COMPLEX128_MATHOP(abs)
-COMPLEX128_MATHOP(sin)
-COMPLEX128_MATHOP(cos)
-COMPLEX128_MATHOP(tan)
-COMPLEX128_MATHOP(sinh)
-COMPLEX128_MATHOP(cosh)
-COMPLEX128_MATHOP(tanh)
-COMPLEX128_MATHOP(exp)
-COMPLEX128_MATHOP(log)
-COMPLEX128_MATHOP(log10)
-COMPLEX128_MATHOP(sqrt)
-#undef COMPLEX128_MATHOP
-
-#define COMPLEX128_MATHOP_NOTIMPLEMENTED(op)								\
-template <>\
-void SGVector<complex128_t>::op()		\
-{												\
-	SG_SERROR("SGVector::%s():: Not supported for complex128_t\n",#op);\
-}
-
-COMPLEX128_MATHOP_NOTIMPLEMENTED(asin)
-COMPLEX128_MATHOP_NOTIMPLEMENTED(acos)
-COMPLEX128_MATHOP_NOTIMPLEMENTED(atan)
-#undef COMPLEX128_MATHOP_NOTIMPLEMENTED
-
-template <class T> void SGVector<T>::atan2(T x)
-{
-	for (int32_t i=0; i<vlen; i++)
-		vector[i]=CMath::atan2(vector[i], x);
-}
-
-BOOL_ERROR_ONEARG(atan2)
-COMPLEX128_ERROR_ONEARG(atan2)
-
-template <class T> void SGVector<T>::pow(T q)
-{
-	for (int32_t i=0; i<vlen; i++)
-		vector[i]=(T) CMath::pow((double) vector[i], (double) q);
-}
-
 template <class T>
 SGVector<float64_t> SGVector<T>::linspace_vec(T start, T end, int32_t n)
 {
@@ -1286,13 +1214,6 @@ float64_t* SGVector<complex128_t>::linspace(complex128_t start, complex128_t end
 	float64_t* output = SG_MALLOC(float64_t, n);
 	SG_SERROR("SGVector::linspace():: Not supported for complex128_t\n");
 	return output;
-}
-
-template <>
-void SGVector<complex128_t>::pow(complex128_t q)
-{
-	for (int32_t i=0; i<vlen; i++)
-		vector[i]=CMath::pow(vector[i], q);
 }
 
 template <class T> SGVector<float64_t> SGVector<T>::get_real()

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -629,39 +629,6 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		void save(CFile* saver);
 
-		/// Absolute value of vector elements
-		void abs();
-		/// Arc cosine of vector elements
-		void acos();
-		/// Arc sine of vector elements
-		void asin();
-		/// Arc tangent of vector elements
-		void atan();
-		/// Atan2 of vector elements
-		void atan2(T x);
-		/// Cosine of vector elements
-		void cos();
-		/// Hyperbolic cosine of vector elements
-		void cosh();
-		/// Exponential of vector elements
-		void exp();
-		/// Natural logarithm of vector elements
-		void log();
-		/// Common logarithm of vector elements
-		void log10();
-		/// Power of vector elements
-		void pow(T q);
-		/// Sine of vector elements
-		void sin();
-		/// Hyperbolic sine of vector elements
-		void sinh();
-		/// Square root of vector elements
-		void sqrt();
-		/// Tangent of vector elements
-		void tan();
-		/// Hyperbolic tangent of vector elements
-		void tanh();
-
 		/** Real part of a complex128_t vector */
 		SGVector<float64_t> get_real();
 

--- a/src/shogun/machine/gp/LogitLikelihood.cpp
+++ b/src/shogun/machine/gp/LogitLikelihood.cpp
@@ -374,7 +374,8 @@ SGVector<float64_t> CLogitLikelihood::get_log_zeroth_moments(
 
 	SG_UNREF(h);
 
-	r.log();
+	for (index_t i=0; i<r.vlen; i++)
+		r[i]=CMath::log(r[i]);
 
 	return r;
 }

--- a/src/shogun/machine/gp/StudentsTLikelihood.cpp
+++ b/src/shogun/machine/gp/StudentsTLikelihood.cpp
@@ -604,7 +604,8 @@ SGVector<float64_t> CStudentsTLikelihood::get_log_zeroth_moments(
 
 	SG_UNREF(h);
 
-	r.log();
+	for (index_t i=0; i<r.vlen; i++)
+		r[i]=CMath::log(r[i]);
 
 	return r;
 }

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -228,31 +228,7 @@ TEST(SGVectorTest,complex128_tests)
 	EXPECT_NEAR(norm2.real(), 10.0, 1E-14);
 	EXPECT_NEAR(norm2.imag(), 12.0, 1E-14);
 
-	// tests ::maths
-	a.set_const(complex128_t(1.0, 2.0));
-	a.abs();
-	for (index_t i=0; i<a.vlen; ++i)
-	{
-		EXPECT_NEAR(a[i].real(), 2.23606797749978980505, 1E-14);
-		EXPECT_NEAR(a[i].imag(), 0.0, 1E-14);
-	}
-
-	a.set_const(complex128_t(1.0, 2.0));
-	a.sin();
-	for (index_t i=0; i<a.vlen; ++i)
-	{
-		EXPECT_NEAR(a[i].real(), 3.16577851321616821068, 1E-14);
-		EXPECT_NEAR(a[i].imag(), 1.95960104142160607132, 1E-14);
-	}
-
-	a.set_const(complex128_t(1.0, 2.0));
-	a.cos();
-	for (index_t i=0; i<a.vlen; ++i)
-	{
-		EXPECT_NEAR(a[i].real(), 2.03272300701966557313, 1E-14);
-		EXPECT_NEAR(a[i].imag(), -3.05189779915179970615, 1E-14);
-	}
-
+	// tests ::get_real and ::get_imag
 	a.set_const(complex128_t(1.0, 2.0));
 	SGVector<float64_t> a_real=a.get_real();
 	SGVector<float64_t> a_imag=a.get_imag();


### PR DESCRIPTION
These methods in SGVector (sin, cos, cosh, atan, abs, exp, log, etc) are barely used in Shogun; I only had to change two calls to `SGVector::log` and one call to `SGVector::exp`. In fact, IMHO, in C++ one should just write a loop through all the vector elements instead of having these convenience methods that are typical in e.g. Python, Matlab, etc. It should still be possible to resort to Eigen3 if these "vectorised-styled" calls are badly wanted for some reason.

In addition, it doesn't make much sense to keep them to provide access to them from interfaces. The typemaps are mapping the data in SGVectors to data structures in the target languages where these operations are normally already available (like `numpy.sin(a numpy array)`).
