### PR TITLE
Fix issue 2766. Changed all 'initialize' methods names

### DIFF
--- a/doc/OpenCV_docs/OpenCV_NN_vs_Shogun_NN.md
+++ b/doc/OpenCV_docs/OpenCV_NN_vs_Shogun_NN.md
@@ -286,7 +286,7 @@ The hidden layer has ```10``` neurons and similarly the output layer has ```4```
 * Initialize the network. The input is nothing but the standard deviation of the gaussian which is used to randomly initialize the parameters. We chose ```0.1``` here.
 
 ```CPP
-    network->initialize(0.1);
+    network->initialize_neural_network(0.1);
 ```
 
 * Specify the training parameters if needed.

--- a/doc/OpenCV_docs/OpenCV_NN_vs_Shogun_NN.md
+++ b/doc/OpenCV_docs/OpenCV_NN_vs_Shogun_NN.md
@@ -249,7 +249,7 @@ To use Neural Networks in **Shogun** the following things need to be done:
 
 * Specify how the layers are connected together. This can be done using either ```connect()``` or ```quick_connect()```.
 
-* Call ```initialize()```.
+* Call ```initialize_neural_network()```.
 
 * Specify the training parameters if needed.
 

--- a/doc/ipython-notebooks/neuralnets/neuralnets_digits.ipynb
+++ b/doc/ipython-notebooks/neuralnets/neuralnets_digits.ipynb
@@ -127,19 +127,19 @@
       "# create the networks\n",
       "net_no_reg = NeuralNetwork(layers)\n",
       "net_no_reg.quick_connect()\n",
-      "net_no_reg.initialize()\n",
+      "net_no_reg.initialize_neural_network()\n",
       "\n",
       "net_l2 = NeuralNetwork(layers)\n",
       "net_l2.quick_connect()\n",
-      "net_l2.initialize()\n",
+      "net_l2.initialize_neural_network()\n",
       "\n",
       "net_l1 = NeuralNetwork(layers)\n",
       "net_l1.quick_connect()\n",
-      "net_l1.initialize()\n",
+      "net_l1.initialize_neural_network()\n",
       "\n",
       "net_dropout = NeuralNetwork(layers)\n",
       "net_dropout.quick_connect()\n",
-      "net_dropout.initialize()"
+      "net_dropout.initialize_neural_network()"
      ],
      "language": "python",
      "metadata": {},
@@ -413,7 +413,7 @@
       "# create and initialize the network\n",
       "net_conv = NeuralNetwork(layers_conv)\n",
       "net_conv.quick_connect()\n",
-      "net_conv.initialize()"
+      "net_conv.initialize_neural_network()"
      ],
      "language": "python",
      "metadata": {},

--- a/doc/ipython-notebooks/neuralnets/rbms_dbns.ipynb
+++ b/doc/ipython-notebooks/neuralnets/rbms_dbns.ipynb
@@ -181,7 +181,7 @@
       "rbms = []\n",
       "for i in range(10):\n",
       "    rbms.append(RBM(25, 256, RBMVUT_BINARY)) # 25 hidden units, 256 visible units (one for each pixel in a 16x16 binary image)\n",
-      "    rbms[i].initialize()"
+      "    rbms[i].initialize_neural_network()"
      ],
      "language": "python",
      "metadata": {},
@@ -297,7 +297,7 @@
      "source": [
       "Now we'll create a DBN, pre-train it on the digits dataset, and use it initialize a neural network which we can use for classification.\n",
       "\n",
-      "DBNs are handled in Shogun through the [CDeepBeliefNetwork](http://www.shogun-toolbox.org/doc/en/latest/classshogun_1_1CDeepBeliefNetwork.html) class. We create a network by specifying the number of visible units it has, and then add the desired number of hidden layers using [add_hidden_layer()](http://www.shogun-toolbox.org/doc/en/latest/classshogun_1_1CDeepBeliefNetwork.html#ae765aad072aef83a41906140c9f9a8c5). When done, we call [initialize()](http://www.shogun-toolbox.org/doc/en/latest/classshogun_1_1CDeepBeliefNetwork.html#aae4e01a7cfd234a1895b40be197ef83a) to initialize the network:"
+      "DBNs are handled in Shogun through the [CDeepBeliefNetwork](http://www.shogun-toolbox.org/doc/en/latest/classshogun_1_1CDeepBeliefNetwork.html) class. We create a network by specifying the number of visible units it has, and then add the desired number of hidden layers using [add_hidden_layer()](http://www.shogun-toolbox.org/doc/en/latest/classshogun_1_1CDeepBeliefNetwork.html#ae765aad072aef83a41906140c9f9a8c5). When done, we call [initialize_neural_network()](http://www.shogun-toolbox.org/doc/en/latest/classshogun_1_1CDeepBeliefNetwork.html#aae4e01a7cfd234a1895b40be197ef83a) to initialize the network:"
      ]
     },
     {
@@ -310,7 +310,7 @@
       "dbn.add_hidden_layer(200) # 200 units in the first hidden layer\n",
       "dbn.add_hidden_layer(300) # 300 units in the second hidden layer\n",
       "\n",
-      "dbn.initialize()"
+      "dbn.initialize_neural_network()"
      ],
      "language": "python",
      "metadata": {},

--- a/examples/undocumented/libshogun/neuralnets_basic.cpp
+++ b/examples/undocumented/libshogun/neuralnets_basic.cpp
@@ -87,7 +87,7 @@ int main(int, char*[])
 
 	// initialize the network
 	network->quick_connect();
