### PR TITLE
fix gTest segfaults with GCC >= 6.0.0.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
-2016-02-09 Heiko Strathmann <heiko.strathmann@shogun-toolbox.org >
+2016-02-17 Björn Esser <me@besser82.io>
+	* SHOGUN Release version 4.2.0 (libshogun 17.2, data 0.11, parameter 1)
+	* Bugfixes:
+		- Fix gTest segfaults with GCC >= 6.0.0 [Björn Esser].
+
+2016-02-09 Heiko Strathmann <heiko.strathmann@shogun-toolbox.org>
 
 	* SHOGUN Release version 4.1.0 (libshogun 17.1, data 0.10, parameter 1)
 	* This is a new feature and cleanup release:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -86,6 +86,20 @@ IF (SANITIZER_FLAGS)
 	set_target_properties(shogun-unit-test PROPERTIES COMPILE_FLAGS ${SANITIZER_FLAGS})
 ENDIF()
 
+# In some cases gTest segfaults with GCC >= 6.0.0.  This is a dirty fix.
+# TODO: Update to gTest-release with proper support for GCC >= 6.0.0.
+# See:  https://github.com/google/googletest/issues/705
+IF(CMAKE_COMPILER_IS_GNUCXX)
+	# in order to support cmake 2.8.7 and older
+	IF(NOT CMAKE_CXX_COMPILER_VERSION)
+		include(CheckCompiler)
+	ENDIF(NOT CMAKE_CXX_COMPILER_VERSION)
+	IF(NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "6.0.0")
+		target_compile_options(shogun-unit-test
+			PUBLIC -fno-delete-null-pointer-checks)
+	ENDIF(NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "6.0.0")
+ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+
 ADD_CUSTOM_TARGET(unit-tests
 	COMMAND ${CMAKE_CURRENT_BINARY_DIR}/shogun-unit-test
 	DEPENDS shogun-unit-test)


### PR DESCRIPTION
In some cases gTest segfaults with GCC >= 6.0.0.  This is a dirty fix.
TODO: Update to gTest-release with proper support for GCC >= 6.0.0.
See:  https://github.com/google/googletest/issues/705