### PR TITLE
Added element-wise unary operators in linalg

### DIFF
--- a/benchmarks/elementwise_benchmark.cpp
+++ b/benchmarks/elementwise_benchmark.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/GPUMatrix.h>
+#include <shogun/mathematics/linalg/linalg.h>
+#include <vector>
+#include <algorithm>
+#include <hayai/hayai.hpp>
+
+using namespace shogun;
+
+/**
+ * Instructions :
+ * 1. Install benchmarking toolkit "hayai" (https://github.com/nickbruun/hayai)
+ * 2. Compile against libhayai_main, e.g.
+ * g++ -O3 -std=c++11 elementwise_benchmark.cpp -I/usr/include/eigen3 -lshogun -lhayai_main -lOpenCL -o benchmark
+ * 3. ./benchmark
+ */
+
+/** Generate data only once */
+struct Data
+{
+	Data()
+	{
+		init();
+	}
+
+	void init()
+	{
+		m_cpu=SGMatrix<float32_t>(num_rows, num_cols);
+		std::iota(m_cpu.data(), m_cpu.data()+m_cpu.size(), 1);
+		m_gpu=CGPUMatrix<float32_t>(m_cpu);
+	}
+
+	SGMatrix<float32_t> m_cpu;
+	CGPUMatrix<float32_t> m_gpu;
+
+	static constexpr index_t num_rows=1000;
+	static constexpr index_t num_cols=1000;
+};
+
+Data data;
+
+BENCHMARK(SGMatrix, elementwise, 10, 1000)
+{
+	float32_t weights=0.6;
+	float32_t std_dev=0.2;
+	float32_t mean=0.01;
+
+	SGMatrix<float32_t> result=linalg::elementwise_compute(data.m_cpu,
+	[&weights, &std_dev, &mean](float32_t& sqr_dist)
+	{
+		float32_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+		float32_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::sq(std_dev));
+		float32_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+		return outer_factor*exp_factor*sin_factor;
+	});
+
+}
+
+BENCHMARK(SGMatrix, loop, 10, 1000)
+{
+	float32_t weights=0.6;
+	float32_t std_dev=0.2;
+	float32_t mean=0.01;
+
+	SGMatrix<float32_t> result(data.m_cpu.num_rows, data.m_cpu.num_cols);
+
+	for (index_t j=0; j<data.m_cpu.num_cols; ++j)
+	{
+		for (index_t i=0; i<data.m_cpu.num_rows; ++i)
+		{
+			float32_t sqr_dist=data.m_cpu(i, j);
+			float32_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+			float32_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::sq(std_dev));
+			float32_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+			result(i, j)=outer_factor*exp_factor*sin_factor;
+		}
+	}
+}
+
+BENCHMARK(CGPUMatrix, elementwise, 10, 1000)
+{
+	float32_t weights=0.6;
+	float32_t std_dev=0.2;
+	float32_t mean=0.01;
+
+	std::string data_type=linalg::implementation::ocl::get_type_string<float32_t>();
+
+	std::string s_weights=std::to_string(weights);
+	std::string s_std_dev=std::to_string(std_dev);
+	std::string s_mean=std::to_string(mean);
+	std::string s_pi=std::to_string(CMath::PI);
+
+	std::string operation;
+	operation.append(data_type+" outer_factor=-2*"+s_pi+"*sqrt(element)*pow("+s_weights+", 2);\n");
+	operation.append(data_type+" exp_factor=exp(-2*pow("+s_pi+",2)*element*pow("+s_std_dev+", 2));\n");
+	operation.append(data_type+" sin_factor=sin(2*"+s_pi+"*sqrt(element)*"+s_mean+");\n");
+	operation.append("return outer_factor*exp_factor*sin_factor;");
+
+	linalg::elementwise_compute_inplace(data.m_gpu, operation);
+}

--- a/src/shogun/lib/GPUMatrix.h
+++ b/src/shogun/lib/GPUMatrix.h
@@ -87,6 +87,9 @@ public:
 	/** The scalar type of the matrix */
 	typedef T Scalar;
 
+	/** The container type for a given template argument */
+	template <typename ST> using container_type = CGPUMatrix<ST>;
+
 	/** Default Constructor */
 	CGPUMatrix();
 
@@ -121,6 +124,18 @@ public:
 	/** Converts the matrix into an Eigen3 matrix */
 	operator EigenMatrixXt() const;
 #endif // HAVE_EIGEN3
+
+	/** The data */
+	inline VCLMatrixBase data()
+	{
+		return vcl_matrix();
+	}
+
+	/** The size */
+	inline index_t size() const
+	{
+		return num_rows*num_cols;
+	}
 
 	/** Returns a ViennaCL matrix wrapped around the data of this matrix. Can be
 	 * used to call native ViennaCL methods on this matrix

--- a/src/shogun/lib/GPUMatrix.h
+++ b/src/shogun/lib/GPUMatrix.h
@@ -42,6 +42,7 @@
 #include <shogun/lib/common.h>
 #include <memory>
 
+#ifndef SWIG // SWIG should skip this part
 namespace viennacl
 {
 	template <class, class, class, class> class matrix_base;
@@ -78,6 +79,7 @@ template <class> class SGMatrix;
  */
 template <class T> class CGPUMatrix
 {
+
 	typedef viennacl::matrix_base<T, viennacl::column_major, std::size_t, std::ptrdiff_t> VCLMatrixBase;
 	typedef viennacl::backend::mem_handle VCLMemoryArray;
 
@@ -117,8 +119,8 @@ public:
 	/** Converts the matrix into an SGMatrix */
 	operator SGMatrix<T>() const;
 
-#ifndef SWIG // SWIG should skip this part
 #ifdef HAVE_EIGEN3
+	/** Creates a gpu matrix using data from an Eigen3 matrix */
 	CGPUMatrix(const EigenMatrixXt& cpu_mat);
 
 	/** Converts the matrix into an Eigen3 matrix */
@@ -132,17 +134,16 @@ public:
 	}
 
 	/** The size */
-	inline index_t size() const
+	inline uint64_t size() const
 	{
-		return num_rows*num_cols;
+		const uint64_t c=num_cols;
+		return num_rows*c;
 	}
 
 	/** Returns a ViennaCL matrix wrapped around the data of this matrix. Can be
 	 * used to call native ViennaCL methods on this matrix
 	 */
 	VCLMatrixBase vcl_matrix();
-
-#endif // SWIG
 
 	/** Sets all the elements of the matrix to zero */
 	void zero();
@@ -206,6 +207,7 @@ public:
 };
 
 }
+#endif // SWIG
 
 #endif // HAVE_CXX11
 #endif // HAVE_VIENNACL

--- a/src/shogun/lib/GPUVector.h
+++ b/src/shogun/lib/GPUVector.h
@@ -86,6 +86,9 @@ public:
 	/** The scalar type of the vector */
 	typedef T Scalar;
 
+	/** The container type for a given template argument */
+	template <typename ST> using container_type = CGPUVector<ST>;
+
 	/** Default Constructor */
 	CGPUVector();
 
@@ -120,8 +123,19 @@ public:
 
 	/** Converts the vector into an Eigen3 row vector */
 	operator EigenRowVectorXt() const;