-	network->initialize();
+	network->initialize_neural_network();
 
 	// uncomment this line to enable info logging
 	// network->io->set_loglevel(MSG_INFO);

--- a/examples/undocumented/libshogun/neuralnets_convolutional.cpp
+++ b/examples/undocumented/libshogun/neuralnets_convolutional.cpp
@@ -107,7 +107,7 @@ int main(int, char*[])
 	// create and initialize the network
 	CNeuralNetwork* network = new CNeuralNetwork(layers);
 	network->quick_connect();
-	network->initialize(0.1);
+	network->initialize_neural_network(0.1);
 
 	// uncomment this line to enable info logging
 	// network->io->set_loglevel(MSG_INFO);

--- a/examples/undocumented/libshogun/neuralnets_deep_belief_network.cpp
+++ b/examples/undocumented/libshogun/neuralnets_deep_belief_network.cpp
@@ -82,7 +82,7 @@ int main(int, char*[])
 	dbn->add_hidden_layer(10);
 	dbn->add_hidden_layer(20);
 
-	dbn->initialize();
+	dbn->initialize_neural_network();
 
 	// uncomment this line to enable info logging
 	// dbn->io->set_loglevel(MSG_INFO);

--- a/examples/undocumented/python_modular/neuralnets_simple_modular.py
+++ b/examples/undocumented/python_modular/neuralnets_simple_modular.py
@@ -19,7 +19,7 @@ def neuralnets_simple_modular (train_fname, test_fname,
 	layers = NeuralLayers()
 	network = NeuralNetwork(layers.input(feats_train.get_num_features()).linear(50).softmax(2).done())
 	network.quick_connect()
-	network.initialize()
+	network.initialize_neural_network()
 
 	network.set_labels(labels)
 	network.train(feats_train)

--- a/src/shogun/distributions/HMM.cpp
+++ b/src/shogun/distributions/HMM.cpp
@@ -190,7 +190,7 @@ CHMM::CHMM(CHMM* h)
 
 	this->N=h->get_N();
 	this->M=h->get_M();
-	status=initialize(NULL, h->get_pseudo());
+	status=initialize_hmm(NULL, h->get_pseudo());
 	this->copy_model(h);
 	set_observations(h->p_observations);
 }
@@ -206,7 +206,7 @@ CHMM::CHMM(int32_t p_N, int32_t p_M, Model* p_model, float64_t p_PSEUDO)
 	SG_INFO("hmm is using %i separate tables\n",  parallel->get_num_threads())
 #endif
 
-	status=initialize(p_model, p_PSEUDO);
+	status=initialize_hmm(p_model, p_PSEUDO);
 }
 
 CHMM::CHMM(
@@ -222,7 +222,7 @@ CHMM::CHMM(
 	SG_INFO("hmm is using %i separate tables\n",  parallel->get_num_threads())
 #endif
 
-	initialize(model, p_PSEUDO);
+	initialize_hmm(model, p_PSEUDO);
 	set_observations(obs);
 }
 
@@ -393,7 +393,7 @@ CHMM::CHMM(FILE* model_file, float64_t p_PSEUDO)
 	SG_INFO("hmm is using %i separate tables\n",  parallel->get_num_threads())
 #endif
 
-	status=initialize(NULL, p_PSEUDO, model_file);
+	status=initialize_hmm(NULL, p_PSEUDO, model_file);
 }
 
 CHMM::~CHMM()
@@ -595,7 +595,7 @@ void CHMM::free_state_dependend_arrays()
 	end_state_distribution_q=NULL;
 }
 
-bool CHMM::initialize(Model* m, float64_t pseudo, FILE* modelfile)
+bool CHMM::initialize_hmm(Model* m, float64_t pseudo, FILE* modelfile)
 {
 	//yes optimistic
 	bool files_ok=true;

--- a/src/shogun/distributions/HMM.h
+++ b/src/shogun/distributions/HMM.h
@@ -520,7 +520,7 @@ class CHMM : public CDistribution
 		 * @param PSEUDO Pseudo Value
 		 * @param model_file Filehandle to a hmm model file (*.mod)
 		 */
-		bool initialize(Model* model, float64_t PSEUDO, FILE* model_file=NULL);
+		bool initialize_hmm(Model* model, float64_t PSEUDO, FILE* model_file=NULL);
 		//@}
 
 		/// allocates memory that depends on N

--- a/src/shogun/io/NeuralNetworkFileReader.cpp
+++ b/src/shogun/io/NeuralNetworkFileReader.cpp
@@ -173,7 +173,7 @@ CNeuralNetwork* CNeuralNetworkFileReader::parse_network(json_object* json_networ
 			SG_ERROR("Invalid parameter (%s)\n", iter.key);
 	}
 
-	network->initialize(sigma);
+	network->initialize_neural_network(sigma);
 
 	return network;
 }

