### PR TITLE
Removed unused template parameter from CLinearOperator

### DIFF
--- a/src/interfaces/modular/Mathematics.i
+++ b/src/interfaces/modular/Mathematics.i
@@ -27,10 +27,10 @@
 namespace shogun
 {
 #ifdef USE_FLOAT64
-    %template(RealLinearOperator) CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >;
+    %template(RealLinearOperator) CLinearOperator<float64_t>;
 #endif
 #ifdef USE_COMPLEX128
-    %template(ComplexLinearOperator) CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >;
+    %template(ComplexLinearOperator) CLinearOperator<complex128_t>;
 #endif
 }
 

--- a/src/shogun/mathematics/linalg/eigsolver/DirectEigenSolver.cpp
+++ b/src/shogun/mathematics/linalg/eigsolver/DirectEigenSolver.cpp
@@ -28,7 +28,7 @@ CDirectEigenSolver::CDirectEigenSolver()
 
 CDirectEigenSolver::CDirectEigenSolver(
 	CDenseMatrixOperator<float64_t>* linear_operator)
-	: CEigenSolver((CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >*)linear_operator)
+	: CEigenSolver((CLinearOperator<float64_t>*)linear_operator)
 {
 	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 }

--- a/src/shogun/mathematics/linalg/eigsolver/EigenSolver.h
+++ b/src/shogun/mathematics/linalg/eigsolver/EigenSolver.h
@@ -37,7 +37,7 @@ public:
 	 * @param linear_operator real valued self-adjoint linear operator
 	 * whose eigenvalues have to be found
 	 */
-	CEigenSolver(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator)
+	CEigenSolver(CLinearOperator<float64_t>* linear_operator)
 	: CSGObject()
 	{
 		init();
@@ -96,7 +96,7 @@ protected:
 	float64_t m_max_eigenvalue;
 
 	/** the linear solver whose eigenvalues have to be found */
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* m_linear_operator;
+	CLinearOperator<float64_t>* m_linear_operator;
 
 	/** flag that denotes that the minimum eigenvalue is already computed */
 	bool m_is_computed_min;

--- a/src/shogun/mathematics/linalg/eigsolver/LanczosEigenSolver.cpp
+++ b/src/shogun/mathematics/linalg/eigsolver/LanczosEigenSolver.cpp
@@ -33,7 +33,7 @@ CLanczosEigenSolver::CLanczosEigenSolver()
 }
 
 CLanczosEigenSolver::CLanczosEigenSolver(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator)
+	CLinearOperator<float64_t>* linear_operator)
 	: CEigenSolver(linear_operator)
 {
 	init();

--- a/src/shogun/mathematics/linalg/eigsolver/LanczosEigenSolver.h
+++ b/src/shogun/mathematics/linalg/eigsolver/LanczosEigenSolver.h
@@ -18,7 +18,7 @@
 
 namespace shogun
 {
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Class that computes eigenvalues of a real valued, self-adjoint
  * linear operator using Lanczos algorithm
@@ -35,7 +35,7 @@ public:
 	 * @param linear_operator self-adjoint linear operator whose eigenvalues
 	 * are to be found
 	 */
-	CLanczosEigenSolver(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator);
+	CLanczosEigenSolver(CLinearOperator<float64_t>* linear_operator);
 
 	/** destructor */
 	virtual ~CLanczosEigenSolver();

--- a/src/shogun/mathematics/linalg/linop/DenseMatrixOperator.h
+++ b/src/shogun/mathematics/linalg/linop/DenseMatrixOperator.h
@@ -91,7 +91,6 @@ public:
 			for (index_t j=0; j<m_operator.num_rows; ++j)
 				casted_m(j,i)=static_cast<Scalar>(m_operator(j,i));
 		}
-		SG_SDEBUG("DenseMatrixOperator::static_cast(): Creating casted operator!\n");
 
 		return new CDenseMatrixOperator<Scalar>(casted_m);
 	}