-#endif
-#endif
+
+#endif // HAVE_EIGEN3
+	/** The data */
+	inline VCLVectorBase data()
+	{
+		return vcl_vector();
+	}
+
+	/** The size */
+	inline index_t size() const
+	{
+		return vlen;
+	}
 
 	/** Converts the vector into an SGVector */
 	operator SGVector<T>() const;
@@ -130,6 +144,7 @@ public:
 	 * used to call native ViennaCL methods on this vector
 	 */
 	VCLVectorBase vcl_vector();
+#endif // SWIG
 
 	/** Sets all the elements of the vector to zero */
 	void zero();

--- a/src/shogun/lib/GPUVector.h
+++ b/src/shogun/lib/GPUVector.h
@@ -42,7 +42,7 @@
 #include <shogun/lib/common.h>
 #include <memory>
 
-
+#ifndef SWIG // SWIG should skip this part
 namespace viennacl
 {
 	template <class, class, class> class vector_base;
@@ -76,6 +76,7 @@ namespace shogun
  */
 template <class T> class CGPUVector
 {
+
 	typedef viennacl::vector_base<T, std::size_t, std::ptrdiff_t> VCLVectorBase;
 	typedef viennacl::backend::mem_handle VCLMemoryArray;
 
@@ -110,7 +111,6 @@ public:
 	/** Creates a gpu vector using data from an SGVector */
 	CGPUVector(const SGVector<T>& cpu_vec);
 
-#ifndef SWIG // SWIG should skip this part
 #ifdef HAVE_EIGEN3
 	/** Creates a gpu vector using data from an Eigen3 column vector */
 	CGPUVector(const EigenVectorXt& cpu_vec);
@@ -125,6 +125,7 @@ public:
 	operator EigenRowVectorXt() const;
 
 #endif // HAVE_EIGEN3
+
 	/** The data */
 	inline VCLVectorBase data()
 	{
@@ -144,7 +145,6 @@ public:
 	 * used to call native ViennaCL methods on this vector
 	 */
 	VCLVectorBase vcl_vector();
-#endif // SWIG
 
 	/** Sets all the elements of the vector to zero */
 	void zero();
@@ -189,6 +189,7 @@ public:
 };
 
 }
+#endif // SWIG
 
 #endif // HAVE_CXX11
 #endif // HAVE_VIENNACL

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -39,13 +39,6 @@ template<class T> class SGMatrix : public SGReferencedData
 		/** The scalar type of the matrix */
 		typedef T Scalar;
 
-#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
-
-		/** The container type for a given template argument */
-		template <typename ST> using container_type = SGMatrix<ST>;
-
-#endif // define (HAVE_CXX0X) || defined(HAVE_CXX11)
-
 		/** Default constructor */
 		SGMatrix();
 
@@ -65,6 +58,13 @@ template<class T> class SGMatrix : public SGReferencedData
 		SGMatrix(index_t nrows, index_t ncols, bool ref_counting=true);
 
 #ifndef SWIG // SWIG should skip this part
+#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
+
+		/** The container type for a given template argument */
+		template <typename ST> using container_type = SGMatrix<ST>;
+
+#endif // define (HAVE_CXX0X) || defined(HAVE_CXX11)
+
 		/**
 		 * Constructor for creating a SGMatrix from a SGVector with refcounting.
 		 * We do not copy the data here, just the pointer to data and the ref-
@@ -184,9 +184,10 @@ template<class T> class SGMatrix : public SGReferencedData
 		}
 
 		/** The size */
-		inline index_t size() const
+		inline uint64_t size() const
 		{
-			return num_rows*num_cols;
+			const uint64_t c=num_cols;
+			return num_rows*c;
 		}
 
 		/** Check for pointer identity */

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -39,6 +39,13 @@ template<class T> class SGMatrix : public SGReferencedData
 		/** The scalar type of the matrix */
 		typedef T Scalar;
 
+#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
+
+		/** The container type for a given template argument */
+		template <typename ST> using container_type = SGMatrix<ST>;
+
+#endif // define (HAVE_CXX0X) || defined(HAVE_CXX11)
+
 		/** Default constructor */
 		SGMatrix();
 
@@ -168,6 +175,18 @@ template<class T> class SGMatrix : public SGReferencedData
 		inline SGMatrix<T> get()
 		{
 			return *this;
+		}
+
+		/** The data */
+		inline T* data() const
+		{
+			return matrix;
+		}
+
+		/** The size */
+		inline index_t size() const
+		{
+			return num_rows*num_cols;
 		}
 
 		/** Check for pointer identity */

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -46,6 +46,13 @@ template<class T> class SGVector : public SGReferencedData
 		/** The scalar type of the vector */
 		typedef T Scalar;
 
+#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
+
+		/** The container type for a given template argument */
+		template <typename ST> using container_type = SGVector<ST>;
+
+#endif // define (HAVE_CXX0X) || defined(HAVE_CXX11)
+
 		/** Default constructor */
 		SGVector();
 
@@ -107,8 +114,14 @@ template<class T> class SGVector : public SGReferencedData
 		/** Size */
 		inline int32_t size() const { return vlen; }
 
+		/** Data pointer */
+		inline T* data() const
+		{
+			return vector;
+		}
+
 		/** Cast to pointer */
-		operator T*() { return vector; };
+		operator T*() { return vector; }
 
 		/** Fill vector with zeros */
 		void zero();

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -46,13 +46,6 @@ template<class T> class SGVector : public SGReferencedData
 		/** The scalar type of the vector */
 		typedef T Scalar;
 
-#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
-
-		/** The container type for a given template argument */
-		template <typename ST> using container_type = SGVector<ST>;
-
-#endif // define (HAVE_CXX0X) || defined(HAVE_CXX11)
-
 		/** Default constructor */
 		SGVector();
 
@@ -70,6 +63,13 @@ template<class T> class SGVector : public SGReferencedData
 		SGVector(const SGVector &orig);
 
 #ifndef SWIG // SWIG should skip this part
+#if defined(HAVE_CXX0X) || defined(HAVE_CXX11)
+
+		/** The container type for a given template argument */
+		template <typename ST> using container_type = SGVector<ST>;
+
+#endif // define (HAVE_CXX0X) || defined(HAVE_CXX11)
+
 #ifdef HAVE_EIGEN3
 		/** Wraps a matrix around the data of an Eigen3 column vector */
 		SGVector(EigenVectorXt& vec);
@@ -82,8 +82,8 @@ template<class T> class SGVector : public SGReferencedData
 
 		/** Wraps an Eigen3 row vector around the data of this matrix */
 		operator EigenRowVectorXtMap() const;
-#endif
-#endif
+#endif // HAVE_EIGEN3
+#endif // SWIG
 
 		/** Set vector to a constant
 		 *

--- a/src/shogun/mathematics/linalg/internal/implementation/ElementwiseUnaryOperation.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/ElementwiseUnaryOperation.h
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef ELEMENTWISE_OPERATION_H_
+#define ELEMENTWISE_OPERATION_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/SGMatrix.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUMatrix.h>
+#include <shogun/mathematics/linalg/internal/opencl_config.h>
+#include <shogun/mathematics/linalg/internal/opencl_util.h>
+#endif // HAVE_VIENNACL
+
+#include <algorithm>
+#include <type_traits>
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+namespace implementation
+{
+
+/**
+ * @brief Template struct elementwise_unary_operation. This struct is specialized for
+ * computing element-wise operations for both matrices and vectors of CPU
+ * (SGMatrix/SGVector) or GPU (CGPUMatrix/CGPUVector).
+ */
+template <enum Backend, class Operand, class ReturnType, class UnaryOp>
+struct elementwise_unary_operation
+{
+};
+
+/**
+ * @brief Specialization for elementwise_unary_operation with NATIVE backend. It
+ * provides two compute methods, one works for predefined unary operators and
+ * the other one works with custom unary operators.
+ *
+ * The operand types MUST be of CPU types (SGMatrix/SGVector).
+ */
+template <class Operand, class ReturnType, class UnaryOp>
+struct elementwise_unary_operation<Backend::NATIVE, Operand, ReturnType, UnaryOp>
+{
+	/** The scalar type of the operand */
+	using T = typename Operand::Scalar;
+
+	/** The scalar type of the result */
+	using ST = typename ReturnType::Scalar;
+
+	/** Ensure that this struct is not being instantiated with any GPU operand types */
+	static_assert(!(std::is_same<CGPUMatrix<T>, Operand>::value
+				|| std::is_same<CGPUVector<T>, Operand>::value),
+			"NATIVE backend not allowed for GPU operands! Use SGMatrix/SGVector "
+			"in order to use NATIVE or use VIENNACL backend instead.\n");
+
+	/**
+	 * Method compute that computes element-wise UnaryOp operation for the Operand.
+	 * This method is used for predefined standard unary operators.
+	 *
+	 * @param operand The operand on which element-wise unary operation has to be performed
+	 * @param result The result of applying the unary operator on each scalar of the operand
+	 */
+	static void compute(Operand operand, ReturnType result)
+	{
+		UnaryOp unary_op;
+		compute(operand, result, unary_op);
+	}
+
+	/**
+	 * Method compute that computes element-wise UnaryOp operation for the Operand.
+	 * This method is used for custom unary operations, such as lambda expressions or
+	 * function pointers as unary_op.
+	 *
+	 * @param operand The operand on which element-wise unary operation has to be performed
+	 * @param result The result of applying the unary operator on each scalar of the operand
+	 * @param unary_op The custom unary operator (a functor, lambda expression or a function
+	 * pointer)
+	 */
+	static void compute(Operand operand, ReturnType result, UnaryOp unary_op)
+	{
+		static_assert(std::is_same<ST,decltype(unary_op(operand.data()[0]))>::value,
+				"The return type of the unary operator and the scalar types of the "
+				"result must be the same!\n");
+
+		std::transform(operand.data(), operand.data()+operand.size(), result.data(),
+		[&unary_op](T& value)
+		{
+			return unary_op(value);
+		});
+	}
+};
+
+#ifdef HAVE_EIGEN3
+/**
+ * @brief Specialization for elementwise_unary_operation with EIGEN3 backend. It
+ * provides one compute method which work for predefined unary operators in Eigen3.
+ *
+ * The operand types MUST be other than GPU types (CGPUMatrix/CGPUVector).
+ */
+template <class Operand, class ReturnType, class UnaryOp>
+struct elementwise_unary_operation<Backend::EIGEN3, Operand, ReturnType, UnaryOp>
+{
+	/** The scalar type of the operand */
+	using T = typename Operand::Scalar;
+
+	/** The scalar type of the result */
+	using ST = typename UnaryOp::return_type;
+
+	/** Ensure that this struct is not being instantiated with any GPU operand types */
+	static_assert(!(std::is_same<CGPUMatrix<T>, Operand>::value
+			 || std::is_same<CGPUVector<T>, Operand>::value),
+			"EIGEN3 backend not allowed for GPU operands! Use SGMatrix/SGVector "
+			"in order to use EIGEN3 or use VIENNACL backend instead.\n");
+
+	/**
+	 * Method compute that computes element-wise UnaryOp operation for the Operand
+	 * using EIGEN3 backend.
+	 *
+	 * @param operand The operand on which element-wise unary operation has to be performed
+	 * @param result The result of applying the unary operator on each scalar of the operand
+	 */
+	static void compute(Operand operand, ReturnType result)
+	{
+		UnaryOp unary_op;
+		auto eigen_result=unary_op.compute_using_eigen3(operand);
+		std::copy(eigen_result.data(), eigen_result.data()+eigen_result.size(), result.data());
+	}
+};
+#endif // HAVE_EIGEN3
+
+#ifdef HAVE_VIENNACL
+/**
+ * @brief Specialization for elementwise_unary_operation with VIENNACL backend.
+ * It provides one compute method which works for predefined unary operators.
+ *
+ * The operand types MUST be of GPU types (CGPUMatrix/CGPUVector).
+ *
+ * The return type and the operand type must be the same for ViennaCL.
+ */
+template <class Operand, class UnaryOp>
+struct elementwise_unary_operation<Backend::VIENNACL, Operand, Operand, UnaryOp>
+{
+	/** The scalar type of the operand */
+	using T = typename Operand::Scalar;
+
+	/** Ensure that the scalar type is not a std::complex<double> type */
+	static_assert(!std::is_same<T,complex128_t>::value,
+			"Complex numbers not supported!\n");
+
+	/** Ensure that this struct is being instantiated with only GPU operand types */
+	static_assert(std::is_same<CGPUMatrix<T>, Operand>::value ||
+			std::is_same<CGPUVector<T>, Operand>::value,
+			"VIENNACL backend not allowed for CPU operands! Use CGPUMatrix/CGPUVector "
+			"in order to use VIENNACL or use NATIVE/EIGEN3 backend instead.\n");
+
+	/**
+	 * Method compute that computes element-wise UnaryOp operation for the Operand
+	 * using VIENNACL backend. Works for predefined unary operations.
+	 *
+	 * @param operand The operand on which element-wise unary operation has to be performed
+	 * @param result The result of applying the unary operator on each scalar of the operand
+	 */
+	static void compute(Operand operand, Operand result)
+	{
+		static const std::string operation=UnaryOp::operation();
+		static const std::string opname=UnaryOp::name();
+		static const std::string kernel_name=opname+"_"+ocl::get_type_string<T>();
+
+		viennacl::ocl::kernel& kernel=
+			ocl::generate_single_arg_elementwise_kernel<T>(kernel_name, operation);
+
+		kernel.global_work_size(0, ocl::align_to_multiple_1d(operand.size()));
+
+		viennacl::ocl::enqueue(kernel(operand.data(),
+			cl_int(operand.size()), cl_int(operand.offset),
+			result.data(), cl_int(result.offset)));
+	}
+};
+
+/**
+ * @brief Specialization for elementwise_unary_operation with VIENNACL backend.
+ * It provides one compute method which work for custom unary operators in VIENNACL.
+ *
+ * The operand types MUST be of GPU types (CGPUMatrix/CGPUVector).
+ *
+ * The return type and the operand type must be the same for ViennaCL.
+ */
+template <class Operand>
+struct elementwise_unary_operation<Backend::VIENNACL, Operand, Operand, std::string>
+{
+	/** The scalar type of the operand */
+	using T = typename Operand::Scalar;
+
+	/** Ensure that the scalar type is not a std::complex<double> type */
+	static_assert(!std::is_same<T,complex128_t>::value,
+			"Complex numbers not supported!\n");
+
+	/** Ensure that this struct is being instantiated with only GPU operand types */
+	static_assert(std::is_same<CGPUMatrix<T>, Operand>::value ||
+			std::is_same<CGPUVector<T>, Operand>::value,
+			"VIENNACL backend not allowed for CPU operands! Use CGPUMatrix/CGPUVector "
+			"in order to use VIENNACL or use NATIVE/EIGEN3 backend instead.\n");
+
+	/**
+	 * Method compute that computes element-wise UnaryOp operation for the Operand
+	 * using VIENNACL backend. Works for custom unary operations.
+	 *
+	 * @param operand The operand on which element-wise unary operation has to be performed
+	 * @param result The result of applying the unary operator on each scalar of the operand
+	 * @param unary_op The operation body as string to be used inside an OpenCL kernel
+	 */
+	static void compute(Operand operand, Operand result, std::string unary_op)
+	{
+		std::hash<std::string> hash_fn;
+		std::string hash=std::to_string(hash_fn(unary_op));
+		std::string kernel_name="kernel_"+hash+"_"+ocl::get_type_string<T>();
+
+		viennacl::ocl::kernel& kernel=
+			ocl::generate_single_arg_elementwise_kernel<T>(kernel_name, unary_op);
+
+		kernel.global_work_size(0, ocl::align_to_multiple_1d(operand.size()));
+
+		viennacl::ocl::enqueue(kernel(operand.data(),
+			cl_int(operand.size()), cl_int(operand.offset),
+			result.data(), cl_int(result.offset)));
+	}
+};
+#endif // HAVE_VIENNACL
+
+}
+
+}
+
+}
+#endif // ELEMENTWISE_OPERATION_H_

