### PR TITLE
Lua for cookbook & meta examples

### DIFF
--- a/doc/cookbook/source/conf.py
+++ b/doc/cookbook/source/conf.py
@@ -191,6 +191,7 @@ target_languages = (
         ('r', 'R'),
         ('java', 'java'),
         ('csharp', 'cs'),
+        ('lua', 'lua')
         )
 
 generated_examples_path = None

--- a/examples/meta/CMakeLists.txt
+++ b/examples/meta/CMakeLists.txt
@@ -55,4 +55,9 @@ IF(ENABLE_TESTING)
     IF (CSharpModular AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/csharp)
         add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/csharp)
     ENDIF()
+    
+    # lua
+    IF (LuaModular AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/lua)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lua)
+    ENDIF()
 ENDIF()

--- a/examples/meta/generator/generate.py
+++ b/examples/meta/generator/generate.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--output", help="path to output directory")
     parser.add_argument("-i", "--input", help="path to examples directory (input)")
     parser.add_argument("-t", "--targetsfolder", help="path to directory with target JSON files")
-    parser.add_argument('targets', nargs='*', help="Targets to include (one or more of: python java r octave csharp). If not specified all targets are produced.")
+    parser.add_argument('targets', nargs='*', help="Targets to include (one or more of: python java r octave csharp lua). If not specified all targets are produced.")
 
     args = parser.parse_args()
 

--- a/examples/meta/generator/targets/lua.json
+++ b/examples/meta/generator/targets/lua.json
@@ -1,0 +1,27 @@
+{
+    "Program": "require 'modshogun'\n\n$dependencies$program",
+    "Statement": "$statement\n",
+    "Comment": "--$comment\n",
+    "Init": {
+        "Construct": "$name = modshogun.$type($arguments)",
+        "Copy": "$name = $expr"
+    },
+    "Assign": "$name = $expr",
+    "Type": {
+        "Default": "$type"
+    },
+    "Expr": {
+        "StringLiteral": "'$literal'",
+        "BoolLiteral": {
+            "True": "True",
+            "False": "False"
+        },
+        "NumberLiteral": "$number",
+        "MethodCall": "$object:$method($arguments)",
+        "Identifier": "$identifier",
+        "Enum":"$value"
+    },
+    "Print": "print($expr)",
+    "OutputDirectoryName": "lua",
+    "FileExtension": ".lua"
+}

--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -286,7 +286,7 @@ def loadTargetDict(targetJsonPath):
 if __name__ == "__main__":
     # Parse command line arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument("-t", "--target", nargs='?', help="Translation target. Possible values: python, java, r, octave, csharp. (default: python)")
+    parser.add_argument("-t", "--target", nargs='?', help="Translation target. Possible values: python, java, r, octave, csharp, lua. (default: python)")
     parser.add_argument("path", nargs='?', help="Path to input file. If not specified input is read from stdin")
     args = parser.parse_args()
 

--- a/examples/meta/lua/CMakeLists.txt
+++ b/examples/meta/lua/CMakeLists.txt
@@ -1,0 +1,17 @@
+# add test case for each generated example
+# (not generated yet so have to fake filenames from META_EXAMPLES list)
+FOREACH(META_EXAMPLE ${META_EXAMPLES})
+    # assume a structure <target_language>/<category>/listing.sg
+	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
+	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
+	STRING(REGEX REPLACE "/" "-" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
+    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+
+    # run test in source dir, to have access to "data" folder
+    # run listing from binary dir though as it is generated there
+	add_test(NAME generated_lua-${EXAMPLE_NAME_WITH_DIR}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+			COMMAND ${LUA_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLE_REL_DIR}/${EXAMPLE_NAME}.lua)
+	set_property(TEST generated_lua-${EXAMPLE_NAME_WITH_DIR} PROPERTY
+		ENVIRONMENT "LUA_CPATH=${LUA_MODULAR_BUILD_DIR}/libmodshogun.so")
+ENDFOREACH()


### PR DESCRIPTION
This does not work yet, and I am not sure why. Meta examples are generated nicely, but executing the knn example leads to the error:
```
lua: bad argument #1 to '?' (matrix expected, got userdata)
stack traceback:
	[C]: ?
	[C]: in function 'RealFeatures'
	...op/shogun/build/examples/meta/lua/classifier/knn.lua:5: in main chunk
```

Line 4,5 are:
```lua
trainf = modshogun.CSVFile('../data/fm_train_real.dat')
feats_train = modshogun.RealFeatures(trainf)
```

This means that passing SGObjects into RealFeatures somehow does not work in lua. Any ideas?

