### PR TITLE
Shorten time and diagnose failing python modular examples.

### DIFF
--- a/examples/undocumented/libshogun/so_multiclass_BMRM.cpp
+++ b/examples/undocumented/libshogun/so_multiclass_BMRM.cpp
@@ -29,8 +29,8 @@ using namespace shogun;
 
 #define	DIMS		2
 #define EPSILON	10e-5
-#define	NUM_SAMPLES	100
-#define NUM_CLASSES	10
+#define	NUM_SAMPLES	30
+#define NUM_CLASSES	3
 
 char FNAME[] = "data.svmlight";
 

--- a/examples/undocumented/python_modular/regression_cartree_modular.py
+++ b/examples/undocumented/python_modular/regression_cartree_modular.py
@@ -4,7 +4,7 @@ from numpy import array
 # set both input attributes as not nominal (ie. continuous)
 feattypes = array([False])
 
-parameter_list = [[500,50,15,0.2,feattypes]]
+parameter_list = [[50,5,15,0.2,feattypes]]
 
 def regression_cartree_modular(num_train=500,num_test=50,x_range=15,noise_var=0.2,ft=feattypes):
 	try:

--- a/examples/undocumented/python_modular/statistics_hsic.py
+++ b/examples/undocumented/python_modular/statistics_hsic.py
@@ -10,7 +10,7 @@
 import numpy as np
 from math import pi
 
-parameter_list = [[250,3,3]]
+parameter_list = [[150,3,3]]
 
 def statistics_hsic (n, difference, angle):
 	from modshogun import RealFeatures

--- a/examples/undocumented/python_modular/structure_graphcuts.py
+++ b/examples/undocumented/python_modular/structure_graphcuts.py
@@ -148,13 +148,13 @@ def evaluation(labels_pr, labels_gt, model):
 
     return ave_loss
 
-def graphcuts_sosvm(num_train_samples = 20, len_label = 10, len_feat = 40, num_test_samples = 10):
+def graphcuts_sosvm(num_train_samples = 10, len_label = 5, len_feat = 20, num_test_samples = 5):
     """ Graph cuts as approximate inference in structured output SVM framework.
 
         Args:
             num_train_samples: number of training samples
             len_label: number of classes, i.e., size of label space
-            len_feat: the dimention of the feature vector
+            len_feat: the dimension of the feature vector
             num_test_samples: number of testing samples
     """
     import time
@@ -268,4 +268,3 @@ def structure_graphcuts(test_general=True, test_sosvm=True):
 if __name__ == '__main__':
     print("Graph cuts")
     structure_graphcuts(*parameter_list[0])
-

--- a/examples/undocumented/python_modular/structure_plif_hmsvm_bmrm.py
+++ b/examples/undocumented/python_modular/structure_plif_hmsvm_bmrm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-parameter_list=[[100, 250, 10, 2]]
+parameter_list=[[50, 125, 10, 2]]
 
 def structure_plif_hmsvm_bmrm (num_examples, example_length, num_features, num_noise_features):
 	from modshogun import RealMatrixFeatures, TwoStateModel, DualLibQPBMSOSVM, StructuredAccuracy

--- a/tests/unit/base/RefCount_unittest.cc
+++ b/tests/unit/base/RefCount_unittest.cc
@@ -17,7 +17,7 @@ void * stress_test_helper(void * args)
 {
 	RefCount * rc = (RefCount *) args;
 
-	for (index_t i = 0; i < 1000000; i++)
+	for (index_t i = 0; i < 10; i++)
 	{
 		rc->ref();
 		rc->ref();
@@ -35,14 +35,14 @@ TEST(RefCount, stress_test)
 	rc->ref();
 	EXPECT_EQ(rc->ref_count(), 1);
 
-	pthread_t * threads = new pthread_t[10];
+	pthread_t * threads = new pthread_t[5];
 
-	for (index_t i = 0; i < 10; i++)
+	for (index_t i = 0; i < 5; i++)
 	{
 		pthread_create(&threads[i], NULL, stress_test_helper, static_cast<void *>(rc));
 	}
 
-	for (index_t i = 0; i < 10; i++)
+	for (index_t i = 0; i < 5; i++)
 	{
 		pthread_join(threads[i], NULL);
 	}


### PR DESCRIPTION
For #3005.
I haven't touched those that use shogun-data. Final output of `make test` after changes is [here](https://gist.github.com/sanuj/36dbf0ff8af9de9c8468).
