### PR TITLE
Meta-Language: Fix ruby enum rule

### DIFF
--- a/examples/meta/generator/targets/ruby.json
+++ b/examples/meta/generator/targets/ruby.json
@@ -19,7 +19,7 @@
         "NumberLiteral": "$number",
         "MethodCall": "$object.$method $arguments",
         "Identifier": "$identifier",
-        "Enum":"$type.$value"
+        "Enum":"Modshogun::$value"
     },
     "Print": "puts $expr",
     "OutputDirectoryName": "ruby",


### PR DESCRIPTION
Correct syntax for enums in Ruby