### PR TITLE
Added Neural Tanh Layer and corresponding unit test

### DIFF
--- a/src/shogun/neuralnets/NeuralTanhLayer.cpp
+++ b/src/shogun/neuralnets/NeuralTanhLayer.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2016, Shogun Toolbox Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Written (W) 2016 Arasu Arun
+ */
+
+#include <shogun/neuralnets/NeuralTanhLayer.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/lib/SGVector.h>
+
+using namespace shogun;
+
+CNeuralTanhLayer::CNeuralTanhLayer() : CNeuralLinearLayer()
+{
+}
+
+CNeuralTanhLayer::CNeuralTanhLayer(int32_t num_neurons):
+CNeuralLinearLayer(num_neurons)
+{
+}
+
+void CNeuralTanhLayer::compute_activations(SGVector<float64_t> parameters,
+		CDynamicObjectArray* layers)
+{
+	CNeuralLinearLayer::compute_activations(parameters, layers);
+
+	// apply tanh activation function
+	int32_t length = m_num_neurons*m_batch_size;
+	for (int32_t i=0; i<length; i++)
+		m_activations[i] = CMath::exp(-2.0*m_activations[i]));
+		m_activations[i] = (1.0-m_activations[i])/(1.0+m_activations[i]);
+}
+
+float64_t CNeuralTanhLayer::compute_contraction_term(
+	SGVector< float64_t > parameters)
+{
+	int32_t num_inputs = SGVector<int32_t>::sum(m_input_sizes.vector, m_input_sizes.vlen);
+
+	SGMatrix<float64_t> W(parameters.vector+m_num_neurons,
+		m_num_neurons, num_inputs, false);
+
+	float64_t contraction_term = 0;
+	for (int32_t i=0; i<m_num_neurons; i++)
+	{
+		float64_t sum_j = 0;
+		for (int32_t j=0; j<num_inputs; j++)
+			sum_j += W(i,j)*W(i,j);
+
+		for (int32_t k=0; k<m_batch_size; k++)
+		{
+			float64_t h_ = 1-m_activations(i,k)*m_activations(i,k);
+			contraction_term += h_*h_*sum_j;
+		}
+	}
+
+	return (contraction_coefficient/m_batch_size) * contraction_term;
+}
+
+void CNeuralTanhLayer::compute_contraction_term_gradients(
+	SGVector< float64_t > parameters, SGVector< float64_t > gradients)
+{
+	int32_t num_inputs = SGVector<int32_t>::sum(m_input_sizes.vector, m_input_sizes.vlen);
+
+	SGMatrix<float64_t> W(parameters.vector+m_num_neurons,
+		m_num_neurons, num_inputs, false);
+	SGMatrix<float64_t> WG(gradients.vector+m_num_neurons,
+		m_num_neurons, num_inputs, false);
+
+	for (int32_t k = 0; k<m_batch_size; k++)
+	{
+		for (int32_t i=0; i<m_num_neurons; i++)
+		{
+			float64_t sum_j = 0;
+			for (int32_t j=0; j<num_inputs; j++)
+				sum_j += W(i,j)*W(i,j);
+
+			for (int32_t j=0; j<num_inputs; j++)
+			{
+				float64_t h = m_activations(i,k);
+				float64_t w = W(i,j);
+				float64_t h_ = 1-m_activations(i,k)*m_activations(i,k);
+
+				float64_t g = 2*h_*h_*(w-2*h*sumj);
+
+				WG(i,j) += (contraction_coefficient/m_batch_size)*g;
+			}
+		}
+	}
+}
+
+
+void CNeuralTanhLayer::compute_local_gradients(SGMatrix<float64_t> targets)
+{
+	CNeuralLinearLayer::compute_local_gradients(targets);
+
+	// multiply by the derivative of the tanh function
+	int32_t length = m_num_neurons*m_batch_size;
+	for (int32_t i=0; i<length; i++)
+		m_local_gradients[i] *= 1.0-m_activations[i]*m_activations[i];
+}

