### PR TITLE
fix FC22 buildbot (hopefully)

### DIFF
--- a/examples/meta/cpp/CMakeLists.txt
+++ b/examples/meta/cpp/CMakeLists.txt
@@ -2,10 +2,10 @@
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-    STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-    STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-    STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
 
     # meta examples have to be generated before executable and test is added
     SET(GENERATED_CPP ${EXAMPLE_REL_DIR}/${EXAMPLE_NAME}.cpp)

--- a/examples/meta/csharp/CMakeLists.txt
+++ b/examples/meta/csharp/CMakeLists.txt
@@ -4,10 +4,10 @@ SET(CSHARP_FLAGS "/lib:${CSHARP_MODULAR_BUILD_DIR};/r:modshogun")
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
 
 	ADD_CUSTOM_COMMAND(OUTPUT compiled_csharp_${EXAMPLE_NAME_WITH_DIR}
 		COMMAND	${CSHARP_COMPILER} ${EXAMPLE_NAME}.cs ${CSHARP_FLAGS} -out:${EXAMPLE_NAME}.exe

--- a/examples/meta/java/CMakeLists.txt
+++ b/examples/meta/java/CMakeLists.txt
@@ -6,10 +6,10 @@ SET(JAVA_LIB_PATH "${JAVA_MODULAR_BUILD_DIR}")
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
 
 	ADD_CUSTOM_COMMAND(OUTPUT compiled_java_${EXAMPLE_NAME_WITH_DIR}
 				  COMMAND ${Java_JAVAC_EXECUTABLE} -cp ${CLASSPATH}

--- a/examples/meta/lua/CMakeLists.txt
+++ b/examples/meta/lua/CMakeLists.txt
@@ -2,10 +2,10 @@
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
 
 	add_test(NAME generated_lua-${EXAMPLE_NAME_WITH_DIR}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/{EXAMPLE_REL_DIR}

--- a/examples/meta/octave/CMakeLists.txt
+++ b/examples/meta/octave/CMakeLists.txt
@@ -2,10 +2,10 @@
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
     
 	add_test(NAME generated_octave-${EXAMPLE_NAME_WITH_DIR}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLE_REL_DIR}

--- a/examples/meta/python/CMakeLists.txt
+++ b/examples/meta/python/CMakeLists.txt
@@ -5,10 +5,10 @@ GET_PYTHON_ENV()
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
     
 	add_test(NAME generated_python-${EXAMPLE_NAME_WITH_DIR}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLE_REL_DIR}

--- a/examples/meta/r/CMakeLists.txt
+++ b/examples/meta/r/CMakeLists.txt
@@ -2,10 +2,10 @@
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
     
 	add_test(NAME generated_r-${EXAMPLE_NAME_WITH_DIR}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLE_REL_DIR}

--- a/examples/meta/ruby/CMakeLists.txt
+++ b/examples/meta/ruby/CMakeLists.txt
@@ -4,10 +4,10 @@ STRING(REGEX REPLACE "(.*)/narray.*$" "\\1" NARRAY_PATH ${NARRAY_LIB})
 # (not generated yet so have to fake filenames from META_EXAMPLES list)
 FOREACH(META_EXAMPLE ${META_EXAMPLES})
     # assume a structure <target_language>/<category>/listing.sg
-	STRING(REGEX REPLACE ".*/(.*).sg" "\\1" EXAMPLE_NAME ${META_EXAMPLE})
-	STRING(REGEX REPLACE ".*/(.*/.*).sg" "\\1" EXAMPLE_NAME_WITH_DIR ${META_EXAMPLE})
-	STRING(REGEX REPLACE "/" "_" EXAMPLE_NAME_WITH_DIR ${EXAMPLE_NAME_WITH_DIR})
-    STRING(REGEX REPLACE ".*/(.*)/.*.sg" "\\1" EXAMPLE_REL_DIR ${META_EXAMPLE})
+	get_filename_component(EXAMPLE_NAME ${META_EXAMPLE} NAME_WE)
+	get_filename_component(FULL_DIR ${META_EXAMPLE} DIRECTORY)
+	get_filename_component(EXAMPLE_REL_DIR ${FULL_DIR} NAME)
+	set(EXAMPLE_NAME_WITH_DIR "${EXAMPLE_REL_DIR}-${EXAMPLE_NAME}")
     
 	add_test(NAME generated_ruby-${EXAMPLE_NAME_WITH_DIR}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLE_REL_DIR}

--- a/tests/meta/CMakeLists.txt
+++ b/tests/meta/CMakeLists.txt
@@ -23,10 +23,10 @@ target_link_libraries(meta_example_integration_tester shogun ${SANITIZER_LIBRARY
 FILE(GLOB META_INTEGRATION_REFERENCES ${CMAKE_CURRENT_BINARY_DIR}/reference_results/*/*.dat)
 FOREACH(REFERENCE_FILE ${META_INTEGRATION_REFERENCES})
 	# assume a structure <target_language>/<category>/result.dat
-	STRING(REGEX REPLACE ".*/(.*).dat" "\\1" NAME ${REFERENCE_FILE})
-	STRING(REGEX REPLACE ".*/(.*//.*).dat" "\\1" NAME_WITH_DIR ${REFERENCE_FILE})
-	STRING(REGEX REPLACE "//" "_" NAME_WITH_DIR ${NAME_WITH_DIR})
-	STRING(REGEX REPLACE ".*/(.*)//.*.dat" "\\1" REL_DIR ${REFERENCE_FILE})
+	get_filename_component(NAME ${REFERENCE_FILE} NAME_WE)
+	get_filename_component(FULL_DIR ${REFERENCE_FILE} DIRECTORY)
+	get_filename_component(REL_DIR ${FULL_DIR} NAME)
+	set(NAME_WITH_DIR "${REL_DIR}-${NAME}")
 
 	# cpp
 	# TODO implement other languages tests


### PR DESCRIPTION
http://buildbot.shogun-toolbox.org/builders/FC22%20-%20libshogun/builds/150/steps/test/logs/stdio

Avoid using REGEXP for untangling filenames in meta examples, but rather leave this to cmake. Hoping this fixes the problem on buildbot