--- a/src/shogun/mathematics/linalg/linop/LinearOperator.cpp
+++ b/src/shogun/mathematics/linalg/linop/LinearOperator.cpp
@@ -9,21 +9,59 @@
  */
 
 #include <shogun/mathematics/linalg/linop/LinearOperator.h>
+#include <shogun/base/Parameter.h>
 
 namespace shogun
 {
-template class CLinearOperator<SGVector<bool>, SGVector<bool> >;
-template class CLinearOperator<SGVector<char>, SGVector<char> >;
-template class CLinearOperator<SGVector<int8_t>, SGVector<int8_t> >;
-template class CLinearOperator<SGVector<uint8_t>, SGVector<uint8_t> >;
-template class CLinearOperator<SGVector<int16_t>, SGVector<int16_t> >;
-template class CLinearOperator<SGVector<uint16_t>, SGVector<uint16_t> >;
-template class CLinearOperator<SGVector<int32_t>, SGVector<int32_t> >;
-template class CLinearOperator<SGVector<uint32_t>, SGVector<uint32_t> >;
-template class CLinearOperator<SGVector<int64_t>, SGVector<int64_t> >;
-template class CLinearOperator<SGVector<uint64_t>, SGVector<uint64_t> >;
-template class CLinearOperator<SGVector<float32_t>, SGVector<float32_t> >;
-template class CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >;
-template class CLinearOperator<SGVector<floatmax_t>, SGVector<floatmax_t> >;
-template class CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >;
+
+template<class T>
+CLinearOperator<T>::CLinearOperator() : CSGObject()
+{
+	init();
+}
+
+template<class T>
+CLinearOperator<T>::CLinearOperator(index_t dimension) : CSGObject()
+{
+	init();
+
+	m_dimension=dimension;
+}
+
+template<class T>
+CLinearOperator<T>::~CLinearOperator()
+{
+}
+
+template<class T>
+const index_t CLinearOperator<T>::get_dimension() const
+{
+	return m_dimension;
+}
+
+template<class T>
+void CLinearOperator<T>::init()
+{
+	m_dimension=0;
+
+	SG_ADD(&m_dimension, "dimension",
+		"Dimension of the vector on which linear operator can apply",
+		MS_NOT_AVAILABLE);
+}
+
+template class CLinearOperator<bool>;
+template class CLinearOperator<char>;
+template class CLinearOperator<int8_t>;
+template class CLinearOperator<uint8_t>;
+template class CLinearOperator<int16_t>;
+template class CLinearOperator<uint16_t>;
+template class CLinearOperator<int32_t>;
+template class CLinearOperator<uint32_t>;
+template class CLinearOperator<int64_t>;
+template class CLinearOperator<uint64_t>;
+template class CLinearOperator<float32_t>;
+template class CLinearOperator<float64_t>;
+template class CLinearOperator<floatmax_t>;
+template class CLinearOperator<complex128_t>;
+
 }

