### PR TITLE
added normal_cdf

### DIFF
--- a/src/shogun/mathematics/Statistics.cpp
+++ b/src/shogun/mathematics/Statistics.cpp
@@ -15,8 +15,9 @@
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGSparseMatrix.h>
 #include <shogun/lib/SGSparseVector.h>
-
+#include <cmath>
 #include <shogun/mathematics/eigen3.h>
+
 using namespace Eigen;
 
 using namespace shogun;
@@ -573,9 +574,7 @@ float64_t CStatistics::erfc8_weighted_sum(float64_t x)
 
 float64_t CStatistics::normal_cdf(float64_t x, float64_t std_dev)
 {
-	SG_SERROR("NOT IMPLEMENTED");
-	return 0;
-//	return 0.5*(error_function_complement(-x/std_dev/1.41421356237309514547));
+	return 0.5*(erfc(-x*M_SQRT1_2/std_dev));
 }
 
 float64_t CStatistics::inverse_gamma_cdf(float64_t p, float64_t a,

--- a/tests/unit/mathematics/Statistics_unittest.cc
+++ b/tests/unit/mathematics/Statistics_unittest.cc
@@ -374,6 +374,28 @@ TEST(Statistics, lnormal_cdf)
 
 }
 
+TEST(Statistics, normal_cdf)
+{
+	// assert with value calculated via Octave normcdf() method
+	float64_t phi=CStatistics::normal_cdf(-2);
+	EXPECT_NEAR(phi, 0.0227501319481792190, 1e-15);
+
+	phi=CStatistics::normal_cdf(-3, 4);
+	EXPECT_NEAR(phi, 0.2266273523768682074, 1e-15);
+
+	phi=CStatistics::normal_cdf(-0.3);
+	EXPECT_NEAR(phi, 0.3820885778110473807, 1e-15);
+
+	phi=CStatistics::normal_cdf(0.7);
+	EXPECT_NEAR(phi, 0.7580363477769269664, 1e-15);
+
+	phi=CStatistics::normal_cdf(1);
+	EXPECT_NEAR(phi, 0.8413447460685429258, 1e-15);
+
+	phi=CStatistics::normal_cdf(2);
+	EXPECT_NEAR(phi, 0.9772498680518207914, 1e-15);
+}
+
 TEST(Statistics, chi2_cdf)
 {
 	float64_t chi2c=CStatistics::chi2_cdf(1.0, 5.0);


### PR DESCRIPTION
@karlnapf sending a PR because I wanted you to have a look. `erfc(...)` is a C-function so no C++11 is needed for this one.