### PR TITLE
Revert "Removing deprecated SGRefObject and SGDynamicRefObjectArray (…

### DIFF
--- a/src/interfaces/modular/SGBase.i
+++ b/src/interfaces/modular/SGBase.i
@@ -2,8 +2,8 @@
 %include "stdint.i"
 %include "exception.i"
 
-%feature("ref")   shogun::CSGObject "SG_REF($this);"
-%feature("unref") shogun::CSGObject "SG_UNREF($this);"
+%feature("ref")   shogun::SGRefObject "SG_REF($this);"
+%feature("unref") shogun::SGRefObject "SG_UNREF($this);"
 
 #ifdef SWIGJAVA
 %typemap(javainterfaces) shogun::CSGObject "java.io.Externalizable"
@@ -106,6 +106,7 @@ public void readExternal(java.io.ObjectInput in) throws java.io.IOException, jav
  #include <shogun/lib/DataType.h>
  #include <shogun/base/Version.h>
  #include <shogun/base/Parallel.h>
+ #include <shogun/base/SGRefObject.h>
  #include <shogun/base/SGObject.h>
 
  extern void sg_global_print_message(FILE* target, const char* str);
@@ -321,6 +322,7 @@ namespace std {
 #ifndef SWIGR
 %include <shogun/base/init.h>
 #endif
+%include <shogun/base/SGRefObject.h>
 %include <shogun/base/SGObject.h>
 %include <shogun/io/SGIO.h>
 %include <shogun/base/Version.h>

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -6,13 +6,9 @@
  *
  * Written (W) 2008-2009 Soeren Sonnenburg
  * Written (W) 2011-2013 Heiko Strathmann
- * Written (W) 2013-2014 Thoralf Klein
+ * Written (W) 2013 Thoralf Klein
  * Copyright (C) 2008-2009 Fraunhofer Institute FIRST and Max Planck Society
  */
-
-#include <shogun/lib/config.h>
-#include <shogun/lib/memory.h>
-#include <shogun/lib/RefCount.h>
 
 #include <shogun/base/SGObject.h>
 #include <shogun/io/SGIO.h>
@@ -119,67 +115,27 @@ namespace shogun
 using namespace shogun;
 
 CSGObject::CSGObject()
+: SGRefObject()
 {
 	init();
 	set_global_objects();
-	m_refcount = new RefCount(0);
-
-	SG_SGCDEBUG("SGObject created (%p)\n", this)
 }
 
 CSGObject::CSGObject(const CSGObject& orig)
-:io(orig.io), parallel(orig.parallel), version(orig.version)
+:SGRefObject(orig), io(orig.io), parallel(orig.parallel), version(orig.version)
 {
 	init();
 	set_global_objects();
-	m_refcount = new RefCount(0);
-
-	SG_SGCDEBUG("SGObject copied (%p)\n", this)
 }
 
 CSGObject::~CSGObject()
 {
-	SG_SGCDEBUG("SGObject destroyed (%p)\n", this)
-
 	unset_global_objects();
 	delete m_parameters;
 	delete m_model_selection_parameters;
 	delete m_gradient_parameters;
 	delete m_parameter_map;
-	delete m_refcount;
 }
-
-#ifdef USE_REFERENCE_COUNTING
-int32_t CSGObject::ref()
-{
-	int32_t count = m_refcount->ref();
-	SG_SGCDEBUG("ref() refcount %ld obj %s (%p) increased\n", count, this->get_name(), this)
-	return m_refcount->ref_count();
-}
-
-int32_t CSGObject::ref_count()
-{
-	int32_t count = m_refcount->ref_count();
-	SG_SGCDEBUG("ref_count(): refcount %d, obj %s (%p)\n", count, this->get_name(), this)
-	return m_refcount->ref_count();
-}
-
-int32_t CSGObject::unref()
-{
-	int32_t count = m_refcount->unref();
-	if (count<=0)
-	{
-		SG_SGCDEBUG("unref() refcount %ld, obj %s (%p) destroying\n", count, this->get_name(), this)
-		delete this;
-		return 0;
-	}
-	else
-	{
-		SG_SGCDEBUG("unref() refcount %ld obj %s (%p) decreased\n", count, this->get_name(), this)
-		return m_refcount->ref_count();
-	}
-}
-#endif //USE_REFERENCE_COUNTING
 
 #ifdef TRACE_MEMORY_ALLOCS
 #include <shogun/lib/Map.h>

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -6,7 +6,7 @@
  *
  * Written (W) 2008-2010 Soeren Sonnenburg
  * Written (W) 2011-2013 Heiko Strathmann
- * Written (W) 2013-2014 Thoralf Klein
+ * Written (W) 2013 Thoralf Klein
  * Copyright (C) 2008-2010 Fraunhofer Institute FIRST and Max Planck Society
  */
 
@@ -17,6 +17,7 @@
 
 #include <shogun/lib/common.h>
 #include <shogun/lib/DataType.h>
+#include <shogun/base/SGRefObject.h>
 #include <shogun/lib/ShogunException.h>
 #include <shogun/base/Version.h>
 
@@ -25,7 +26,6 @@
  */
 namespace shogun
 {
-class RefCount;
 class SGIO;
 class Parallel;
 class Parameter;
@@ -38,20 +38,6 @@ template <class T, class K> class CMap;
 struct TParameter;
 template <class T> class DynArray;
 template <class T> class SGStringList;
-
-/*******************************************************************************
- * define reference counter macros
- ******************************************************************************/
-
-#ifdef USE_REFERENCE_COUNTING
-#define SG_REF(x) { if (x) (x)->ref(); }
-#define SG_UNREF(x) { if (x) { if ((x)->unref()==0) (x)=NULL; } }
-#define SG_UNREF_NO_NULL(x) { if (x) { (x)->unref(); } }
-#else
-#define SG_REF(x)
-#define SG_UNREF(x)
-#define SG_UNREF_NO_NULL(x)
-#endif
 
 /*******************************************************************************
  * Macros for registering parameters/model selection parameters
@@ -109,7 +95,7 @@ enum EGradientAvailability
  *
  * All objects can be cloned and compared (deep copy, recursively)
  */
-class CSGObject
+class CSGObject : public SGRefObject
 {
 public:
 	/** default constructor */
@@ -120,31 +106,6 @@ public:
 
 	/** destructor */
 	virtual ~CSGObject();
-
-#ifdef USE_REFERENCE_COUNTING
-	/** increase reference counter
-	 *
-	 * @return reference count
-	 */
-	int32_t ref();
-
-	/** display reference counter
-	 *
-	 * @return reference count
-	 */
-	int32_t ref_count();
-
-	/** decrement reference counter and deallocate object if refcount is zero
-	 * before or after decrementing it
-	 *
-	 * @return reference count
-	 */
-	int32_t unref();
-#endif //USE_REFERENCE_COUNTING
-
-#ifdef TRACE_MEMORY_ALLOCS
-	static void list_memory_allocs();
-#endif
 
 	/** A shallow copy.
 	 * All the SGObject instance variables will be simply assigned and SG_REF-ed.
@@ -523,8 +484,6 @@ private:
 	bool m_load_post_called;
 	bool m_save_pre_called;
 	bool m_save_post_called;
-
-	RefCount* m_refcount;
 };
 }
 #endif // __SGOBJECT_H__

--- a/src/shogun/base/SGRefObject.cpp
+++ b/src/shogun/base/SGRefObject.cpp
@@ -1,0 +1,99 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2008-2009 Soeren Sonnenburg
+ * Written (W) 2011-2013 Heiko Strathmann
+ * Written (W) 2013 Thoralf Klein
+ * Copyright (C) 2008-2009 Fraunhofer Institute FIRST and Max Planck Society
+ */
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/memory.h>
+
+#include <shogun/base/SGRefObject.h>
+#include <shogun/io/SGIO.h>
+#include <shogun/lib/RefCount.h>
+
+using namespace shogun;
+
+SGRefObject::SGRefObject()
+{
+	init();
+	m_refcount = new RefCount(0);
+
+	SG_SGCDEBUG("SGRefObject created (%p)\n", this)
+}
+
+SGRefObject::SGRefObject(const SGRefObject& orig)
+{
+	init();
+	m_refcount = new RefCount(0);
+
+	SG_SGCDEBUG("SGRefObject copied (%p)\n", this)
+}
+
+SGRefObject::~SGRefObject()
+{
+	SG_SGCDEBUG("SGRefObject destroyed (%p)\n", this)
+	delete m_refcount;
+}
+
+#ifdef USE_REFERENCE_COUNTING
+int32_t SGRefObject::ref()
+{
+	int32_t count = m_refcount->ref();
+	SG_SGCDEBUG("ref() refcount %ld obj %s (%p) increased\n", count, this->get_name(), this)
+	return m_refcount->ref_count();
+}
+
+int32_t SGRefObject::ref_count()
+{
+	int32_t count = m_refcount->ref_count();
+	SG_SGCDEBUG("ref_count(): refcount %d, obj %s (%p)\n", count, this->get_name(), this)
+	return m_refcount->ref_count();
+}
+
+int32_t SGRefObject::unref()
+{
+	int32_t count = m_refcount->unref();
+	if (count<=0)
+	{
+		SG_SGCDEBUG("unref() refcount %ld, obj %s (%p) destroying\n", count, this->get_name(), this)
+		delete this;
+		return 0;
+	}
+	else
+	{
+		SG_SGCDEBUG("unref() refcount %ld obj %s (%p) decreased\n", count, this->get_name(), this)
+		return m_refcount->ref_count();
+	}
+}
+#endif //USE_REFERENCE_COUNTING
+
+#ifdef TRACE_MEMORY_ALLOCS
+#include <shogun/lib/Map.h>
+extern CMap<void*, shogun::MemoryBlock>* sg_mallocs;
+
+void SGRefObject::list_memory_allocs()
+{
+	shogun::list_memory_allocs();
+}
+#endif
+
+void SGRefObject::init()
+{
+#ifdef TRACE_MEMORY_ALLOCS
+	if (sg_mallocs)
+	{
+		int32_t idx=sg_mallocs->index_of(this);
+		if (idx>-1)
+		{
+			MemoryBlock* b=sg_mallocs->get_element_ptr(idx);
+			b->set_sgobject();
+		}
+	}
+#endif
+}

--- a/src/shogun/base/SGRefObject.h
+++ b/src/shogun/base/SGRefObject.h
@@ -1,0 +1,98 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2008-2010 Soeren Sonnenburg
+ * Written (W) 2011-2013 Heiko Strathmann
+ * Written (W) 2013 Thoralf Klein
+ * Copyright (C) 2008-2010 Fraunhofer Institute FIRST and Max Planck Society
+ */
+
+#ifndef __SGREFOBJECT_H__
+#define __SGREFOBJECT_H__
+
+#include <shogun/lib/config.h>
+
+/** \namespace shogun
+ * @brief all of classes and functions are contained in the shogun namespace
+ */
+namespace shogun
+{
+
+class RefCount;
+class SGRefObject;
+
+// define reference counter macros
+//
+#ifdef USE_REFERENCE_COUNTING
+#define SG_REF(x) { if (x) (x)->ref(); }
+#define SG_UNREF(x) { if (x) { if ((x)->unref()==0) (x)=NULL; } }
+#define SG_UNREF_NO_NULL(x) { if (x) { (x)->unref(); } }
+#else
+#define SG_REF(x)
+#define SG_UNREF(x)
+#define SG_UNREF_NO_NULL(x)
+#endif
+
+/** @brief Class SGRefObject is a reference count based memory management class
+ *
+ * It deals with reference counting that is used to manage shogun
+ * objects in memory (erase unused object, avoid cleaning objects when they are
+ * still in use)
+ *
+ */
+class SGRefObject
+{
+public:
+	/** default constructor */
+	SGRefObject();
+
+	/** copy constructor */
+	SGRefObject(const SGRefObject& orig);
+
+	/** destructor */
+	virtual ~SGRefObject();
+
+#ifdef USE_REFERENCE_COUNTING
+	/** increase reference counter
+	 *
+	 * @return reference count
+	 */
+	int32_t ref();
+
+	/** display reference counter
+	 *
+	 * @return reference count
+	 */
+	int32_t ref_count();
+
+	/** decrement reference counter and deallocate object if refcount is zero
+	 * before or after decrementing it
+	 *
+	 * @return reference count
+	 */
+	int32_t unref();
+#endif //USE_REFERENCE_COUNTING
+
+	/** Returns the name of the SGSerializable instance.  It MUST BE
+	 *  the CLASS NAME without the prefixed `C'.
+	 *
+	 *  @return name of the SGSerializable
+	 */
+	virtual const char* get_name() const = 0;
+
+#ifdef TRACE_MEMORY_ALLOCS
+	static void list_memory_allocs();
+#endif
+
+private:
+	void init();
+
+private:
+
+	RefCount* m_refcount;
+};
+}
+#endif // __SGREFOBJECT_H__

--- a/src/shogun/base/init.cpp
+++ b/src/shogun/base/init.cpp
@@ -17,7 +17,7 @@
 #include <shogun/io/SGIO.h>
 #include <shogun/base/Parallel.h>
 #include <shogun/base/Version.h>
-#include <shogun/base/SGObject.h>
+#include <shogun/base/SGRefObject.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
…closes #1853, #1764)."

This reverts commit a6bf26d6448b49244fe2c5c7abaad3c451c37e53.

Conflicts:
	src/shogun/base/SGObject.cpp

Partial revert because the removal of SGDynamicRefObjectArray has not been reverted