--- a/src/shogun/lib/external/ssl.cpp
+++ b/src/shogun/lib/external/ssl.cpp
@@ -36,10 +36,10 @@ void ssl_train(struct data *Data,
 		struct vector_double *Outputs)
 {
 	// initialize
-	initialize(Weights,Data->n,0.0);
-	initialize(Outputs,Data->m,0.0);
+	initialize_ssl(Weights,Data->n,0.0);
+	initialize_ssl(Outputs,Data->m,0.0);
 	vector_int    *Subset  = SG_MALLOC(vector_int, 1);
-	initialize(Subset,Data->m);
+	initialize_ssl(Subset,Data->m);
 	// call the right algorithm
 	int32_t optimality = 0;
 	switch(Options->algo)
@@ -447,7 +447,7 @@ int32_t TSVM_MFN(
 	/* Setup labeled-only examples and train L2_SVM_MFN */
 	struct data *Data_Labeled = SG_MALLOC(data, 1);
 	struct vector_double *Outputs_Labeled = SG_MALLOC(vector_double, 1);
-	initialize(Outputs_Labeled,Data->l,0.0);
+	initialize_ssl(Outputs_Labeled,Data->l,0.0);
 	SG_SDEBUG("Initializing weights, unknown labels")
 	GetLabeledData(Data_Labeled,Data); /* gets labeled data and sets C=1/l */
 	L2_SVM_MFN(Data_Labeled, Options, Weights,Outputs_Labeled,0);
@@ -1080,7 +1080,7 @@ float64_t norm_square(const vector_double *A)
 	return x;
 }
 
-void initialize(struct vector_double *A, int32_t k, float64_t a)
+void initialize_ssl(struct vector_double *A, int32_t k, float64_t a)
 {
 	float64_t *vec = SG_MALLOC(float64_t, k);
 	for (int32_t i=0;i<k;i++)
@@ -1090,7 +1090,7 @@ void initialize(struct vector_double *A, int32_t k, float64_t a)
 	return;
 }
 
-void initialize(struct vector_int *A, int32_t k)
+void initialize_ssl(struct vector_int *A, int32_t k)
 {
 	int32_t *vec = SG_MALLOC(int32_t, k);
 	for(int32_t i=0;i<k;i++)

--- a/src/shogun/lib/external/ssl.h
+++ b/src/shogun/lib/external/ssl.h
@@ -135,9 +135,9 @@ inline bool operator<(const Delta& a , const Delta& b)
 	return (a.delta < b.delta);
 }
 
-void initialize(struct vector_double *A, int32_t k, float64_t a);
+void initialize_ssl(struct vector_double *A, int32_t k, float64_t a);
 /* initializes a vector_double to be of length k, all elements set to a */
-void initialize(struct vector_int *A, int32_t k);
+void initialize_ssl(struct vector_int *A, int32_t k);
 /* initializes a vector_int to be of length k, elements set to 1,2..k. */
 void GetLabeledData(struct data *Data_Labeled, const struct data *Data);
 /* extracts labeled data from Data and copies it into Data_Labeled */

--- a/src/shogun/machine/gp/GaussianARDSparseKernel.cpp
+++ b/src/shogun/machine/gp/GaussianARDSparseKernel.cpp
@@ -39,9 +39,9 @@ using namespace shogun;
 
 CGaussianARDSparseKernel::CGaussianARDSparseKernel() : CGaussianARDKernel()
 {
-	initialize();
+	initialize_sparse_kernel();
 }
-void CGaussianARDSparseKernel::initialize()
+void CGaussianARDSparseKernel::initialize_sparse_kernel()
 {
 }
 
@@ -55,14 +55,14 @@ using namespace Eigen;
 CGaussianARDSparseKernel::CGaussianARDSparseKernel(int32_t size)
 		: CGaussianARDKernel(size)
 {
-	initialize();
+	initialize_sparse_kernel();
 }
 
 CGaussianARDSparseKernel::CGaussianARDSparseKernel(CDotFeatures* l,
 		CDotFeatures* r, int32_t size)
 		: CGaussianARDKernel(l, r, size)
 {
-	initialize();
+	initialize_sparse_kernel();
 }
 
 CGaussianARDSparseKernel* CGaussianARDSparseKernel::obtain_from_generic(CKernel* kernel)

--- a/src/shogun/machine/gp/GaussianARDSparseKernel.h
+++ b/src/shogun/machine/gp/GaussianARDSparseKernel.h
@@ -69,7 +69,7 @@ public:
 	virtual ~CGaussianARDSparseKernel();
 
 private:
-	void initialize();
+	void initialize_sparse_kernel();
 
 #if defined(HAVE_EIGEN3) && defined(HAVE_LINALG_LIB)
 public:

--- a/src/shogun/neuralnets/Autoencoder.cpp
+++ b/src/shogun/neuralnets/Autoencoder.cpp
@@ -65,7 +65,7 @@ CAutoencoder::CAutoencoder(int32_t num_inputs, CNeuralLayer* hidden_layer,
 	hidden_layer->autoencoder_position = NLAP_ENCODING;
 	decoding_layer->autoencoder_position = NLAP_DECODING;
 
-	initialize(sigma);
+	initialize_neural_network(sigma);
 }
 
 CAutoencoder::CAutoencoder(
@@ -89,7 +89,7 @@ CAutoencoder::CAutoencoder(
 	hidden_layer->autoencoder_position = NLAP_ENCODING;
 	decoding_layer->autoencoder_position = NLAP_DECODING;
 
-	initialize(sigma);
+	initialize_neural_network(sigma);
 }
 
 

--- a/src/shogun/neuralnets/DeepAutoencoder.cpp
+++ b/src/shogun/neuralnets/DeepAutoencoder.cpp
@@ -66,7 +66,7 @@ CAutoencoder()
 			get_layer(i)->autoencoder_position = NLAP_DECODING;
 	}
 
-	initialize(m_sigma);
+	initialize_neural_network(m_sigma);
 
 	for (int32_t i=0; i<m_num_layers; i++)
 	{
@@ -185,7 +185,7 @@ CNeuralNetwork* CDeepAutoencoder::convert_to_neural_network(
 
 	CNeuralNetwork* net = new CNeuralNetwork(layers);
 	net->quick_connect();
-	net->initialize(sigma);
+	net->initialize_neural_network(sigma);
 
 	SGVector<float64_t> net_params = net->get_parameters();
 

--- a/src/shogun/neuralnets/DeepBeliefNetwork.cpp
+++ b/src/shogun/neuralnets/DeepBeliefNetwork.cpp
@@ -73,7 +73,7 @@ void CDeepBeliefNetwork::add_hidden_layer(int32_t num_units)
 	m_num_layers++;
 }
 
-void CDeepBeliefNetwork::initialize(float64_t sigma)
+void CDeepBeliefNetwork::initialize_neural_network(float64_t sigma)
 {
 	m_bias_index_offsets = SGVector<int32_t>(m_num_layers);
 	m_weights_index_offsets = SGVector<int32_t>(m_num_layers-1);
@@ -164,7 +164,7 @@ void CDeepBeliefNetwork::pre_train(int32_t index,
 		rbm.add_visible_group(m_layer_sizes->element(index), m_visible_units_type);
 	else
 		rbm.add_visible_group(m_layer_sizes->element(index), RBMVUT_BINARY);
-	rbm.initialize(m_sigma);
+	rbm.initialize_neural_network(m_sigma);
 
 	rbm.cd_num_steps = pt_cd_num_steps[index];
 	rbm.cd_persistent = pt_cd_persistent[index];
@@ -252,7 +252,7 @@ void CDeepBeliefNetwork::train(CDenseFeatures<float64_t>* features)
 	else
 		top_rbm.add_visible_group(m_layer_sizes->element(0), m_visible_units_type);
 
-	top_rbm.initialize();
+	top_rbm.initialize_neural_network();
 	top_rbm.m_params = SGVector<float64_t>(
 		m_params.vector+m_bias_index_offsets[m_num_layers-2],
 		top_rbm.get_num_parameters(), false);
@@ -373,7 +373,7 @@ CNeuralNetwork* CDeepBeliefNetwork::convert_to_neural_network(
 	CNeuralNetwork* network = new CNeuralNetwork(layers);
 
 	network->quick_connect();
-	network->initialize(sigma);
+	network->initialize_neural_network(sigma);
 
 	for (int32_t i=1; i<m_num_layers; i++)
 	{

--- a/src/shogun/neuralnets/DeepBeliefNetwork.h
+++ b/src/shogun/neuralnets/DeepBeliefNetwork.h
@@ -81,7 +81,7 @@ class CNeuralLayer;
  * Steps for using the DBN class:
  * 	- Specify the number of visible units and their type using the constructor
  * 	- Add the hidden layers using add_visible_layer() and add_hidden_layer().
- * 	- Initialize the DBN using initialize()
+ * 	- Initialize the DBN using initialize_neural_network()
  * 	- Pre-train the DBN using pre_train()
  * 	- Optionally do some unsupervised fine-tuning using train()
  * 	- If needed, call convert_to_neural_network() to convert the DBN into a
@@ -116,7 +116,7 @@ public:
 	 * @param sigma Standard deviation of the gaussian used to initialize the
 	 * weights
 	 */
-	virtual void initialize(float64_t sigma = 0.01);
+	virtual void initialize_neural_network(float64_t sigma = 0.01);
 
 	/** Sets the number of train/test cases the RBM will deal with
 	 *

--- a/src/shogun/neuralnets/NeuralConvolutionalLayer.cpp
+++ b/src/shogun/neuralnets/NeuralConvolutionalLayer.cpp
@@ -79,7 +79,7 @@ void CNeuralConvolutionalLayer::set_batch_size(int32_t batch_size)
 }
 
 
-void CNeuralConvolutionalLayer::initialize(CDynamicObjectArray* layers,
+void CNeuralConvolutionalLayer::initialize_neural_layer(CDynamicObjectArray* layers,
 		SGVector< int32_t > input_indices)
 {
 	CNeuralLayer* first_input_layer =
@@ -103,7 +103,7 @@ void CNeuralConvolutionalLayer::initialize(CDynamicObjectArray* layers,
 
 	m_num_neurons = m_width*m_height*m_num_maps;
 
-	CNeuralLayer::initialize(layers, input_indices);
+	CNeuralLayer::initialize_neural_layer(layers, input_indices);
 
 	m_input_num_channels = 0;
 	for (int32_t l=0; l<input_indices.vlen; l++)

--- a/src/shogun/neuralnets/NeuralConvolutionalLayer.h
+++ b/src/shogun/neuralnets/NeuralConvolutionalLayer.h
@@ -125,7 +125,7 @@ public:
 	 * @param input_indices  Indices of the layers that are connected to this
 	 * layer as input
 	 */
-	virtual void initialize(CDynamicObjectArray* layers,
+	virtual void initialize_neural_layer(CDynamicObjectArray* layers,
 			SGVector<int32_t> input_indices);
 
 	/** Initializes the layer's parameters. The layer should fill the given

--- a/src/shogun/neuralnets/NeuralLayer.cpp
+++ b/src/shogun/neuralnets/NeuralLayer.cpp
@@ -58,7 +58,7 @@ CNeuralLayer::~CNeuralLayer()
 {
 }
 
-void CNeuralLayer::initialize(CDynamicObjectArray* layers,
+void CNeuralLayer::initialize_neural_layer(CDynamicObjectArray* layers,
 		SGVector< int32_t > input_indices)
 {
 	m_input_indices = input_indices;

--- a/src/shogun/neuralnets/NeuralLayer.h
+++ b/src/shogun/neuralnets/NeuralLayer.h
@@ -106,7 +106,7 @@ public:
 	 * @param input_indices  Indices of the layers that are connected to this
 	 * layer as input
 	 */
-	virtual void initialize(CDynamicObjectArray* layers,
+	virtual void initialize_neural_layer(CDynamicObjectArray* layers,
 			SGVector<int32_t> input_indices);
 
 	/** Sets the batch_size and allocates memory for m_activations and

--- a/src/shogun/neuralnets/NeuralLinearLayer.cpp
+++ b/src/shogun/neuralnets/NeuralLinearLayer.cpp
@@ -50,10 +50,10 @@ CNeuralLayer(num_neurons)
 {
 }
 
-void CNeuralLinearLayer::initialize(CDynamicObjectArray* layers,
+void CNeuralLinearLayer::initialize_neural_layer(CDynamicObjectArray* layers,
 		SGVector< int32_t > input_indices)
 {
-	CNeuralLayer::initialize(layers, input_indices);
+	CNeuralLayer::initialize_neural_layer(layers, input_indices);
 
 	m_num_parameters = m_num_neurons;
 	for (int32_t i=0; i<input_indices.vlen; i++)

--- a/src/shogun/neuralnets/NeuralLinearLayer.h
+++ b/src/shogun/neuralnets/NeuralLinearLayer.h
@@ -83,7 +83,7 @@ public:
 	 * @param input_indices  Indices of the layers that are connected to this
 	 * layer as input
 	 */
-	virtual void initialize(CDynamicObjectArray* layers,
+	virtual void initialize_neural_layer(CDynamicObjectArray* layers,
 			SGVector<int32_t> input_indices);
 
 	/** Initializes the layer's parameters. The layer should fill the given

--- a/src/shogun/neuralnets/NeuralNetwork.cpp
+++ b/src/shogun/neuralnets/NeuralNetwork.cpp
@@ -95,7 +95,7 @@ void CNeuralNetwork::disconnect_all()
 	m_adj_matrix.zero();
 }
 
-void CNeuralNetwork::initialize(float64_t sigma)
+void CNeuralNetwork::initialize_neural_network(float64_t sigma)
 {
 	for (int32_t j=0; j<m_num_layers; j++)
 	{
@@ -117,7 +117,7 @@ void CNeuralNetwork::initialize(float64_t sigma)
 				}
 			}
 
-			get_layer(j)->initialize(m_layers, input_indices);
+			get_layer(j)->initialize_neural_layer(m_layers, input_indices);
 		}
 	}
 

--- a/src/shogun/neuralnets/NeuralNetwork.h
+++ b/src/shogun/neuralnets/NeuralNetwork.h
@@ -70,7 +70,7 @@ enum ENNOptimizationMethod
  * i must be less than j.
  * 	- Specify how the layers are connected together. This can be done using
  * either connect() or quick_connect().
- * 	- Call initialize()
+ * 	- Call initialize_neural_network()
  * 	- Specify the training parameters if needed
  * 	- Train set_labels() and train()
  * 	- If needed, the network with the learned parameters can be stored on disk
@@ -152,7 +152,7 @@ public:
 	 * @param sigma standard deviation of the gaussian used to randomly
 	 * initialize the parameters
 	 */
-	virtual void initialize(float64_t sigma = 0.01f);
+	virtual void initialize_neural_network(float64_t sigma = 0.01f);
 
 	virtual ~CNeuralNetwork();
 

--- a/src/shogun/neuralnets/RBM.cpp
+++ b/src/shogun/neuralnets/RBM.cpp
@@ -84,7 +84,7 @@ void CRBM::add_visible_group(int32_t num_units, ERBMVisibleUnitType unit_type)
 			m_visible_state_offsets->element(n-1)+m_visible_group_sizes->element(n-1));
 }
 
-void CRBM::initialize(float64_t sigma)
+void CRBM::initialize_neural_network(float64_t sigma)
 {
 	m_num_params = m_num_visible + m_num_hidden + m_num_visible*m_num_hidden;
 	m_params = SGVector<float64_t>(m_num_params);

--- a/src/shogun/neuralnets/RBM.h
+++ b/src/shogun/neuralnets/RBM.h
@@ -159,7 +159,7 @@ public:
 	 * @param sigma Standard deviation of the gaussian used to initialize the
 	 * weights
 	 */
-	virtual void initialize(float64_t sigma=0.01);
+	virtual void initialize_neural_network(float64_t sigma=0.01);
 
 	/** Sets the number of train/test cases the RBM will deal with
 	 *

--- a/src/shogun/preprocessor/BAHSIC.cpp
+++ b/src/shogun/preprocessor/BAHSIC.cpp
@@ -35,10 +35,10 @@ using namespace shogun;
 
 CBAHSIC::CBAHSIC() : CKernelDependenceMaximization()
 {
-	initialize();
+	initialize_parameters();
 }
 
-void CBAHSIC::initialize()
+void CBAHSIC::initialize_parameters()
 {
 	m_estimator=new CHSIC();
 	SG_REF(m_estimator);

--- a/src/shogun/preprocessor/BAHSIC.h
+++ b/src/shogun/preprocessor/BAHSIC.h
@@ -84,7 +84,7 @@ public:
 
 private:
 	/** Register params and initialize with default values */
-	void initialize();
+	void initialize_parameters();
 
 };
 

--- a/src/shogun/preprocessor/DimensionReductionPreprocessor.cpp
+++ b/src/shogun/preprocessor/DimensionReductionPreprocessor.cpp
@@ -15,7 +15,7 @@ CDimensionReductionPreprocessor::CDimensionReductionPreprocessor()
 	m_kernel = new CLinearKernel();
 	m_converter = NULL;
 
-	initialize();
+	initialize_parameters();
 }
 
 CDimensionReductionPreprocessor::CDimensionReductionPreprocessor(CEmbeddingConverter* converter)
@@ -27,7 +27,7 @@ CDimensionReductionPreprocessor::CDimensionReductionPreprocessor(CEmbeddingConve
 	m_kernel = new CLinearKernel();
 	m_converter = converter;
 
-	initialize();
+	initialize_parameters();
 }
 
 CDimensionReductionPreprocessor::~CDimensionReductionPreprocessor()
@@ -104,7 +104,7 @@ CKernel* CDimensionReductionPreprocessor::get_kernel() const
 	return m_kernel;
 }
 
-void CDimensionReductionPreprocessor::initialize()
+void CDimensionReductionPreprocessor::initialize_parameters()
 {
 	SG_ADD((CSGObject**)&m_converter, "converter",
 					  "embedding converter used to apply to data", MS_AVAILABLE);

--- a/src/shogun/preprocessor/DimensionReductionPreprocessor.h
+++ b/src/shogun/preprocessor/DimensionReductionPreprocessor.h
@@ -110,7 +110,7 @@ public:
 private:
 
 	/** default init */
-	void initialize();
+	void initialize_parameters();
 
 protected:
 

--- a/src/shogun/preprocessor/FeatureSelection.cpp
+++ b/src/shogun/preprocessor/FeatureSelection.cpp
@@ -42,11 +42,11 @@ namespace shogun
 template <class ST>
 CFeatureSelection<ST>::CFeatureSelection() : CPreprocessor()
 {
-	initialize();
+	initialize_parameters();
 }
 
 template <class ST>
-void CFeatureSelection<ST>::initialize()
+void CFeatureSelection<ST>::initialize_parameters()
 {
 	SG_ADD(&m_target_dim, "target_dim", "target dimension",
 			MS_NOT_AVAILABLE);

--- a/src/shogun/preprocessor/FeatureSelection.h
+++ b/src/shogun/preprocessor/FeatureSelection.h
@@ -320,7 +320,7 @@ protected:
 
 private:
 	/** Register params and initialize with default values */
-	void initialize();
+	void initialize_parameters();
 
 };
 

--- a/src/shogun/preprocessor/FisherLDA.cpp
+++ b/src/shogun/preprocessor/FisherLDA.cpp
@@ -52,12 +52,12 @@ using namespace shogun;
 CFisherLDA::CFisherLDA (EFLDAMethod method, float64_t thresh):
 	CDimensionReductionPreprocessor()
 {
-	initialize();
+	initialize_parameters();
 	m_method=method;
 	m_threshold=thresh;
 }
 
-void CFisherLDA::initialize()
+void CFisherLDA::initialize_parameters()
 {
 	m_method=AUTO_FLDA;
 	m_threshold=0.01;

--- a/src/shogun/preprocessor/FisherLDA.h
+++ b/src/shogun/preprocessor/FisherLDA.h
@@ -148,7 +148,7 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 
 	private:
 
-		void initialize();
+		void initialize_parameters();
 
 	protected:
 

--- a/src/shogun/preprocessor/KernelDependenceMaximization.cpp
+++ b/src/shogun/preprocessor/KernelDependenceMaximization.cpp
@@ -37,10 +37,10 @@ using namespace shogun;
 CKernelDependenceMaximization::CKernelDependenceMaximization()
 	: CDependenceMaximization()
 {
-	initialize();
+	initialize_parameters();
 }
 
-void CKernelDependenceMaximization::initialize()
+void CKernelDependenceMaximization::initialize_parameters()
 {
 	SG_ADD((CSGObject**)&m_kernel_features, "kernel_features",
 			"the kernel to be used for features", MS_NOT_AVAILABLE);

--- a/src/shogun/preprocessor/KernelDependenceMaximization.h
+++ b/src/shogun/preprocessor/KernelDependenceMaximization.h
@@ -97,7 +97,7 @@ protected:
 
 private:
 	/** Register params and initialize with default values */
-	void initialize();
+	void initialize_parameters();
 
 };
 

--- a/tests/unit/neuralnets/Autoencoder_unittest.cc
+++ b/tests/unit/neuralnets/Autoencoder_unittest.cc
@@ -118,7 +118,7 @@ TEST(Autoencoder, contractive_logistic)
 	CMath::init_random(10);
 
 	CAutoencoder ae(10, new CNeuralLogisticLayer(15));
-	ae.initialize();
+	ae.initialize_neural_network();
 
 	ae.set_contraction_coefficient(1.0);
 

--- a/tests/unit/neuralnets/DeepBeliefNetwork_unittest.cc
+++ b/tests/unit/neuralnets/DeepBeliefNetwork_unittest.cc
@@ -50,7 +50,7 @@ TEST(DeepBeliefNetwork, convert_to_neural_network)
 	dbn.add_hidden_layer(4);
 	dbn.add_hidden_layer(8);
 
-	dbn.initialize();
+	dbn.initialize_neural_network();
 
 	CNeuralNetwork* nn = dbn.convert_to_neural_network();
 

--- a/tests/unit/neuralnets/NeuralLeakyRectifiedLinearLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralLeakyRectifiedLinearLayer_unittest.cc
@@ -63,7 +63,7 @@ TEST(NeuralLeakyRectifiedLinearLayer, compute_activations)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);

--- a/tests/unit/neuralnets/NeuralLinearLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralLinearLayer_unittest.cc
@@ -72,7 +72,7 @@ TEST(NeuralLinearLayer, compute_activations)
 	input_indices[1] = 1;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);
@@ -149,7 +149,7 @@ TEST(NeuralLinearLayer, compute_error)
 
 	// initialize the layer
 	CNeuralLinearLayer layer(y.num_rows);
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);
@@ -198,7 +198,7 @@ TEST(NeuralLinearLayer, compute_local_gradients)
 
 	// initialize the layer
 	CNeuralLinearLayer layer(y.num_rows);
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 0.01);
@@ -268,7 +268,7 @@ TEST(NeuralLinearLayer, compute_parameter_gradients_output)
 
 	// initialize the layer
 	CNeuralLinearLayer layer(y.num_rows);
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 0.01);
@@ -351,7 +351,7 @@ TEST(NeuralLinearLayer, compute_parameter_gradients_hidden)
 		y[i] = CMath::random(0.0,1.0);
 
 	// initialize the hidden layer
-	layer_hid->initialize(layers, input_indices_hid);
+	layer_hid->initialize_neural_layer(layers, input_indices_hid);
 	SGVector<float64_t> param_hid(layer_hid->get_num_parameters());
 	SGVector<bool> param_regularizable_hid(layer_hid->get_num_parameters());
 	layer_hid->initialize_parameters(param_hid, param_regularizable_hid, 0.01);
@@ -359,7 +359,7 @@ TEST(NeuralLinearLayer, compute_parameter_gradients_hidden)
 
 	// initialize the output layer
 	CNeuralLinearLayer layer_out(y.num_rows);
-	layer_out.initialize(layers, input_indices_out);
+	layer_out.initialize_neural_layer(layers, input_indices_out);
 	SGVector<float64_t> param_out(layer_out.get_num_parameters());
 	SGVector<bool> param_regularizable_out(layer_out.get_num_parameters());
 	layer_out.initialize_parameters(param_out, param_regularizable_out, 0.01);

--- a/tests/unit/neuralnets/NeuralLogisticLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralLogisticLayer_unittest.cc
@@ -63,7 +63,7 @@ TEST(NeuralLogisticLayer, compute_activations)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);
@@ -124,7 +124,7 @@ TEST(NeuralLogisticLayer, compute_local_gradients)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);

