### PR TITLE
Implement Vector Mean in linalg

### DIFF
--- a/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2016 Pan Deng
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef MEAN_EIGEN_H_
+#define MEAN_EIGEN_H_
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/mathematics/linalg/internal/implementation/Sum.h>
+
+#include <shogun/mathematics/eigen3.h>
+#include <numeric>
+
+#include <iostream>
+
+namespace shogun
+{
+
+namespace linalg
+{
+    
+namespace implementation
+{
+    
+/**
+ * @brief Generic class int2float which converts different types of integer 
+ * into float64 type.
+ */
+template <typename inputType>
+struct int2float
+{
+	using floatType = inputType;
+};
+
+/**
+ * @brief Specialization of generic class int2float which converts int32 into float64.
+ */
+template <>
+struct int2float<int32_t>
+{
+	using floatType = float64_t;
+};
+
+/**
+ * @brief Specialization of generic class int2float which converts int64 into float64.
+ */
+template <>
+struct int2float<int64_t>
+{
+	using floatType = float64_t;
+};
+ 
+/**
+ * @brief Generic class mean which provides a static compute method. This class
+ * is specialized for different types of vectors and matrices, providing a mean
+ * to deal with various vectors and matrices directly.
+ */
+template <enum Backend, class Matrix>
+struct mean
+{
+	/** Scalar type */
+	typedef typename Matrix::Scalar T;
+
+	/** int2float type */
+	typedef typename int2float<T>::floatType ReturnType;
+
+	/**
+	 * Method that computes the vector/matrix mean
+	 *
+	 * @param a vector/matrix whose mean has to be computed
+	 * @return the vector/matrix mean \f$\mean_i a_i\f$
+	 */
+	static ReturnType compute(Matrix a, bool no_diag=false);
+};
+
+/**
+ * @brief Specialization of generic mean which works with SGVector and 
+ * SGMatrix and uses Eigen3 as backend for computing mean.
+ */
+template <class Matrix>
+struct mean<Backend::EIGEN3, Matrix>
+{
+	/** Scalar type */
+	typedef typename Matrix::Scalar T;
+
+	/** int2float type */
+	typedef typename int2float<T>::floatType ReturnType;
+
+	/**
+	 * Method that computes the mean of SGVectors using Eigen3
+	 *
+	 * @param a vector whose mean has to be computed
+	 * @return the vector mean \f$\mean_i a_i\f$
+	 */
+	static ReturnType compute(SGVector<T> vec)
+	{
+		REQUIRE(vec.vlen > 0, "Vector cannot be empty!\n");
+		return (vector_sum<Backend::EIGEN3, SGVector<T> >::compute(vec)
+			/ ReturnType(vec.vlen));
+	}
+        
+}; 
+    
+}
+             
+}
+
+}
+
+#endif

--- a/src/shogun/mathematics/linalg/internal/modules/Redux.h
+++ b/src/shogun/mathematics/linalg/internal/modules/Redux.h
@@ -36,6 +36,7 @@
 #include <shogun/mathematics/linalg/internal/implementation/Sum.h>
 #include <shogun/mathematics/linalg/internal/implementation/VectorSum.h>
 #include <shogun/mathematics/linalg/internal/implementation/Max.h>
+#include <shogun/mathematics/linalg/internal/implementation/MeanEigen3.h>
 
 namespace shogun
 {
@@ -82,6 +83,17 @@ typename Vector::Scalar vector_sum(Vector a)
 }
 
 #ifdef HAVE_LINALG_LIB
+/**
+ * Wrapper method for internal implementation of vector mean of values that works
+ * with generic dense vectors
+ * @param a vector whose mean has to be computed
+ * @return the vector mean \f$\mean_i a_i\f$
+ */
+template <Backend backend=linalg_traits<Redux>::backend, class Vector>
+typename implementation::int2float<typename Vector::Scalar>::floatType mean(Vector a)
+{
+	return implementation::mean<backend,Vector>::compute(a);
+}
 
 /**
  * Wrapper method for internal implementation of matrix sum of values that works

--- a/tests/unit/mathematics/linalg/MeanEigen3_unittest.cc
+++ b/tests/unit/mathematics/linalg/MeanEigen3_unittest.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2016 Pan Deng
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/config.h>
+#include <shogun/mathematics/linalg/linalg.h>
+#include <shogun/lib/SGVector.h>
+#include <gtest/gtest.h>
+
+#include <shogun/mathematics/eigen3.h>
+
+using namespace shogun;
+
+#ifdef HAVE_LINALG_LIB
+
+TEST(MeanEigen3, SGVector_explicit_eigen3_backend_float64)
+{
+	const index_t size = 10;
+	SGVector<float64_t> a(size);
+	for (index_t i = 0; i < 10; ++i) a[i] = i;
+	float64_t result = linalg::mean<linalg::Backend::EIGEN3>(a);
+	EXPECT_NEAR(result, 4.5, 1E-15);
+}
+
+TEST(MeanEigen3, SGVector_explicit_eigen3_backend_int32)
+{
+	index_t size = 10;
+	SGVector<int32_t> a(size);
+	for (index_t i = 0; i < 10; ++i) a[i] = i;
+	float64_t result = linalg::mean<linalg::Backend::EIGEN3>(a);
+	EXPECT_NEAR(result, 4.5, 1E-15);
+}
+
+TEST(MeanEigen3, SGVector_explicit_eigen3_backend_int64)
+{
+	index_t size = 10;
+	SGVector<int64_t> a(size);
+	for (index_t i = 0; i < 10; ++i) a[i] = i;
+	float64_t result = linalg::mean<linalg::Backend::EIGEN3>(a);
+	EXPECT_NEAR(result, 4.5, 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_dynamic_explicit_eigen3_backend_float)
+{
+	const index_t size = 10;
+	Eigen::VectorXd a(size);
+	a << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(a), 4.5, 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_dynamic_explicit_eigen3_backend_int)
+{
+	index_t size = 10;
+	Eigen::VectorXd a(size); 
+	a << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9;
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(a), 4.5, 1E-15);
+}
+
+#endif // HAVE_LINALG_LIB
+


### PR DESCRIPTION
To make things less messy I put this part in a new branch so I opened a new PR. Ref #3085,  #3070 and issue #3051 .

Simple implementation - return vector mean `decltype(vector data type) vector mean` for Eigen3.

Seems I can add both `Vector` and `Matrix` to `Matrix` template?