### PR TITLE
Use get_strdup instead of strdup to avoid cygwin crashes

### DIFF
--- a/src/interfaces/octave_static/OctaveInterface.cpp
+++ b/src/interfaces/octave_static/OctaveInterface.cpp
@@ -633,8 +633,8 @@ void COctaveInterface::clear_octave_globals()
 
 void COctaveInterface::run_octave_init()
 {
-	char* name=strdup("octave");
-	char* opts=strdup("-q");
+	char* name=get_strdup("octave");
+	char* opts=get_strdup("-q");
 	char* argv[2]={name, opts};
 	octave_main(2,argv,1);
 	free(opts);

--- a/src/interfaces/r_static/RInterface.cpp
+++ b/src/interfaces/r_static/RInterface.cpp
@@ -18,6 +18,7 @@ extern "C" {
 #include <shogun/lib/ShogunException.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/base/init.h>
+#include <shogun/lib/memory.h>
 
 #ifdef HAVE_PYTHON
 #include "../python_static/PythonInterface.h"
@@ -552,8 +553,8 @@ void CRInterface::run_r_init()
 #ifdef R_HOME_ENV
 	setenv("R_HOME", R_HOME_ENV, 0);
 #endif
-	char* name=strdup("R");
-	char* opts=strdup("-q");
+	char* name=get_strdup("R");
+	char* opts=get_strdup("-q");
 	char* argv[2]={name, opts};
 	Rf_initEmbeddedR(2, argv);
 	free(opts);

--- a/src/shogun/io/File.cpp
+++ b/src/shogun/io/File.cpp
@@ -185,12 +185,12 @@ CFile::~CFile()
 void CFile::set_variable_name(const char* name)
 {
 	SG_FREE(variable_name);
-	variable_name=strdup(name);
+	variable_name=get_strdup(name);
 }
 
 char* CFile::get_variable_name()
 {
-	return strdup(variable_name);
+	return get_strdup(variable_name);
 }
 
 #define SPARSE_VECTOR_GETTER(type)										\


### PR DESCRIPTION
Fixes one of the reasons for the issue #2380