### PR TITLE
Removed unwanted includes and shifted non shogun include to .cpp files. #2557

### DIFF
--- a/src/shogun/classifier/AveragedPerceptron.h
+++ b/src/shogun/classifier/AveragedPerceptron.h
@@ -12,7 +12,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <stdio.h>
 #include <shogun/lib/common.h>
 #include <shogun/features/DotFeatures.h>
 #include <shogun/machine/LinearMachine.h>

--- a/src/shogun/classifier/LPBoost.h
+++ b/src/shogun/classifier/LPBoost.h
@@ -14,7 +14,6 @@
 #include <shogun/lib/config.h>
 #ifdef USE_CPLEX
 
-#include <stdio.h>
 #include <shogun/lib/common.h>
 #include <shogun/lib/DynamicArray.h>
 

--- a/src/shogun/classifier/LPM.h
+++ b/src/shogun/classifier/LPM.h
@@ -14,7 +14,6 @@
 #include <shogun/lib/config.h>
 #ifdef USE_CPLEX
 
-#include <stdio.h>
 #include <shogun/lib/common.h>
 #include <shogun/features/Features.h>
 #include <shogun/machine/LinearMachine.h>

--- a/src/shogun/classifier/NearestCentroid.h
+++ b/src/shogun/classifier/NearestCentroid.h
@@ -12,7 +12,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <stdio.h>
 #include <shogun/lib/common.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/features/Features.h>

--- a/src/shogun/classifier/Perceptron.h
+++ b/src/shogun/classifier/Perceptron.h
@@ -13,7 +13,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <stdio.h>
 #include <shogun/lib/common.h>
 #include <shogun/features/DotFeatures.h>
 #include <shogun/machine/LinearMachine.h>

--- a/src/shogun/classifier/mkl/MKL.cpp
+++ b/src/shogun/classifier/mkl/MKL.cpp
@@ -16,6 +16,7 @@
 #include <shogun/classifier/svm/LibSVM.h>
 #include <shogun/kernel/CombinedKernel.h>
 
+
 using namespace shogun;
 
 CMKL::CMKL(CSVM* s) : CSVM(), svm(NULL), C_mkl(0), mkl_norm(1), ent_lambda(0),

--- a/src/shogun/classifier/mkl/MKLMulticlass.cpp
+++ b/src/shogun/classifier/mkl/MKLMulticlass.cpp
@@ -16,6 +16,8 @@
 #include <shogun/io/SGIO.h>
 #include <shogun/labels/MulticlassLabels.h>
 
+#include <vector>
+
 using namespace shogun;
 
 

--- a/src/shogun/classifier/mkl/MKLMulticlass.h
+++ b/src/shogun/classifier/mkl/MKLMulticlass.h
@@ -14,8 +14,6 @@
 #ifndef MKLMulticlass_H_
 #define MKLMulticlass_H_
 
-#include <vector>
-
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
 #include <shogun/kernel/Kernel.h>

--- a/src/shogun/classifier/mkl/MKLMulticlassGLPK.cpp
+++ b/src/shogun/classifier/mkl/MKLMulticlassGLPK.cpp
@@ -13,6 +13,7 @@
 
 #include <shogun/classifier/mkl/MKLMulticlassGLPK.h>
 #include <shogun/io/SGIO.h>
+#include <vector>
 
 #ifdef USE_GLPK
 #include <glpk.h>

--- a/src/shogun/classifier/mkl/MKLMulticlassGLPK.h
+++ b/src/shogun/classifier/mkl/MKLMulticlassGLPK.h
@@ -16,7 +16,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <vector>
 #include <shogun/base/SGObject.h>
 #include <shogun/classifier/mkl/MKLMulticlassOptimizationBase.h>
 

--- a/src/shogun/classifier/mkl/MKLMulticlassGradient.cpp
+++ b/src/shogun/classifier/mkl/MKLMulticlassGradient.cpp
@@ -13,6 +13,9 @@
 
 #include <shogun/classifier/mkl/MKLMulticlassGradient.h>
 #include <shogun/mathematics/Math.h>
+#include <vector>
+#include <cmath>
+#include <cassert>
 
 using namespace shogun;
 

--- a/src/shogun/classifier/mkl/MKLMulticlassGradient.h
+++ b/src/shogun/classifier/mkl/MKLMulticlassGradient.h
@@ -16,9 +16,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <vector>
-#include <cmath>
-#include <cassert>
 #include <shogun/base/SGObject.h>
 #include <shogun/classifier/mkl/MKLMulticlassOptimizationBase.h>
 

--- a/src/shogun/classifier/svm/GNPPLib.h
+++ b/src/shogun/classifier/svm/GNPPLib.h
@@ -17,8 +17,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <limits.h>
-
 #include <shogun/base/SGObject.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/lib/common.h>

--- a/src/shogun/classifier/svm/GPBTSVM.h
+++ b/src/shogun/classifier/svm/GPBTSVM.h
@@ -16,7 +16,6 @@
 #include <shogun/classifier/svm/SVM.h>
 #include <shogun/lib/external/shogun_libsvm.h>
 
-#include <stdio.h>
 
 namespace shogun
 {

--- a/src/shogun/classifier/svm/LibSVMOneClass.h
+++ b/src/shogun/classifier/svm/LibSVMOneClass.h
@@ -18,7 +18,6 @@
 #include <shogun/classifier/svm/SVM.h>
 #include <shogun/lib/external/shogun_libsvm.h>
 
-#include <stdio.h>
 
 namespace shogun
 {

--- a/src/shogun/classifier/svm/QPBSVMLib.h
+++ b/src/shogun/classifier/svm/QPBSVMLib.h
@@ -15,8 +15,6 @@
 #ifndef QPBSVMLIB_H__
 #define QPBSVMLIB_H__
 
-#include <limits.h>
-
 #include <shogun/base/SGObject.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/lib/config.h>

--- a/src/shogun/classifier/svm/SVMLight.cpp
+++ b/src/shogun/classifier/svm/SVMLight.cpp
@@ -42,6 +42,12 @@
 #include <shogun/base/Parallel.h>
 #include <shogun/labels/BinaryLabels.h>
 
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
 #endif

--- a/src/shogun/classifier/svm/SVMLight.h
+++ b/src/shogun/classifier/svm/SVMLight.h
@@ -28,12 +28,6 @@
 #include <shogun/classifier/svm/SVM.h>
 #include <shogun/lib/common.h>
 
-#include <stdio.h>
-#include <ctype.h>
-#include <string.h>
-#include <stdlib.h>
-#include <time.h>
-
 namespace shogun
 {
 


### PR DESCRIPTION
There were stdio includes in many header files which were not required, they have been removed. Also non shogun includes were shifted to .cpp files. Everything was compiled locally which went correct.
If some changes are required let me know i ll run them locally and then squash commits.