--- a/tests/unit/neuralnets/NeuralNetwork_unittest.cc
+++ b/tests/unit/neuralnets/NeuralNetwork_unittest.cc
@@ -74,7 +74,7 @@ TEST(NeuralNetwork, backpropagation_linear)
 	network->connect(3,5);
 	network->connect(4,5);
 
-	network->initialize();
+	network->initialize_neural_network();
 	network->l2_coefficient = 0.01;
 	network->l1_coefficient = 0.03;
 
@@ -106,7 +106,7 @@ TEST(NeuralNetwork, neural_layers_builder)
 	network->connect(3,5);
 	network->connect(4,5);
 
-	network->initialize();
+	network->initialize_neural_network();
 	network->l2_coefficient = 0.01;
 	network->l1_coefficient = 0.03;
 
@@ -141,7 +141,7 @@ TEST(NeuralNetwork, backpropagation_logistic)
 	network->connect(3,5);
 	network->connect(4,5);
 
-	network->initialize();
+	network->initialize_neural_network();
 	network->l1_coefficient = 0.03;
 	network->l2_coefficient = 0.01;
 	EXPECT_NEAR(network->check_gradients(), 0.0, tolerance);
@@ -173,7 +173,7 @@ TEST(NeuralNetwork, backpropagation_softmax)
 	network->connect(3,5);
 	network->connect(4,5);
 
