### PR TITLE
support proximal gradient methods as proximal penalty

### DIFF
--- a/src/shogun/optimization/ElasticNetPenalty.h
+++ b/src/shogun/optimization/ElasticNetPenalty.h
@@ -93,11 +93,11 @@ public:
 		m_l1_penalty->set_rounding_eplison(eplison);
 	}
 
-	virtual void update_sparse_variable(SGVector<float64_t> variable,
-		float64_t penalty_delta)
+	virtual void update_variable_for_proximity(SGVector<float64_t> variable,
+		float64_t proximal_weight)
 	{
 		check_ratio();
-		m_l1_penalty->update_sparse_variable(variable, penalty_delta*m_l1_ratio);
+		m_l1_penalty->update_variable_for_proximity(variable, proximal_weight*m_l1_ratio);
 	}
 
 	/** Update a context object to store mutable variables
@@ -121,6 +121,12 @@ public:
 		REQUIRE(context, "Context must set\n");
 		m_l1_penalty->load_from_context(context);
 		m_l2_penalty->load_from_context(context);
+	}
+
+	virtual float64_t get_sparse_variable(float64_t variable, float64_t penalty_weight)
+	{
+		check_ratio();
+		return m_l1_penalty->get_sparse_variable(variable, penalty_weight*m_l1_ratio);
 	}
 protected:
 	virtual void check_ratio()

--- a/src/shogun/optimization/FirstOrderStochasticMinimizer.h
+++ b/src/shogun/optimization/FirstOrderStochasticMinimizer.h
@@ -34,6 +34,8 @@
 #include <shogun/optimization/FirstOrderStochasticCostFunction.h>
 #include <shogun/optimization/DescendUpdater.h>
 #include <shogun/optimization/LearningRate.h>
+#include <shogun/optimization/SparsePenalty.h>
+#include <shogun/optimization/ProximalPenalty.h>
 namespace shogun
 {
 
@@ -150,6 +152,21 @@ public:
 
 	virtual int32_t get_iteration_counter() {return m_iter_counter;}
 protected:
+	virtual void do_proximal_operation(SGVector<float64_t>variable_reference)
+	{
+		ProximalPenalty* proximal_penalty=dynamic_cast<ProximalPenalty*>(m_penalty_type);
+		if(proximal_penalty)
+		{
+			float64_t proximal_weight=m_penalty_weight;
+			SparsePenalty* sparse_penalty=dynamic_cast<SparsePenalty*>(m_penalty_type);
+			if(sparse_penalty)
+			{
+				REQUIRE(m_learning_rate, "Learning rate must set when Sparse Penalty (eg, L1) is used\n");
+				proximal_weight*=m_learning_rate->get_learning_rate(m_iter_counter);
+			}
+			proximal_penalty->update_variable_for_proximity(variable_reference,proximal_weight);
+		}
+	}
 
 	/** Update a context object to store mutable variables
 	 *

--- a/src/shogun/optimization/L1Penalty.h
+++ b/src/shogun/optimization/L1Penalty.h
@@ -69,11 +69,11 @@ public:
 		m_rounding_eplison=eplison;
 	}
 
-	virtual void update_sparse_variable(SGVector<float64_t> variable,
-		float64_t penalty_delta)
+	virtual void update_variable_for_proximity(SGVector<float64_t> variable,
+		float64_t proximal_weight)
 	{
 		for(index_t idx=0; idx<variable.vlen; idx++)
-			variable[idx]=get_sparse_variable(variable[idx], penalty_delta);
+			variable[idx]=get_sparse_variable(variable[idx], proximal_weight);
 	}
 
 	/** Update a context object to store mutable variables
@@ -94,20 +94,18 @@ public:
 	{
 		REQUIRE(context, "Context must set\n");
 	}
-protected:
-	float64_t m_rounding_eplison;
 
-	virtual float64_t get_sparse_variable(float64_t variable, float64_t penalty_delta)
+	virtual float64_t get_sparse_variable(float64_t variable, float64_t penalty_weight)
 	{
 	  if (variable>0.0)
 	  {
-		  variable-=penalty_delta;
+		  variable-=penalty_weight;
 		  if (variable<0.0)
 			  variable=0.0;
 	  }
 	  else
 	  {
-		  variable+=penalty_delta;
+		  variable+=penalty_weight;
 		  if (variable>0.0)
 			  variable=0.0;
 	  }
@@ -116,6 +114,9 @@ protected:
 	  return variable;
 		return 0;
 	}
+protected:
+	float64_t m_rounding_eplison;
+
 
 private:
 	void init()

--- a/src/shogun/optimization/L1PenaltyForTG.h
+++ b/src/shogun/optimization/L1PenaltyForTG.h
@@ -56,8 +56,8 @@ public:
 	/* Destructor */
 	virtual ~L1PenaltyForTG() {}
 
