### PR TITLE
Add matrix_mean in linalg using Eigen3

### DIFF
--- a/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
@@ -93,10 +93,19 @@ struct mean
 	typedef typename int2float<T>::floatType ReturnType;
 
 	/**
-	 * Method that computes the vector/matrix mean
+	 * Method that computes the vector mean
 	 *
-	 * @param a vector/matrix whose mean has to be computed
-	 * @return the vector/matrix mean \f$\mean_i a_i\f$
+	 * @param a vector whose mean has to be computed
+	 * @return the vector mean \f$\mean_i a_i\f$
+	 */
+	static ReturnType compute(Matrix a);
+
+	/**
+	 * Method that computes the matrix mean
+	 *
+	 * @param a matrix whose mean has to be computed
+	 * @param no_diag if true, diagonal entries are excluded from the mean (default - false) 
+	 * @return the matrix mean \f$\1/N^2\sum_{i,j=1}^N m_{i,j}\f$
 	 */
 	static ReturnType compute(Matrix a, bool no_diag=false);
 };
@@ -126,7 +135,36 @@ struct mean<Backend::EIGEN3, Matrix>
 		return (vector_sum<Backend::EIGEN3, SGVector<T> >::compute(vec)
 			/ ReturnType(vec.vlen));
 	}
-        
+
+	/**
+	 * Method that computes the mean of SGMatrix using Eigen3
+	 *
+	 * @param a matrix whose mean has to be computed
+	 * @param no_diag if true, diagonal entries are excluded from the mean (default - false) 
+	 * @return the matrix mean \f$\mu_{i,j}m_{i,j}\f$
+	 */
+        static ReturnType compute(SGMatrix<T> mat, bool no_diag=false)
+	{
+		REQUIRE(mat.num_rows > 0, "Matrix row number cannot be zero!\n");
+		if (no_diag) 
+		{
+			if (mat.num_rows > mat.num_cols)
+			{
+				return (sum<Backend::EIGEN3, SGMatrix<T> >::compute(mat, no_diag)
+					/ ReturnType(mat.num_rows * mat.num_cols - mat.num_cols));
+			}
+			else
+			{
+				return (sum<Backend::EIGEN3, SGMatrix<T> >::compute(mat, no_diag)
+					/ ReturnType(mat.num_rows * mat.num_cols - mat.num_rows));
+			}
+		}
+		else 
+		{
+			return (sum<Backend::EIGEN3, SGMatrix<T> >::compute(mat, no_diag)
+				/ ReturnType(mat.num_rows * mat.num_cols));
+		}
+	}     
 }; 
     
 }

--- a/src/shogun/mathematics/linalg/internal/modules/Redux.h
+++ b/src/shogun/mathematics/linalg/internal/modules/Redux.h
@@ -84,18 +84,6 @@ typename Vector::Scalar vector_sum(Vector a)
 
 #ifdef HAVE_LINALG_LIB
 /**
- * Wrapper method for internal implementation of vector mean of values that works
- * with generic dense vectors
- * @param a vector whose mean has to be computed
- * @return the vector mean \f$\mean_i a_i\f$
- */
-template <Backend backend=linalg_traits<Redux>::backend, class Vector>
-typename implementation::int2float<typename Vector::Scalar>::floatType mean(Vector a)
-{
-	return implementation::mean<backend,Vector>::compute(a);
-}
-
-/**
  * Wrapper method for internal implementation of matrix sum of values that works
  * with generic dense matrices
  *
@@ -190,10 +178,37 @@ typename implementation::rowwise_sum<backend,Matrix>::ReturnType rowwise_sum(
  * @param no_diag if true, diagonal entries are excluded from the sum (default - false)
  * @param result Pre-allocated vector for the result of the computation
  */
-template <Backend backend=linalg_traits<Redux>::backend,class Matrix, class Vector>
+template <Backend backend=linalg_traits<Redux>::backend, class Matrix, class Vector>
 void rowwise_sum(Matrix m, Vector result, bool no_diag=false)
 {
 	implementation::rowwise_sum<backend,Matrix>::compute(m, result, no_diag);
+}
+
+/**
+ * Wrapper method for internal implementation of vector mean of values that works
+ * with generic dense vectors
+ * @param a vector whose mean has to be computed
+ * @return the vector mean \f$\mean_i a_i\f$
+ */
+template <Backend backend=linalg_traits<Redux>::backend, class Vector>
+typename implementation::int2float<typename Vector::Scalar>::floatType mean(Vector a)
+{
+	return implementation::mean<backend,Vector>::compute(a);
+}
+
+/**
+ * Wrapper method for internal implementation of matrix mean of values that works
+ * with generic dense vectors
+ *
+ * @param a matrix whose mean has to be computed
+ * @param no_diag if true, diagonal entries are excluded from the mean (default - false) 
+ * @return the matrix mean \f$\1/N^2 \sum_{i,j=1}^N m_{i,j}\f$
+ */
+template <Backend backend=linalg_traits<Redux>::backend, class Matrix>
+typename implementation::int2float<typename Matrix::Scalar>
+			::floatType mean(Matrix m, bool no_diag)
+{
+	return implementation::mean<backend,Matrix>::compute(m, no_diag);
 }
 
 #endif // HAVE_LINALG_LIB

--- a/tests/unit/mathematics/linalg/MeanEigen3_unittest.cc
+++ b/tests/unit/mathematics/linalg/MeanEigen3_unittest.cc
@@ -82,5 +82,125 @@ TEST(MeanEigen3, Eigen3_dynamic_explicit_eigen3_backend_int)
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(a), 4.5, 1E-15);
 }
 
+TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_with_diag_float)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<float64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_no_diag_float)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<float64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_with_diag_int32)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<int32_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_no_diag_int32)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<int32_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_with_diag_int64)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<int64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_no_diag_int64)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<int64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_Matrix_asymmetric_eigen3_backend_with_diag)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	Eigen::MatrixXd mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_Matrix_asymmetric_eigen3_backend_no_diag)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	Eigen::MatrixXd mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+	{
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + i * j + j + 1;
+	}
+
+	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
+}
+
 #endif // HAVE_LINALG_LIB
 


### PR DESCRIPTION
Refer #3051 and PR #3070 

An issue with current solution is one has to have `no_diag` parameter when computing the mean of a matrix. 
Maybe a better way is to map `vector` to `matrix` in `Redux.h`?

Also I am wondering maybe the test file is too long.