### PR TITLE
kmeans update

### DIFF
--- a/src/shogun/clustering/KMeans.h
+++ b/src/shogun/clustering/KMeans.h
@@ -254,9 +254,7 @@ class CKMeans : public CDistanceMachine
 		*
 		* @return initial cluster centers: matrix (k columns, dim rows)
 		*/
-		void set_random_centers(SGVector<float64_t> weights_set, SGVector<int32_t> ClList, int32_t XSize);
-		void set_initial_centers(SGVector<float64_t> weights_set,
-					SGVector<int32_t> ClList, int32_t XSize);
+		void set_random_centers();
 		void compute_cluster_variances();
 
 	private:

--- a/src/shogun/clustering/KMeansLloydImpl.cpp
+++ b/src/shogun/clustering/KMeansLloydImpl.cpp
@@ -9,6 +9,7 @@
 
 #include "shogun/clustering/KMeansLloydImpl.h"
 #include <shogun/distance/Distance.h>
+#include <shogun/distance/EuclideanDistance.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/io/SGIO.h>
@@ -17,127 +18,138 @@ using namespace shogun;
 
 namespace shogun
 {
-void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_iter, SGMatrix<float64_t> mus,
-		SGVector<int32_t> ClList, SGVector<float64_t> weights_set, bool fixed_centers)
+void CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_iter, SGMatrix<float64_t> mus, 
+		bool fixed_centers)
 {
 	CDenseFeatures<float64_t>* lhs=
 		CDenseFeatures<float64_t>::obtain_from_generic(distance->get_lhs());
-	int32_t XSize=lhs->get_num_vectors();
+	
+	int32_t lhs_size=lhs->get_num_vectors();
 	int32_t dimensions=lhs->get_num_features();
 
 	CDenseFeatures<float64_t>* rhs_mus=new CDenseFeatures<float64_t>(0);
 	CFeatures* rhs_cache=distance->replace_rhs(rhs_mus);
 
-	SGVector<float64_t> dists=SGVector<float64_t>(k*XSize);
-	dists.zero();
+	SGVector<int32_t> cluster_assignments=SGVector<int32_t>(lhs_size);
+	cluster_assignments.zero();
+
+	/* Weights : Number of points in each cluster */
+	SGVector<float64_t> weights_set=SGVector<float64_t>(k);
+	weights_set.zero();
+	/* Initially set all weights for zeroth cluster, Changes in assignement step */
+	weights_set[0]=lhs_size;
+
+	distance->precompute_lhs();
 
 	int32_t changed=1;
-	int32_t iter=0;
-	int32_t vlen=0;
-	bool vfree=false;
-	float64_t* vec=NULL;
+	int32_t iter;
 
-	while (changed && (iter<max_iter))
+	for(iter=0; iter<max_iter; iter++)
 	{
-		iter++;
 		if (iter==max_iter-1)
-			SG_SWARNING("kmeans clustering changed throughout %d iterations stopping...\n", max_iter-1)
+			SG_SWARNING("KMeans clustering has reached maximum number of ( %d ) iterations without having converged. \
+				   	Terminating. \n", iter)
 
-		if (iter%1000 == 0)
-			SG_SINFO("Iteration[%d/%d]: Assignment of %i patterns changed.\n", iter, max_iter, changed)
 		changed=0;
+		rhs_mus->copy_feature_matrix(mus);
 
+		distance->precompute_rhs();
+		
+		/* Assigment step : Assign each point to nearest cluster */
+		for (int32_t i=0; i<lhs_size; i++)
+		{ 
+			const int32_t cluster_assignments_i=cluster_assignments[i];
+			int32_t min_cluster, j;
+			float64_t min_dist, dist;
+			
+			min_cluster=0;
+		   	min_dist=distance->distance(i,0);
+			for (j=1; j<k; j++)
+			{
+				dist=distance->distance(i,j);
+				if (dist<min_dist)
+				{
+					min_dist=dist;
+					min_cluster=j;
+				}
+			}
+
+			if (min_cluster!=cluster_assignments_i)
+			{
+				changed++;
+				weights_set[min_cluster]+= 1.0;
+				weights_set[cluster_assignments_i]-= 1.0;
+
+				if(fixed_centers)
+				{
+					SGVector<float64_t>vec=lhs->get_feature_vector(i);
+					
+					/* mu_new = mu_old + (x - mu_old)/(w) */					
+					for (j=0; j<dimensions; j++)
+					{
+						mus(j, min_cluster)+=
+							(vec[j]-mus(j, min_cluster)) / weights_set[min_cluster];
+					}
+
+					lhs->free_feature_vector(vec, i);
+
+					/* mu_new = mu_old - (x - mu_old)/(w-1) */
+					/* if weights_set(j)~=0 */
+					if (weights_set[cluster_assignments_i]!=0.0)
+					{
+						SGVector<float64_t>vec1=lhs->get_feature_vector(i);
+
+						for (j=0; j<dimensions; j++)
+						{
+							mus(j, cluster_assignments_i)-=
+								(vec1[j]-mus(j, cluster_assignments_i)) / weights_set[cluster_assignments_i];
+						}
+						lhs->free_feature_vector(vec1, i);
+					}
+					else
+					{
+						/*  mus(:,j)=zeros(dimensions,1) ; */
+						for (j=0; j<dimensions; j++)
+							mus(j, cluster_assignments_i)=0;
+					}
+					
+				}
+
+				cluster_assignments[i] = min_cluster;
+			}
+		}
+		if(changed==0)
+			break;
+
+		/* Update Step : Calculate new means */
 		if (!fixed_centers)
 		{
 			/* mus=zeros(dimensions, k) ; */
 			mus.zero();
-			for (int32_t i=0; i<XSize; i++)
+			for (int32_t i=0; i<lhs_size; i++)
 			{
-				int32_t Cl=ClList[i];
+				int32_t cluster_i=cluster_assignments[i];
 
-				vec=lhs->get_feature_vector(i, vlen, vfree);
+				SGVector<float64_t>vec=lhs->get_feature_vector(i);
 
 				for (int32_t j=0; j<dimensions; j++)
-					mus.matrix[Cl*dimensions+j] += vec[j];
-
-				lhs->free_feature_vector(vec, i, vfree);
+					mus(j, cluster_i) += vec[j];
+				lhs->free_feature_vector(vec, i);
 			}
-
+		
 			for (int32_t i=0; i<k; i++)
 			{
 				if (weights_set[i]!=0.0)
 				{
 					for (int32_t j=0; j<dimensions; j++)
-						mus.matrix[i*dimensions+j] /= weights_set[i];
+						mus(j, i) /= weights_set[i];
 				}
 			}
 		}
-		rhs_mus->copy_feature_matrix(mus);
-		for (int32_t i=0; i<XSize; i++)
-		{
-			/* ks=ceil(rand(1,XSize)*XSize) ; */
-			const int32_t Pat=CMath::random(0, XSize-1);
-			const int32_t ClList_Pat=ClList[Pat];
-			int32_t imini, j;
-			float64_t mini;
-
-			/* compute the distance of this point to all centers */
-			for(int32_t idx_k=0;idx_k<k;idx_k++)
-				dists[idx_k]=distance->distance(Pat,idx_k);
-
-			/* [mini,imini]=min(dists(:,i)) ; */
-			imini=0 ; mini=dists[0];
-			for (j=1; j<k; j++)
-				if (dists[j]<mini)
-				{
-					mini=dists[j];
-					imini=j;
-				}
-
-			if (imini!=ClList_Pat)
-			{
-				changed++;
-
-				/* weights_set(imini) = weights_set(imini) + 1.0 ; */
-				weights_set[imini]+= 1.0;
-				/* weights_set(j)     = weights_set(j)     - 1.0 ; */
-				weights_set[ClList_Pat]-= 1.0;
-
-				vec=lhs->get_feature_vector(Pat, vlen, vfree);
-
-				for (j=0; j<dimensions; j++)
-				{
-					mus.matrix[imini*dimensions+j]-=
-						(vec[j]-mus.matrix[imini*dimensions+j]) / weights_set[imini];
-				}
-
-				lhs->free_feature_vector(vec, Pat, vfree);
-
-				/* mu_new = mu_old - (x - mu_old)/(n-1) */
-				/* if weights_set(j)~=0 */
-				if (weights_set[ClList_Pat]!=0.0)
-				{
-					vec=lhs->get_feature_vector(Pat, vlen, vfree);
-
-					for (j=0; j<dimensions; j++)
-					{
-						mus.matrix[ClList_Pat*dimensions+j]-=
-								(vec[j]-mus.matrix[ClList_Pat*dimensions+j]) / weights_set[ClList_Pat];
-					}
-					lhs->free_feature_vector(vec, Pat, vfree);
-				}
-				else
-				{
-					/*  mus(:,j)=zeros(dimensions,1) ; */
-					for (j=0; j<dimensions; j++)
-						mus.matrix[ClList_Pat*dimensions+j]=0;
-				}
-
-				/* ClList(i)= imini ; */
-				ClList[Pat] = imini;
-			}
-		}
+		if (iter%(max_iter/10) == 0)
+			SG_SINFO("Iteration[%d/%d]: Assignment of %i patterns changed.\n", iter, max_iter, changed)
 	}
+	distance->reset_precompute();
 	distance->replace_rhs(rhs_cache);
 	delete rhs_mus;
 	SG_UNREF(lhs);

--- a/src/shogun/clustering/KMeansLloydImpl.h
+++ b/src/shogun/clustering/KMeansLloydImpl.h
@@ -34,7 +34,7 @@ class CKMeansLloydImpl
 		 * @param fixed_centers keep centers fixed or not
 		 */
 		static void Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_iter, SGMatrix<float64_t> mus,
-			SGVector<int32_t> ClList, SGVector<float64_t> weights_set, bool fixed_centers);
+			bool fixed_centers);
 };
 }
 #endif

