### PR TITLE
Fix for issue #2729

### DIFF
--- a/src/shogun/kernel/GaussianARDKernel.cpp
+++ b/src/shogun/kernel/GaussianARDKernel.cpp
@@ -29,7 +29,7 @@ void CGaussianARDKernel::init()
 	SG_ADD(&m_width, "width", "Kernel width", MS_AVAILABLE, GRADIENT_AVAILABLE);
 }
 
-#ifdef HAVE_CXX11
+#ifdef HAVE_LINALG_LIB
 #include <shogun/mathematics/linalg/linalg.h>
 CGaussianARDKernel::CGaussianARDKernel(int32_t size, float64_t width)
 		: CLinearARDKernel(size)
@@ -122,4 +122,4 @@ float64_t CGaussianARDKernel::distance(int32_t idx_a, int32_t idx_b)
 	float64_t result=compute_helper(avec, avec);
 	return result/m_width;
 }
-#endif /* HAVE_CXX11 */
+#endif /* HAVE_LINALG_LIB */

--- a/src/shogun/kernel/GaussianARDKernel.h
+++ b/src/shogun/kernel/GaussianARDKernel.h
@@ -33,7 +33,7 @@ namespace shogun
  *
  * where \f$\tau\f$ is the kernel width.
  *
- * There are three variants based on \f$||\cdot||\f$. 
+ * There are three variants based on \f$||\cdot||\f$.
  * The default case is
  * \f$\sum_{i=1}^{p}{{[\lambda \times ({\bf x_i}-{\bf y_i})] }^2}\f$
  * where \f$\lambda\f$ is a scalar and \f$p\f$ is # of features
@@ -50,7 +50,7 @@ namespace shogun
  * The last case is
  * \f$({\bf x}-{\bf y})^T \Lambda^T \Lambda ({\bf x}-{\bf y})\f$
  * where \f$\Lambda\f$ is a \f$d\f$-by-\f$p\f$ matrix,
- * \f$p\f$ is # of features and \f$d\f$ can be \f$ d \ge p\f$ or \f$ d \le p\f$ 
+ * \f$p\f$ is # of features and \f$d\f$ can be \f$ d \ge p\f$ or \f$ d \le p\f$
  * To use this case,  please call set_matrix_weights(\f$\Lambda\f$)
  * where \f$\Lambda\f$ is a \f$d\f$-by-\f$p\f$ matrix
  *
@@ -91,7 +91,7 @@ protected:
 	/** kernel width */
 	float64_t m_width;
 
-#ifdef HAVE_CXX11
+#ifdef HAVE_LINALG_LIB
 public:
 	/** constructor
 	 *
@@ -160,7 +160,7 @@ protected:
 	 */
 	virtual float64_t distance(int32_t idx_a, int32_t idx_b);
 
-#endif /* HAVE_CXX11 */
+#endif /* HAVE_LINALG_LIB */
 };
 }
 #endif /* _GAUSSIANARDKERNEL_H_ */

--- a/src/shogun/kernel/LinearARDKernel.cpp
+++ b/src/shogun/kernel/LinearARDKernel.cpp
@@ -32,7 +32,7 @@ void CLinearARDKernel::init()
 			GRADIENT_AVAILABLE);
 }
 
-#ifdef HAVE_CXX11
+#ifdef HAVE_LINALG_LIB
 #include <shogun/mathematics/linalg/linalg.h>
 
 CLinearARDKernel::CLinearARDKernel(int32_t size) : CDotKernel(size)
@@ -78,7 +78,7 @@ SGMatrix<float64_t> CLinearARDKernel::compute_right_product(SGVector<float64_t>r
 		right=SGMatrix<float64_t>(right_vec.vector,right_vec.vlen,1,false);
 		scalar_weight*=m_weights[0];
 	}