-	network->initialize();
+	network->initialize_neural_network();
 	network->l1_coefficient = 0.03;
 	network->l2_coefficient = 0.01;
 	EXPECT_NEAR(network->check_gradients(), 0.0, tolerance);
@@ -205,7 +205,7 @@ TEST(NeuralNetwork, backpropagation_rectified_linear)
 	network->connect(3,5);
 	network->connect(4,5);
 
-	network->initialize();
+	network->initialize_neural_network();
 	network->l1_coefficient = 0.03;
 	network->l2_coefficient = 0.01;
 	EXPECT_NEAR(network->check_gradients(), 0.0, tolerance);
@@ -240,7 +240,7 @@ TEST(NeuralNetwork, backpropagation_convolutional)
 	network->connect(3,5);
 	network->connect(4,5);
 
-	network->initialize();
+	network->initialize_neural_network();
 	network->l1_coefficient = 0.03;
 	network->l2_coefficient = 0.01;
 	EXPECT_NEAR(network->check_gradients(), 0.0, tolerance);

--- a/tests/unit/neuralnets/NeuralNetwork_unittest.cc
+++ b/tests/unit/neuralnets/NeuralNetwork_unittest.cc
@@ -282,7 +282,7 @@ TEST(NeuralNetwork, binary_classification)
 
 	CNeuralNetwork* network = new CNeuralNetwork(layers);
 	network->quick_connect();
