### PR TITLE
add precompute to base Distance

### DIFF
--- a/src/shogun/distance/Distance.h
+++ b/src/shogun/distance/Distance.h
@@ -120,6 +120,29 @@ class CDistance : public CSGObject
 			return distance(idx_a, idx_b);
 		}
 
+		/**  
+		 * Precomputation related to features of right hand side
+		 * WARNING : Make sure to reset computations using reset_precompute()
+		 * when features or feature matrix are changed.
+		 * This method is empty, should be overloaded in derived class.
+		 */
+		virtual void precompute_rhs(){}
+
+		/** 
+		 * Precomputation related to features of left hand side
+		 * WARNING : Make sure to reset computations using reset_precompute()
+		 * when features or feature matrix are changed.
+		 * This method is empty, should be overloaded in derived class.
+		 */
+		virtual void precompute_lhs(){}
+	
+		/** 
+		 * Reset precomputations for features of both sides
+		 * Should be used to reset whenever features or feature matrix are changed.
+		 * This method is empty, should be overloaded in derived class.
+		 */
+		virtual void reset_precompute(){}
+
 		/** get distance matrix
 		 *
 		 * @return computed distance matrix (needs to be cleaned up)

--- a/src/shogun/distance/EuclideanDistance.cpp
+++ b/src/shogun/distance/EuclideanDistance.cpp
@@ -80,7 +80,7 @@ float64_t CEuclideanDistance::compute(int32_t idx_a, int32_t idx_b)
 	return CMath::sqrt(result);
 }
 
-void CEuclideanDistance::precompute_rhs_squared_norms()
+void CEuclideanDistance::precompute_rhs()
 {
 #ifdef HAVE_LINALG_LIB
 	SGVector<float64_t>rhs_sq=SGVector<float64_t>(rhs->get_num_vectors());
@@ -97,7 +97,7 @@ void CEuclideanDistance::precompute_rhs_squared_norms()
 	
 }
 
-void CEuclideanDistance::precompute_lhs_squared_norms()
+void CEuclideanDistance::precompute_lhs()
 {
 #ifdef HAVE_LINALG_LIB
 	SGVector<float64_t>lhs_sq=SGVector<float64_t>(lhs->get_num_vectors());
@@ -113,7 +113,7 @@ void CEuclideanDistance::precompute_lhs_squared_norms()
 #endif
 }
 
-void CEuclideanDistance::reset_squared_norms()
+void CEuclideanDistance::reset_precompute()
 {
 	m_lhs_squared_norms=SGVector<float64_t>();
 	m_rhs_squared_norms=SGVector<float64_t>();
@@ -122,7 +122,7 @@ void CEuclideanDistance::reset_squared_norms()
 void CEuclideanDistance::init()
 {
 	disable_sqrt=false;
-	reset_squared_norms();
+	reset_precompute();
 	m_parameters->add(&disable_sqrt, "disable_sqrt", "If sqrt shall not be applied.");
 	m_parameters->add(&m_rhs_squared_norms, "m_rhs_squared_norms", "Squared norms from features of right hand side");	
 	m_parameters->add(&m_lhs_squared_norms, "m_lhs_squared_norms", "Squared norms from features of left hand side");	

--- a/src/shogun/distance/EuclideanDistance.h
+++ b/src/shogun/distance/EuclideanDistance.h
@@ -120,25 +120,25 @@ class CEuclideanDistance: public CRealDistance
 		 */
 		virtual float64_t distance_upper_bounded(int32_t idx_a, int32_t idx_b, float64_t upper_bound);
 		
-		/**
-		 * Precompute squared norms from features of right hand side
-		 * WARNING : Make sure to reset squared norms using reset_squared_norms()
-		 * when features feature matrix are changed.
-		 */
-		virtual void precompute_rhs_squared_norms();
-
-		/**
-		 * Precompute squared norms from features of left hand side
-		 * WARNING : Make sure to reset squared norms using reset_squared_norms()
+		/**  
+		 * Precomputation of squared norms for features of right hand side
+		 * WARNING : Make sure to reset computations using reset_precompute()
 		 * when features or feature matrix are changed.
 		 */
-		virtual void precompute_lhs_squared_norms();
-	
-		/**
-		 * Reset squared norms for features of both sides
-		 * squared norms should be reset whenever features or feature matrix are changed.
+		virtual void precompute_rhs();
+
+		/** 
+		 * Precomputation of squared norms for features of left hand side
+		 * WARNING : Make sure to reset computations using reset_precompute()
+		 * when features or feature matrix are changed.
 		 */
-		virtual void reset_squared_norms();
+		virtual void precompute_lhs();
+	
+		/** 
+		 * Reset squared norm precomputations for features of both sides
+		 * Should be used to reset whenever features or feature matrix are changed.
+		 */
+		virtual void reset_precompute();
 
 	protected:
 		/// compute kernel function for features a and b

--- a/tests/unit/distance/EuclideanDistance_unittest.cc
+++ b/tests/unit/distance/EuclideanDistance_unittest.cc
@@ -69,14 +69,16 @@ TEST(EuclideanDistance, distance_precomputed_norms)
 
 	CEuclideanDistance* euclidean=new CEuclideanDistance(features_lhs,features_rhs);
 	euclidean->set_disable_sqrt(true);
-	euclidean->precompute_lhs_squared_norms();
-	euclidean->precompute_rhs_squared_norms();	
+	euclidean->precompute_lhs();
+	euclidean->precompute_rhs();	
 
 	// check distances computed one by one
 	EXPECT_EQ(euclidean->distance(0,0), 2);
 	EXPECT_EQ(euclidean->distance(0,1), 2);
 	EXPECT_EQ(euclidean->distance(1,0), 5);
 	EXPECT_EQ(euclidean->distance(1,1), 5);
+
+	euclidean->reset_precompute();
 
 	SG_UNREF(euclidean); 
 }


### PR DESCRIPTION
Adding precompute to base distance to overload in sub class.
Discussed in PR https://github.com/shogun-toolbox/shogun/pull/3067 based on https://github.com/shogun-toolbox/shogun/issues/2987