### PR TITLE
Meta-Language: Fix Lua enum rule

### DIFF
--- a/examples/meta/generator/targets/lua.json
+++ b/examples/meta/generator/targets/lua.json
@@ -19,7 +19,7 @@
         "NumberLiteral": "$number",
         "MethodCall": "$object:$method($arguments)",
         "Identifier": "$identifier",
-        "Enum":"$value"
+        "Enum":"modshogun.$value"
     },
     "Print": "print($expr)",
     "OutputDirectoryName": "lua",


### PR DESCRIPTION
I think this is the last one. The enums have already been tested in Python, R, Octave, and Java.