--- a/src/shogun/mathematics/linalg/internal/implementation/operations/Sin.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/operations/Sin.h
@@ -39,6 +39,8 @@
 #include <shogun/mathematics/eigen3.h>
 #endif // HAVE_EIGEN3
 
+#include <shogun/mathematics/linalg/internal/implementation/operations/opencl_operation.h>
+
 namespace shogun
 {
 
@@ -50,15 +52,21 @@ namespace operations
 
 /**
  * Template struct sin for computing element-wise sin for matrices and vectors.
- * The operator() is for NATIVE backend implementation. method operations() is
- * for VIENNACL/OPENCL backend implementation. Methods compute_using_eigen3
+ * The operator() is for NATIVE backend implementation. Methods compute_using_eigen3
  * are for computing element-wise sin using EIGEN3 backend.
  */
 template <typename T>
-struct sin
+struct sin : public ocl_operation
 {
 	/** The return type */
 	using return_type = float64_t;
+
+	/*
+	 * Default constructor. Initializes the OpenCL operation
+	 */
+	sin() : ocl_operation("return sin(element);")
+	{
+	}
 
 	/**
 	 * @param val The scalar value
@@ -100,22 +108,6 @@ struct sin
 		return v.array().template cast<double>().sin();
 	}
 #endif // HAVE_EIGEN3
-
-	/**
-	 * @return The OpenCL sin operation to be used in a OpenCL kernel
-	 */
-	static constexpr std::string operation()
-	{
-		return "return sin(element);";
-	}
-
-	/**
-	 * @return The name of sin operation to be used in a OpenCL kernel
-	 */
-	static constexpr std::string name()
-	{
-		return "sin";
-	}
 };
 
 /**

--- a/src/shogun/mathematics/linalg/internal/implementation/operations/Sin.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/operations/Sin.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef SIN_IMPL_H_
+#define SIN_IMPL_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/mathematics/Math.h>
+#include <string>
+
+#ifdef HAVE_EIGEN3
+#include <shogun/mathematics/eigen3.h>
+#endif // HAVE_EIGEN3
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+namespace operations
+{
+
+/**
+ * Template struct sin for computing element-wise sin for matrices and vectors.
+ * The operator() is for NATIVE backend implementation. method operations() is
+ * for VIENNACL/OPENCL backend implementation. Methods compute_using_eigen3
+ * are for computing element-wise sin using EIGEN3 backend.
+ */
+template <typename T>
+struct sin
+{
+	/** The return type */
+	using return_type = float64_t;
+
+	/**
+	 * @param val The scalar value
+	 * @return sin(val)
+	 */
+	return_type operator () (T& val) const
+	{
+		return CMath::sin(val);
+	}
+
+#ifdef HAVE_EIGEN3
+	/** Eigen3 matrix type */
+	using MatrixXt = Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic>;
+
+	/** Eigen3 vector type */
+	using VectorXt = Eigen::Matrix<T,Eigen::Dynamic,1>;
+
+	/** Eigen3 matrix map type */
+	using MapMatrixXt = Eigen::Map<MatrixXt>;
+
+	/** Eigen3 vector map type */
+	using MapVectorXt = Eigen::Map<VectorXt>;
+
+	/**
+	 * @param m The Eigen3 matrix map of the operand
+	 * @return Element-wise sin in a newly allocated matrix
+	 */
+	Eigen::MatrixXd compute_using_eigen3(MapMatrixXt m) const
+	{
+		return m.array().template cast<double>().sin();
+	}
+
+	/**
+	 * @param v The Eigen3 vector map of the operand
+	 * @return Element-wise sin in a newly allocated vector
+	 */
+	Eigen::VectorXd compute_using_eigen3(MapVectorXt v) const
+	{
+		return v.array().template cast<double>().sin();
+	}
+#endif // HAVE_EIGEN3
+
+	/**
+	 * @return The OpenCL sin operation to be used in a OpenCL kernel
+	 */
+	static constexpr std::string operation()
+	{
+		return "return sin(element);";
+	}
+
+	/**
+	 * @return The name of sin operation to be used in a OpenCL kernel
+	 */
+	static constexpr std::string name()
+	{
+		return "sin";
+	}
+};
+
+/**
+ * Specialization of template struct sin when scalar type is complex<double>.
+ * The operator() is for NATIVE backend implementation. Not available for
+ * ViennaCL or Eigen3 backend.
+ */
+template <>
+struct sin<complex128_t>
+{
+	/** The return type */
+	using return_type = complex128_t;
+
+	/**
+	 * @param val The scalar value
+	 * @return sin(val)
+	 */
+	return_type operator () (complex128_t& val) const
+	{
+		return CMath::sin(val);
+	}
+};
+
+}
+
+}
+
+}
+#endif // SIN_IMPL_H_

