### PR TITLE
Revert "remove migration methods from all classes and blacklist depending libshogun examples"

### DIFF
--- a/examples/undocumented/libshogun/CMakeLists.txt
+++ b/examples/undocumented/libshogun/CMakeLists.txt
@@ -39,14 +39,6 @@ LIST(REMOVE_ITEM EXAMPLES_CPP
 	"structure_discrete_hmsvm_bmrm.cpp"
 	"structure_hmsvm_mosek.cpp"
 	"structure_plif_hmsvm_bmrm.cpp"
-	"base_load_all_file_parameters.cpp"
-	"base_load_file_parameters.cpp"
-	"base_map_parameters.cpp"
-	"base_parameter_map.cpp"
-	"base_migration_dropping_and_new.cpp"
-	"base_migration_type_conversion.cpp"
-	"base_migration_new_buggy.cpp"
-	"base_migration_multiple_dependencies.cpp"
 )
 
 FOREACH(EXAMPLE_CPP ${EXAMPLES_CPP})

--- a/src/shogun/base/ParameterMap.cpp
+++ b/src/shogun/base/ParameterMap.cpp
@@ -1,0 +1,396 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2011 Heiko Strathmann
+ * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <shogun/lib/common.h>
+#include <shogun/lib/memory.h>
+
+#include <shogun/base/ParameterMap.h>
+#include <shogun/base/Parameter.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/io/SGIO.h>
+#include <shogun/base/DynArray.h>
+#include <shogun/lib/DataType.h>
+
+using namespace shogun;
+
+SGParamInfo::SGParamInfo()
+{
+	m_name=NULL;
+	m_ctype=CT_UNDEFINED;
+	m_stype=ST_UNDEFINED;
+	m_ptype=PT_UNDEFINED;
+	m_param_version=-1;
+}
+
+SGParamInfo::SGParamInfo(const SGParamInfo& orig)
+{
+	/* copy name if existent */
+	m_name=get_strdup(orig.m_name);
+
+	m_ctype=orig.m_ctype;
+	m_stype=orig.m_stype;
+	m_ptype=orig.m_ptype;
+	m_param_version=orig.m_param_version;
+}
+
+SGParamInfo::SGParamInfo(const char* name, EContainerType ctype,
+		EStructType stype, EPrimitiveType ptype, int32_t param_version)
+{
+	/* copy name if existent */
+	m_name=get_strdup(name);
+
+	m_ctype=ctype;
+	m_stype=stype;
+	m_ptype=ptype;
+	m_param_version=param_version;
+}
+
+SGParamInfo::SGParamInfo(const TParameter* param, int32_t param_version)
+{
+	/* copy name if existent */
+	m_name=get_strdup(param->m_name);
+
+	TSGDataType type=param->m_datatype;
+	m_ctype=type.m_ctype;
+	m_stype=type.m_stype;
+	m_ptype=type.m_ptype;
+	m_param_version=param_version;
+}
+
+SGParamInfo::~SGParamInfo()
+{
+	SG_FREE(m_name);
+}
+
+char* SGParamInfo::to_string() const
+{
+	char* buffer=SG_MALLOC(char, 200);
+	strcpy(buffer, "SGParamInfo with: ");
+	strcat(buffer, "name=\"");
+	strcat(buffer, m_name ? m_name : "NULL");
+	strcat(buffer, "\", type=");
+
+	char* b;
+	/* only cat type if it is defined (is not when std constructor was used)*/
+	if (!is_empty())
+	{
+		TSGDataType t(m_ctype, m_stype, m_ptype);
+		index_t l=100;
+		b=SG_MALLOC(char, l);
+		t.to_string(b, l);
+		strcat(buffer, b);
+		SG_FREE(b);
+	}
+	else
+		strcat(buffer, "no type");
+
+	b=SG_MALLOC(char, 10);
+	sprintf(b, "%d", m_param_version);
+	strcat(buffer, ", version=");
+	strcat(buffer, b);
+	SG_FREE(b);
+
+	return buffer;
+}
+
+void SGParamInfo::print_param_info(const char* prefix) const
+{
+	char* s=to_string();
+	SG_SPRINT("%s%s\n", prefix, s)
+	SG_FREE(s);
+}
+
+SGParamInfo* SGParamInfo::duplicate() const
+{
+	return new SGParamInfo(m_name, m_ctype, m_stype, m_ptype, m_param_version);
+}
+
+bool SGParamInfo::operator==(const SGParamInfo& other) const
+{
+	bool result=true;
+
+	/* handle NULL strings */
+	if ((!m_name && other.m_name) || (m_name && !other.m_name))
+		return false;
+
+	if (m_name && other.m_name)
+		result&=!strcmp(m_name, other.m_name);
+
+	result&=m_ctype==other.m_ctype;
+	result&=m_stype==other.m_stype;
+	result&=m_ptype==other.m_ptype;
+	result&=m_param_version==other.m_param_version;
+	return result;
+}
+
+bool SGParamInfo::operator!=(const SGParamInfo& other) const
+{
+	return !operator ==(other);
+}
+
+bool SGParamInfo::operator<(const SGParamInfo& other) const
+{
+	/* NULL here is always smaller than anything */
+	if (!m_name)
+	{
+		if (!other.m_name)
+			return false;
+		else
+			return true;
+	}
+	else if (!other.m_name)
+		return true;
+
+	int32_t result=strcmp(m_name, other.m_name);
+
+	if (result==0)
+	{
+		if (m_param_version==other.m_param_version)
+		{
+			if (m_ctype==other.m_ctype)
+			{
+				if (m_stype==other.m_stype)
+				{
+					if (m_ptype==other.m_ptype)
+					{
+						return false;
+					}
+					else
+						return m_ptype<other.m_ptype;
+				}
+				else
+					return m_stype<other.m_stype;
+			}
+			else
+				return m_ctype<other.m_ctype;
+		}
+		else
+			return m_param_version<other.m_param_version;
+
+	}
+	else
+		return result<0;
+}
+
+bool SGParamInfo::operator>(const SGParamInfo& other) const
+{
+	return !(*this<(other)) && !(*this==other);
+}
+
+bool SGParamInfo::is_empty() const
+{
+	/* return true if this info is for empty parameter */
+	return m_ctype==CT_UNDEFINED && m_stype==ST_UNDEFINED && m_ptype==PT_UNDEFINED && !m_name;
+}
+
+ParameterMapElement::ParameterMapElement()
+{
+	m_key=NULL;
+	m_values=NULL;
+}
+
+ParameterMapElement::ParameterMapElement(const SGParamInfo* key,
+		DynArray<const SGParamInfo*>* values)
+{
+	m_key=key;
+	m_values=values;
+}
+
+ParameterMapElement::~ParameterMapElement()
+{
+	delete m_key;
+
+	if (m_values)
+	{
+		for (index_t i=0; i<m_values->get_num_elements(); ++i)
+			delete m_values->get_element(i);
+
+		delete m_values;
+	}
+}
+
+bool ParameterMapElement::operator==(const ParameterMapElement& other) const
+{
+	return *m_key==*other.m_key;
+}
+
+bool ParameterMapElement::operator<(const ParameterMapElement& other) const
+{
+	return *m_key<*other.m_key;
+}
+
+bool ParameterMapElement::operator>(const ParameterMapElement& other) const
+{
+	return *m_key>*other.m_key;
+}
+
+/*
+  Initializing m_map_elements(1), m_multi_map_elements(1) with small
+  preallocation-size, because ParameterMap will be constructed several
+  times for EACH SGObject instance.
+*/
+ParameterMap::ParameterMap()
+: m_map_elements(1), m_multi_map_elements(1)
+{
+	m_finalized=false;
+}
+
+ParameterMap::~ParameterMap()
+{
+	for (index_t i=0; i<m_map_elements.get_num_elements(); ++i)
+		delete m_map_elements[i];
+
+	for (index_t i=0; i<m_multi_map_elements.get_num_elements(); ++i)
+		delete m_multi_map_elements[i];
+}
+
+void ParameterMap::put(const SGParamInfo* key, const SGParamInfo* value)
+{
+	/* assert that versions do differ exactly one if mapping is non-empty */
+	if (key->m_param_version-value->m_param_version!=1)
+	{
+		if (!key->is_empty() && !value->is_empty())
+		{
+			char* s=key->to_string();
+			char* t=value->to_string();
+			SG_SERROR("Versions of parameter mappings from \"%s\" to \"%s\" have"
+					" to differ exactly one\n", s, t);
+			SG_FREE(s);
+			SG_FREE(t);
+		}
+	}
+
+	/* always add array of ONE element as values, will be processed later
+	 * in finalize map method */
+	DynArray<const SGParamInfo*>* values=new DynArray<const SGParamInfo*>();
+	values->append_element(value);
+	m_map_elements.append_element(new ParameterMapElement(key, values));
+	m_finalized=false;
+}
+
+DynArray<const SGParamInfo*>* ParameterMap::get(const SGParamInfo key) const
+{
+	return get(&key);
+}
+
+DynArray<const SGParamInfo*>* ParameterMap::get(const SGParamInfo* key) const
+{
+	index_t num_elements=m_multi_map_elements.get_num_elements();
+
+	/* check if maps is finalized */
+	if (!m_finalized && num_elements)
+		SG_SERROR("Call finalize_map() before calling get()\n")
+
+	/* do binary search in array of pointers */
+	/* dummy element for searching */
+	ParameterMapElement* dummy=new ParameterMapElement(key->duplicate(), NULL);
+	index_t index=CMath::binary_search<ParameterMapElement> (
+			m_multi_map_elements.get_array(), num_elements, dummy);
+	delete dummy;
+
+	if (index==-1)
+		return NULL;
+
+	ParameterMapElement* element=m_multi_map_elements.get_element(index);
+	return element->m_values;
+}
+
+void ParameterMap::finalize_map()
+{
+	/* only do something if there are elements in map */
+	if (!m_map_elements.get_num_elements())
+		return;
+
+	/* sort underlying array */
+	CMath::qsort<ParameterMapElement> (m_map_elements.get_array(),
+			m_map_elements.get_num_elements());
+
+//	SG_SPRINT("map elements before finalize\n")
+//	for (index_t i=0; i<m_map_elements.get_num_elements(); ++i)
+//	{
+//		ParameterMapElement* current=m_map_elements[i];
+//		SG_SPRINT("element %d:\n", i)
+//		SG_SPRINT("\tkey: ")
+//		current->m_key->print_param_info();
+//		SG_SPRINT("\t%d values:\n", current->m_values->get_num_elements())
+//		for (index_t j=0; j<current->m_values->get_num_elements(); ++j)
+//			current->m_values->get_element(j)->print_param_info("\t\t");
+//	}
+
+	/* clear old multi elements. These were copies. */
+	for (index_t i=0; i<m_multi_map_elements.get_num_elements(); ++i)
+		delete m_multi_map_elements[i];
+
+	m_multi_map_elements.reset(NULL);
+//	SG_SPRINT("\nstarting finalization\n")
+
+	/* iterate over all elements of map elements (have all one value (put)) and
+	 * add all values of same key to ONE map element of hidden structure */
+	DynArray<const SGParamInfo*>* values=new DynArray<const SGParamInfo*>();
+	const SGParamInfo* current_key=m_map_elements[0]->m_key;
+//	char* s=current_key->to_string();
+//	SG_SPRINT("current key: %s\n", s)
+//	SG_FREE(s);
+	for (index_t i=0; i<m_map_elements.get_num_elements(); ++i)
+	{
+		const ParameterMapElement* current=m_map_elements[i];
+		if (*current_key != *current->m_key)
+		{
+			/* create new values array to add and update key */
+			values=new DynArray<const SGParamInfo*>();
+			current_key=current->m_key;
+//			s=current_key->to_string();
+//			SG_SPRINT("new current key: %s\n", s)
+//			SG_FREE(s);
+		}
+
+		/* add to values array */
+		char* t=current->m_values->get_element(0)->to_string();
+//		SG_SPRINT("\tadding %s\n", t)
+		SG_FREE(t);
+		values->append_element(current->m_values->get_element(0)->duplicate());
+
+		/* if current values array has not been added to multi map elements, do
+		 * now */
+		index_t last_idx=m_multi_map_elements.get_num_elements()-1;
+		if (last_idx<0 ||
+				m_multi_map_elements.get_element(last_idx)->m_values != values)
+		{
+//			SG_SPRINT("adding values array\n")
+			m_multi_map_elements.append_element(
+				new ParameterMapElement(current_key->duplicate(), values));
+		}
+	}
+
+	m_finalized=true;
+//	SG_SPRINT("leaving finalize_map()\n")
+}
+
+void ParameterMap::print_map()
+{
+	/* check if maps is finalized */
+	if (!m_finalized && m_map_elements.get_num_elements())
+		SG_SERROR("Call finalize_map() before calling print_map()\n")
+
+//	SG_SPRINT("map with %d keys:\n", m_multi_map_elements.get_num_elements())
+	for (index_t i=0; i<m_multi_map_elements.get_num_elements(); ++i)
+	{
+		ParameterMapElement* current=m_multi_map_elements[i];
+//		SG_SPRINT("element %d:\n", i)
+//		SG_SPRINT("\tkey: ")
+//		current->m_key->print_param_info();
+//		SG_SPRINT("\t%d values:\n", current->m_values->get_num_elements())
+		for (index_t j=0; j<current->m_values->get_num_elements(); ++j)
+			current->m_values->get_element(j)->print_param_info("\t\t");
+	}
+}

