### PR TITLE
fix enum rule for ruby

### DIFF
--- a/examples/meta/generator/targets/ruby.json
+++ b/examples/meta/generator/targets/ruby.json
@@ -19,7 +19,7 @@
         "NumberLiteral": "$number",
         "MethodCall": "$object.$method $arguments",
         "Identifier": "$identifier",
-        "Enum":"$value"
+        "Enum":"$type.$value"
     },
     "Print": "puts $expr",
     "OutputDirectoryName": "ruby",


### PR DESCRIPTION
@karlnapf Couldn't build it on my local. Got this error:
```
Linking CXX shared module modshogun.so
/usr/bin/ld: /usr/local/lib/libruby-static.a(array.o): relocation R_X86_64_PC32 against symbol `rb_ary_free' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```