--- a/src/shogun/distance/Distance.h
+++ b/src/shogun/distance/Distance.h
@@ -77,6 +77,12 @@ enum EDistanceType
  * In the means of Shogun toolbox the distance function is defined
  * on the 'space' of CFeatures.
  *
+ * Precomputations can be done for left hand side and right hand side features.
+ * This has to be implemented in overloaded methods for precompute_lhs() and 
+ * precompute_rhs() in derived classes.
+ * WARNING : Make sure to reset precomputations for features using reset_precompute() 
+ * when features or feature matrix are changed.
+ *
  */
 class CDistance : public CSGObject
 {

--- a/tests/unit/clustering/kmeans_unittest.cc
+++ b/tests/unit/clustering/kmeans_unittest.cc
@@ -36,6 +36,7 @@ TEST(KMeans, manual_center_initialization_test)
 	initial_centers(1,1)=5;
 
 	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(rect);
+	SG_REF(features);	
 	CEuclideanDistance* distance=new CEuclideanDistance(features, features);
 	CKMeans* clustering=new CKMeans(2, distance,initial_centers);
 
@@ -141,6 +142,7 @@ TEST(KMeans, minibatch_training_test)
 	initial_centers(1,0)=0;
 
 	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(rect);
+	SG_REF(features);	
 	CEuclideanDistance* distance=new CEuclideanDistance(features, features);
 	CKMeans* clustering=new CKMeans(1, distance,initial_centers);
 
@@ -158,6 +160,120 @@ TEST(KMeans, minibatch_training_test)
 		SG_UNREF(learnt_centers);
 	}
 