--- a/src/shogun/base/ParameterMap.h
+++ b/src/shogun/base/ParameterMap.h
@@ -1,0 +1,234 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2011 Heiko Strathmann
+ * Copyright (C) 2011 Berlin Institute of Technology and Max-Planck-Society
+ */
+
+#ifndef __PARAMETERMAP_
+#define __PARAMETERMAP_
+
+#include <shogun/lib/config.h>
+
+#include <shogun/base/DynArray.h>
+#include <shogun/lib/DataType.h>
+#include <shogun/lib/common.h>
+
+namespace shogun
+{
+
+struct TParameter;
+
+/** @brief Class that holds informations about a certain parameter of an
+ * CSGObject. Contains name, type, etc.
+ * This is used for mapping types that have changed in different versions of
+ * shogun.
+ * Instances of this class may be compared to each other. Ordering is based on
+ * name, equalness is based on all attributes
+ */
+class SGParamInfo
+{
+public:
+	/** constructor */
+	SGParamInfo();
+
+	/** constructor
+	 *
+	 * @param name name of parameter, is copied
+	 * @param ctype container type of parameter
+	 * @param stype struct type of parameter
+	 * @param ptype primitive type of parameter
+	 * @param param_version version of parameter
+	 */
+	SGParamInfo(const char* name, EContainerType ctype, EStructType stype,
+			EPrimitiveType ptype, int32_t param_version);
+
+	/** constructor to create from a TParameter instance
+	 *
+	 * @param param TParameter instance to use
+	 * @param param_version version of parameter
+	 */
+	SGParamInfo(const TParameter* param, int32_t param_version);
+
+	/** copy constructor
+	 * @param orig element to copy from
+	 */
+	SGParamInfo(const SGParamInfo& orig);
+
+	/** destructor */
+	virtual ~SGParamInfo();
+
+	/** prints all parameter values */
+	void print_param_info(const char* prefix="") const;
+
+	/** @return string representation, caller has to clean up */
+	char* to_string() const;
+
+	/** @return an identical copy */
+	SGParamInfo* duplicate() const;
+
+	/** operator for comparison, true iff all attributes are equal */
+	bool operator==(const SGParamInfo& other) const;
+
+	/** operator for comparison, false iff all attributes are equal */
+	bool operator!=(const SGParamInfo& other) const;
+
+	/** operator for comparison (by string m_name, if equal by others) */
+	bool operator<(const SGParamInfo& other) const;
+
+	/** operator for comparison (by string m_name, if equal by others) */
+	bool operator>(const SGParamInfo& other) const;
+
+	/** @return true iff this was constructed using the std constructor (empty
+	 * parameter used to say that it appeared here first time */
+	bool is_empty() const;
+
+public:
+	/** name */
+	char* m_name;
+
+	/** container type */
+	EContainerType m_ctype;
+
+	/** struct type */
+	EStructType m_stype;
+
+	/** primitive type */
+	EPrimitiveType m_ptype;
+
+	/** version of the parameter */
+	int32_t m_param_version;
+};
+
+/** @brief Class to hold instances of a parameter map. Each element contains a
+ * key and a set of values, which each are of type SGParamInfo.
+ * May be compared to each other based on their keys
+ */
+class ParameterMapElement
+{
+public:
+	/** constructor */
+	ParameterMapElement();
+
+	/** constructor
+	 *
+	 * @param key key of this element
+	 * @param values array of value of this element
+	 */
+	ParameterMapElement(const SGParamInfo* key,
+			DynArray<const SGParamInfo*>* values);
+
+	/** destructor */
+	virtual ~ParameterMapElement();
+
+	/** operator for comparison, true iff m_key is equal */
+	bool operator==(const ParameterMapElement& other) const;
+
+	/** operator for comparison (by m_key) */
+	bool operator<(const ParameterMapElement& other) const;
+
+	/** operator for comparison (by m_key) */
+	bool operator>(const ParameterMapElement& other) const;
+
+	/** @return name of the SG_SERIALIZABLE */
+	virtual const char* get_name() const
+	{
+		return "ParameterMapElement";
+	}
+
+public:
+	/** key */
+	const SGParamInfo* m_key;
+
+	/** values */
+	DynArray<const SGParamInfo*>* m_values;
+
+};
+
+/** @brief Implements a map of ParameterMapElement instances
+ * Maps one key to a set of values.
+ *
+ * Implementation is done via an array. Via the call finalize_map(), a hidden
+ * structure is built which bundles all values for each key.
+ * Then, get() may be called, which returns an array of values for a key.
+ * If it is called before, an error is
+ * thrown.
+ *
+ * Putting elements is in O(1).
+ * finalize_map sorts the underlying array and then regroups values, O(n*log n).
+ * Add all values and then call once.
+ * Getting a set of values is possible in O(log n) via binary search
+ */
+class ParameterMap
+{
+public:
+	/** constructor */
+	ParameterMap();
+
+	/** destructor */
+	virtual ~ParameterMap();
+
+	/** Puts an newly allocated element into the map. Note that get(...)
+	 * returns an array of value elements, so it is allowed to add multiple
+	 * values for one key. Note that there is also no check for double entries,
+	 * i.e. same key and same value.This will result in two elements when get
+	 * is called.
+	 * Operation in O(1).
+	 *
+	 * @param key key of the element
+	 * @param value value of the lement
+	 */
+	void put(const SGParamInfo* key, const SGParamInfo* value);
+
+	/** Gets a specific element of the map
+	 * finalize_map() has to be called first if more than one elements are in
+	 * map.
+	 *
+	 * Operation in O(log n)
+	 *
+	 * Same as below but without pointer for syntactic ease.
+	 *
+	 * parameter key: key of the element to get
+	 * returns set of values of the key element
+	 */
+	DynArray<const SGParamInfo*>* get(const SGParamInfo) const;
+
+	/** Gets a specific element of the map.
+	 * finalize_map() has to be called first if more than one elements are in
+	 * map.
+	 *
+	 * Operation in O(log n)
+	 *
+	 * @param key key of the element to get
+	 * @return set of values of the key element
+	 */
+	DynArray<const SGParamInfo*>* get(const SGParamInfo* key) const;
+
+	/** Finalizes the map. Has to be called before get may be called if more
+	 * than one element in map
+	 *
+	 * Operation in O(n*log n)
+	 */
+	void finalize_map();
+
+	/** prints all elements of this map */
+	void print_map();
+
+protected:
+	/** list of CLinearMap elements, this is always kept sorted */
+	DynArray<ParameterMapElement*> m_map_elements;
+
+	/** hidden internal structure which is used to hold multiple values for one
+	 * key. It is built when finalize_map() is called. */
+	DynArray<ParameterMapElement*> m_multi_map_elements;
+
+	/** variable that indicates if its possible to call get method */
+	bool m_finalized;
+};
+
+}
+
+#endif /* __PARAMETERMAP_ */

