### PR TITLE
fixes for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ else()
 endif()
 
 ############### VERSION #####################
-FILE(STRINGS "@CMAKE_SOURCE_DIR@/NEWS" NEWS LIMIT_COUNT 5)
+FILE(STRINGS "${CMAKE_SOURCE_DIR}/NEWS" NEWS LIMIT_COUNT 5)
 STRING(REGEX REPLACE ".*SHOGUN Release version ([0-9.]*).*" "\\1" VERSION "${NEWS}")
 STRING(REGEX REPLACE ".*SHOGUN Release version.*\\(libshogun ([0-9.]*).*" "\\1" LIBSHOGUNVER "${NEWS}")
 STRING(REGEX REPLACE ".*SHOGUN Release version.*\\(libshogun ([0-9]*).*" "\\1" LIBSHOGUNSO "${NEWS}")

--- a/src/.doxy2swig.py
+++ b/src/.doxy2swig.py
@@ -41,13 +41,20 @@ def my_open_read(source):
     if hasattr(source, "read"):
         return source
     else:
-        return open(source)
+        try:
+            return open(source, encoding='utf-8')
+        except TypeError:
+            return open(source)
+
 
 def my_open_write(dest):
     if hasattr(dest, "write"):
         return dest
     else:
-        return open(dest, 'w')
+        try:
+            return open(dest, 'w', encoding='utf-8')
+        except TypeError:
+            return open(dest, 'w')
 
 
 class Doxy2SWIG:

--- a/src/interfaces/r_modular/CMakeLists.txt
+++ b/src/interfaces/r_modular/CMakeLists.txt
@@ -6,7 +6,7 @@ set_target_properties(r_modular PROPERTIES PREFIX "")
 
 ADD_CUSTOM_COMMAND(TARGET r_modular
 	POST_BUILD
-	COMMAND echo 'f="modshogun.R"\; fdata="modshogun.RData"\; source(f)\; save(list=ls(all=TRUE),file=fdata, compress=TRUE)\; q(save="no")' | ${R_EXECUTABLE} --silent --no-save
+	COMMAND echo 'f="modshogun.R" \; fdata="modshogun.RData" \; source( f ) \; save( list=ls( all=TRUE ) , file=fdata , compress=TRUE ) \; q( save="no" ) \;' | ${R_EXECUTABLE} --silent --no-save
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	COMMENT "Generating modshogun.RData"
 )


### PR DESCRIPTION
* failsafe fix for new CMake-policy CMP0053 introduced by CMake >= 3.1
* fix "Argument not separated from preceding token by whitespace." for R-modular
* fix doxy2swig to use "encoding='utf-8'" when opening files by default  
on e.g. Fedora there are encoding-errors when using Python 3.X