-	network->initialize(0.1);
+	network->initialize_neural_network(0.1);
 
 	network->epsilon = 1e-8;
 
@@ -341,7 +341,7 @@ TEST(NeuralNetwork, multiclass_classification)
 
 	CNeuralNetwork* network = new CNeuralNetwork(layers);
 	network->quick_connect();
-	network->initialize(0.1);
+	network->initialize_neural_network(0.1);
 
 	network->epsilon = 1e-8;
 
@@ -392,7 +392,7 @@ TEST(NeuralNetwork, regression)
 
 	CNeuralNetwork* network = new CNeuralNetwork(layers);
 	network->quick_connect();
-	network->initialize(1e-6);
+	network->initialize_neural_network(1e-6);
 
 	network->epsilon = 1e-6;
 
@@ -446,7 +446,7 @@ TEST(NeuralNetwork, gradient_descent)
 
 	CNeuralNetwork* network = new CNeuralNetwork(layers);
 	network->quick_connect();
-	network->initialize(0.1);
+	network->initialize_neural_network(0.1);
 
 	network->optimization_method = NNOM_GRADIENT_DESCENT;
 	network->gd_learning_rate = 10.0;

--- a/tests/unit/neuralnets/NeuralRectifiedLinearLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralRectifiedLinearLayer_unittest.cc
@@ -63,7 +63,7 @@ TEST(NeuralRectifiedLinearLayer, compute_activations)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);
@@ -142,7 +142,7 @@ TEST(NeuralRectifiedLinearLayer, compute_parameter_gradients_hidden)
 		y[i] = CMath::random(0.0,1.0);
 
 	// initialize the hidden layer