--- a/src/shogun/evaluation/CrossValidation.cpp
+++ b/src/shogun/evaluation/CrossValidation.cpp
@@ -13,6 +13,7 @@
 #include <shogun/evaluation/Evaluation.h>
 #include <shogun/evaluation/SplittingStrategy.h>
 #include <shogun/base/Parameter.h>
+#include <shogun/base/ParameterMap.h>
 #include <shogun/mathematics/Statistics.h>
 #include <shogun/evaluation/CrossValidationOutput.h>
 #include <shogun/lib/List.h>

--- a/src/shogun/evaluation/MachineEvaluation.cpp
+++ b/src/shogun/evaluation/MachineEvaluation.cpp
@@ -16,6 +16,7 @@
 #include <shogun/evaluation/Evaluation.h>
 #include <shogun/evaluation/SplittingStrategy.h>
 #include <shogun/base/Parameter.h>
+#include <shogun/base/ParameterMap.h>
 #include <shogun/mathematics/Statistics.h>
 
 using namespace shogun;
@@ -99,6 +100,17 @@ void CMachineEvaluation::init()
 			"Whether machine should automatically try to be locked before ",
 			MS_NOT_AVAILABLE);
 
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+			new SGParamInfo("m_do_unlock", CT_SCALAR, ST_NONE, PT_BOOL, 1),
+			new SGParamInfo()
+	);
+
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+			new SGParamInfo("m_autolock", CT_SCALAR, ST_NONE, PT_BOOL, 1),
+			new SGParamInfo()
+	);
 }
 
 CMachine* CMachineEvaluation::get_machine() const