--- a/src/shogun/mathematics/linalg/internal/implementation/operations/opencl_operation.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/operations/opencl_operation.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef OPENCL_OPERATION_H_
+#define OPENCL_OPERATION_H_
+
+#include <shogun/lib/config.h>
+#include <string>
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+namespace operations
+{
+/**
+ * @brief class ocl_operation for element-wise unary OpenCL operations for
+ * GPU-types (CGPUMatrix/CGPUVector).
+ */
+class ocl_operation
+{
+public:
+	/**
+	 * Constructor
+	 * @param operation The unary operation string. The current element
+	 * has to be refered as "element".
+	 */
+	ocl_operation(std::string operation) : m_operation(operation)
+	{
+	}
+
+	/**
+	 * @return The OpenCL operation to be used in a OpenCL kernel
+	 */
+	std::string get_operation() const
+	{
+		return m_operation;
+	}
+
+private:
+	std::string m_operation;
+};
+
+}
+
+}
+
+}
+#endif // OPENCL_OPERATION_H_

--- a/src/shogun/mathematics/linalg/internal/implementation/util/AllocResultUtil.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/util/AllocResultUtil.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef ALLOC_RESULT_UTIL_H_
+#define ALLOC_RESULT_UTIL_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/SGMatrix.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUMatrix.h>
+#endif // HAVE_VIENNACL
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+namespace util
+{
+
+/**
+ * @brief Template struct allocate_result for allocating objects of return type
+ * for element-wise operations. This generic version takes care of the vector
+ * types supported by Shogun (SGVector and CGPUVector).
+ */
+template <class Operand, class ReturnType>
+struct allocate_result
+{
+	/**
+	 * Creates a newly allocated memory for ReturnType, assuming that the
+	 * ReturnType is a vector.
+	 *
+	 * @param op The operand for the element-wise operation
+	 * @return The newly allocated result of ReturnType
+	 */
+	static ReturnType alloc(Operand op)
+	{
+		return ReturnType(op.size());
+	}
+};
+
+/**
+ * @brief Specialization for allocate_result when return type is SGMatrix. Works
+ * with different scalar types as well. T defines the scalar type for the operand
+ * and whereas ST is the scalar type for the result of the element-wise operation.
+ */
+template <typename T, typename ST>
+struct allocate_result<SGMatrix<T>,SGMatrix<ST>>
+{
+	/**
+	 * Creates a newly allocated memory for SGMatrix.
+	 *
+	 * @param m The operand for the element-wise operation of scalar type T
+	 * @return The newly allocated result of SGMatrix of scalar type ST
+	 */
+	static SGMatrix<ST> alloc(SGMatrix<T> m)
+	{
+		return SGMatrix<ST>(m.num_rows, m.num_cols);
+	}
+};
+
+#ifdef HAVE_VIENNACL
+/**
+ * @brief Specialization for allocate_result when return type is CGPUMatrix. Works
+ * with different scalar types as well. T defines the scalar type for the operand
+ * and whereas ST is the scalar type for the result of the element-wise operation.
+ */
+template <typename T, typename ST>
+struct allocate_result<CGPUMatrix<T>, CGPUMatrix<ST>>
+{
+	/**
+	 * Creates a newly allocated memory for CGPUMatrix.
+	 *
+	 * @param m The operand for the element-wise operation of scalar type T
+	 * @return The newly allocated result of CGPUMatrix of scalar type ST
+	 */
+	static CGPUMatrix<ST> alloc(CGPUMatrix<T> m)
+	{
+		return CGPUMatrix<ST>(m.num_rows, m.num_cols);
+	}
+};
+#endif // HAVE_VIENNACL
+
+}
+
+}
+
+}
+#endif // ALLOC_RESULT_UTIL_H_