-	virtual void update_sparse_variable(SGVector<float64_t> variable,
-		float64_t penalty_delta)
+	virtual void update_variable_for_proximity(SGVector<float64_t> variable,
+		float64_t proximal_weight)
 	{
 		if(m_q.vlen==0)
 		{
@@ -69,7 +69,7 @@ public:
 			REQUIRE(variable.vlen==m_q.vlen,
 				"The length of variable (%d) is changed. Last time, the length of variable was %d", variable.vlen, m_q.vlen);
 		}
-		m_u+=penalty_delta;
+		m_u+=proximal_weight;
 		for(index_t idx=0; idx<variable.vlen; idx++)
 		{
 			float64_t z=variable[idx];

--- a/src/shogun/optimization/ProximalPenalty.h
+++ b/src/shogun/optimization/ProximalPenalty.h
@@ -29,9 +29,9 @@
  *
  */
 
-#ifndef SPARSEPENALTY_H
-#define SPARSEPENALTY_H
-#include <shogun/optimization/ProximalPenalty.h>
+#ifndef PROXIMALPENALTY_H
+#define PROXIMALPENALTY_H
+#include <shogun/optimization/Penalty.h>
 namespace shogun
 {
 /** @brief The base class for sparse penalty/regularization used in minimization.
@@ -43,10 +43,11 @@ namespace shogun
  * ) 
  *
  */
-class SparsePenalty: public ProximalPenalty
+class ProximalPenalty: public Penalty
 {
 public:
-	virtual float64_t get_sparse_variable(float64_t variable, float64_t penalty_weight)=0;
+	virtual void update_variable_for_proximity(SGVector<float64_t> variable,
+		float64_t proximal_weight)=0;
 
 };
 

--- a/src/shogun/optimization/SGDMinimizer.cpp
+++ b/src/shogun/optimization/SGDMinimizer.cpp
@@ -30,7 +30,6 @@
  */
 #include <shogun/optimization/SGDMinimizer.h>
 #include <shogun/optimization/GradientDescendUpdater.h>
-#include <shogun/optimization/SparsePenalty.h>
 #include <shogun/lib/config.h>
 using namespace shogun;
 
@@ -70,12 +69,7 @@ float64_t SGDMinimizer::minimize()
 			update_gradient(grad,variable_reference);
 			m_gradient_updater->update_variable(variable_reference,grad,learning_rate);
 
-			SparsePenalty* sparse_penalty=dynamic_cast<SparsePenalty*>(m_penalty_type);
-			if(sparse_penalty)
-			{
-				REQUIRE(m_learning_rate, "Learning rate must set when Sparse Penalty (eg, L1) is used\n");
-				sparse_penalty->update_sparse_variable(variable_reference,learning_rate*m_penalty_weight);
-			}
+			do_proximal_operation(variable_reference);
 		}
 	}
 	float64_t cost=m_fun->get_cost();

--- a/src/shogun/optimization/SMIDASMinimizer.cpp
+++ b/src/shogun/optimization/SMIDASMinimizer.cpp
@@ -79,7 +79,7 @@ float64_t SMIDASMinimizer::minimize()
 
 			SGVector<float64_t> grad=m_fun->get_gradient();
 			m_gradient_updater->update_variable(m_dual_variable,grad, learning_rate);
-			penalty_type->update_sparse_variable(m_dual_variable, m_penalty_weight*learning_rate);
+			penalty_type->update_variable_for_proximity(m_dual_variable, m_penalty_weight*learning_rate);
 			m_mapping_fun->update_variable(variable_reference, m_dual_variable);
 		}
 	}

--- a/src/shogun/optimization/SVRGMinimizer.cpp
+++ b/src/shogun/optimization/SVRGMinimizer.cpp
@@ -117,12 +117,7 @@ float64_t SVRGMinimizer::minimize()
 			update_gradient(grad_new,variable_reference);
 			m_gradient_updater->update_variable(variable_reference,grad_new,learning_rate);
 
-			SparsePenalty* sparse_penalty=dynamic_cast<SparsePenalty*>(m_penalty_type);
-			if(sparse_penalty)
-			{
-				REQUIRE(m_learning_rate, "Learning rate must set when Sparse Penalty (eg, L1) is used\n");
-				sparse_penalty->update_sparse_variable(variable_reference,learning_rate*m_penalty_weight);
-			}
+			do_proximal_operation(variable_reference);
 		}
 	}
 	float64_t cost=m_fun->get_cost();


### PR DESCRIPTION
consider the following problem
`min f(x)+h(x)`
where 
* f(x) is convex, differentiable, `domain of f(x)=R^n`  
* h(x) is closed, convex, possibly non-differentiable

Proximal gradient method:
at iteration k+1
* x^{k+1/2} = x^{k} - learning_rate * d_f(x^{k})
* x^{k+1} = prox_h (x^{k+1/2}) 

where `prox_h` is a proximal penalty for `h(x)`

for example, `h(x)=L1_weight * |x|_1`
