### PR TITLE
Prune k-means, remove random-sampling during iteration

### DIFF
--- a/src/shogun/clustering/KMeansLloydImpl.cpp
+++ b/src/shogun/clustering/KMeansLloydImpl.cpp
@@ -25,7 +25,8 @@ void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_
 	int32_t XSize=lhs->get_num_vectors();
 	int32_t dimensions=lhs->get_num_features();
 
-	CFeatures* rhs_cache=distance->replace_rhs(mus);
+	CDenseFeatures<float64_t>* rhs_mus=new CDenseFeatures<float64_t>(0);
+	CFeatures* rhs_cache=distance->replace_rhs(rhs_mus);
 
 	SGVector<float64_t> dists=SGVector<float64_t>(k*XSize);
 	dists.zero();
@@ -71,6 +72,8 @@ void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_
 				}
 			}
 		}
+		rhs_mus->copy_feature_matrix(mus);
+
 		for (int32_t i=0; i<XSize; i++)
 		{
 			const int32_t ClList_i=ClList[i];
@@ -100,6 +103,7 @@ void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_
 			break;
 	}
 	distance->replace_rhs(rhs_cache);
+	delete rhs_mus;
 	SG_UNREF(lhs);
 }
 }

--- a/src/shogun/clustering/KMeansLloydImpl.cpp
+++ b/src/shogun/clustering/KMeansLloydImpl.cpp
@@ -25,8 +25,7 @@ void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_
 	int32_t XSize=lhs->get_num_vectors();
 	int32_t dimensions=lhs->get_num_features();
 
-	CDenseFeatures<float64_t>* rhs_mus=new CDenseFeatures<float64_t>(0);
-	CFeatures* rhs_cache=distance->replace_rhs(rhs_mus);
+	CFeatures* rhs_cache=distance->replace_rhs(mus);
 
 	SGVector<float64_t> dists=SGVector<float64_t>(k*XSize);
 	dists.zero();
@@ -72,18 +71,15 @@ void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_
 				}
 			}
 		}
-		rhs_mus->copy_feature_matrix(mus);
 		for (int32_t i=0; i<XSize; i++)
 		{
-			/* ks=ceil(rand(1,XSize)*XSize) ; */
-			const int32_t Pat=CMath::random(0, XSize-1);
-			const int32_t ClList_Pat=ClList[Pat];
+			const int32_t ClList_i=ClList[i];
 			int32_t imini, j;
 			float64_t mini;
 
 			/* compute the distance of this point to all centers */
 			for(int32_t idx_k=0;idx_k<k;idx_k++)
-				dists[idx_k]=distance->distance(Pat,idx_k);
+				dists[idx_k]=distance->distance(i,idx_k);
 
 			/* [mini,imini]=min(dists(:,i)) ; */
 			imini=0 ; mini=dists[0];
@@ -94,52 +90,16 @@ void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_
 					imini=j;
 				}
 
-			if (imini!=ClList_Pat)
+			if (imini!=ClList_i)
 			{
 				changed++;
-
-				/* weights_set(imini) = weights_set(imini) + 1.0 ; */
-				weights_set[imini]+= 1.0;
-				/* weights_set(j)     = weights_set(j)     - 1.0 ; */
-				weights_set[ClList_Pat]-= 1.0;
-
-				vec=lhs->get_feature_vector(Pat, vlen, vfree);
-
-				for (j=0; j<dimensions; j++)
-				{
-					mus.matrix[imini*dimensions+j]-=
-						(vec[j]-mus.matrix[imini*dimensions+j]) / weights_set[imini];
-				}
-
-				lhs->free_feature_vector(vec, Pat, vfree);
-
-				/* mu_new = mu_old - (x - mu_old)/(n-1) */
-				/* if weights_set(j)~=0 */
-				if (weights_set[ClList_Pat]!=0.0)
-				{
-					vec=lhs->get_feature_vector(Pat, vlen, vfree);
-
-					for (j=0; j<dimensions; j++)
-					{
-						mus.matrix[ClList_Pat*dimensions+j]-=
-								(vec[j]-mus.matrix[ClList_Pat*dimensions+j]) / weights_set[ClList_Pat];
-					}
-					lhs->free_feature_vector(vec, Pat, vfree);
-				}
-				else
-				{
-					/*  mus(:,j)=zeros(dimensions,1) ; */
-					for (j=0; j<dimensions; j++)
-						mus.matrix[ClList_Pat*dimensions+j]=0;
-				}
-
-				/* ClList(i)= imini ; */
-				ClList[Pat] = imini;
+				ClList[i] = imini;
 			}
 		}
+		if (fixed_centers)
+			break;
 	}
 	distance->replace_rhs(rhs_cache);
-	delete rhs_mus;
 	SG_UNREF(lhs);
 }
 }


### PR DESCRIPTION
1. The means are updated at the beginning of the loop. No need to update them inbetween (the result will not be used).

2. Instead of sampling n times from n objects, use all n objects once (can be reassigned only once anyway!)

3. `fixed_centers` will do the same every iteration, so only iterate once. This codepath should be removed completely!

Not fixed: A) no need to store `dists`. B) remove `fixed_centers` C) bad initialization D) allow kmeans++ from commandline.

*I have never compiled this code.* I don't use Shogun, but I have been looking at different k-means implementations and Shogun stood out as very slow, so I investigated the reasons for this. See also: #2987