### PR TITLE
Add linalg max native implementation

### DIFF
--- a/tests/unit/mathematics/linalg/Max_unittest.cc
+++ b/tests/unit/mathematics/linalg/Max_unittest.cc
@@ -30,7 +30,7 @@
 
 #include <shogun/lib/config.h>
 
-#ifdef HAVE_LINALG_LIB
+#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
 #include <shogun/mathematics/linalg/linalg.h>
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/lib/SGVector.h>
@@ -47,6 +47,33 @@
 
 using namespace shogun;
 
+TEST(MaxMatrix, native_backend)
+{
+	SGMatrix<float64_t> A(3,3);
+	
+	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
+	
+	for (int32_t i=0; i<9; i++)
+		A[i] = a[i];
+	
+	for (int32_t i=0; i<9; i++)
+		EXPECT_NEAR(8, linalg::max<linalg::Backend::NATIVE>(A), 1e-15);
+}
+
+TEST(MaxVector, native_backend)
+{
+	SGVector<float64_t> A(9);
+	
+	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
+	
+	for (int32_t i=0; i<9; i++)
+		A[i] = a[i];
+	
+	for (int32_t i=0; i<9; i++)
+		EXPECT_NEAR(8, linalg::max<linalg::Backend::NATIVE>(A), 1e-15);
+}
+
+#ifdef HAVE_LINALG_LIB
 #ifdef HAVE_EIGEN3
 TEST(MaxMatrix, eigen3_backend)
 {
@@ -102,5 +129,5 @@ TEST(MaxVector, viennacl_backend)
 		EXPECT_NEAR(8, linalg::max<linalg::Backend::VIENNACL>(A), 1e-15);
 }
 #endif // HAVE_VIENNACL
-
 #endif // HAVE_LINALG_LIB
+#endif // defined(HAVE_CXX0X) || defined(HAVE_CXX11)


### PR DESCRIPTION
@lambday @iglesias Max function for vectors is also available in CMath. We can remove it from CMath if we are adding it here after the C++11 issue is resolved.