### PR TITLE
fix segfaults when calling delete[] twice on SGMatrix-instances and fix minor issues with swig 3.X

### DIFF
--- a/examples/undocumented/python_modular/kernel_sparse_poly_modular.py
+++ b/examples/undocumented/python_modular/kernel_sparse_poly_modular.py
@@ -17,8 +17,8 @@ def kernel_sparse_poly_modular (fm_train_real=traindat,fm_test_real=testdat,
 
 
 
-	kernel=PolyKernel(feats_train, feats_train, size_cache, degree,
-		inhomogene)
+	kernel=PolyKernel(feats_train, feats_train, size_cache,
+		inhomogene, degree)
 	km_train=kernel.get_kernel_matrix()
 
 	kernel.init(feats_train, feats_test)

--- a/examples/undocumented/python_modular/tests_check_commwordkernel_memleak_modular.py
+++ b/examples/undocumented/python_modular/tests_check_commwordkernel_memleak_modular.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-parameter_list=[[10,7,0,0]]
+parameter_list=[[10,7,0,False]]
 
 def tests_check_commwordkernel_memleak_modular (num, order, gap, reverse):
 	import gc

--- a/src/shogun/evaluation/CrossValidationMulticlassStorage.cpp
+++ b/src/shogun/evaluation/CrossValidationMulticlassStorage.cpp
@@ -33,31 +33,25 @@ CCrossValidationMulticlassStorage::CCrossValidationMulticlassStorage(bool comput
 
 CCrossValidationMulticlassStorage::~CCrossValidationMulticlassStorage()
 {
-	if (m_compute_ROC)
+	if (m_compute_ROC && m_fold_ROC_graphs)
 	{
-		for (int32_t i=0; i<m_num_folds*m_num_runs*m_num_classes; i++)
-			m_fold_ROC_graphs[i].~SGMatrix<float64_t>();
-
 		SG_FREE(m_fold_ROC_graphs);
 	}
 
-	if (m_compute_PRC)
+	if (m_compute_PRC && m_fold_PRC_graphs)
 	{
-		for (int32_t i=0; i<m_num_folds*m_num_runs*m_num_classes; i++)
-			m_fold_PRC_graphs[i].~SGMatrix<float64_t>();
-
 		SG_FREE(m_fold_PRC_graphs);
 	}
 
-	if (m_compute_conf_matrices)
+	if (m_compute_conf_matrices && m_conf_matrices)
 	{
-		for (int32_t i=0; i<m_num_folds*m_num_runs; i++)
-			m_conf_matrices[i].~SGMatrix<int32_t>();
-
 		SG_FREE(m_conf_matrices);
 	}
 
-	SG_UNREF(m_binary_evaluations);
+	if (m_binary_evaluations)
+	{
+		SG_UNREF(m_binary_evaluations);
+	}
 };
 
 

--- a/src/shogun/evaluation/MulticlassOVREvaluation.cpp
+++ b/src/shogun/evaluation/MulticlassOVREvaluation.cpp
@@ -28,12 +28,14 @@ CMulticlassOVREvaluation::CMulticlassOVREvaluation(CBinaryClassEvaluation* binar
 
 CMulticlassOVREvaluation::~CMulticlassOVREvaluation()
 {
-	SG_UNREF(m_binary_evaluation);
 	if (m_graph_results)
 	{
-		for (int32_t i=0; i<m_num_graph_results; i++)
-			m_graph_results[i].~SGMatrix<float64_t>();
 		SG_FREE(m_graph_results);
+	}
+
+	if (m_binary_evaluation)
+	{
+		SG_UNREF(m_binary_evaluation);
 	}
 }
 


### PR DESCRIPTION
fix minor issues when building python_modular with "patched" swig 3.X
 * fix failing test when building with swig 3.X
 * fix segfault when calling delete[] twice on SGMatrix-instances