### PR TITLE
eigen3 correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,11 +779,15 @@ ELSE ()
 ENDIF ()
 
 # Linear algebra default global backend setups
-OPTION (LinAlgBackend "Set global linear algebra backend library for all modules")
-IF (LinAlgBackend STREQUAL "EIGEN3")
+if( NOT LINALG_DEFAULT_BACKEND )
+  set( LINALG_DEFAULT_BACKEND EIGEN3 CACHE STRING
+       "Set global linear algebra backend library for all modules: EIGEN3, VIENNACL"
+       FORCE )
+endif()
+IF (LINALG_DEFAULT_BACKEND STREQUAL "EIGEN3")
 	SET(USE_EIGEN3 1)
 	MESSAGE("-- Eigen3 set as default global linear algebra backend library")
-ELSEIF (LinAlgBackend STREQUAL "VIENNACL")
+ELSEIF (LINALG_DEFAULT_BACKEND STREQUAL "VIENNACL")
 	FIND_PACKAGE(ViennaCL ${VIENNACL_VERSION_MINIMUM} REQUIRED)
 	IF (VIENNACL_FOUND AND ENABLE_VIENNACL)
 		SET(USE_VIENNACL 1)
@@ -796,11 +800,15 @@ ENDIF ()
 # Linear algebra default module specific backend setup
 
 # Core module
-OPTION (CoreLib "Set linear algebra backend library for core module")
-IF (CoreLib STREQUAL "EIGEN3")
+if( NOT LINALG_CORE_LIB )
+  set( LINALG_CORE_LIB EIGEN3 CACHE STRING
+       "Set linear algebra backend library for core module: EIGEN3, VIENNACL"
+       FORCE )
+endif()
+IF (LINALG_CORE_LIB STREQUAL "EIGEN3")
 	SET(USE_EIGEN3_CORE 1)
 	MESSAGE("-- Eigen3 set as default core module (linalg) backend library")
-ELSEIF (CoreLib STREQUAL "VIENNACL")
+ELSEIF (LINALG_CORE_LIB STREQUAL "VIENNACL")
 	FIND_PACKAGE(ViennaCL ${VIENNACL_VERSION_MINIMUM} REQUIRED)
 	IF (VIENNACL_FOUND AND ENABLE_VIENNACL)
 		SET(USE_VIENNACL_CORE 1)
@@ -811,11 +819,15 @@ ELSEIF (CoreLib STREQUAL "VIENNACL")
 ENDIF ()
 
 # Reduction module
-OPTION (ReduxLib "Set linear algebra backend library for reduction module")
-IF (ReduxLib STREQUAL "EIGEN3")
+if( NOT LINALG_REDUX_LIB )
+  set( LINALG_REDUX_LIB EIGEN3 CACHE STRING
+       "Set linear algebra backend library for reduction module: EIGEN3, VIENNACL"
+       FORCE )
+endif()
+IF (LINALG_REDUX_LIB STREQUAL "EIGEN3")
 	SET(USE_EIGEN3_REDUX 1)
 	MESSAGE("-- Eigen3 set as default reduction module (linalg) backend library")
-ELSEIF (ReduxLib STREQUAL "VIENNACL")
+ELSEIF (LINALG_REDUX_LIB STREQUAL "VIENNACL")
 	FIND_PACKAGE(ViennaCL ${VIENNACL_VERSION_MINIMUM} REQUIRED)
 	IF (VIENNACL_FOUND AND ENABLE_VIENNACL)
 		SET(USE_VIENNACL_REDUX 1)
@@ -826,11 +838,15 @@ ELSEIF (ReduxLib STREQUAL "VIENNACL")
 ENDIF ()
 
 # Linear solver module
-OPTION (LinSolverLib "Set linear algebra backend library for linear solver module")
-IF (LinSolverLib STREQUAL "EIGEN3")
+if( NOT LINALG_LINEAR_SOLVER_LIB )
+  set( LINALG_SOLVER_LIB EIGEN3 CACHE STRING
+       "Set linear algebra backend library for linear solver module: EIGEN3, VIENNACL"
+       FORCE )
+endif()
+IF (LINALG_LINEAR_SOLVER_LIB STREQUAL "EIGEN3")
 	SET(USE_EIGEN3_LINSLV 1)
 	MESSAGE("-- Eigen3 set as default linear solver module (linalg) backend library")
-ELSEIF (LinSolverLib STREQUAL "VIENNACL")
+ELSEIF (LINALG_LINEAR_SOLVER_LIB STREQUAL "VIENNACL")
 	FIND_PACKAGE(ViennaCL ${VIENNACL_VERSION_MINIMUM} REQUIRED)
 	IF (VIENNACL_FOUND AND ENABLE_VIENNACL)
 		SET(USE_VIENNACL_LINSLV 1)
@@ -841,11 +857,15 @@ ELSEIF (LinSolverLib STREQUAL "VIENNACL")
 ENDIF ()
 
 # Eigen solver module
-OPTION (EigenSolver "Set linear algebra backend library for eigen solver module")
-IF (EigenSolver STREQUAL "EIGEN3")
+if( NOT LINALG_EIGENSOLVER_LIB )
+  set( LINALG_EIGENSOLVER_LIB EIGEN3 CACHE STRING
+       "Set linear algebra backend library for eigen solver module: EIGEN3, VIENNACL"
+       FORCE )
+endif()
+IF (LINALG_EIGENSOLVER_LIB STREQUAL "EIGEN3")
 	SET(USE_EIGEN3_EIGSLV 1)
 	MESSAGE("-- Eigen3 set as default eigen solver module (linalg) backend library")
-ELSEIF (EigenSolver STREQUAL "VIENNACL")
+ELSEIF (LINALG_EIGENSOLVER_LIB STREQUAL "VIENNACL")
 	FIND_PACKAGE(ViennaCL ${VIENNACL_VERSION_MINIMUM} REQUIRED)
 	IF (VIENNACL_FOUND AND ENABLE_VIENNACL)
 		SET(USE_VIENNACL_EIGSLV 1)


### PR DESCRIPTION
@vigsterkr UPDATE: I applied the fix to develop as it is definitely necessary. The rest is optional for cleaner cmake options.


I renamed them to start with LINALG_ so that they are grouped if ppl check the options and not scattered all over without it being clear that they change linag behaviour. Also, ccmake which shows the cached options now does't show a binary ON/OFF, but the string. Just like CMAKE_BUILD_TYPE

 This might interfere with some builds. Let me know