--- a/src/shogun/kernel/CustomKernel.cpp
+++ b/src/shogun/kernel/CustomKernel.cpp
@@ -15,6 +15,7 @@
 #include <shogun/features/DummyFeatures.h>
 #include <shogun/features/IndexFeatures.h>
 #include <shogun/io/SGIO.h>
+#include <shogun/base/ParameterMap.h>
 
 using namespace shogun;
 
@@ -43,6 +44,25 @@ void CCustomKernel::init()
 			MS_NOT_AVAILABLE);
 	SG_ADD(&kmatrix, "kmatrix", "Kernel matrix.", MS_NOT_AVAILABLE);
 	SG_ADD(&upper_diagonal, "upper_diagonal", "Upper diagonal", MS_NOT_AVAILABLE);
+
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+			new SGParamInfo("free_km", CT_SCALAR, ST_NONE, PT_BOOL, 1),
+			new SGParamInfo()
+	);
+
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+			new SGParamInfo("row_subset_stack", CT_SCALAR, ST_NONE, PT_SGOBJECT, 1),
+			new SGParamInfo()
+	);
+
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+			new SGParamInfo("col_subset_stack", CT_SCALAR, ST_NONE, PT_SGOBJECT, 1),
+			new SGParamInfo()
+	);
+	m_parameter_map->finalize_map();
 }
 
 CCustomKernel::CCustomKernel()

