### PR TITLE
Add automatic bias computation in LinearMachine

### DIFF
--- a/src/shogun/classifier/svm/LibLinear.cpp
+++ b/src/shogun/classifier/svm/LibLinear.cpp
@@ -56,6 +56,8 @@ void CLibLinear::init()
 	C2=1;
 	set_max_iterations();
 	epsilon=1e-5;
+	/** Prevent default bias computation*/
+	set_compute_bias(false);
 
 	SG_ADD(&C1, "C1", "C Cost constant 1.", MS_AVAILABLE);
 	SG_ADD(&C2, "C2", "C Cost constant 2.", MS_AVAILABLE);

--- a/src/shogun/machine/LinearMachine.h
+++ b/src/shogun/machine/LinearMachine.h
@@ -66,11 +66,24 @@ class CLinearMachine : public CMachine
 		/** default constructor */
 		CLinearMachine();
 
+		/** Constructor
+		 *
+		 * @param  compute_bias new m_compute_bias
+		 * Determines if bias_compution is considered or not
+		 */
+		CLinearMachine(bool compute_bias);
+
 		/** destructor */
 		virtual ~CLinearMachine();
 
 		/** copy constructor */
 		CLinearMachine(CLinearMachine* machine);
+
+		/** Train machine
+		 *
+		 * @return whether training was successful
+		 */
+		virtual bool train(CFeatures* data=NULL);
 
 		/** get w
 		 *
@@ -95,6 +108,19 @@ class CLinearMachine : public CMachine
 		 * @return bias
 		 */
 		virtual float64_t get_bias();
+
+		/** Set m_compute_bias
+		 *
+		 * Determines if bias compution is considered or not
+		 * @param  compute_bias new m_compute_bias
+		 */
+		virtual void set_compute_bias(bool compute_bias);
+
+		/** Get compute bias
+		 *
+		 * @return compute_bias
+		 */
+		virtual bool get_compute_bias();		
 
 		/** set features
 		 *
@@ -149,6 +175,12 @@ class CLinearMachine : public CMachine
 		 */
 		virtual void store_model_features();
 
+		/** Computes the added bias. The bias is computed 
+		 * as the mean error between the predictions and 
+		 * the true labels.
+		*/
+		void compute_bias(CFeatures* data);
+
 	private:
 
 		void init();
@@ -160,6 +192,8 @@ class CLinearMachine : public CMachine
 		float64_t bias;
 		/** features */
 		CDotFeatures* features;
+		/** If true, bias is computed in ::train method */
+		bool m_compute_bias;
 };
 }
 #endif

--- a/src/shogun/regression/LinearRidgeRegression.h
+++ b/src/shogun/regression/LinearRidgeRegression.h
@@ -37,7 +37,7 @@ namespace shogun
  * {\bf w} = \left(\tau {\bf I}+ \sum_{i=1}^N{\bf x}_i{\bf x}_i^T\right)^{-1}\left(\sum_{i=1}^N y_i{\bf x}_i\right)
  * \f]
  *
- * The expressed solution is a linear method with bias 0 (cf. CLinearMachine).
+ * The expressed solution is a linear method with bias b (cf. CLinearMachine).
  */
 class CLinearRidgeRegression : public CLinearMachine
 {

--- a/tests/unit/regression/LinearMachine_unittest.cc
+++ b/tests/unit/regression/LinearMachine_unittest.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (W) 2016 Youssef Emad El-Din
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ *
+ */
+#include <shogun/lib/config.h>
+
+
+#include <shogun/labels/RegressionLabels.h>
+#include <shogun/features/DenseFeatures.h>
+#include <gtest/gtest.h>
+#include <shogun/regression/Regression.h>
+#include <shogun/machine/LinearMachine.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/regression/LinearRidgeRegression.h>
+#include <shogun/mathematics/eigen3.h>
+
+using namespace shogun;
+using namespace Eigen;
+
+TEST(LinearMachine,apply_train)
+{
+	index_t n=20;
+
+	SGMatrix<float64_t> X(1, n);
+	SGMatrix<float64_t> X_test(1, 3);
+	SGVector<float64_t> Y(n);
+
+	X_test[0]=3;
+	X_test[1]=7.5;
+	X_test[2]=12;
+
+	for (index_t i=0; i<n; ++i)
+	{
+		X[i] = i;
+		Y[i]=2*X[i] +1;
+	}
+
+	CDenseFeatures<float64_t>* feat_train=new CDenseFeatures<float64_t>(X);
+	CDenseFeatures<float64_t>* feat_test=new CDenseFeatures<float64_t>(X_test);
+	CRegressionLabels* label_train=new CRegressionLabels(Y);
+
+	float64_t tau=0.8;
+	CLinearRidgeRegression* model=new CLinearRidgeRegression(tau, feat_train,label_train);
+	model->train();
+
+	CRegressionLabels* predictions=model->apply_regression(feat_test);
+	SGVector<float64_t> prediction_vector=predictions->get_labels();
+
+	EXPECT_LE(CMath::abs(prediction_vector[0]-7), 0.5);
+	EXPECT_LE(CMath::abs(prediction_vector[1]-16), 0.5);
+	EXPECT_LE(CMath::abs(prediction_vector[2]-25), 0.5);
+}
+
+TEST(LinearMachine,compute_bias)
+{
+	index_t n=3;
+
+	SGMatrix<float64_t> X(1, n);
+	SGMatrix<float64_t> X_test(1, n);
+	SGVector<float64_t> Y(n);
+
+	X[0]=0;
+	X[1]=1.1;
+	X[2]=2.2;
+
+
+	for (index_t i=0; i<n; ++i)
+	{
+		Y[i]=CMath::sin(X(0, i));
+	}
+
+	CDenseFeatures<float64_t>* feat_train=new CDenseFeatures<float64_t>(X);
+	CRegressionLabels* label_train=new CRegressionLabels(Y);
+
+	float64_t tau=0.8;
+	CLinearRidgeRegression* model=new CLinearRidgeRegression(tau, feat_train,label_train);
+	model->train();
+	float64_t output_bias = model->get_bias();
+
+	CLinearRidgeRegression* model_nobias=new CLinearRidgeRegression(tau, feat_train,label_train);
+	model_nobias->set_compute_bias(false);
+	model_nobias->train();
+
+	// Calculate bias manually
+	CRegressionLabels* predictions_nobias = model_nobias->apply_regression(feat_train);
+	SGVector<float64_t> prediction_vector = predictions_nobias->get_labels();
+
+	Map<VectorXd> eigen_prediction(prediction_vector.vector, 3);
+	Map<VectorXd> eigen_labels(Y, 3);
+	float64_t expected_bias = (eigen_labels-eigen_prediction).mean();
+
+	EXPECT_LE(CMath::abs(output_bias - expected_bias), 10E-15);
+}


### PR DESCRIPTION
@karlnapf  check changes for issue #3033 :
1- Replace `lapack` calls in `CLinearRidgeRegression::train_machine()` by `eigen` calls.
2- Add `bias_flag` to `LinearMachine` class
3- Add `compute_bias()` method to `LinearMachine` class
4- Override `train()` to add optional `compute_bias()`