### PR TITLE
Remove transpose of rotations in QDA

### DIFF
--- a/src/shogun/multiclass/QDA.cpp
+++ b/src/shogun/multiclass/QDA.cpp
@@ -258,7 +258,6 @@ bool CQDA::train_machine(CFeatures* data)
 
 		SGVector<float64_t>::vector_multiply(col, col, col, m_dim);
 		SGVector<float64_t>::scale_vector(1.0/(class_nums[k]-1), col, m_dim);
-		rotations.transpose_matrix(k);
 
 		if (m_store_covs)
 		{


### PR DESCRIPTION
Removing the unnecessary transpose enhances Shogun's performance to be same as scikit-learn.
check this [notebook](https://github.com/youssef-emad/shogun_notebooks/blob/master/QDA.Investigation.ipynb) for results before and after modification.