--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -1,6 +1,7 @@
 #include <shogun/labels/DenseLabels.h>
 #include <shogun/labels/BinaryLabels.h>
 #include <shogun/labels/MulticlassLabels.h>
+#include <shogun/base/ParameterMap.h>
 
 using namespace shogun;
 
@@ -31,6 +32,12 @@ CMulticlassLabels::~CMulticlassLabels()
 
 void CMulticlassLabels::init()
 {
+	/* for this to work, migration has to be fixed */
+//	SG_ADD(&m_multiclass_confidences, "multiclass_confidences", "Vectors of "
+//			"multiclass confidences", MS_NOT_AVAILABLE);
+
+//	m_parameter_map->finalize_map();
+
 	m_multiclass_confidences=SGMatrix<float64_t>();
 }
 

--- a/src/shogun/machine/KernelMachine.cpp
+++ b/src/shogun/machine/KernelMachine.cpp
@@ -13,6 +13,7 @@
 #include <shogun/lib/Signal.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/io/SGIO.h>
+#include <shogun/base/ParameterMap.h>
 
 #include <shogun/kernel/Kernel.h>
 #include <shogun/kernel/CustomKernel.h>
@@ -694,6 +695,19 @@ void CKernelMachine::init()
 	SG_ADD(&m_alpha, "m_alpha", "Array of coefficients alpha.",
 			MS_NOT_AVAILABLE);
 	SG_ADD(&m_svs, "m_svs", "Number of ``support vectors''.", MS_NOT_AVAILABLE);