--- a/src/shogun/mathematics/linalg/linop/LinearOperator.h
+++ b/src/shogun/mathematics/linalg/linop/LinearOperator.h
@@ -12,53 +12,32 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/base/SGObject.h>
-#include <shogun/base/Parameter.h>
 
 namespace shogun
 {
-template<class T> class SGVector;
 
 /** @brief Abstract template base class that represents a linear operator,
  *  e.g. a matrix
  */
-template<class RetType, class OperandType> class CLinearOperator : public CSGObject
+template<class T>
+class CLinearOperator : public CSGObject
 {
 public:
 	/** default constructor */
-	CLinearOperator()
-	: CSGObject()
-	{
-		init();
-
-		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
-	}
+	CLinearOperator();
 
 	/**
 	 * constructor
 	 *
 	 * @param dimension dimension of the vector on which the operator can be applied
 	 */
-	CLinearOperator(index_t dimension)
-	: CSGObject()
-	{
-		init();
-
-		m_dimension=dimension;
-
-		SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
-	}
+	CLinearOperator(index_t dimension);
 
 	/** destructor */
-	virtual ~CLinearOperator()
-	{
-		SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
-	}
+	virtual ~CLinearOperator();
 
 	/** @return the dimension on which the linear operator can apply */
-	const index_t get_dimension() const
-	{
-		return m_dimension;
-	}
+	const index_t get_dimension() const;
 
 	/**
 	 * abstract method that applies the linear operator to Operand(eg. a vector)
@@ -66,29 +45,24 @@ public:
 	 * @param b the Operand to which the linear operator applies
 	 * @return the result(eg. a vector)
 	 */
-	virtual RetType apply(OperandType b) const = 0;
+	virtual SGVector<T> apply(SGVector<T> b) const=0;
 
 	/** @return object name */
 	virtual const char* get_name() const
 	{
 		return "LinearOperator";
 	}
+
 protected:
 	/** the dimension of vector on which the linear operator can apply */
 	index_t m_dimension;
 
 private:
 	/** initialize with default values and register params */
-	void init()
-	{
-		m_dimension=0;
-
-		SG_ADD(&m_dimension, "dimension",
-			"Dimension of the vector on which linear operator can apply",
-			MS_NOT_AVAILABLE);
-	}
+	void init();
 
 };
+
 }
 
 #endif // LINEAR_OPERATOR_H_

--- a/src/shogun/mathematics/linalg/linop/MatrixOperator.h
+++ b/src/shogun/mathematics/linalg/linop/MatrixOperator.h
@@ -23,12 +23,12 @@ namespace shogun
  * \mathbb{C}^{n}\f$ being the vector. The result is a vector \f$y\in
  * \mathbb{C}^{m}\f$.
  */