-	else 
+	else
 	{
 		right=SGMatrix<float64_t> (m_weights.num_rows,1);
 
@@ -110,7 +110,7 @@ float64_t CLinearARDKernel::compute_helper(SGVector<float64_t> avec, SGVector<fl
 		left=SGMatrix<float64_t>(avec.vector,1,avec.vlen,false);
 		scalar_weight=m_weights[0];
 	}
-	else 
+	else
 	{
 		left=SGMatrix<float64_t>(1,m_weights.num_rows);
 
@@ -288,4 +288,4 @@ void CLinearARDKernel::set_matrix_weights(SGMatrix<float64_t> weights)
 {
 	set_weights(weights);
 }
-#endif //HAVE_CXX11
+#endif //HAVE_LINALG_LIB

--- a/src/shogun/kernel/LinearARDKernel.h
+++ b/src/shogun/kernel/LinearARDKernel.h
@@ -36,7 +36,7 @@ enum EARDKernelType
  * k({\bf x},{\bf y})= \frac{||{\bf x}-{\bf y}||}
  * \f]
  *
- * There are three variants based on \f$||\cdot||\f$. 
+ * There are three variants based on \f$||\cdot||\f$.
  * The default case is
  * \f$\sum_{i=1}^{p}{{[\lambda \times ({\bf x_i}-{\bf y_i})] }^2}\f$
  * where \f$\lambda\f$ is a scalar and \f$p\f$ is # of features
@@ -53,7 +53,7 @@ enum EARDKernelType
  * The last case is
  * \f$({\bf x}-{\bf y})^T \Lambda^T \Lambda ({\bf x}-{\bf y})\f$
  * where \f$\Lambda\f$ is a \f$d\f$-by-\f$p\f$ matrix,
- * \f$p\f$ is # of features and \f$d\f$ can be \f$ d \ge p\f$ or \f$ d \le p\f$ 
+ * \f$p\f$ is # of features and \f$d\f$ can be \f$ d \ge p\f$ or \f$ d \le p\f$
  * To use this case,  please call set_matrix_weights(\f$\Lambda\f$),
  * where \f$\Lambda\f$ is a \f$d\f$-by-\f$p\f$ matrix
  *
@@ -105,7 +105,7 @@ protected:
 	/** type of ARD kernel */
 	EARDKernelType m_ARD_type;
 
-#ifdef HAVE_CXX11
+#ifdef HAVE_LINALG_LIB
 public:
 	/** constructor
 	 *
@@ -219,7 +219,7 @@ protected:
 	 */
 	virtual SGMatrix<float64_t> compute_right_product(SGVector<float64_t>right_vec, float64_t & scalar_weight);
 
-#endif /* HAVE_CXX11 */
+#endif /* HAVE_LINALG_LIB */
 };
 }
 #endif /* _LINEARARDKERNEL_H_ */

--- a/src/shogun/mathematics/linalg/internal/implementation/Add.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/Add.h
@@ -64,7 +64,7 @@ struct add
 {
 	/** Scalar type */
 	typedef typename Matrix::Scalar T;
-	
+
 	/**
 	 * Performs the operation C = alpha*A + beta*B. Works for both matrices and vectors
 	 * @param A first matrix
@@ -77,11 +77,12 @@ struct add
 };
 
 /**
- * @brief Specialization of add for the Native backend
+ * @brief Partial specialization of add for the Native backend
  */
-template <> template <class Matrix>
+template <class Matrix>
 struct add<Backend::NATIVE, Matrix>
 {
+	/** Scalar type */
 	typedef typename Matrix::Scalar T;
 
 	/**
@@ -101,7 +102,7 @@ struct add<Backend::NATIVE, Matrix>
 			"Matrices should have same number of columns!\n");
 		compute(A.matrix, B.matrix, C.matrix, alpha, beta, A.num_rows*A.num_cols);
 	}
-	
+
 	/**
 	 * Performs the operation C = alpha*A + beta*B.
 	 * @param A first vector
@@ -126,27 +127,31 @@ struct add<Backend::NATIVE, Matrix>
 	 * @param beta constant to be multiplied by the second vector
 	 * @param len length of the vectors/matrices
 	 */
-	static void compute(T* A, T* B, T* C,
-		T alpha, T beta, index_t len)
+	static void compute(T* A, T* B, T* C, T alpha, T beta, index_t len)
 	{
 		for (int32_t i=0; i<len; i++)
 			C[i]=alpha*A[i]+beta*B[i];
-	}	
+	}
 };
 
 #ifdef HAVE_EIGEN3
 
-/** 
- * @brief Specialization of add for the Eigen3 backend
+/**
+ * @brief Partial specialization of add for the Eigen3 backend
  */
