### PR TITLE
Add solver for linear and least square to linalg

### DIFF
--- a/src/shogun/mathematics/linalg/linop/DenseMatrixOperator.h
+++ b/src/shogun/mathematics/linalg/linop/DenseMatrixOperator.h
@@ -11,6 +11,8 @@
 #define DENSE_MATRIX_OPERATOR_H_
 
 #include <shogun/lib/config.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
 
 #ifdef HAVE_EIGEN3
 #include <shogun/mathematics/linalg/linop/MatrixOperator.h>

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.cpp
@@ -1,0 +1,62 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2015 Yingrui Chang
+ */
+
+#include <shogun/lib/config.h>
+#include <iostream>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/SGVector.h>
+#include <shogun/mathematics/linalg/linop/DenseMatrixOperator.h>
+#include <shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.h>
+#include <Eigen/LU>
+#include <shogun/mathematics/eigen3.h>
+
+using namespace Eigen;
+
+namespace shogun
+{
+
+CDirectDenseLeastSquareSolverQR::CDirectDenseLeastSquareSolverQR()
+	: CLinearSolver<float64_t, float64_t>()
+{
+}
+
+CDirectDenseLeastSquareSolverQR::~CDirectDenseLeastSquareSolverQR()
+{
+}
+
+SGVector<float64_t> CDirectDenseLeastSquareSolverQR::solve(
+		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
+{
+	REQUIRE(A, "Operator is NULL!\n");
+	REQUIRE(A->get_dimension() == b.vlen, "Dimension mismatch!\n");
+	CDenseMatrixOperator<float64_t>* op
+		=dynamic_cast<CDenseMatrixOperator<float64_t>*>(A);
+	REQUIRE(op, "Operator is not DenseMatrixOperator type!\n");
+
+	// creating eigen3 Dense Matrix
+	SGMatrix<float64_t> sm = op->get_matrix_operator();
+	Map<MatrixXd> map_m(sm.matrix, sm.num_rows, sm.num_cols);
+
+	// creating eigen3 maps for vectors
+	SGVector<float64_t> x(sm.num_rows);
+	x.set_const(0.0);
+	Map<VectorXd> map_x(x.vector, x.vlen);
+	Map<VectorXd> map_b(b.vector, b.vlen);
+	
+	// using Householder QR decomposition to find the least square solution to A^T x = b
+	HouseholderQR<MatrixXd> hqr;
+	hqr.compute(map_m.transpose());
+	map_x = hqr.solve(map_b);
+
+	return x;
+}
+
+}
+#endif // HAVE_EIGEN3

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.cpp
@@ -1,10 +1,32 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
+ * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (W) 2015 Yingrui Chang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
  */
 
 #include <shogun/lib/config.h>
@@ -35,10 +57,10 @@ SGVector<float64_t> CDirectDenseLeastSquareSolverQR::solve(
 		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
 {
 	REQUIRE(A, "Operator is NULL!\n");
-	REQUIRE(A->get_dimension() == b.vlen, "Dimension mismatch!\n");
+	REQUIRE(A->get_dimension() == b.vlen, "Matrix dimension (%d) does not match vector dimension (%d)\n", A->get_dimension(), b.vlen);
 	CDenseMatrixOperator<float64_t>* op
 		=dynamic_cast<CDenseMatrixOperator<float64_t>*>(A);
-	REQUIRE(op, "Operator is not DenseMatrixOperator type!\n");
+	REQUIRE(op, "Operator \"%s\" is not of type DenseMatrixOperator.\n", op->get_name());
 
 	// creating eigen3 Dense Matrix
 	SGMatrix<float64_t> sm = op->get_matrix_operator();

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.h
@@ -1,0 +1,54 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General turalPublic License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2015 Yingrui Chang
+ */
+
+#ifndef DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H_
+#define DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H_
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/mathematics/linalg/linsolver/LinearSolver.h>
+
+namespace shogun
+{
+
+/** @brief Class that provides a solve method for least square problem
+ * using QR decomposition
+ */
+class CDirectDenseLeastSquareSolverQR : public CLinearSolver<float64_t, float64_t>
+{
+public:
+	/** default constructor */
+	CDirectDenseLeastSquareSolverQR();
+
+	/** destructor */
+	virtual ~CDirectDenseLeastSquareSolverQR();
+
+	/**
+	 * solve method for solving real-valued least square problem based on QR decomposition
+	 *
+	 * @param A the dense linear operator of the system
+	 * @param b the vector of the system
+	 * @return the solution vector
+	 */
+	virtual SGVector<float64_t> solve(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A,
+		SGVector<float64_t> b);
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "DirectDenseLeastSquareSolverQR";
+	}
+
+};
+
+}
+
+#endif // HAVE_EIGEN3
+#endif // DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H_

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.h
@@ -1,14 +1,36 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General turalPublic License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
+ * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (W) 2015 Yingrui Chang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
  */
 
-#ifndef DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H_
-#define DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H_
+#ifndef DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H
+#define DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H
 
 #include <shogun/lib/config.h>
 
@@ -18,22 +40,27 @@
 namespace shogun
 {
 
-/** @brief Class that provides a solve method for least square problem
- * using QR decomposition
+/** @brief Class that provides a solve method for finding the optimal least square solution
+ * for linear system A*x=b using using QR decomposition.
+ *
+ * http://en.wikipedia.org/wiki/QR_decomposition
+ *
+ * Assumption: Inpute dense operator A needs to be full row rank.
+ *
  */
 class CDirectDenseLeastSquareSolverQR : public CLinearSolver<float64_t, float64_t>
 {
 public:
-	/** default constructor */
+	/** Default constructor */
 	CDirectDenseLeastSquareSolverQR();
 
-	/** destructor */
+	/** Destructor */
 	virtual ~CDirectDenseLeastSquareSolverQR();
 
 	/**
-	 * solve method for solving real-valued least square problem based on QR decomposition
+	 * Solve method for solving real-valued least square problem based on QR decomposition
 	 *
-	 * @param A the dense linear operator of the system
+	 * @param A the dense linear operator of the system, should be full row rank
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
@@ -51,4 +78,4 @@ public:
 }
 
 #endif // HAVE_EIGEN3
-#endif // DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H_
+#endif // DIRECT_DENSE_LEAST_SQUARE_SOLVER_QR_H

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.cpp
@@ -1,10 +1,32 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
+ * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (W) 2015 Yingrui Chang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
  */
 
 #include <shogun/lib/config.h>
@@ -35,10 +57,10 @@ SGVector<float64_t> CDirectDenseLinearSolverLLT::solve(
 		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
 {
 	REQUIRE(A, "Operator is NULL!\n");
-	REQUIRE(A->get_dimension()==b.vlen, "Dimension mismatch!\n");
+	REQUIRE(A->get_dimension() == b.vlen, "Matrix dimension (%d) does not match vector dimension (%d)\n", A->get_dimension(), b.vlen);
 	CDenseMatrixOperator<float64_t>* op
 		=dynamic_cast<CDenseMatrixOperator<float64_t>*>(A);
-	REQUIRE(op, "Operator is not DenseMatrixOperator type!\n");
+	REQUIRE(op, "Operator \"%s\" is not of type DenseMatrixOperator.\n", op->get_name());
 
 	// creating eigen3 Dense Matrix
 	SGMatrix<float64_t> sm=op->get_matrix_operator();
@@ -56,8 +78,8 @@ SGVector<float64_t> CDirectDenseLinearSolverLLT::solve(
 	map_x=llt.solve(map_b);
 	
 	// checking for success
-	if (llt.info()!=Success)
-		SG_WARNING("LLU solver failed! maybe input operator is not symmetric positive definite.\n");
+	if (llt.info() == NumericalIssue)
+		SG_WARNING("LLU solver failed! Input operator appears to be negative.\n");
 
 	return x;
 }

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.cpp
@@ -9,16 +9,15 @@
 
 #include <shogun/lib/config.h>
 #include <iostream>
-#include <shogun/mathematics/eigen3.h>
 
 #ifdef HAVE_EIGEN3
 #include <shogun/lib/SGVector.h>
 #include <shogun/mathematics/linalg/linop/DenseMatrixOperator.h>
 #include <shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h>
 #include <Eigen/LU>
+#include <shogun/mathematics/eigen3.h>
 
 using namespace Eigen;
-using namespace std;
 
 namespace shogun
 {

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.cpp
@@ -1,0 +1,67 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2015 Yingrui Chang
+ */
+
+#include <shogun/lib/config.h>
+#include <iostream>
+#include <shogun/mathematics/eigen3.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/lib/SGVector.h>
+#include <shogun/mathematics/linalg/linop/DenseMatrixOperator.h>
+#include <shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h>
+#include <Eigen/LU>
+
+using namespace Eigen;
+using namespace std;
+
+namespace shogun
+{
+
+CDirectDenseLinearSolverLLT::CDirectDenseLinearSolverLLT()
+	: CLinearSolver<float64_t, float64_t>()
+{
+}
+
+CDirectDenseLinearSolverLLT::~CDirectDenseLinearSolverLLT()
+{
+}
+
+SGVector<float64_t> CDirectDenseLinearSolverLLT::solve(
+		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
+{
+	REQUIRE(A, "Operator is NULL!\n");
+	REQUIRE(A->get_dimension()==b.vlen, "Dimension mismatch!\n");
+	CDenseMatrixOperator<float64_t>* op
+		=dynamic_cast<CDenseMatrixOperator<float64_t>*>(A);
+	REQUIRE(op, "Operator is not DenseMatrixOperator type!\n");
+
+	// creating eigen3 Dense Matrix
+	SGMatrix<float64_t> sm=op->get_matrix_operator();
+	Map<MatrixXd> map_m(sm.matrix, sm.num_rows, sm.num_cols);
+
+	// creating eigen3 maps for vectors
+	SGVector<float64_t> x(sm.num_rows);
+	x.set_const(0.0);
+	Map<VectorXd> map_x(x.vector, x.vlen);
+	Map<VectorXd> map_b(b.vector, b.vlen);
+	
+	// using LLT to solve the system Ax=b
+	LLT<MatrixXd> llt;
+	llt.compute(map_m);
+	map_x=llt.solve(map_b);
+	
+	// checking for success
+	if (llt.info()!=Success)
+		SG_WARNING("LLU solver failed! maybe input operator is not symmetric positive definite.\n");
+
+	return x;
+}
+
+}
+#endif // HAVE_EIGEN3

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h
@@ -7,8 +7,8 @@
  * Written (W) 2015 Yingrui Chang
  */
 
-#ifndef DIRECT_DENSE_LINEAR_SOLVER_H_
-#define DIRECT_DENSE_LINEAR_SOLVER_H_
+#ifndef DIRECT_DENSE_LINEAR_SOLVER_LLT_H_
+#define DIRECT_DENSE_LINEAR_SOLVER_LLT_H_
 
 #include <shogun/lib/config.h>
 
@@ -51,4 +51,4 @@ public:
 }
 
 #endif // HAVE_EIGEN3
-#endif // DIRECT_DENSE_LINEAR_SOLVER_H_
+#endif // DIRECT_DENSE_LINEAR_SOLVER_LLT_H_

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h
@@ -1,0 +1,54 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General turalPublic License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2015 Yingrui Chang
+ */
+
+#ifndef DIRECT_DENSE_LINEAR_SOLVER_H_
+#define DIRECT_DENSE_LINEAR_SOLVER_H_
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/mathematics/linalg/linsolver/LinearSolver.h>
+
+namespace shogun
+{
+
+/** @brief Class that provides a solve method for real SPD dense systems
+ * using LLT decomposition
+ */
+class CDirectDenseLinearSolverLLT : public CLinearSolver<float64_t, float64_t>
+{
+public:
+	/** default constructor */
+	CDirectDenseLinearSolverLLT();
+
+	/** destructor */
+	virtual ~CDirectDenseLinearSolverLLT();
+
+	/**
+	 * solve method for solving real-valued SPD linear systems
+	 *
+	 * @param A the dense linear operator of the system
+	 * @param b the vector of the system
+	 * @return the solution vector
+	 */
+	virtual SGVector<float64_t> solve(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A,
+		SGVector<float64_t> b);
+
+	/** @return object name */
+	virtual const char* get_name() const
+	{
+		return "DirectDenseLinearSolverLLT";
+	}
+
+};
+
+}
+
+#endif // HAVE_EIGEN3
+#endif // DIRECT_DENSE_LINEAR_SOLVER_H_

--- a/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h
@@ -1,14 +1,35 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General turalPublic License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
+ * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (W) 2015 Yingrui Chang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
  */
-
-#ifndef DIRECT_DENSE_LINEAR_SOLVER_LLT_H_
-#define DIRECT_DENSE_LINEAR_SOLVER_LLT_H_
+#ifndef DIRECT_DENSE_LINEAR_SOLVER_LLT_H
+#define DIRECT_DENSE_LINEAR_SOLVER_LLT_H
 
 #include <shogun/lib/config.h>
 
@@ -18,22 +39,26 @@
 namespace shogun
 {
 
-/** @brief Class that provides a solve method for real SPD dense systems
- * using LLT decomposition
+/** @brief Class that provides a solve method for finding the solution
+ * for linear system A*x=b using using standard Cholesky decomposition (L*L^T).
+ *
+ * http://en.wikipedia.org/wiki/Cholesky_decomposition
+ *
+ * Assumption: Inpute dense operator A needs to be symmetic positive definite.
  */
 class CDirectDenseLinearSolverLLT : public CLinearSolver<float64_t, float64_t>
 {
 public:
-	/** default constructor */
+	/** Default constructor */
 	CDirectDenseLinearSolverLLT();
 
-	/** destructor */
+	/** Destructor */
 	virtual ~CDirectDenseLinearSolverLLT();
 
 	/**
-	 * solve method for solving real-valued SPD linear systems
+	 * Solve method for solving real-valued SPD linear systems
 	 *
-	 * @param A the dense linear operator of the system
+	 * @param A the dense linear operator of the system, needs to be SPD
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
@@ -51,4 +76,4 @@ public:
 }
 
 #endif // HAVE_EIGEN3
-#endif // DIRECT_DENSE_LINEAR_SOLVER_LLT_H_
+#endif // DIRECT_DENSE_LINEAR_SOLVER_LLT_H

--- a/tests/unit/mathematics/linalg/DirectDenseLeastSquareSolverQR_unittest.cc
+++ b/tests/unit/mathematics/linalg/DirectDenseLeastSquareSolverQR_unittest.cc
@@ -1,10 +1,32 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
+ * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (W) 2015 Yingrui Chang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
  */
 
 #include <shogun/lib/config.h>

--- a/tests/unit/mathematics/linalg/DirectDenseLeastSquareSolverQR_unittest.cc
+++ b/tests/unit/mathematics/linalg/DirectDenseLeastSquareSolverQR_unittest.cc
@@ -1,0 +1,54 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2015 Yingrui Chang
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/mathematics/linalg/linop/DenseMatrixOperator.h>
+#include <shogun/mathematics/linalg/linsolver/DirectDenseLeastSquareSolverQR.h>
+#include <shogun/lib/SGMatrix.h>
+#include <gtest/gtest.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/Random.h>
+
+using namespace shogun;
+
+TEST(DirectDenseLeastSquareSolverQR, compute)
+{
+	//setup matix size and random seed
+	const index_t rows = 10;
+	const index_t cols = 20;
+	const index_t randSeed = 0;
+
+	//generate matrix m and dense operator A
+	CRandom randGenerator(randSeed);
+	SGMatrix<float64_t> m(rows, cols);
+	for (index_t rowIndex=0; rowIndex<rows; ++rowIndex)
+		for (index_t colIndex=0; colIndex<cols; ++colIndex)
+			m(rowIndex, colIndex) = randGenerator.random(0.0, 10.0);
+
+	CDenseMatrixOperator<float64_t> A(m);
+
+	//setup RHS vector
+	SGVector<float64_t> b(cols);
+	for (index_t index=0; index<cols; ++index)
+		b[index] = randGenerator.random(0.0, 10.0);
+
+	//setup QR decomposition find the least square solution
+	CDirectDenseLeastSquareSolverQR qr_solver;
+	SGVector<float64_t> x = qr_solver.solve(&A,b);
+
+	//check normal condition
+	Eigen::Map<Eigen::MatrixXd> map_m(&m(0,0), rows, cols);
+	Eigen::Map<Eigen::VectorXd> map_x(&x[0], rows);
+	Eigen::Map<Eigen::VectorXd> map_b(&b[0], cols);
+
+	EXPECT_NEAR((map_m*(map_b-map_m.transpose()*map_x)).norm(), 0.0, 1E-10);
+}
+#endif //HAVE_EIGEN3

--- a/tests/unit/mathematics/linalg/DirectDenseLinearSolverLLT_unittest.cc
+++ b/tests/unit/mathematics/linalg/DirectDenseLinearSolverLLT_unittest.cc
@@ -1,10 +1,32 @@
 /*
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
+ * Copyright (c) The Shogun Machine Learning Toolbox
  * Written (W) 2015 Yingrui Chang
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
  */
 
 #include <shogun/lib/config.h>

--- a/tests/unit/mathematics/linalg/DirectDenseLinearSolverLLT_unittest.cc
+++ b/tests/unit/mathematics/linalg/DirectDenseLinearSolverLLT_unittest.cc
@@ -1,0 +1,55 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2015 Yingrui Chang
+ */
+
+#include <shogun/lib/config.h>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/mathematics/linalg/linop/DenseMatrixOperator.h>
+#include <shogun/mathematics/linalg/linsolver/DirectDenseLinearSolverLLT.h>
+#include <shogun/lib/SGMatrix.h>
+#include <gtest/gtest.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/Random.h>
+
+using namespace shogun;
+
+TEST(DirectDenseLinearSolverLLT, compute)
+{
+	//setup matix size and random seed
+	const index_t size = 10;
+	const index_t randSeed = 0;
+
+	//generate SPD matrix m and dense operator A
+	CRandom randGenerator(randSeed);
+	SGMatrix<float64_t> m(size, size);
+	for (index_t rowIndex=0; rowIndex<size; ++rowIndex)
+		for (index_t colIndex=0; colIndex<size; ++colIndex)
+			m(rowIndex, colIndex) = randGenerator.random(0.0, 10.0);
+	
+	Eigen::Map<Eigen::MatrixXd> map_m(&m(0,0), size, size);
+	map_m=map_m*map_m.transpose();
+
+	CDenseMatrixOperator<float64_t> A(m);
+
+	//setup RHS vector
+	SGVector<float64_t> b(size);
+	for (index_t index=0; index<size; ++index)
+		b[index] = randGenerator.random(0.0, 10.0);
+
+	//setup linear solver and solve the system
+	CDirectDenseLinearSolverLLT linear_solver;
+	SGVector<float64_t> x = linear_solver.solve(&A,b);
+
+	//check result
+	Eigen::Map<Eigen::VectorXd> map_x(&x[0], size);
+	Eigen::Map<Eigen::VectorXd> map_b(&b[0], size);
+
+	EXPECT_NEAR((map_m*map_x-map_b).norm(), 0.0, 1E-10);
+}
+#endif //HAVE_EIGEN3


### PR DESCRIPTION
 corresponds to #2526, built interface to call Eigen3 internal dense solver for linear systems (LLT) and least square problem (Householder QR). Please check if this form is what you want, @karlnapf May add more solver's later.