--- a/src/shogun/neuralnets/NeuralTanhLayer.h
+++ b/src/shogun/neuralnets/NeuralTanhLayer.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016, Shogun Toolbox Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Written (W) 2016 Arasu Arun
+ */
+
+#ifndef __NEURALTANHLAYER_H__
+#define __NEURALTANHLAYER_H__
+
+#include <shogun/neuralnets/NeuralLinearLayer.h>
+
+namespace shogun
+{
+/** @brief Neural layer with linear neurons, with a [tanh activation
+ * function](http://en.wikipedia.org/wiki/Hyperbolic_function). can be used as a
+ * hidden layer or an output layer.
+ *
+ * When used as an output layer, a
+ * [squared error measure](http://en.wikipedia.org/wiki/Mean_squared_error) is
+ * used
+ */
+class CNeuralTanhLayer : public CNeuralLinearLayer
+{
+public:
+	/** default constructor */
+	CNeuralTanhLayer();
+
+	/** Constuctor
+	 *
+	 * @param num_neurons Number of neurons in this layer
+	 */
+	CNeuralTanhLayer(int32_t num_neurons);
+
+	virtual ~CNeuralTanhLayer() {}
+
+	/** Computes the activations of the neurons in this layer, results should
+	 * be stored in m_activations. To be used only with non-input layers
+	 *
+	 * @param parameters Vector of size get_num_parameters(), contains the
+	 * parameters of the layer
+	 *
+	 * @param layers Array of layers that form the network that this layer is
+	 * being used with
+	 */
+	virtual void compute_activations(SGVector<float64_t> parameters,
+			CDynamicObjectArray* layers);
+
+	/** Computes
+	 * \f[ \frac{\lambda}{N} \sum_{k=0}^{N-1} \left \| J(x_k) \right \|^2_F \f]
+	 * where \f$ \left \| J(x_k)) \right \|^2_F \f$ is the Frobenius norm of
+	 * the Jacobian of the activations of the hidden layer with respect to its
+	 * inputs, \f$ N \f$ is the batch size, and \f$ \lambda \f$ is the
+	 * contraction coefficient.
+	 *
+	 * Should be implemented by layers that support being used as a hidden
+	 * layer in a contractive autoencoder.
+	 *
+	 * @param parameters Vector of size get_num_parameters(), contains the
+	 * parameters of the layer
+	 */
+	virtual float64_t compute_contraction_term(SGVector<float64_t> parameters);
+
+	/** Adds the gradients of
+	 * \f[ \frac{\lambda}{N} \sum_{k=0}^{N-1} \left \| J(x_k) \right \|^2_F \f]
+	 * to the gradients vector, where \f$ \left \| J(x_k)) \right \|^2_F \f$ is
+	 * the Frobenius norm of the Jacobian of the activations of the hidden layer
+	 * with respect to its inputs, \f$ N \f$ is the batch size, and
+	 * \f$ \lambda \f$ is the contraction coefficient.
+	 *
+	 * Should be implemented by layers that support being used as a hidden
+	 * layer in a contractive autoencoder.
+	 *
+	 * @param parameters Vector of size get_num_parameters(), contains the
+	 * parameters of the layer
+	 * @param gradients Vector of size get_num_parameters(). Gradients of the
+	 * contraction term will be added to it
+	 */
+	virtual void compute_contraction_term_gradients(
+		SGVector<float64_t> parameters, SGVector<float64_t> gradients);
+
+	/** Computes the gradients of the error with respect to this layer's
+	 * pre-activations. Results are stored in m_local_gradients.
+	 *
+	 * This is used by compute_gradients() and can be overriden to implement
+	 * layers with different activation functions
+	 *
+	 * @param targets a matrix of size num_neurons*batch_size. If the layer is
+	 * being used as an output layer, targets is the desired values for the
+	 * layer's activations, otherwise it's an empty matrix
+	 */
+	virtual void compute_local_gradients(SGMatrix<float64_t> targets);
+
+	virtual const char* get_name() const { return "NeuralTanhLayer"; }
+};
+
+}
+#endif