-template <> template <class Matrix>
+template <class Matrix>
 struct add<Backend::EIGEN3, Matrix>
 {
+	/** Scalar type */
 	typedef typename Matrix::Scalar T;
+
+	/** Eigen3 matrix type */
 	typedef Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> MatrixXt;
+
+	/** Eigen3 vector type */
 	typedef Eigen::Matrix<T,Eigen::Dynamic,1> VectorXt;
-	
-	/** 
+
+	/**
 	 * Performs the operation C = alpha*A + beta*B using Eigen3
 	 * @param A first matrix
 	 * @param B second matrix
@@ -154,17 +159,17 @@ struct add<Backend::EIGEN3, Matrix>
 	 * @param alpha constant to be multiplied by the first matrix
 	 * @param beta constant to be multiplied by the second matrix
 	 */
-	static void compute(SGMatrix<T> A, SGMatrix<T> B, SGMatrix<T> C, 
+	static void compute(SGMatrix<T> A, SGMatrix<T> B, SGMatrix<T> C,
 		T alpha, T beta)
 	{
-		Eigen::Map<MatrixXt> A_eig = A;
-		Eigen::Map<MatrixXt> B_eig = B;
-		Eigen::Map<MatrixXt> C_eig = C;
-		
-		C_eig = alpha*A_eig + beta*B_eig;
+		Eigen::Map<MatrixXt> A_eig=A;
+		Eigen::Map<MatrixXt> B_eig=B;
+		Eigen::Map<MatrixXt> C_eig=C;
+
+		C_eig=alpha*A_eig+beta*B_eig;
 	}
-	
-	/** 
+
+	/**
 	 * Performs the operation C = alpha*A + beta*B using Eigen3
 	 * @param A first vector
 	 * @param B second vector
@@ -172,29 +177,30 @@ struct add<Backend::EIGEN3, Matrix>
 	 * @param alpha constant to be multiplied by the first vector
 	 * @param beta constant to be multiplied by the second vector
 	 */
-	static void compute(SGVector<T> A, SGVector<T> B, SGVector<T> C, 
+	static void compute(SGVector<T> A, SGVector<T> B, SGVector<T> C,
 		T alpha, T beta)
 	{
-		Eigen::Map<VectorXt> A_eig = A;
-		Eigen::Map<VectorXt> B_eig = B;
-		Eigen::Map<VectorXt> C_eig = C;
-		
-		C_eig = alpha*A_eig + beta*B_eig;
+		Eigen::Map<VectorXt> A_eig=A;
+		Eigen::Map<VectorXt> B_eig=B;
+		Eigen::Map<VectorXt> C_eig=C;
+
+		C_eig=alpha*A_eig+beta*B_eig;
 	}
 };
 #endif // HAVE_EIGEN3
 
 #ifdef HAVE_VIENNACL
 
-/** 
- * @brief Specialization of add for the ViennaCL backend
+/**
+ * @brief Partial specialization of add for the ViennaCL backend
  */
-template <> template <class Matrix>
+template <class Matrix>
 struct add<Backend::VIENNACL, Matrix>
 {
+	/** Scalar type */
 	typedef typename Matrix::Scalar T;
-	
-	/** 
+
+	/**
 	 * Performs the operation C = alpha*A + beta*B using Viennacl
 	 * @param A first matrix
 	 * @param B second matrix
@@ -202,13 +208,13 @@ struct add<Backend::VIENNACL, Matrix>
 	 * @param alpha constant to be multiplied by the first matrix
 	 * @param beta constant to be multiplied by the second matrix
 	 */
-	static void compute(CGPUMatrix<T> A, CGPUMatrix<T> B, CGPUMatrix<T> C, 
+	static void compute(CGPUMatrix<T> A, CGPUMatrix<T> B, CGPUMatrix<T> C,
 		T alpha, T beta)
 	{
-		C.vcl_matrix() = alpha*A.vcl_matrix() + beta*B.vcl_matrix();
+		C.vcl_matrix()=alpha*A.vcl_matrix()+beta*B.vcl_matrix();
 	}
-	
-	/** 
+
+	/**
 	 * Performs the operation C = alpha*A + beta*B using Viennacl
 	 * @param A first vector
 	 * @param B second vector
@@ -216,10 +222,10 @@ struct add<Backend::VIENNACL, Matrix>
 	 * @param alpha constant to be multiplied by the first vector
 	 * @param beta constant to be multiplied by the second vector
 	 */
-	static void compute(CGPUVector<T> A, CGPUVector<T> B, CGPUVector<T> C, 
+	static void compute(CGPUVector<T> A, CGPUVector<T> B, CGPUVector<T> C,
 		T alpha, T beta)
 	{
-		C.vcl_vector() = alpha*A.vcl_vector() + beta*B.vcl_vector();
+		C.vcl_vector()=alpha*A.vcl_vector()+beta*B.vcl_vector();
 	}
 };
 

--- a/src/shogun/mathematics/linalg/internal/implementation/VectorSum.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/VectorSum.h
@@ -79,15 +79,15 @@ struct vector_sum
 /**
  * @brief Specialization of generic vector_sum for the Native backend
  */
-template<> template <class Vector>
+template <class Vector>
 struct vector_sum<Backend::NATIVE, Vector>
 {
 	/** Scalar type */
 	typedef typename Vector::Scalar T;
-	
+
 	/**
 	 * Method that computes the sum of SGVectors
-	 * 
+	 *
 	 * @param vec a vector whose sum has to be computed
 	 * @return the vector sum \f$\sum_i a_i\f$
 	 */
@@ -99,7 +99,7 @@ struct vector_sum<Backend::NATIVE, Vector>
 
 	/**
 	 * Method that computes the sum of SGVectors
-	 * 
+	 *
 	 * @param vec a vector whose sum has to be computed
 	 * @param len the length of the vector
 	 * @return the vector sum \f$\sum_i a_i\f$
@@ -109,14 +109,15 @@ struct vector_sum<Backend::NATIVE, Vector>
 		return std::accumulate(vec,vec+len,0);
 	}
 };
-	
+
 #ifdef HAVE_EIGEN3
 /**
  * @brief Specialization of generic vector_sum for the Eigen3 backend
  */
-template <> template <class Vector>
+template <class Vector>
 struct vector_sum<Backend::EIGEN3, Vector>
 {
+	/** Scalar type */
 	typedef typename Vector::Scalar T;
 
 	/**
@@ -139,9 +140,10 @@ struct vector_sum<Backend::EIGEN3, Vector>
 /**
  * @brief Specialization of generic vector_sum for the ViennaCL backend
  */
-template <> template <class Vector>
+template <class Vector>
 struct vector_sum<Backend::VIENNACL, Vector>
 {
+	/** Scalar type */
 	typedef typename Vector::Scalar T;
 
 	/**

--- a/src/shogun/mathematics/linalg/internal/modules/Core.h
+++ b/src/shogun/mathematics/linalg/internal/modules/Core.h
@@ -32,8 +32,6 @@
 #ifndef CORE_H_
 #define CORE_H_
 
-#ifdef HAVE_LINALG_LIB
-
 #include <shogun/mathematics/linalg/internal/implementation/ElementwiseSquare.h>
 #include <shogun/mathematics/linalg/internal/implementation/MatrixProduct.h>
 #include <shogun/mathematics/linalg/internal/implementation/Add.h>
@@ -47,6 +45,23 @@ namespace shogun
 namespace linalg
 {
 
+/** Performs the operation \f$C = \alpha A + \beta B\f$.
+ * Works for both matrices and vectors.
+ *
+ * @param A First matrix
+ * @param B Second matrix
+ * @param C Result of the operation
+ * @param alpha scaling parameter for first matrix
+ * @param beta scaling parameter for second matrix
+ */
+template <Backend backend=linalg_traits<Core>::backend,class Matrix>
+void add(Matrix A, Matrix B, Matrix C, typename Matrix::Scalar alpha=1.0,
+		typename Matrix::Scalar beta=1.0)
+{
+	implementation::add<backend, Matrix>::compute(A, B, C, alpha, beta);
+}
+
+#ifdef HAVE_LINALG_LIB
 /** Performs matrix multiplication
  *
  * @param A First matrix
@@ -62,14 +77,6 @@ void matrix_product(Matrix A, Matrix B, Matrix C,
 	bool transpose_A=false, bool transpose_B=false, bool overwrite=true)
 {
 	implementation::matrix_product<backend, Matrix>::compute(A, B, C, transpose_A, transpose_B, overwrite);
-}
-
-/** Performs the operation C = alpha*A + beta*B. Works for both matrices and vectors */
-template <Backend backend=linalg_traits<Core>::backend,class Matrix>
-void add(Matrix A, Matrix B, Matrix C,
-	typename Matrix::Scalar alpha=1.0, typename Matrix::Scalar beta=1.0)
-{
-	implementation::add<backend, Matrix>::compute(A, B, C, alpha, beta);
 }
 
 /** Performs the operation C = alpha*A - beta*B. Works for both matrices and vectors */
@@ -122,17 +129,17 @@ void elementwise_square(Matrix m, ResultMatrix result)
 }
 
 /** Computes the 2D convolution of X with W
- * 
- * NOTE: For the ViennaCL backend, the size of W (number of bytes) must not exceed 
- * [CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE](http://www.khronos.org/registry/cl/sdk/1.2/docs/man/xhtml/clGetDeviceInfo.html). 
- * 
+ *
+ * NOTE: For the ViennaCL backend, the size of W (number of bytes) must not exceed
+ * [CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE](http://www.khronos.org/registry/cl/sdk/1.2/docs/man/xhtml/clGetDeviceInfo.html).
+ *
  * @param X Input image
  * @param W Filter coefficients. The dimensions of the matrix must be odd-numbered.
- * @param Y Output image of the same size as the input image, as the borders 
+ * @param Y Output image of the same size as the input image, as the borders
  * of the input image are implicitly padded with zeros during the computation
- * @param flip If true the filter coefficients are flipped, performing cross-correlation 
+ * @param flip If true the filter coefficients are flipped, performing cross-correlation
  * instead of convolution
- * @param overwrite If true, the values in Y are overwritten with result of the 
+ * @param overwrite If true, the values in Y are overwritten with result of the
  * computation. Otherwise, the result is added to the existing values in Y.
  * @param stride_x Stride in the x (column) direction
  * @param stride_y Stride in the y (row) direction
@@ -143,9 +150,9 @@ void convolve(Matrix X, Matrix W, Matrix Y, bool flip = false,
 {
 	implementation::convolve<backend, Matrix>::compute(X, W, Y, flip, overwrite, stride_x, stride_y);
 }
-
-}
-
-}
 #endif // HAVE_LINALG_LIB
+
+}
+
+}
 #endif // CORE_H_

--- a/src/shogun/mathematics/linalg/internal/modules/Redux.h
+++ b/src/shogun/mathematics/linalg/internal/modules/Redux.h
@@ -58,6 +58,29 @@ typename Vector::Scalar dot(Vector a, Vector b)
 	return implementation::dot<backend,Vector>::compute(a, b);
 }
 
+/** Returns the largest element in a matrix or vector
+ * @param m the matrix or the vector
+ * @return the value of the largest element
+ */
+template <Backend backend=linalg_traits<Redux>::backend, class Matrix>
+typename Matrix::Scalar max(Matrix m)
+{
+	return implementation::max<backend,Matrix>::compute(m);
+}
+
+/**
+ * Wrapper method for internal implementation of vector sum of values that works
+ * with generic dense vectors
+
+ * @param a vector whose sum has to be computed
+ * @return the vector sum \f$\sum_i a_i\f$
+ */
+template <Backend backend=linalg_traits<Redux>::backend, class Vector>
+typename Vector::Scalar vector_sum(Vector a)
+{
+	return implementation::vector_sum<backend,Vector>::compute(a);
+}
+
 #ifdef HAVE_LINALG_LIB
 
 /**
@@ -159,26 +182,6 @@ template <Backend backend=linalg_traits<Redux>::backend,class Matrix, class Vect
 void rowwise_sum(Matrix m, Vector result, bool no_diag=false)
 {
 	implementation::rowwise_sum<backend,Matrix>::compute(m, result, no_diag);
-}
-
-/**
- * Wrapper method for internal implementation of vector sum of values that works
- * with generic dense vectors
-
- * @param a vector whose sum has to be computed
- * @return the vector sum \f$\sum_i a_i\f$
- */
-template <Backend backend=linalg_traits<Redux>::backend, class Vector>
-typename Vector::Scalar vector_sum(Vector a)
-{
-	return implementation::vector_sum<backend,Vector>::compute(a);
-}
-
-/** Returns the largest element in a matrix or vector */
-template <Backend backend=linalg_traits<Redux>::backend, class Matrix>
-typename Matrix::Scalar max(Matrix m)
-{
-	return implementation::max<backend,Matrix>::compute(m);
 }
 
 #endif // HAVE_LINALG_LIB


### PR DESCRIPTION
- moved `add`, `max`, and `vector_sum` outside the `HAVE_LINALG_LIB` guard
- guarded `CLinearARDKernel` and `CGaussianARDKernel` with `HAVE_LINALG_LIB` instead of `HAVE_CXX11` since the linalg methods used there are still dependent on third party libs and are not available natively (yet).