### PR TITLE
fix issue: remove mktemp warnings in unit tests and libshogun example…

### DIFF
--- a/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
@@ -155,9 +155,9 @@ public:
 void test_load_file_parameter()
 {
 	char filename_tmp[] = "load_all_file_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
-        char* filename = filename_tmp;
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassInt* int_instance=new CTestClassInt();

--- a/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
@@ -155,7 +155,9 @@ public:
 void test_load_file_parameter()
 {
 	char filename_tmp[] = "load_all_file_test.XXXXXX";
-	char* filename=mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+    char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassInt* int_instance=new CTestClassInt();

--- a/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
@@ -155,9 +155,9 @@ public:
 void test_load_file_parameter()
 {
 	char filename_tmp[] = "load_all_file_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
-    char* filename = filename_tmp;
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
+        char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassInt* int_instance=new CTestClassInt();

--- a/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_all_file_parameters.cpp
@@ -157,6 +157,8 @@ void test_load_file_parameter()
 	char filename_tmp[] = "load_all_file_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_load_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_file_parameters.cpp
@@ -151,7 +151,9 @@ public:
 void test_load_file_parameters()
 {
 	char filename_tmp[] = "/tmp/file_params_test.XXXXXX";
-	char* filename = mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassInt* int_instance=new CTestClassInt();

--- a/examples/undocumented/libshogun/base_load_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_file_parameters.cpp
@@ -151,8 +151,8 @@ public:
 void test_load_file_parameters()
 {
 	char filename_tmp[] = "/tmp/file_params_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_load_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_file_parameters.cpp
@@ -151,8 +151,8 @@ public:
 void test_load_file_parameters()
 {
 	char filename_tmp[] = "/tmp/file_params_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_load_file_parameters.cpp
+++ b/examples/undocumented/libshogun/base_load_file_parameters.cpp
@@ -153,6 +153,8 @@ void test_load_file_parameters()
 	char filename_tmp[] = "/tmp/file_params_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_map_parameters.cpp
+++ b/examples/undocumented/libshogun/base_map_parameters.cpp
@@ -243,8 +243,8 @@ public:
 void test_load_file_parameter()
 {
 	char filename_tmp[] = "map_params_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_map_parameters.cpp
+++ b/examples/undocumented/libshogun/base_map_parameters.cpp
@@ -243,7 +243,9 @@ public:
 void test_load_file_parameter()
 {
 	char filename_tmp[] = "map_params_test.XXXXXX";
-	char* filename=mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassInt* int_instance=new CTestClassInt();

--- a/examples/undocumented/libshogun/base_map_parameters.cpp
+++ b/examples/undocumented/libshogun/base_map_parameters.cpp
@@ -243,8 +243,8 @@ public:
 void test_load_file_parameter()
 {
 	char filename_tmp[] = "map_params_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_map_parameters.cpp
+++ b/examples/undocumented/libshogun/base_map_parameters.cpp
@@ -245,6 +245,8 @@ void test_load_file_parameter()
 	char filename_tmp[] = "map_params_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
+++ b/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
@@ -117,7 +117,9 @@ void check_equalness(CTestClassOld* old_instance,
 void test_migration()
 {
 	char filename_template[] = "migration_dropping_test.XXXXXX";
-	char* filename = mktemp(filename_template);
+    int fd = mkstemp(filename_template);
+    ASSERT(fd != -1);
+	char* filename = filename_template;
 
 	/* create one instance of each class */
 	CTestClassOld* old_instance=new CTestClassOld();

--- a/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
+++ b/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
@@ -117,8 +117,8 @@ void check_equalness(CTestClassOld* old_instance,
 void test_migration()
 {
 	char filename_template[] = "migration_dropping_test.XXXXXX";
-        int fd = mkstemp(filename_template);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_template);
+	ASSERT(fd != -1);
 	char* filename = filename_template;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
+++ b/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
@@ -119,6 +119,8 @@ void test_migration()
 	char filename_template[] = "migration_dropping_test.XXXXXX";
 	int fd = mkstemp(filename_template);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_template;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
+++ b/examples/undocumented/libshogun/base_migration_dropping_and_new.cpp
@@ -117,8 +117,8 @@ void check_equalness(CTestClassOld* old_instance,
 void test_migration()
 {
 	char filename_template[] = "migration_dropping_test.XXXXXX";
-    int fd = mkstemp(filename_template);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_template);
+        ASSERT(fd != -1);
 	char* filename = filename_template;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
+++ b/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
@@ -132,8 +132,8 @@ public:
 void test_migration()
 {
 	char filename_tmp[] = "migration_multiple_dep_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
+++ b/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
@@ -132,7 +132,9 @@ public:
 void test_migration()
 {
 	char filename_tmp[] = "migration_multiple_dep_test.XXXXXX";
-	char* filename=mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassOld* old_instance=new CTestClassOld();

--- a/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
+++ b/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
@@ -134,6 +134,8 @@ void test_migration()
 	char filename_tmp[] = "migration_multiple_dep_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
+++ b/examples/undocumented/libshogun/base_migration_multiple_dependencies.cpp
@@ -132,8 +132,8 @@ public:
 void test_migration()
 {
 	char filename_tmp[] = "migration_multiple_dep_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_new_buggy.cpp
+++ b/examples/undocumented/libshogun/base_migration_new_buggy.cpp
@@ -58,6 +58,8 @@ void test()
 	char filename_tmp[] = "migration_buggy_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_new_buggy.cpp
+++ b/examples/undocumented/libshogun/base_migration_new_buggy.cpp
@@ -56,7 +56,9 @@ public:
 void test()
 {
 	char filename_tmp[] = "migration_buggy_test.XXXXXX";
-	char* filename=mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassOld* old_instance=new CTestClassOld();

--- a/examples/undocumented/libshogun/base_migration_new_buggy.cpp
+++ b/examples/undocumented/libshogun/base_migration_new_buggy.cpp
@@ -56,8 +56,8 @@ public:
 void test()
 {
 	char filename_tmp[] = "migration_buggy_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_new_buggy.cpp
+++ b/examples/undocumented/libshogun/base_migration_new_buggy.cpp
@@ -56,8 +56,8 @@ public:
 void test()
 {
 	char filename_tmp[] = "migration_buggy_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_type_conversion.cpp
+++ b/examples/undocumented/libshogun/base_migration_type_conversion.cpp
@@ -315,7 +315,9 @@ void check_equalness(CTestClassInt* int_instance,
 void test_migration()
 {
 	char filename_tmp[] = "migration_type_conv_test.XXXXXX";
-	char* filename=mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	/* create one instance of each class */
 	CTestClassInt* int_instance=new CTestClassInt();

--- a/examples/undocumented/libshogun/base_migration_type_conversion.cpp
+++ b/examples/undocumented/libshogun/base_migration_type_conversion.cpp
@@ -315,8 +315,8 @@ void check_equalness(CTestClassInt* int_instance,
 void test_migration()
 {
 	char filename_tmp[] = "migration_type_conv_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_type_conversion.cpp
+++ b/examples/undocumented/libshogun/base_migration_type_conversion.cpp
@@ -315,8 +315,8 @@ void check_equalness(CTestClassInt* int_instance,
 void test_migration()
 {
 	char filename_tmp[] = "migration_type_conv_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/base_migration_type_conversion.cpp
+++ b/examples/undocumented/libshogun/base_migration_type_conversion.cpp
@@ -317,6 +317,8 @@ void test_migration()
 	char filename_tmp[] = "migration_type_conv_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	/* create one instance of each class */

--- a/examples/undocumented/libshogun/serialization_basic_tests.cpp
+++ b/examples/undocumented/libshogun/serialization_basic_tests.cpp
@@ -80,6 +80,8 @@ void test_test_class_serial()
 	char filename_tmp[] = "serialization_test.XXXXXX";
 	int fd = mkstemp(filename_tmp);
 	ASSERT(fd != -1);
+	int retval = close(fd);
+	ASSERT(retval != -1);
 	char* filename = filename_tmp;
 
 	CTestClass* to_save=new CTestClass(10, 0, 0);

--- a/examples/undocumented/libshogun/serialization_basic_tests.cpp
+++ b/examples/undocumented/libshogun/serialization_basic_tests.cpp
@@ -78,8 +78,8 @@ public:
 void test_test_class_serial()
 {
 	char filename_tmp[] = "serialization_test.XXXXXX";
-    int fd = mkstemp(filename_tmp);
-    ASSERT(fd != -1);
+        int fd = mkstemp(filename_tmp);
+        ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	CTestClass* to_save=new CTestClass(10, 0, 0);

--- a/examples/undocumented/libshogun/serialization_basic_tests.cpp
+++ b/examples/undocumented/libshogun/serialization_basic_tests.cpp
@@ -78,8 +78,8 @@ public:
 void test_test_class_serial()
 {
 	char filename_tmp[] = "serialization_test.XXXXXX";
-        int fd = mkstemp(filename_tmp);
-        ASSERT(fd != -1);
+	int fd = mkstemp(filename_tmp);
+	ASSERT(fd != -1);
 	char* filename = filename_tmp;
 
 	CTestClass* to_save=new CTestClass(10, 0, 0);

--- a/examples/undocumented/libshogun/serialization_basic_tests.cpp
+++ b/examples/undocumented/libshogun/serialization_basic_tests.cpp
@@ -78,7 +78,9 @@ public:
 void test_test_class_serial()
 {
 	char filename_tmp[] = "serialization_test.XXXXXX";
-	char* filename=mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+	char* filename = filename_tmp;
 
 	CTestClass* to_save=new CTestClass(10, 0, 0);
 	CTestClass* to_load=new CTestClass(20, 10, 66);

--- a/examples/undocumented/libshogun/streaming_onlineliblinear_sparse.cpp
+++ b/examples/undocumented/libshogun/streaming_onlineliblinear_sparse.cpp
@@ -32,7 +32,9 @@ int main(int argc, char* argv[])
     char *train_file_name = (char*)"../data/train_sparsereal.light";
     char *test_file_name = (char*)"../data/test_sparsereal.light";
     char filename_tmp[] = "test_sparsereal.light.labels.XXXXXX";
-    char *test_labels_file_name = mktemp(filename_tmp);
+    int fd = mkstemp(filename_tmp);
+    ASSERT(fd != -1);
+    char *test_labels_file_name = filename_tmp;
 
     if (argc > 4) {
         int32_t idx = 1;

--- a/examples/undocumented/libshogun/streaming_onlineliblinear_sparse.cpp
+++ b/examples/undocumented/libshogun/streaming_onlineliblinear_sparse.cpp
@@ -34,6 +34,8 @@ int main(int argc, char* argv[])
     char filename_tmp[] = "test_sparsereal.light.labels.XXXXXX";
     int fd = mkstemp(filename_tmp);
     ASSERT(fd != -1);
+    int retval = close(fd);
+    ASSERT(retval != -1);
     char *test_labels_file_name = filename_tmp;
 
     if (argc > 4) {


### PR DESCRIPTION
fix #2750