+	SG_UNREF(clustering);
+	SG_UNREF(features);
+}
+
+TEST(KMeans, fixed_centers)
+{
+	/*create a rectangle with four points as (0,0) (0,10) (20,0) (20,10)*/
+	SGMatrix<float64_t> rect(2, 4);
+	rect(0,0)=0;
+	rect(1,0)=0;
+	rect(0,1)=0;
+	rect(1,1)=10;
+	rect(0,2)=20;
+	rect(1,2)=0;
+	rect(0,3)=20;
+	rect(1,3)=10;
+
+	/*choose local minima points (but not exact means) (0,4) (20,4) as initial centers */
+	SGMatrix<float64_t> initial_centers(2,2);
+	initial_centers(0,0)=0;
+	initial_centers(1,0)=4;
+	initial_centers(0,1)=20;
+	initial_centers(1,1)=4;
+
+	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(rect);
+	SG_REF(features);	
+	CEuclideanDistance* distance=new CEuclideanDistance(features, features);
+	CKMeans* clustering=new CKMeans(2, distance,initial_centers);
+	clustering->set_fixed_centers(true);
+
+	clustering->train(features);
+	CDenseFeatures<float64_t>* learnt_centers=(CDenseFeatures<float64_t>*)distance->get_lhs();
+
+	ASSERT_NE(learnt_centers, (CDenseFeatures<float64_t>*)NULL);
+	SGMatrix<float64_t> c=learnt_centers->get_feature_matrix();
+		
+	EXPECT_EQ(c(0,0), 0);
+	EXPECT_EQ(c(1,0), 5);
+	EXPECT_EQ(c(0,1), 20);
+	EXPECT_EQ(c(1,1), 5);
+	
+	SG_UNREF(clustering);
+	SG_UNREF(features);
+}
+
+TEST(KMeans, random_centers_init)
+{
+	/* Random centers should initialize with unique centers  */
+	SGMatrix<float64_t> rect(2, 3);
+	rect(0,0)=0;
+	rect(1,0)=0;
+	rect(0,1)=10;
+	rect(1,1)=10;
+	rect(0,2)=20;
+	rect(1,2)=20;
+
+	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(rect);
+	SG_REF(features);	
+	CEuclideanDistance* distance=new CEuclideanDistance(features, features);
+	CKMeans* clustering=new CKMeans(3, distance);
+
+	clustering->train(features);
+	CDenseFeatures<float64_t>* learnt_centers=(CDenseFeatures<float64_t>*)distance->get_lhs();
+	ASSERT_NE(learnt_centers, (CDenseFeatures<float64_t>*)NULL);
+	SGMatrix<float64_t> c=learnt_centers->get_feature_matrix();
+		
+	EXPECT_NE(c(0,0),c(0,1));
+	EXPECT_NE(c(0,0),c(0,2));
+	EXPECT_NE(c(0,1),c(0,2));
+	
+	SG_UNREF(clustering);
+	SG_UNREF(features);
+}
+
+TEST(KMeans, random_centers_assign)
+{
+	/* Random centers initialization should correctly assign two very separate clusters  */
+	SGMatrix<float64_t> rect(2, 4);
+	rect(0,0)=0;
+	rect(1,0)=0;
+	rect(0,1)=0;
+	rect(1,1)=10;
+	rect(0,2)=20;
+	rect(1,2)=0;
+	rect(0,3)=20;
+	rect(1,3)=10;
+
+	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(rect);
+	SG_REF(features);	
+	CEuclideanDistance* distance=new CEuclideanDistance(features, features);
+	CKMeans* clustering=new CKMeans(2, distance);
+
+	clustering->train(features);
+	CDenseFeatures<float64_t>* learnt_centers=(CDenseFeatures<float64_t>*)distance->get_lhs();
+	ASSERT_NE(learnt_centers, (CDenseFeatures<float64_t>*)NULL);	
+	SGMatrix<float64_t> c=learnt_centers->get_feature_matrix();
+	
+	SGVector<float64_t> count=SGVector<float64_t>(2);
+	count.zero();
+
+	if ((c(0,0)==0) && (c(1,0)==5))
+		count[0]++;
+	if ((c(0,1)==0) && (c(1,1)==5))
+		count[0]++;
+	if ((c(0,0)==20) && (c(1,0)==5))
+		count[1]++;
+	if ((c(0,1)==20) && (c(1,1)==5))
+		count[1]++;	
+
+	if (count[0] == 0)
+		EXPECT_EQ(count[1], 0);
+	if (count[0] == 1)
+		EXPECT_EQ(count[1], 1);
+	
 	SG_UNREF(clustering);
 	SG_UNREF(features);
 }


### PR DESCRIPTION
This has most of the primary changes to Kmeans based on https://github.com/shogun-toolbox/shogun/issues/2987 and some general cleanups.
Still have to do some aesthetic changes.

- Changed random initialization
  - now chooses `k` random points as centers rather than assigning random centers to all points.
  - Removed unnecessary paramters, cluster_list, weight_set, etc. This should be calculated in the Lloyds implementation.
- changed manual initialization
  - again Removed unnecessary paramters
  - removed calculation of  distances and assigning of clusters from here, this along wth the parameters now takes place in assignment step of lloyds.

- made clear separation for assigment step and update step in lloyds impl.
- removed random sampling of instances to be updated in each iteration, each sample should be updated. 
- used precomputed squared norms for euclidean distances
- removed various unnecessary computations in lloyds impl
  - no need to change center values in assigment steps now takes place only in update step.
  - no need to store distances in iterations, now calculated in place (scope for parallelisation) 
- some new unit-tests