### PR TITLE
only do c++ meta examples if c++11 is available

### DIFF
--- a/examples/descriptions/modular/classifier_knn.txt
+++ b/examples/descriptions/modular/classifier_knn.txt
@@ -1,4 +1,0 @@
-This example shows usage of a k-nearest neighbor (KNN) classification rule on
-a toy data set. The number of the nearest neighbors is set to k=3 and the distances
-are measured by the Euclidean metric. Finally, the KNN rule is applied to predict
-labels of test examples.

--- a/examples/meta/CMakeLists.txt
+++ b/examples/meta/CMakeLists.txt
@@ -42,7 +42,11 @@ IF(ENABLE_TESTING)
 
     # c++
     IF (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cpp)
-        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp)
+        IF(HAVE_CXX0X OR HAVE_CXX11)
+            add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cpp)
+        ELSE()
+            MESSAGE(WARNING "Skipping C++ meta examples; requires a c++11 compatible compiler.")
+        ENDIF()
     ENDIF()
 
     # Python

--- a/tests/meta/CMakeLists.txt
+++ b/tests/meta/CMakeLists.txt
@@ -30,12 +30,16 @@ FOREACH(REFERENCE_FILE ${META_INTEGRATION_REFERENCES})
 
 	# cpp
 	# TODO implement other languages tests
-	add_test(NAME integration_meta_cpp-${NAME_WITH_DIR}
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		COMMAND meta_example_integration_tester ${REL_DIR} ${NAME}.dat cpp generated_results reference_results)
-	set_tests_properties(
-		integration_meta_cpp-${NAME_WITH_DIR}
-			PROPERTIES
-			DEPENDS generated_cpp-${NAME}
-	)
+	IF(HAVE_CXX0X OR HAVE_CXX11)
+	    add_test(NAME integration_meta_cpp-${NAME_WITH_DIR}
+		    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		    COMMAND meta_example_integration_tester ${REL_DIR} ${NAME}.dat cpp generated_results reference_results)
+	    set_tests_properties(
+		    integration_meta_cpp-${NAME_WITH_DIR}
+			    PROPERTIES
+			    DEPENDS generated_cpp-${NAME}
+	    )
+	ELSE()
+	    MESSAGE(WARNING "Skipping C++ meta integration tests; requires a c++11 compatible compiler.")
+	ENDIF()
 ENDFOREACH()


### PR DESCRIPTION
since they use the auto keyword (and there is not other way to infer types in the meta language with reasonable effort)