+
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+		new SGParamInfo("custom_kernel", CT_SCALAR, ST_NONE, PT_SGOBJECT, 1),
+		new SGParamInfo()
+	);
+
+	/* new parameter from param version 0 to 1 */
+	m_parameter_map->put(
+		new SGParamInfo("kernel_backup", CT_SCALAR, ST_NONE, PT_SGOBJECT, 1),
+		new SGParamInfo()
+	);
+	m_parameter_map->finalize_map();
 }
 
 bool CKernelMachine::supports_locking() const

--- a/src/shogun/machine/Machine.cpp
+++ b/src/shogun/machine/Machine.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <shogun/machine/Machine.h>
+#include <shogun/base/ParameterMap.h>
 
 using namespace shogun;
 
@@ -29,6 +30,13 @@ CMachine::CMachine() : CSGObject(), m_max_train_time(0), m_labels(NULL),
 	       "Should feature data of model be stored after training?", MS_NOT_AVAILABLE);
 	SG_ADD(&m_data_locked, "data_locked",
 			"Indicates whether data is locked", MS_NOT_AVAILABLE);
+
+	m_parameter_map->put(
+		new SGParamInfo("data_locked", CT_SCALAR, ST_NONE, PT_BOOL, 1),
+		new SGParamInfo()
+	);
+
+	m_parameter_map->finalize_map();
 }
 
 CMachine::~CMachine()


### PR DESCRIPTION
SerializationASCII heavily depends on migration-framework, so we cannot drop that easy, unfortunately.

This reverts commit 5af68edff0f7ea7100c142d280307a0e7acaf350.