-	layer_hid->initialize(layers, input_indices_hid);
+	layer_hid->initialize_neural_layer(layers, input_indices_hid);
 	SGVector<float64_t> param_hid(layer_hid->get_num_parameters());
 	SGVector<bool> param_regularizable_hid(layer_hid->get_num_parameters());
 	layer_hid->initialize_parameters(param_hid, param_regularizable_hid, 0.01);
@@ -150,7 +150,7 @@ TEST(NeuralRectifiedLinearLayer, compute_parameter_gradients_hidden)
 
 	// initialize the output layer
 	CNeuralLinearLayer layer_out(y.num_rows);
-	layer_out.initialize(layers, input_indices_out);
+	layer_out.initialize_neural_layer(layers, input_indices_out);
 	SGVector<float64_t> param_out(layer_out.get_num_parameters());
 	SGVector<bool> param_regularizable_out(layer_out.get_num_parameters());
 	layer_out.initialize_parameters(param_out, param_regularizable_out, 0.01);

--- a/tests/unit/neuralnets/NeuralSoftmaxLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralSoftmaxLayer_unittest.cc
@@ -63,7 +63,7 @@ TEST(NeuralSoftmaxLayer, compute_activations)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);
@@ -134,7 +134,7 @@ TEST(NeuralSoftmaxLayer, compute_error)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);
@@ -195,7 +195,7 @@ TEST(NeuralSoftmaxLayer, compute_local_gradients)
 	input_indices[0] = 0;
 
 	// initialize the layer