--- a/tests/unit/neuralnets/NeuralTanhLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralTanhLayer_unittest.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2016, Shogun Toolbox Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Written (W) 2016 Arasu Arun
+ */
+
+#include <shogun/neuralnets/NeuralTanhlayer.h>
+#include <shogun/neuralnets/NeuralInputLayer.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/mathematics/Math.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+/** Compares the activations computed using the layer against manually computed
+ * activations
+ */
+TEST(NeuralTanhlayer, compute_activations)
+{
+	CNeuralTanhLayer layer(9);
+
+	// initialize some random inputs
+	CMath::init_random(100);
+	SGMatrix<float64_t> x(12,3);
+	for (int32_t i=0; i<x.num_rows*x.num_cols; i++)
+		x[i] = CMath::random(-10.0,10.0);
+
+	CNeuralInputLayer* input = new CNeuralInputLayer (x.num_rows);
+	input->set_batch_size(x.num_cols);
+
+	CDynamicObjectArray* layers = new CDynamicObjectArray();
+	layers->append_element(input);
+
+	SGVector<int32_t> input_indices(1);
+	input_indices[0] = 0;
+
+	// initialize the layer
+	layer.initialize_neural_layer(layers, input_indices);
+	SGVector<float64_t> params(layer.get_num_parameters());
+	SGVector<bool> param_regularizable(layer.get_num_parameters());
+	layer.initialize_parameters(params, param_regularizable, 1.0);
+	layer.set_batch_size(x.num_cols);
+
+	// compute the layer's activations
+	input->compute_activations(x);
+	layer.compute_activations(params, layers);
+	SGMatrix<float64_t> A = layer.get_activations();
+
+	// manually compute the layer's activations
+	SGMatrix<float64_t> A_ref(layer.get_num_neurons(), x.num_cols);
+
+	float64_t* biases = params.vector;
+	float64_t* weights = biases + layer.get_num_neurons();
+
+	for (int32_t i=0; i<A_ref.num_rows; i++)
+	{
+		for (int32_t j=0; j<A_ref.num_cols; j++)
+		{
+			A_ref(i,j) = biases[i];
+
+			for (int32_t k=0; k<x.num_rows; k++)
+				A_ref(i,j) += weights[i+k*A_ref.num_rows]*x(k,j);
+
+			A_ref(i,j) = CMath::exp(-2.0*A_ref(i,j));
+			A_ref(i,j) = (1-A_ref(i,j))/(1+A_ref(i,j));
+		}
+	}
+
+	// compare
+	EXPECT_EQ(A_ref.num_rows, A.num_rows);
+	EXPECT_EQ(A_ref.num_cols, A.num_cols);
+	for (int32_t i=0; i<A.num_rows*A.num_cols; i++)
+		EXPECT_NEAR(A_ref[i], A[i], 1e-12);
+
+	SG_UNREF(layers);
+}
+
+/** Compares the local gradients computed using the layer against gradients
+ * computed using numerical approximation
+ */
+TEST(NeuralTanhLayer, compute_local_gradients)
+{
+	CNeuralTanhLayer layer(9);
+
+	CMath::init_random(100);
+	SGMatrix<float64_t> x(12,3);
+	for (int32_t i=0; i<x.num_rows*x.num_cols; i++)
+		x[i] = CMath::random(-10.0,10.0);
+
+	CNeuralInputLayer* input = new CNeuralInputLayer (x.num_rows);
+	input->set_batch_size(x.num_cols);
+
+	CDynamicObjectArray* layers = new CDynamicObjectArray();
+	layers->append_element(input);
+
+	SGVector<int32_t> input_indices(1);
+	input_indices[0] = 0;
+
+	// initialize the layer
+	layer.initialize_neural_layer(layers, input_indices);
+	SGVector<float64_t> params(layer.get_num_parameters());
+	SGVector<bool> param_regularizable(layer.get_num_parameters());
+	layer.initialize_parameters(params, param_regularizable, 1.0);
+	layer.set_batch_size(x.num_cols);
+
+	SGMatrix<float64_t> y(layer.get_num_neurons(), x.num_cols);
+	for (int32_t i=0; i<y.num_rows*y.num_cols; i++)
+		y[i] = CMath::random(0.0,1.0);
+
+	// compute the layer's local gradients
+	input->compute_activations(x);
+	layer.compute_activations(params, layers);
+	layer.compute_local_gradients(y);
+	SGMatrix<float64_t> LG = layer.get_local_gradients();
+
+	// manually compute local gradients
+	SGMatrix<float64_t> A = layer.get_activations();
+	SGMatrix<float64_t> LG_numerical(A.num_rows, A.num_cols);
+	float64_t epsilon = 1e-9;
+	for (int32_t i=0; i<A.num_rows*A.num_cols; i++)
+	{
+		A[i] += epsilon;
+		float64_t error_plus = layer.compute_error(y);
+		A[i] -= 2*epsilon;
+		float64_t error_minus = layer.compute_error(y);
+		A[i] += epsilon;
+
+		LG_numerical[i] = (error_plus-error_minus)/(2*epsilon);
+		LG_numerical[i] *= 1.0-A[i]*A[i];
+	}
+
+	// compare
+	EXPECT_EQ(LG_numerical.num_rows, LG.num_rows);
+	EXPECT_EQ(LG_numerical.num_cols, LG.num_cols);
+	for (int32_t i=0; i<LG.num_rows*LG.num_cols; i++)
+		EXPECT_NEAR(LG_numerical[i], LG[i], 1e-6);
+
+	SG_UNREF(layers);
+}


### PR DESCRIPTION
The Tanh squasher is a very popular alternative to the sigmoid layer. It's widely used, although not as much as before thanks to relu's. It's definitely important for a complete neural nets package. :) 