--- a/src/shogun/mathematics/linalg/internal/modules/ElementwiseOperations.h
+++ b/src/shogun/mathematics/linalg/internal/modules/ElementwiseOperations.h
@@ -32,6 +32,7 @@
 #define ELEMENTWISE_OPERATIONS_H_
 
 #include <shogun/mathematics/linalg/internal/implementation/operations/Sin.h>
+#include <shogun/mathematics/linalg/internal/implementation/operations/opencl_operation.h>
 #include <shogun/mathematics/linalg/internal/implementation/util/AllocResultUtil.h>
 #include <shogun/mathematics/linalg/internal/implementation/ElementwiseUnaryOperation.h>
 
@@ -86,6 +87,7 @@ void elementwise_compute_inplace(Operand operand, UnaryOp unary_op)
 		Operand, UnaryOp>::compute(operand, operand, unary_op);
 }
 
+#ifdef HAVE_VIENNACL
 /**
  * Template method for computing custom unary operations element-wise for matrices
  * and vectors using VIENNACL/OPENCL backend. Works for CGPUMatrix/CGPUVector.
@@ -100,9 +102,10 @@ template <class Operand>
 Operand elementwise_compute(Operand operand, std::string unary_op)
 {
 	Operand result=util::allocate_result<Operand,Operand>::alloc(operand);
+	operations::ocl_operation operation(unary_op);
 
 	implementation::elementwise_unary_operation<Backend::VIENNACL, Operand,
-		Operand, std::string>::compute(operand, result, unary_op);
+		Operand, operations::ocl_operation>::compute(operand, result, operation);
 
 	return result;
 }
@@ -119,9 +122,11 @@ Operand elementwise_compute(Operand operand, std::string unary_op)
 template <class Operand>
 void elementwise_compute_inplace(Operand operand, std::string unary_op)
 {
+	operations::ocl_operation operation(unary_op);
 	implementation::elementwise_unary_operation<Backend::VIENNACL, Operand,
-		Operand, std::string>::compute(operand, operand, unary_op);
+		Operand, operations::ocl_operation>::compute(operand, operand, operation);
 }
+#endif // HAVE_VIENNACL
 
 /**
  * Template method for computing element-wise sin for matrices and vectors.
@@ -141,8 +146,9 @@ elementwise_sin(Operand operand)
 
 	ReturnType result=util::allocate_result<Operand,ReturnType>::alloc(operand);
 
+	operations::sin<T> operation;
 	implementation::elementwise_unary_operation<backend, Operand,
-		ReturnType, operations::sin<T>>::compute(operand, result);
+		ReturnType, operations::sin<T>>::compute(operand, result, operation);
 
 	return result;
 }
@@ -162,8 +168,9 @@ void elementwise_sin_inplace(Operand operand)
 	typedef typename operations::sin<T>::return_type ST;
 	static_assert(std::is_same<T,ST>::value, "Scalar type mismatch!\n");
 
+	operations::sin<T> operation;
 	implementation::elementwise_unary_operation<backend, Operand,
-		Operand, operations::sin<T>>::compute(operand, operand);
+		Operand, operations::sin<T>>::compute(operand, operand, operation);
 }
 
 }

--- a/src/shogun/mathematics/linalg/internal/modules/ElementwiseOperations.h
+++ b/src/shogun/mathematics/linalg/internal/modules/ElementwiseOperations.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef ELEMENTWISE_OPERATIONS_H_
+#define ELEMENTWISE_OPERATIONS_H_
+
+#include <shogun/mathematics/linalg/internal/implementation/operations/Sin.h>
+#include <shogun/mathematics/linalg/internal/implementation/util/AllocResultUtil.h>
+#include <shogun/mathematics/linalg/internal/implementation/ElementwiseUnaryOperation.h>
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+/**
+ * Template method for computing custom unary operations element-wise for matrices
+ * and vectors using NATIVE backend. Works for SGMatrix/SGVector.
+ *
+ * This method returns the result in a newly allocated matrix/vector.
+ *
+ * @param operand The operand on which the element-wise operation has to be performed
+ * @param unary_op The custom unary operator
+ * @return The result of the unary operator applied element-wise on the operand
+ */
+template <class Operand, class UnaryOp>
+auto elementwise_compute(Operand operand, UnaryOp unary_op)
+-> typename Operand::template container_type<decltype(unary_op(operand.data()[0]))>
+{
+	typedef decltype(unary_op(operand.data()[0])) ST;
+	typedef typename Operand::template container_type<ST> ReturnType;
+
+	ReturnType result=util::allocate_result<Operand,ReturnType>::alloc(operand);
+
+	implementation::elementwise_unary_operation<Backend::NATIVE, Operand,
+		ReturnType, UnaryOp>::compute(operand, result, unary_op);
+
+	return result;
+}
+
+/**
+ * Template method for computing custom unary operations element-wise for matrices
+ * and vectors using NATIVE backend. Works for SGMatrix/SGVector.
+ *
+ * This method computes the result in-place.
+ *
+ * @param operand The operand on which the element-wise operation has to be performed
+ * @param unary_op The custom unary operator
+ */
+template <class Operand, class UnaryOp>
+void elementwise_compute_inplace(Operand operand, UnaryOp unary_op)
+{
+	typedef typename Operand::Scalar T;
+	typedef decltype(unary_op(operand.data()[0])) ST;
+	static_assert(std::is_same<T,ST>::value, "Scalar type mismatch!\n");
+
+	implementation::elementwise_unary_operation<Backend::NATIVE, Operand,
+		Operand, UnaryOp>::compute(operand, operand, unary_op);
+}
+
+/**
+ * Template method for computing custom unary operations element-wise for matrices
+ * and vectors using VIENNACL/OPENCL backend. Works for CGPUMatrix/CGPUVector.
+ *
+ * This method returns the result in a newly allocated matrix/vector.
+ *
+ * @param operand The operand on which the element-wise operation has to be performed
+ * @param unary_op The custom unary operator string
+ * @return The result of the unary operator applied element-wise on the operand
+ */
+template <class Operand>
+Operand elementwise_compute(Operand operand, std::string unary_op)
+{
+	Operand result=util::allocate_result<Operand,Operand>::alloc(operand);
+
+	implementation::elementwise_unary_operation<Backend::VIENNACL, Operand,
+		Operand, std::string>::compute(operand, result, unary_op);
+
+	return result;
+}
+
+/**
+ * Template method for computing custom unary operations element-wise for matrices
+ * and vectors using VIENNACL/OPENCL backend. Works for CGPUMatrix/CGPUVector.
+ *
+ * This method computes the result in-place.
+ *
+ * @param operand The operand on which the element-wise operation has to be performed
+ * @param unary_op The custom unary operator string
+ */
+template <class Operand>
+void elementwise_compute_inplace(Operand operand, std::string unary_op)
+{
+	implementation::elementwise_unary_operation<Backend::VIENNACL, Operand,
+		Operand, std::string>::compute(operand, operand, unary_op);
+}
+
+/**
+ * Template method for computing element-wise sin for matrices and vectors.
+ *
+ * This method returns the result in a newly allocated matrix/vector.
+ *
+ * @param operand The operand on which the element-wise operation has to be performed
+ * @return The result of the unary operator applied element-wise on the operand
+ */
+template <Backend backend, class Operand>
+typename Operand::template container_type<typename operations::sin<typename Operand::Scalar>::return_type>
+elementwise_sin(Operand operand)
+{
+	typedef typename Operand::Scalar T;
+	typedef typename operations::sin<T>::return_type ST;
+	typedef typename Operand::template container_type<ST> ReturnType;
+
+	ReturnType result=util::allocate_result<Operand,ReturnType>::alloc(operand);
+
+	implementation::elementwise_unary_operation<backend, Operand,
+		ReturnType, operations::sin<T>>::compute(operand, result);
+
+	return result;
+}
+
+/**
+ * Template method for computing element-wise sin for matrices and vectors.
+ *
+ * This method computes the result in-place.
+ *
+ * @param operand The operand on which the element-wise operation has to be performed
+ * @return The result of the unary operator applied element-wise on the operand
+ */
+template <Backend backend, class Operand>
+void elementwise_sin_inplace(Operand operand)
+{
+	typedef typename Operand::Scalar T;
+	typedef typename operations::sin<T>::return_type ST;
+	static_assert(std::is_same<T,ST>::value, "Scalar type mismatch!\n");
+
+	implementation::elementwise_unary_operation<backend, Operand,
+		Operand, operations::sin<T>>::compute(operand, operand);
+}
+
+}
+
+}
+#endif // ELEMENTWISE_OPERATIONS_H_