-template<class T> class CMatrixOperator : public CLinearOperator<SGVector<T>, SGVector<T> >
+template<class T> class CMatrixOperator : public CLinearOperator<T>
 {
 public:
 	/** default constructor */
 	CMatrixOperator()
-	: CLinearOperator<SGVector<T>, SGVector<T> >()
+	: CLinearOperator<T>()
 	{
 	}
 
@@ -38,7 +38,7 @@ public:
 	 * @param dimension the dimension of the vector on which this it can apply
 	 */
 	CMatrixOperator(index_t dimension)
-	: CLinearOperator<SGVector<T>, SGVector<T> >(dimension)
+	: CLinearOperator<T>(dimension)
 	{
 	}
 

--- a/src/shogun/mathematics/linalg/linsolver/CGMShiftedFamilySolver.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/CGMShiftedFamilySolver.cpp
@@ -39,7 +39,7 @@ CCGMShiftedFamilySolver::~CCGMShiftedFamilySolver()
 }
 
 SGVector<float64_t> CCGMShiftedFamilySolver::solve(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
+	CLinearOperator<float64_t>* A, SGVector<float64_t> b)
 {
 	SGVector<complex128_t> shifts(1);
 	shifts[0]=0.0;
@@ -50,7 +50,7 @@ SGVector<float64_t> CCGMShiftedFamilySolver::solve(
 }
 
 SGVector<complex128_t> CCGMShiftedFamilySolver::solve_shifted_weighted(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b,
+	CLinearOperator<float64_t>* A, SGVector<float64_t> b,
 	SGVector<complex128_t> shifts, SGVector<complex128_t> weights)
 {
 	SG_DEBUG("Entering\n");

--- a/src/shogun/mathematics/linalg/linsolver/CGMShiftedFamilySolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/CGMShiftedFamilySolver.h
@@ -17,7 +17,7 @@
 
 namespace shogun
 {
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class SGVector;
 
 /**
@@ -50,7 +50,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<float64_t> solve(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A,
+	virtual SGVector<float64_t> solve(CLinearOperator<float64_t>* A,
 		SGVector<float64_t> b);
 
 	/**
@@ -65,7 +65,7 @@ public:
 	 * shift
 	 */
 	virtual SGVector<complex128_t> solve_shifted_weighted(
-		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b,
+		CLinearOperator<float64_t>* A, SGVector<float64_t> b,
 		SGVector<complex128_t> shifts, SGVector<complex128_t> weights);
 
 	/** @return object name */

--- a/src/shogun/mathematics/linalg/linsolver/ConjugateGradientSolver.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/ConjugateGradientSolver.cpp
@@ -12,6 +12,7 @@
 #ifdef HAVE_EIGEN3
 
 #include <shogun/lib/SGVector.h>
+#include <shogun/io/SGIO.h>
 #include <shogun/lib/Time.h>
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/linalg/linop/LinearOperator.h>
@@ -41,7 +42,7 @@ CConjugateGradientSolver::~CConjugateGradientSolver()
 }
 
 SGVector<float64_t> CConjugateGradientSolver::solve(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
+	CLinearOperator<float64_t>* A, SGVector<float64_t> b)
 {
 	SG_DEBUG("CConjugateGradientSolve::solve(): Entering..\n");
 

--- a/src/shogun/mathematics/linalg/linsolver/ConjugateGradientSolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/ConjugateGradientSolver.h
@@ -17,7 +17,7 @@
 
 namespace shogun
 {
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class SGVector;
 
 /**
@@ -45,7 +45,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<float64_t> solve(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A,
+	virtual SGVector<float64_t> solve(CLinearOperator<float64_t>* A,
 		SGVector<float64_t> b);
 
 	/** @return object name */

--- a/src/shogun/mathematics/linalg/linsolver/ConjugateOrthogonalCGSolver.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/ConjugateOrthogonalCGSolver.cpp
@@ -41,7 +41,7 @@ CConjugateOrthogonalCGSolver::~CConjugateOrthogonalCGSolver()
 }
 
 SGVector<complex128_t> CConjugateOrthogonalCGSolver::solve(
-	CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* A, SGVector<float64_t> b)
+	CLinearOperator<complex128_t>* A, SGVector<float64_t> b)
 {
 	SG_DEBUG("CConjugateOrthogonalCGSolver::solve(): Entering..\n");
 

--- a/src/shogun/mathematics/linalg/linsolver/ConjugateOrthogonalCGSolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/ConjugateOrthogonalCGSolver.h
@@ -17,7 +17,7 @@
 
 namespace shogun
 {
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class SGVector;
 
 /**
@@ -51,7 +51,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<complex128_t> solve(CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* A,
+	virtual SGVector<complex128_t> solve(CLinearOperator<complex128_t>* A,
 		SGVector<float64_t> b);
 
 	/** @return object name */

--- a/src/shogun/mathematics/linalg/linsolver/DirectLinearSolverComplex.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectLinearSolverComplex.cpp
@@ -12,6 +12,7 @@
 #ifdef HAVE_EIGEN3
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGMatrix.h>
+#include <shogun/io/SGIO.h>
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/linalg/linop/DenseMatrixOperator.h>
 #include <shogun/mathematics/linalg/linsolver/DirectLinearSolverComplex.h>
@@ -41,7 +42,7 @@ CDirectLinearSolverComplex::~CDirectLinearSolverComplex()
 }
 
 SGVector<complex128_t> CDirectLinearSolverComplex::solve(
-		CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* A, SGVector<float64_t> b)
+		CLinearOperator<complex128_t>* A, SGVector<float64_t> b)
 {
 	SGVector<complex128_t> x(b.vlen);
 

--- a/src/shogun/mathematics/linalg/linsolver/DirectLinearSolverComplex.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectLinearSolverComplex.h
@@ -54,8 +54,8 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<complex128_t> solve(
-		CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* A, SGVector<float64_t> b);
+	virtual SGVector<complex128_t> solve(CLinearOperator<complex128_t>* A,
+			SGVector<float64_t> b);
 
 	/** @return object name */
 	virtual const char* get_name() const

--- a/src/shogun/mathematics/linalg/linsolver/DirectSparseLinearSolver.cpp
+++ b/src/shogun/mathematics/linalg/linsolver/DirectSparseLinearSolver.cpp
@@ -31,7 +31,7 @@ CDirectSparseLinearSolver::~CDirectSparseLinearSolver()
 }
 
 SGVector<float64_t> CDirectSparseLinearSolver::solve(
-		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A, SGVector<float64_t> b)
+		CLinearOperator<float64_t>* A, SGVector<float64_t> b)
 {
 	REQUIRE(A, "Operator is NULL!\n");
 	REQUIRE(A->get_dimension()==b.vlen, "Dimension mismatch!\n");

--- a/src/shogun/mathematics/linalg/linsolver/DirectSparseLinearSolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/DirectSparseLinearSolver.h
@@ -37,7 +37,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<float64_t> solve(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A,
+	virtual SGVector<float64_t> solve(CLinearOperator<float64_t>* A,
 		SGVector<float64_t> b);
 
 	/** @return object name */

--- a/src/shogun/mathematics/linalg/linsolver/IterativeLinearSolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/IterativeLinearSolver.h
@@ -42,7 +42,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<T> solve(CLinearOperator<SGVector<T>, SGVector<T> >* A, SGVector<ST> b) = 0;
+	virtual SGVector<T> solve(CLinearOperator<T>* A, SGVector<ST> b) = 0;
 
 	/** set maximum iteration limit */
 	void set_iteration_limit(index_t iteration_limit)

--- a/src/shogun/mathematics/linalg/linsolver/IterativeShiftedLinearFamilySolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/IterativeShiftedLinearFamilySolver.h
@@ -16,7 +16,7 @@
 namespace shogun
 {
 template <class T> class SGVector;
-template <class RetType, class OperandType> class CLinearOperator;
+template <class T> class CLinearOperator;
 
 /**
  * @brief abstract template base for CG based solvers to the solution of
@@ -52,7 +52,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<T> solve(CLinearOperator<SGVector<T>, SGVector<T> >* A, SGVector<T> b) = 0;
+	virtual SGVector<T> solve(CLinearOperator<T>* A, SGVector<T> b) = 0;
 
 	/**
 	 * abstract method that solves the shifted family of linear systems, multiples
@@ -65,7 +65,7 @@ public:
 	 * @param weights the weights to be multiplied with each solution for each
 	 * shift
 	 */
-	virtual SGVector<ST> solve_shifted_weighted(CLinearOperator<SGVector<T>, SGVector<T> >* A,
+	virtual SGVector<ST> solve_shifted_weighted(CLinearOperator<T>* A,
 		SGVector<T> b, SGVector<ST> shifts, SGVector<ST> weights) = 0;
 
 	/** @return object name */

--- a/src/shogun/mathematics/linalg/linsolver/LinearSolver.h
+++ b/src/shogun/mathematics/linalg/linsolver/LinearSolver.h
@@ -16,7 +16,7 @@
 namespace shogun
 {
 template<class T> class SGVector;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Abstract template base class that provides an abstract solve method
  * for linear systems, that takes a linear operator \f$A\f$, a vector \f$b\f$,
@@ -43,7 +43,7 @@ public:
 	 * @param b the vector of the system
 	 * @return the solution vector
 	 */
-	virtual SGVector<T> solve(CLinearOperator<SGVector<T>, SGVector<T> >* A, SGVector<ST> b) = 0;
+	virtual SGVector<T> solve(CLinearOperator<T>* A, SGVector<ST> b) = 0;
 
 	/** @return object name */
 	virtual const char* get_name() const

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/computation/aggregator/IndividualJobResultAggregator.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/computation/aggregator/IndividualJobResultAggregator.cpp
@@ -31,7 +31,7 @@ CIndividualJobResultAggregator::CIndividualJobResultAggregator()
 }
 
 CIndividualJobResultAggregator::CIndividualJobResultAggregator(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+	CLinearOperator<float64_t>* linear_operator,
 	SGVector<float64_t> vector,
 	const float64_t& const_multiplier)
 	: CStoreVectorAggregator<complex128_t>(vector.vlen),

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/computation/aggregator/IndividualJobResultAggregator.h
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/computation/aggregator/IndividualJobResultAggregator.h
@@ -19,7 +19,7 @@ namespace shogun
 {
 class CJobResult;
 template<class T> class SGVector;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Class that aggregates vector job results in each submit_result call
  * of jobs generated from rational approximation of linear operator function
@@ -44,7 +44,7 @@ public:
 	 * @param const_multiplier the constant multiplier to be multiplied with
 	 * the final vector-vector product to give final result
 	 */
-	CIndividualJobResultAggregator(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >*
+	CIndividualJobResultAggregator(CLinearOperator<float64_t>*
 		linear_operator, SGVector<float64_t> vector,
 		const float64_t& const_multiplier);
 
@@ -64,7 +64,7 @@ public:
 	}
 private:
 	/** the linear operator */
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* m_linear_operator;
+	CLinearOperator<float64_t>* m_linear_operator;
 
 	/** the sample vector */
 	SGVector<float64_t> m_vector;

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationCGMJob.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationCGMJob.cpp
@@ -32,7 +32,7 @@ CRationalApproximationCGMJob::CRationalApproximationCGMJob()
 CRationalApproximationCGMJob::CRationalApproximationCGMJob(
 	CStoreScalarAggregator<float64_t>* aggregator,
 	CCGMShiftedFamilySolver* linear_solver,
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+	CLinearOperator<float64_t>* linear_operator,
 	SGVector<float64_t> vector,
 	SGVector<complex128_t> shifts,
 	SGVector<complex128_t> weights,

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationCGMJob.h
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationCGMJob.h
@@ -18,7 +18,7 @@
 namespace shogun
 {
 template<class T> class SGVector;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T> class CStoreScalarAggregator;
 class CCGMShiftedFamilySolver;
 
@@ -46,7 +46,7 @@ public:
 	 */
 	CRationalApproximationCGMJob(CStoreScalarAggregator<float64_t>* aggregator,
 		CCGMShiftedFamilySolver* linear_solver,
-		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+		CLinearOperator<float64_t>* linear_operator,
 		SGVector<float64_t> vector, SGVector<complex128_t> shifts,
 		SGVector<complex128_t> weights, float64_t const_multiplier);
 
@@ -64,7 +64,7 @@ public:
 
 private:
 	/** the real valued linear operator of linear system to be solved */
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* m_operator;
+	CLinearOperator<float64_t>* m_operator;
 
 	/** the vector of the system to be solved */
 	SGVector<float64_t> m_vector;

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationIndividualJob.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationIndividualJob.cpp
@@ -35,7 +35,7 @@ CRationalApproximationIndividualJob::CRationalApproximationIndividualJob()
 CRationalApproximationIndividualJob::CRationalApproximationIndividualJob(
 	CJobResultAggregator* aggregator,
 	CLinearSolver<complex128_t, float64_t>* linear_solver,
-	CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* linear_operator,
+	CLinearOperator<complex128_t>* linear_operator,
 	SGVector<float64_t> vector,
 	complex128_t weight)
 	: CIndependentJob(aggregator)

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationIndividualJob.h
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/computation/job/RationalApproximationIndividualJob.h
@@ -18,7 +18,7 @@
 namespace shogun
 {
 template<class T> class SGVector;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 template<class T, class ST> class CLinearSolver;
 
 /** @brief Implementation of independent job that solves one of the family
@@ -46,7 +46,7 @@ public:
 	 */
 	CRationalApproximationIndividualJob(CJobResultAggregator* aggregator,
 		CLinearSolver<complex128_t, float64_t>* linear_solver,
-		CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* linear_operator,
+		CLinearOperator<complex128_t>* linear_operator,
 		SGVector<float64_t> vector, complex128_t weight);
 
 	/** destructor */
@@ -63,7 +63,7 @@ public:
 
 private:
 	/** the shifted operator for linear system to be solved */
-	CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >* m_operator;
+	CLinearOperator<complex128_t>* m_operator;
 
 	/** the vector of the system to be solved */
 	SGVector<float64_t> m_vector;

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/DenseMatrixExactLog.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/DenseMatrixExactLog.cpp
@@ -38,8 +38,7 @@ CDenseMatrixExactLog::CDenseMatrixExactLog()
 CDenseMatrixExactLog::CDenseMatrixExactLog(
 	CDenseMatrixOperator<float64_t>* op,
 	CIndependentComputationEngine* engine)
-	: COperatorFunction<float64_t>(
-		(CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >*)op, engine, OF_LOG)
+	: COperatorFunction<float64_t>((CLinearOperator<float64_t>*)op, engine, OF_LOG)
 {
 	SG_GCDEBUG("%s created (%p)\n", this->get_name(), this)
 }

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/LogRationalApproximationCGM.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/LogRationalApproximationCGM.cpp
@@ -33,7 +33,7 @@ CLogRationalApproximationCGM::CLogRationalApproximationCGM()
 }
 
 CLogRationalApproximationCGM::CLogRationalApproximationCGM(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+	CLinearOperator<float64_t>* linear_operator,
 	CIndependentComputationEngine* computation_engine,
 	CEigenSolver* eigen_solver,
 	CCGMShiftedFamilySolver* linear_solver,

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/LogRationalApproximationCGM.h
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/LogRationalApproximationCGM.h
@@ -19,7 +19,7 @@ namespace shogun
 {
 
 template<class T> class SGVector;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 class CCGMShiftedFamilySolver;
 class CJobResultAggregator;
 class CIndependentComputationEngine;
@@ -49,7 +49,7 @@ public:
 	 * the number of shifts automatically
 	 */
 	CLogRationalApproximationCGM(
-		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+		CLinearOperator<float64_t>* linear_operator,
 		CIndependentComputationEngine* computation_engine,
 		CEigenSolver* eigen_solver,
 		CCGMShiftedFamilySolver* linear_solver,

--- a/src/shogun/mathematics/linalg/ratapprox/opfunc/OperatorFunction.h
+++ b/src/shogun/mathematics/linalg/ratapprox/opfunc/OperatorFunction.h
@@ -30,7 +30,7 @@ enum EOperatorFunction
 
 template<class T> class SGVector;
 class CJobResultAggregator;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 
 /** @brief Abstract template base class for computing \f$s^{T} f(C) s\f$ for a
  * linear operator C and a vector s. submit_jobs method creates a bunch of jobs
@@ -55,7 +55,7 @@ public:
 	 * @param engine the computation engine for the independent jobs
 	 * @param type the type of the operator function (sqrt, log, etc)
 	 */
-	COperatorFunction(CLinearOperator<SGVector<T>, SGVector<T> >* op,
+	COperatorFunction(CLinearOperator<T>* op,
 		CIndependentComputationEngine* engine,
 		EOperatorFunction type=OF_UNDEFINED)
 	: CSGObject(),
@@ -78,7 +78,7 @@ public:
 	}
 
 	/** @return the operator */
-	CLinearOperator<SGVector<T>, SGVector<T> >* get_operator() const
+	CLinearOperator<T>* get_operator() const
 	{
 		return m_linear_operator;
 	}
@@ -109,7 +109,7 @@ public:
 	}
 protected:
 	/** the linear operator */
-	CLinearOperator<SGVector<T>, SGVector<T> >* m_linear_operator;
+	CLinearOperator<T>* m_linear_operator;
 
 	/** the computation engine */
 	CIndependentComputationEngine* m_computation_engine;

--- a/src/shogun/mathematics/linalg/ratapprox/opfunc/RationalApproximation.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/opfunc/RationalApproximation.cpp
@@ -31,7 +31,7 @@ CRationalApproximation::CRationalApproximation()
 }
 
 CRationalApproximation::CRationalApproximation(
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+	CLinearOperator<float64_t>* linear_operator,
 	CIndependentComputationEngine* computation_engine,
 	CEigenSolver* eigen_solver,
 	float64_t desired_accuracy,

--- a/src/shogun/mathematics/linalg/ratapprox/opfunc/RationalApproximation.h
+++ b/src/shogun/mathematics/linalg/ratapprox/opfunc/RationalApproximation.h
@@ -18,7 +18,7 @@ namespace shogun
 {
 
 template<class T> class SGVector;
-template<class RetType, class OperandType> class CLinearOperator;
+template<class T> class CLinearOperator;
 class CIndependentComputationEngine;
 class CJobResultAggregator;
 class CEigenSolver;
@@ -79,7 +79,7 @@ public:
 	 * @param function_type operator function type
 	 */
 	CRationalApproximation(
-		CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* linear_operator,
+		CLinearOperator<float64_t>* linear_operator,
 		CIndependentComputationEngine* computation_engine,
 		CEigenSolver* eigen_solver,
 		float64_t desired_accuracy,

--- a/tests/unit/mathematics/linalg/DirectLinearSolverComplex_unittest.cc
+++ b/tests/unit/mathematics/linalg/DirectLinearSolverComplex_unittest.cc
@@ -37,7 +37,7 @@ TEST(DirectLinearSolverComplex, solve_SVD)
 
 	CDirectLinearSolverComplex solver(DS_SVD);
 	SGVector<complex128_t> x
-		=solver.solve((CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >*)A, b);
+		=solver.solve((CLinearOperator<complex128_t>*)A, b);
 
 	SGVector<complex128_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -66,7 +66,7 @@ TEST(DirectLinearSolverComplex, solve_QR_NOPERM)
 
 	CDirectLinearSolverComplex solver(DS_QR_NOPERM);
 	SGVector<complex128_t> x
-		=solver.solve((CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >*)A, b);
+		=solver.solve((CLinearOperator<complex128_t>*)A, b);
 
 	SGVector<complex128_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -95,7 +95,7 @@ TEST(DirectLinearSolverComplex, solve_QR_COLPERM)
 
 	CDirectLinearSolverComplex solver(DS_QR_COLPERM);
 	SGVector<complex128_t> x
-		=solver.solve((CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >*)A, b);
+		=solver.solve((CLinearOperator<complex128_t>*)A, b);
 
 	SGVector<complex128_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -124,7 +124,7 @@ TEST(DirectLinearSolverComplex, solve_QR_FULLPERM)
 
 	CDirectLinearSolverComplex solver(DS_QR_FULLPERM);
 	SGVector<complex128_t> x
-		=solver.solve((CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >*)A, b);
+		=solver.solve((CLinearOperator<complex128_t>*)A, b);
 
 	SGVector<complex128_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);
@@ -154,7 +154,7 @@ TEST(DirectLinearSolverComplex, solve_LLT)
 
 	CDirectLinearSolverComplex solver(DS_LLT);
 	SGVector<complex128_t> x
-		=solver.solve((CLinearOperator<SGVector<complex128_t>, SGVector<complex128_t> >*)A, b);
+		=solver.solve((CLinearOperator<complex128_t>*)A, b);
 
 	SGVector<complex128_t> bp=A->apply(x);
 	Map<VectorXd> map_b(b.vector, b.vlen);

--- a/tests/unit/mathematics/linalg/LanczosEigenSolver_unittest.cc
+++ b/tests/unit/mathematics/linalg/LanczosEigenSolver_unittest.cc
@@ -41,7 +41,7 @@ TEST(LanczosEigenSolver, compute)
 	SGSparseMatrix<float64_t> mat=feat.get_sparse_feature_matrix();
 	CEigenSolver* eig_solver=NULL;
 
-	CLinearOperator<SGVector<float64_t>, SGVector<float64_t> >* A=new CSparseMatrixOperator<float64_t>(mat);
+	CLinearOperator<float64_t>* A=new CSparseMatrixOperator<float64_t>(mat);
 	SG_REF(A);
 
 	eig_solver=new CLanczosEigenSolver(A);


### PR DESCRIPTION
 - CLinearOperator has only one template parameter now
   since the other template parameter is not used anywhere.