### PR TITLE
rename init() method in GP

### DIFF
--- a/src/shogun/machine/gp/GaussianARDSparseKernel.cpp
+++ b/src/shogun/machine/gp/GaussianARDSparseKernel.cpp
@@ -39,9 +39,9 @@ using namespace shogun;
 
 CGaussianARDSparseKernel::CGaussianARDSparseKernel() : CGaussianARDKernel()
 {
-	initialize_sparse_kernel();
+	init();
 }
-void CGaussianARDSparseKernel::initialize_sparse_kernel()
+void CGaussianARDSparseKernel::init()
 {
 }
 
@@ -55,14 +55,14 @@ using namespace Eigen;
 CGaussianARDSparseKernel::CGaussianARDSparseKernel(int32_t size)
 		: CGaussianARDKernel(size)
 {
-	initialize_sparse_kernel();
+	init();
 }
 
 CGaussianARDSparseKernel::CGaussianARDSparseKernel(CDotFeatures* l,
 		CDotFeatures* r, int32_t size)
 		: CGaussianARDKernel(l, r, size)
 {
-	initialize_sparse_kernel();
+	init();
 }
 
 CGaussianARDSparseKernel* CGaussianARDSparseKernel::obtain_from_generic(CKernel* kernel)

--- a/src/shogun/machine/gp/GaussianARDSparseKernel.h
+++ b/src/shogun/machine/gp/GaussianARDSparseKernel.h
@@ -69,7 +69,7 @@ public:
 	virtual ~CGaussianARDSparseKernel();
 
 private:
-	void initialize_sparse_kernel();
+	void init();
 
 #if defined(HAVE_EIGEN3) && defined(HAVE_LINALG_LIB)
 public:


### PR DESCRIPTION
I rename the method to keep the method in the GP modular consistent 