--- a/src/shogun/mathematics/linalg/linalg.h
+++ b/src/shogun/mathematics/linalg/linalg.h
@@ -188,5 +188,7 @@ struct MODULE \
 #include <shogun/mathematics/linalg/internal/modules/Redux.h>
 #include <shogun/mathematics/linalg/internal/modules/SpecialPurpose.h>
 
+#include <shogun/mathematics/linalg/internal/modules/ElementwiseOperations.h>
+
 #endif // defined(HAVE_CXX0X) || defined(HAVE_CXX11)
 #endif // LINALG_H_

--- a/tests/unit/mathematics/linalg/ElementwiseOperations_unittest.cc
+++ b/tests/unit/mathematics/linalg/ElementwiseOperations_unittest.cc
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2015 Soumyajit De
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/config.h>
+
+#if defined(HAVE_CXX11) || defined(HAVE_CXX0X)
+
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/linalg/linalg.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/lib/GPUVector.h>
+#include <shogun/lib/GPUMatrix.h>
+#endif // HAVE_VIENNACL
+
+#include <algorithm>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(Elementwise_sin, SGMatrix_NATIVE)
+{
+	SGMatrix<int32_t> m(3,4);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	SGMatrix<float64_t> sin_m=linalg::elementwise_sin<linalg::Backend::NATIVE>(m);
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(CMath::sin(m[i]), sin_m[i], 1E-15);
+}
+
+TEST(Elementwise_sin, SGMatrix_NATIVE_inplace)
+{
+	SGMatrix<float64_t> m(3,4);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	SGMatrix<float64_t> m_copy(m.num_rows, m.num_cols);
+	std::copy(m.data(), m.data()+m.size(), m_copy.data());
+	linalg::elementwise_sin_inplace<linalg::Backend::NATIVE>(m);
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(CMath::sin(m_copy[i]), m[i], 1E-15);
+}
+
+TEST(Elementwise_sin, SGVector_NATIVE)
+{
+	SGVector<int32_t> v(3);
+	std::iota(v.data(), v.data()+v.size(), 1);
+	SGVector<float64_t> sin_v=linalg::elementwise_sin<linalg::Backend::NATIVE>(v);
+	for (index_t i=0; i<v.size(); ++i)
+		EXPECT_NEAR(CMath::sin(v[i]), sin_v[i], 1E-15);
+}
+
+TEST(Elementwise_sin, SGVector_NATIVE_inplace)
+{
+	SGVector<float64_t> v(3);
+	std::iota(v.data(), v.data()+v.size(), 1);
+	SGVector<float64_t> v_copy(v.size());
+	std::copy(v.data(), v.data()+v.size(), v_copy.data());
+	linalg::elementwise_sin_inplace<linalg::Backend::NATIVE>(v);
+	for (index_t i=0; i<v.size(); ++i)
+		EXPECT_NEAR(CMath::sin(v_copy[i]), v[i], 1E-15);
+}
+
+TEST(Elementwise_sin, SGMatrix_NATIVE_complex128)
+{
+	SGMatrix<complex128_t> m(3,4);
+	for (index_t i=0; i<m.size(); ++i)
+		m[i]=complex128_t(i+1,i+1);
+	SGMatrix<complex128_t> sin_m=linalg::elementwise_sin<linalg::Backend::NATIVE>(m);
+	for (index_t i=0; i<m.size(); ++i)
+	{
+		EXPECT_NEAR(CMath::sin(m[i]).real(), sin_m[i].real(), 1E-15);
+		EXPECT_NEAR(CMath::sin(m[i]).imag(), sin_m[i].imag(), 1E-15);
+	}
+}
+
+TEST(Elementwise_sin, SGMatrix_NATIVE_complex128_inplace)
+{
+	SGMatrix<complex128_t> m(3,4);
+	for (index_t i=0; i<m.size(); ++i)
+		m[i]=complex128_t(i+1,i+1);
+	SGMatrix<complex128_t> m_copy(m.num_rows, m.num_cols);
+	std::copy(m.data(), m.data()+m.size(), m_copy.data());
+	linalg::elementwise_sin_inplace<linalg::Backend::NATIVE>(m);
+	for (index_t i=0; i<m.size(); ++i)
+	{
+		EXPECT_NEAR(CMath::sin(m_copy[i]).real(), m[i].real(), 1E-15);
+		EXPECT_NEAR(CMath::sin(m_copy[i]).imag(), m[i].imag(), 1E-15);
+	}
+}
+
+TEST(Elementwise_sin, SGVector_NATIVE_complex128)
+{
+	SGVector<complex128_t> v(3);
+	for (index_t i=0; i<v.size(); ++i)
+		v[i]=complex128_t(i+1,i+1);
+	SGVector<complex128_t> sin_v=linalg::elementwise_sin<linalg::Backend::NATIVE>(v);
+	for (index_t i=0; i<v.size(); ++i)
+	{
+		EXPECT_NEAR(CMath::sin(v[i]).real(), sin_v[i].real(), 1E-15);
+		EXPECT_NEAR(CMath::sin(v[i]).imag(), sin_v[i].imag(), 1E-15);
+	}
+}
+
+TEST(Elementwise_sin, SGVector_NATIVE_complex128_inplace)
+{
+	SGVector<complex128_t> v(3);
+	for (index_t i=0; i<v.size(); ++i)
+		v[i]=complex128_t(i+1,i+1);
+	SGVector<complex128_t> v_copy(v.size());
+	std::copy(v.data(), v.data()+v.size(), v_copy.data());
+	linalg::elementwise_sin_inplace<linalg::Backend::NATIVE>(v);
+	for (index_t i=0; i<v.size(); ++i)
+	{
+		EXPECT_NEAR(CMath::sin(v_copy[i]).real(), v[i].real(), 1E-15);
+		EXPECT_NEAR(CMath::sin(v_copy[i]).imag(), v[i].imag(), 1E-15);
+	}
+}
+
+#ifdef HAVE_EIGEN3
+TEST(Elementwise_sin, SGMatrix_EIGEN3)
+{
+	SGMatrix<float64_t> m(3,4);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	SGMatrix<float64_t> sin_m=linalg::elementwise_sin<linalg::Backend::EIGEN3>(m);
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(CMath::sin(m[i]), sin_m[i], 1E-15);
+}
+
+TEST(Elementwise_sin, SGVector_EIGEN3)
+{
+	SGVector<float64_t> v(3);
+	std::iota(v.data(), v.data()+v.size(), 1);
+	SGVector<float64_t> sin_v=linalg::elementwise_sin<linalg::Backend::EIGEN3>(v);
+	for (index_t i=0; i<v.size(); ++i)
+		EXPECT_NEAR(CMath::sin(v[i]), sin_v[i], 1E-15);
+}
+#endif // HAVE_EIGEN3
+
+#ifdef HAVE_VIENNACL
+TEST(Elementwise_sin, CGPUMatrix_VIENNACL)
+{
+	SGMatrix<float64_t> m(3,4);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	CGPUMatrix<float64_t> m_gpu(m);
+	CGPUMatrix<float64_t> sin_m=linalg::elementwise_sin<linalg::Backend::VIENNACL>(m_gpu);
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(CMath::sin(m[i]), sin_m[i], 1E-6);
+}
+
+TEST(Elementwise_sin, CGPUMatrix_VIENNACL_inplace)
+{
+	SGMatrix<float64_t> m(3,4);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	CGPUMatrix<float64_t> m_gpu(m);
+	linalg::elementwise_sin_inplace<linalg::Backend::VIENNACL>(m_gpu);
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(CMath::sin(m[i]), m_gpu[i], 1E-15);
+}
+
+TEST(Elementwise_sin, CGPUVector_VIENNACL)
+{
+	SGVector<float64_t> v(3);
+	std::iota(v.data(), v.data()+v.size(), 1);
+	CGPUVector<float64_t> v_gpu(v);
+	CGPUVector<float64_t> sin_v=linalg::elementwise_sin<linalg::Backend::VIENNACL>(v_gpu);
+	for (index_t i=0; i<v.size(); ++i)
+		EXPECT_NEAR(CMath::sin(v[i]), sin_v[i], 1E-6);
+}
+
+TEST(Elementwise_sin, CGPUVector_VIENNACL_inplace)
+{
+	SGVector<float64_t> v(3);
+	std::iota(v.data(), v.data()+v.size(), 1);
+	CGPUVector<float64_t> v_gpu(v);
+	linalg::elementwise_sin_inplace<linalg::Backend::VIENNACL>(v_gpu);
+	for (index_t i=0; i<v.size(); ++i)
+		EXPECT_NEAR(CMath::sin(v[i]), v_gpu[i], 1E-15);
+}
+#endif // HAVE_VIENNACL
+
+TEST(Elementwise_custom, SGMatrix)
+{
+	SGMatrix<float64_t> m(2,2);
+	std::iota(m.data(), m.data()+m.size(), 1);
+
+	float64_t weights=0.6;
+	float64_t std_dev=0.2;
+	float64_t mean=0.01;
+
+	SGMatrix<float64_t> result=linalg::elementwise_compute(m,
+	[&weights, &std_dev, &mean](float64_t& sqr_dist)
+	{
+		float64_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+		float64_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::pow(std_dev, 2));
+		float64_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+		return outer_factor*exp_factor*sin_factor;
+	});
+
+	for (index_t i=0; i<m.num_rows; ++i)
+	{
+		for (index_t j=0; j<m.num_cols; ++j)
+		{
+			float64_t sqr_dist=m(i, j);
+			float64_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+			float64_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::pow(std_dev, 2));
+			float64_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+			m(i, j)=outer_factor*exp_factor*sin_factor;
+		}
+	}
+
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(m.data()[i], result.data()[i], 1E-15);
+}
+
+TEST(Elementwise_custom, SGMatrix_inplace)
+{
+	SGMatrix<float64_t> m(2,2);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	SGMatrix<float64_t> m_copy(m.num_rows, m.num_cols);
+	std::copy(m.data(), m.data()+m.size(), m_copy.data());
+
+	float64_t weights=0.6;
+	float64_t std_dev=0.2;
+	float64_t mean=0.01;
+
+	linalg::elementwise_compute_inplace(m,
+	[&weights, &std_dev, &mean](float64_t& sqr_dist)
+	{
+		float64_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+		float64_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::pow(std_dev, 2));
+		float64_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+		return outer_factor*exp_factor*sin_factor;
+	});
+
+	for (index_t i=0; i<m_copy.num_rows; ++i)
+	{
+		for (index_t j=0; j<m_copy.num_cols; ++j)
+		{
+			float64_t sqr_dist=m_copy(i, j);
+			float64_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+			float64_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::pow(std_dev, 2));
+			float64_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+			m_copy(i, j)=outer_factor*exp_factor*sin_factor;
+		}
+	}
+
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(m.data()[i], m_copy.data()[i], 1E-15);
+}
+
+#ifdef HAVE_VIENNACL
+TEST(Elementwise_custom, CGPUMatrix)
+{
+	SGMatrix<float32_t> m(2,2);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	CGPUMatrix<float32_t> m_gpu(m);
+
+	float32_t weights=0.6;
+	float32_t std_dev=0.2;
+	float32_t mean=0.01;
+
+	std::string data_type=linalg::implementation::ocl::get_type_string<float32_t>();
+
+	std::string s_weights=std::to_string(weights);
+	std::string s_std_dev=std::to_string(std_dev);
+	std::string s_mean=std::to_string(mean);
+	std::string s_pi=std::to_string(CMath::PI);
+
+	std::string operation;
+	operation.append(data_type+" outer_factor=-2*"+s_pi+"*sqrt(element)*pow("+s_weights+", 2);\n");
+	operation.append(data_type+" exp_factor=exp(-2*pow("+s_pi+",2)*element*pow("+s_std_dev+", 2));\n");
+	operation.append(data_type+" sin_factor=sin(2*"+s_pi+"*sqrt(element)*"+s_mean+");\n");
+	operation.append("return outer_factor*exp_factor*sin_factor;");
+
+	CGPUMatrix<float32_t> result=linalg::elementwise_compute(m_gpu, operation);
+
+	for (index_t i=0; i<m.num_rows; ++i)
+	{
+		for (index_t j=0; j<m.num_cols; ++j)
+		{
+			float32_t sqr_dist=m(i, j);
+			float32_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+			float32_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::sq(std_dev));
+			float32_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+			m(i, j)=outer_factor*exp_factor*sin_factor;
+		}
+	}
+
+	for (index_t i=0; i<m.num_rows; ++i)
+	{
+		for (index_t j=0; j<m.num_cols; ++j)
+			EXPECT_NEAR(m(i,j), result(i,j), 1E-6);
+	}
+}
+
+TEST(Elementwise_custom, CGPUMatrix_inplace)
+{
+	SGMatrix<float32_t> m(2,2);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	CGPUMatrix<float32_t> m_gpu(m);
+
+	float32_t weights=0.6;
+	float32_t std_dev=0.2;
+	float32_t mean=0.01;
+
+	std::string data_type=linalg::implementation::ocl::get_type_string<float32_t>();
+
+	std::string s_weights=std::to_string(weights);
+	std::string s_std_dev=std::to_string(std_dev);
+	std::string s_mean=std::to_string(mean);
+	std::string s_pi=std::to_string(CMath::PI);
+
+	std::string operation;
+	operation.append(data_type+" outer_factor=-2*"+s_pi+"*sqrt(element)*pow("+s_weights+", 2);\n");
+	operation.append(data_type+" exp_factor=exp(-2*pow("+s_pi+",2)*element*pow("+s_std_dev+", 2));\n");
+	operation.append(data_type+" sin_factor=sin(2*"+s_pi+"*sqrt(element)*"+s_mean+");\n");
+	operation.append("return outer_factor*exp_factor*sin_factor;");
+
+	linalg::elementwise_compute_inplace(m_gpu, operation);
+
+	for (index_t i=0; i<m.num_rows; ++i)
+	{
+		for (index_t j=0; j<m.num_cols; ++j)
+		{
+			float32_t sqr_dist=m(i, j);
+			float32_t outer_factor=-2*CMath::PI*CMath::sqrt(sqr_dist)*CMath::sq(weights);
+			float32_t exp_factor=CMath::exp(-2*CMath::sq(CMath::PI)*sqr_dist*CMath::sq(std_dev));
+			float32_t sin_factor=CMath::sin(2*CMath::PI*CMath::sqrt(sqr_dist)*mean);
+			m(i, j)=outer_factor*exp_factor*sin_factor;
+		}
+	}
+
+	for (index_t i=0; i<m.num_rows; ++i)
+	{
+		for (index_t j=0; j<m.num_cols; ++j)
+			EXPECT_NEAR(m(i,j), m_gpu(i,j), 1E-6);
+	}
+}
+#endif // HAVE_VIENNACL
+#endif // defined(HAVE_CXX11) || defined(HAVE_CXX0X)