-	layer.initialize(layers, input_indices);
+	layer.initialize_neural_layer(layers, input_indices);
 	SGVector<float64_t> params(layer.get_num_parameters());
 	SGVector<bool> param_regularizable(layer.get_num_parameters());
 	layer.initialize_parameters(params, param_regularizable, 1.0);

--- a/tests/unit/neuralnets/RBM_unittest.cc
+++ b/tests/unit/neuralnets/RBM_unittest.cc
@@ -48,7 +48,7 @@ TEST(RBM, gibbs_sampling)
 	int32_t num_hidden = 6;
 
 	CRBM rbm(num_hidden, num_visible, RBMVUT_BINARY);
-	rbm.initialize();
+	rbm.initialize_neural_network();
 	rbm.set_batch_size(1);
 
 	for (int32_t i=0; i<rbm.get_weights().num_rows*rbm.get_weights().num_cols; i++)
@@ -92,7 +92,7 @@ TEST(RBM, free_energy_binary)
 	int32_t batch_size = 3;
 
 	CRBM rbm(num_hidden, num_visible, RBMVUT_BINARY);
-	rbm.initialize();
+	rbm.initialize_neural_network();
 
 	for (int32_t i=0; i<rbm.get_weights().num_rows*rbm.get_weights().num_cols; i++)
 		rbm.get_weights()[i] = i*1.0e-2;
@@ -123,7 +123,7 @@ TEST(RBM, free_energy_gradients)
 	rbm.add_visible_group(4, RBMVUT_BINARY);
 	rbm.add_visible_group(6, RBMVUT_GAUSSIAN);
 	rbm.add_visible_group(5, RBMVUT_BINARY);
-	rbm.initialize();
+	rbm.initialize_neural_network();
 
 	SGMatrix<float64_t> V(num_visible, batch_size);
 	for (int32_t i=0; i<V.num_rows*V.num_cols; i++)
@@ -161,7 +161,7 @@ TEST(RBM, pseudo_likelihood_binary)
 	int32_t batch_size = 1;
 
 	CRBM rbm(num_hidden, num_visible, RBMVUT_BINARY);
-	rbm.initialize();
+	rbm.initialize_neural_network();
 
 	for (int32_t i=0; i<rbm.get_weights().num_rows*rbm.get_weights().num_cols; i++)
 		rbm.get_weights()[i] = i*1.0e-2;


### PR DESCRIPTION
Refactor methods with name `initialize` to a more meaningful name as to not interfere with Ruby naming.