### PR TITLE
minor fix and comments about time complexity of fitc regression

### DIFF
--- a/src/shogun/kernel/LinearARDKernel.cpp
+++ b/src/shogun/kernel/LinearARDKernel.cpp
@@ -35,6 +35,7 @@ void CLinearARDKernel::initialize()
 	m_weights.set_const(1.0);
 	SG_ADD(&m_weights, "weights", "Feature weights", MS_AVAILABLE,
 			GRADIENT_AVAILABLE);
+	SG_ADD((int *)(&m_ARD_type), "type", "ARD kernel type", MS_NOT_AVAILABLE);
 }
 
 #ifdef HAVE_LINALG_LIB

--- a/src/shogun/machine/gp/EPInferenceMethod.cpp
+++ b/src/shogun/machine/gp/EPInferenceMethod.cpp
@@ -465,21 +465,10 @@ SGVector<float64_t> CEPInferenceMethod::get_derivative_wrt_kernel(
 	// create eigen representation of the matrix Q
 	Map<MatrixXd> eigen_F(m_F.matrix, m_F.num_rows, m_F.num_cols);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-			param->m_datatype.m_ctype==CT_SGVECTOR ||
-			param->m_datatype.m_ctype==CT_MATRIX ||
-			param->m_datatype.m_ctype==CT_SGMATRIX)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-				"Length of the parameter %s should not be NULL\n", param->m_name)
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{

--- a/src/shogun/machine/gp/ExactInferenceMethod.cpp
+++ b/src/shogun/machine/gp/ExactInferenceMethod.cpp
@@ -313,21 +313,10 @@ SGVector<float64_t> CExactInferenceMethod::get_derivative_wrt_kernel(
 	// create eigen representation of the matrix Q
 	Map<MatrixXd> eigen_Q(m_Q.matrix, m_Q.num_rows, m_Q.num_cols);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-		param->m_datatype.m_ctype==CT_SGVECTOR ||
-		param->m_datatype.m_ctype==CT_MATRIX ||
-		param->m_datatype.m_ctype==CT_SGMATRIX)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-			"Length of the parameter %s should not be NULL\n", param->m_name);
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{
@@ -353,20 +342,10 @@ SGVector<float64_t> CExactInferenceMethod::get_derivative_wrt_mean(
 	// create eigen representation of alpha vector
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-			param->m_datatype.m_ctype==CT_SGVECTOR)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-				"Length of the parameter %s should not be NULL\n", param->m_name)
-
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{

--- a/src/shogun/machine/gp/FITCInferenceBase.cpp
+++ b/src/shogun/machine/gp/FITCInferenceBase.cpp
@@ -156,8 +156,12 @@ SGMatrix<float64_t> CFITCInferenceBase::get_cholesky()
 
 void CFITCInferenceBase::update_train_kernel()
 {
+	//time complexity can be O(m*n) if the TO DO is done
 	check_features();
 	convert_features();
+	//to reduce the time complexity from O(n^2) to O(n)
+	//the kernel object only computes diagonal elements
+	//TO DO the following function call should be modified
 	CInferenceMethod::update_train_kernel();
 
 	// create kernel matrix for inducing features

--- a/src/shogun/machine/gp/FITCInferenceBase.h
+++ b/src/shogun/machine/gp/FITCInferenceBase.h
@@ -59,10 +59,10 @@ namespace shogun
  *\f$\Sigma_{M}\f$ is the kernel matrix on inducing points
  *\f$\Sigma_{NM}=\Sigma_{MN}^{T}\f$ is the kernel matrix between features and inducing features
  *
- * Note that the number of inducing points (m) is usually far less than the number of input points (n).
+ * Note that the number of inducing points (m) is usually far less than the number of input points (n). (the time complexity is computed based on the assumption m < n)
  * The idea of FITC approximation is to use a lower-ranked matrix plus a diagonal matrix to approximate the full kernel
  * matrix.
- * The time complexity of the main inference process can be reduced from O(n^3) to O(m*n^2).
+ * The time complexity of the main inference process can be reduced from O(n^3) to O(m^2*n).
  *
  * Since we use \f$\Sigma_{fitc}\f$ to approximate \f$\Sigma_{N}\f$,
  * the (approximated) negative log marginal likelihood are computed based on \f$\Sigma_{fitc}\f$. 

--- a/src/shogun/machine/gp/KLInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLInferenceMethod.cpp
@@ -344,20 +344,10 @@ SGVector<float64_t> CKLInferenceMethod::get_derivative_wrt_mean(const TParameter
 	// create eigen representation of K, Z, dfhat and alpha
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen/2);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-			param->m_datatype.m_ctype==CT_SGVECTOR)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-				"Length of the parameter %s should not be NULL\n", param->m_name)
-
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{
@@ -428,21 +418,10 @@ SGVector<float64_t> CKLInferenceMethod::get_derivative_wrt_inference_method(cons
 
 SGVector<float64_t> CKLInferenceMethod::get_derivative_wrt_kernel(const TParameter* param)
 {
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-			param->m_datatype.m_ctype==CT_SGVECTOR ||
-			param->m_datatype.m_ctype==CT_MATRIX ||
-			param->m_datatype.m_ctype==CT_SGMATRIX)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-				"Length of the parameter %s should not be NULL\n", param->m_name)
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{

--- a/src/shogun/machine/gp/MultiLaplacianInferenceMethod.cpp
+++ b/src/shogun/machine/gp/MultiLaplacianInferenceMethod.cpp
@@ -424,21 +424,10 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_kernel(
 	// create eigen representation of K, Z, dfhat, dlp and alpha
 	Map<MatrixXd> eigen_K(m_ktrtr.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-		param->m_datatype.m_ctype==CT_SGVECTOR ||
-		param->m_datatype.m_ctype==CT_MATRIX ||
-		param->m_datatype.m_ctype==CT_SGMATRIX)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-			"Length of the parameter %s should not be NULL\n", param->m_name)
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{
@@ -467,19 +456,10 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_mean(
 	const index_t C=((CMulticlassLabels*)m_labels)->get_num_classes();
 	const index_t n=m_labels->get_num_labels();
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-			param->m_datatype.m_ctype==CT_SGVECTOR)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-				"Length of the parameter %s should not be NULL\n", param->m_name)
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{

--- a/src/shogun/machine/gp/SingleFITCLaplacianBase.h
+++ b/src/shogun/machine/gp/SingleFITCLaplacianBase.h
@@ -54,6 +54,9 @@ namespace shogun
  * "A unifying view of sparse approximate Gaussian process regression."
  * The Journal of Machine Learning Research 6 (2005): 1939-1959.
  *
+ * Note that the number of inducing points (m) is usually far less than the number of input points (n).
+ * (the time complexity is computed based on the assumption m < n)
+ *
  * This specific implementation was inspired by the infFITC.m and infFITC_Laplace.m file
  * in the GPML toolbox.
  *

--- a/src/shogun/machine/gp/SingleLaplacianInferenceMethod.cpp
+++ b/src/shogun/machine/gp/SingleLaplacianInferenceMethod.cpp
@@ -519,21 +519,10 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_kernel(
 	Map<VectorXd> eigen_dlp(m_dlp.vector, m_dlp.vlen);
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-		param->m_datatype.m_ctype==CT_SGVECTOR ||
-		param->m_datatype.m_ctype==CT_MATRIX ||
-		param->m_datatype.m_ctype==CT_SGMATRIX)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-			"Length of the parameter %s should not be NULL\n", param->m_name)
-			result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{
@@ -570,20 +559,10 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_mean(
 	Map<VectorXd> eigen_dfhat(m_dfhat.vector, m_dfhat.vlen);
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 
+	REQUIRE(param, "Param not set\n");
 	SGVector<float64_t> result;
-
-	if (param->m_datatype.m_ctype==CT_VECTOR ||
-			param->m_datatype.m_ctype==CT_SGVECTOR)
-	{
-		REQUIRE(param->m_datatype.m_length_y,
-				"Length of the parameter %s should not be NULL\n", param->m_name)
-
-		result=SGVector<float64_t>(*(param->m_datatype.m_length_y));
-	}
-	else
-	{
-		result=SGVector<float64_t>(1);
-	}
+	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
+	result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{


### PR DESCRIPTION
@karlnapf 
take a look at this.
There are some issues about fitc inference.
In order to efficiently implement fitc inference, I need to a method to compute diagonal elements of a kernel matrix and related gradients.
I can implement the method for GaussianARD kernel.

Since we have to support general kernels, I may need to modify/add a `init` method in `CKernel`.