--- a/tests/unit/mathematics/linalg/ElementwiseOperations_unittest.cc
+++ b/tests/unit/mathematics/linalg/ElementwiseOperations_unittest.cc
@@ -153,6 +153,17 @@ TEST(Elementwise_sin, SGMatrix_EIGEN3)
 		EXPECT_NEAR(CMath::sin(m[i]), sin_m[i], 1E-15);
 }
 
+TEST(Elementwise_sin, SGMatrix_EIGEN3_inplace)
+{
+	SGMatrix<float64_t> m(3,4);
+	std::iota(m.data(), m.data()+m.size(), 1);
+	SGMatrix<float64_t> m_copy(m.num_rows, m.num_cols);
+	std::copy(m.data(), m.data()+m.size(), m_copy.data());
+	linalg::elementwise_sin_inplace<linalg::Backend::EIGEN3>(m);
+	for (index_t i=0; i<m.size(); ++i)
+		EXPECT_NEAR(CMath::sin(m_copy[i]), m[i], 1E-15);
+}
+
 TEST(Elementwise_sin, SGVector_EIGEN3)
 {
 	SGVector<float64_t> v(3);
@@ -160,6 +171,17 @@ TEST(Elementwise_sin, SGVector_EIGEN3)
 	SGVector<float64_t> sin_v=linalg::elementwise_sin<linalg::Backend::EIGEN3>(v);
 	for (index_t i=0; i<v.size(); ++i)
 		EXPECT_NEAR(CMath::sin(v[i]), sin_v[i], 1E-15);
+}
+
+TEST(Elementwise_sin, SGVector_EIGEN3_inplace)
+{
+	SGVector<float64_t> v(3);
+	std::iota(v.data(), v.data()+v.size(), 1);
+	SGVector<float64_t> v_copy(v.size());
+	std::copy(v.data(), v.data()+v.size(), v_copy.data());
+	linalg::elementwise_sin_inplace<linalg::Backend::EIGEN3>(v);
+	for (index_t i=0; i<v.size(); ++i)
+		EXPECT_NEAR(CMath::sin(v_copy[i]), v[i], 1E-15);
 }
 #endif // HAVE_EIGEN3
 


### PR DESCRIPTION
- Works with predefined operations (sin, cos, log, exp etc.)
- Works with custom unary operators as well (functors, std::function, lambda expressions, function pointers) that developers can provide.
- Implicit type conversion is **turned off** for CPU to/from GPU matrix/vector data-types. NATIVE/EIGEN3 works only with SG-types and VIENNACL works only with CGPU-types.
- Type safety ensured.
- A benchmark of element-wise operation with a custom unary operator.
