### PR TITLE
Added parameterized constructors to DescendUpdater derived classes

### DIFF
--- a/src/shogun/optimization/AdaDeltaUpdater.cpp
+++ b/src/shogun/optimization/AdaDeltaUpdater.cpp
@@ -39,6 +39,15 @@ AdaDeltaUpdater::AdaDeltaUpdater()
 	init();
 }
 
+AdaDeltaUpdater::AdaDeltaUpdater(float64_t learning_rate,float64_t epsilon,float64_t decay_factor)
+	:DescendUpdaterWithCorrection()
+{
+	init();
+	set_learning_rate(learning_rate);
+	set_epsilon(epsilon);
+	set_decay_factor(decay_factor);
+}
+
 void AdaDeltaUpdater::set_learning_rate(float64_t learning_rate)
 {
 	REQUIRE(learning_rate>0,"Learning_rate (%f) must be positive\n",

--- a/src/shogun/optimization/AdaDeltaUpdater.h
+++ b/src/shogun/optimization/AdaDeltaUpdater.h
@@ -61,6 +61,14 @@ public:
 	/* Constructor */
 	AdaDeltaUpdater();
 
+	/** Parameterized Constructor
+	 *
+	 * @param learning_rate learning_rate
+	 * @param epsilon epsilon
+	 * @param decay_factor decay_factor 
+	 */
+	AdaDeltaUpdater(float64_t learning_rate,float64_t epsilon,float64_t decay_factor);
+	
 	/* Destructor */
 	virtual ~AdaDeltaUpdater();
 

--- a/src/shogun/optimization/AdaGradUpdater.cpp
+++ b/src/shogun/optimization/AdaGradUpdater.cpp
@@ -39,6 +39,14 @@ AdaGradUpdater::AdaGradUpdater()
 	init();
 }
 
+AdaGradUpdater::AdaGradUpdater(float64_t learning_rate,float64_t epsilon)
+	:DescendUpdaterWithCorrection()
+{
+	init();
+	set_learning_rate(learning_rate);
+	set_epsilon(epsilon);
+}
+
 void AdaGradUpdater::set_learning_rate(float64_t learning_rate)
 {
 	REQUIRE(learning_rate>0,"Learning_rate (%f) must be positive\n",

--- a/src/shogun/optimization/AdaGradUpdater.h
+++ b/src/shogun/optimization/AdaGradUpdater.h
@@ -59,6 +59,13 @@ public:
 	/* Constructor */
 	AdaGradUpdater();
 
+	/** Parameterized Constructor
+	 * 
+	 * @param learning_rate learning_rate
+	 * @param epsilon epsilon
+	 */
+	AdaGradUpdater(float64_t learning_rate,float64_t epsilon);
+
 	/* Destructor */
 	virtual ~AdaGradUpdater();
 

--- a/src/shogun/optimization/RmsPropUpdater.cpp
+++ b/src/shogun/optimization/RmsPropUpdater.cpp
@@ -39,6 +39,15 @@ RmsPropUpdater::RmsPropUpdater()
 	init();
 }
 
+RmsPropUpdater::RmsPropUpdater(float64_t learning_rate,float64_t epsilon,float64_t decay_factor)
+	:DescendUpdaterWithCorrection()
+{
+	init();
+	set_learning_rate(learning_rate);
+	set_epsilon(epsilon);
+	set_decay_factor(decay_factor);
+}
+
 void RmsPropUpdater::set_learning_rate(float64_t learning_rate)
 {
 	REQUIRE(learning_rate>0,"Learning_rate (%f) must be positive\n",

--- a/src/shogun/optimization/RmsPropUpdater.h
+++ b/src/shogun/optimization/RmsPropUpdater.h
@@ -59,6 +59,14 @@ public:
 	/* Constructor */
 	RmsPropUpdater();
 
+	/** Parameterized Constructor
+	 *
+	 * @param learning_rate learning_rate
+	 * @param epsilon epsilon 
+	 * @param decay_factor decay_factor
+	 */
+	RmsPropUpdater(float64_t learning_rate,float64_t epsilon,float64_t decay_factor);
+
 	/* Destructor */
 	virtual ~RmsPropUpdater();
 

--- a/tests/unit/optimization/StochasticMinimizers_unittest.cc
+++ b/tests/unit/optimization/StochasticMinimizers_unittest.cc
@@ -914,10 +914,12 @@ TEST(AdaDeltaUpdater, test1)
 	delete momentum_correction;
 
 	SGDMinimizer* opt2=new SGDMinimizer(bb);
-	AdaDeltaUpdater* updater2=new AdaDeltaUpdater();
+	AdaDeltaUpdater* updater2=new AdaDeltaUpdater(1.8,1e-6,0.95);
+	/*
 	updater2->set_learning_rate(1.8);
 	updater2->set_epsilon(1e-6);
 	updater2->set_decay_factor(0.95);
+	*/
 	MomentumCorrection* momentum_correction2=new NesterovMomentumCorrection();
 	momentum_correction2->set_correction_weight(0.99);
 	updater2->set_descend_correction(momentum_correction2);
@@ -983,10 +985,12 @@ TEST(AdaptMomentumCorrection, test1)
 	delete correction;
 	delete momentum_correction;
 	SGDMinimizer* opt2=new SGDMinimizer(bb);
-	RmsPropUpdater* updater2=new RmsPropUpdater();
+	RmsPropUpdater* updater2=new RmsPropUpdater(1.0,0.0,0.9);
+	/*	
 	updater2->set_learning_rate(1.0);
 	updater2->set_epsilon(0.0);
 	updater2->RmsPropUpdater::set_decay_factor(0.9);
+	*/	
 	MomentumCorrection* momentum_correction2=new NesterovMomentumCorrection();
 	momentum_correction2->set_correction_weight(0.5);
 	AdaptMomentumCorrection* correction2=new AdaptMomentumCorrection();


### PR DESCRIPTION
Added parameterised constructors to the following classes:
* AdaDeltaUpdater
* AdaGradUpdater
* RmsPropUpdater

This will make initialising those objects in other classes easier. Another advantage of avoiding using the *set_xyz* functions explicitly is that they are not present in the DU class and hence, we can work with just a DU object that is actually cast from a subclass of it.
(I'm not sure if there is a way around it even without a param ctor)

I modified some of the unit tests to use the new constructors for testing. 