### PR TITLE
Added two constructors in SGMatrix with SGVectors

### DIFF
--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -51,6 +51,30 @@ SGMatrix<T>::SGMatrix(index_t nrows, index_t ncols, bool ref_counting)
 }
 
 template <class T>
+SGMatrix<T>::SGMatrix(SGVector<T> vec) : SGReferencedData(vec)
+{
+	REQUIRE(vec.vector, "Vector not initialized!\n");
+	matrix=vec.vector;
+	num_rows=vec.vlen;
+	num_cols=1;
+}
+
+template <class T>
+SGMatrix<T>::SGMatrix(SGVector<T> vec, index_t nrows, index_t ncols)
+: SGReferencedData(vec)
+{
+	REQUIRE(vec.vector, "Vector not initialized!\n");
+	REQUIRE(nrows>0, "Number of rows (%d) has to be a positive integer!\n", nrows);
+	REQUIRE(ncols>0, "Number of cols (%d) has to be a positive integer!\n", ncols);
+	REQUIRE(vec.vlen==nrows*ncols, "Number of elements in the matrix (%d) must "
+			"be the same as the number of elements in the vector (%d)!\n",
+			nrows*ncols, vec.vlen);
+	matrix=vec.vector;
+	num_rows=nrows;
+	num_cols=ncols;
+}
+
+template <class T>
 SGMatrix<T>::SGMatrix(const SGMatrix &orig) : SGReferencedData(orig)
 {
 	copy_data(orig);
@@ -59,13 +83,13 @@ SGMatrix<T>::SGMatrix(const SGMatrix &orig) : SGReferencedData(orig)
 #ifdef HAVE_EIGEN3
 template <class T>
 SGMatrix<T>::SGMatrix(EigenMatrixXt& mat)
-: SGReferencedData(false), matrix(mat.data()), 
+: SGReferencedData(false), matrix(mat.data()),
 	num_rows(mat.rows()), num_cols(mat.cols())
 {
 
 }
 
-template <class T> 
+template <class T>
 SGMatrix<T>::operator EigenMatrixXtMap() const
 {
 	return EigenMatrixXtMap(matrix, num_rows, num_cols);

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -57,18 +57,45 @@ template<class T> class SGMatrix : public SGReferencedData
 		/** Constructor to create new matrix in memory */
 		SGMatrix(index_t nrows, index_t ncols, bool ref_counting=true);
 
-		/** Copy constructor */
-		SGMatrix(const SGMatrix &orig);
-
 #ifndef SWIG // SWIG should skip this part
+		/**
+		 * Constructor for creating a SGMatrix from a SGVector with refcounting.
+		 * We do not copy the data here, just the pointer to data and the ref-
+		 * count object of the SGVector (i.e. vec and this share same data and
+		 * ref-count object).
+		 *
+		 * This constructor assumes that the vector is the column 0 in the matrix.
+		 *
+		 * @param vec The SGVector
+		 */
+		SGMatrix(SGVector<T> vec);
+
+		/**
+		 * Constructor for creating a SGMatrix from a SGVector with refcounting.
+		 * We do not copy the data here, just the pointer to data and the ref-
+		 * count object of the SGVector (i.e. vec and this share same data and
+		 * ref-count object).
+		 *
+		 * The number of elements in the matrix *MUST* be same as the number
+		 * of elements in the vector
+		 *
+		 * @param vec The SGVector
+		 * @param nrows number of rows in the matrix
+		 * @param ncols number of columns in the matrix
+		 */
+		SGMatrix(SGVector<T> vec, index_t nrows, index_t ncols);
+
 #ifdef HAVE_EIGEN3
 		/** Wraps a matrix around the data of an Eigen3 matrix */
 		SGMatrix(EigenMatrixXt& mat);
 
 		/** Wraps an Eigen3 matrix around the data of this matrix */
 		operator EigenMatrixXtMap() const;
-#endif
-#endif
+#endif // HAVE_EIGEN3
+#endif // SWIG
+
+		/** Copy constructor */
+		SGMatrix(const SGMatrix &orig);
 
 		/** Empty destructor */
 		virtual ~SGMatrix();


### PR DESCRIPTION
- Both copy the refcount of the SGVector to make sure that memory
  is not accidentally deleted. Therefore we don't have to turn off
  refcount for the SGMatrix as well