### PR TITLE
Add rowwise_mean to linalg using Eigen3

### DIFF
--- a/src/shogun/mathematics/linalg/internal/modules/Redux.h
+++ b/src/shogun/mathematics/linalg/internal/modules/Redux.h
@@ -189,7 +189,7 @@ void rowwise_sum(Matrix m, Vector result, bool no_diag=false)
  * Wrapper method for internal implementation of vector mean of values that works
  * with generic dense vectors
  * @param a vector whose mean has to be computed
- * @return the vector mean \f$\mean_i a_i\f$
+ * @return the vector mean \f$\bar a_i\f$
  */
 template <Backend backend=linalg_traits<Redux>::backend, class Vector>
 typename implementation::int2float<typename Vector::Scalar>::floatType mean(Vector a)
@@ -206,10 +206,25 @@ typename implementation::int2float<typename Vector::Scalar>::floatType mean(Vect
  * @return the matrix mean \f$\1/N^2 \sum_{i,j=1}^N m_{i,j}\f$
  */
 template <Backend backend=linalg_traits<Redux>::backend, class Matrix>
-typename implementation::int2float<typename Matrix::Scalar>
-			::floatType mean(Matrix m, bool no_diag)
+typename implementation::int2float<typename Matrix::Scalar>::floatType mean(
+        Matrix m, bool no_diag)
 {
 	return implementation::mean<backend,Matrix>::compute(m, no_diag);
+}
+
+/**
+ * Wrapper method for internal implementation of matrix rowwise mean of values 
+ * that works with generic dense matrices
+ *
+ * @param m the matrix whose rowwise mean has to be computed
+ * @param no_diag if true, diagonal entries are excluded from the mean (default - false)
+ * @return the rowwise mean computed as \f$\1/N \sum_{j=1}^N m_{i,j}\f$
+ */
+template <Backend backend=linalg_traits<Redux>::backend,class Matrix>
+SGVector<typename implementation::rowwise_mean<backend,Matrix>::ReturnDataType> 
+	rowwise_mean(Matrix m, bool no_diag=false)
+{
+	return implementation::rowwise_mean<backend,Matrix>::compute(m, no_diag);
 }
 
 /**Wrapper method for internal implementation of cholesky decomposition of a Hermitian positive definite matrix

--- a/tests/unit/mathematics/linalg/MeanEigen3_unittest.cc
+++ b/tests/unit/mathematics/linalg/MeanEigen3_unittest.cc
@@ -89,10 +89,8 @@ TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_with_diag_float)
 	SGMatrix<float64_t> mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
 }
@@ -104,10 +102,8 @@ TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_no_diag_float)
 	SGMatrix<float64_t> mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
 }
@@ -119,10 +115,8 @@ TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_with_diag_int32)
 	SGMatrix<int32_t> mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
 }
@@ -134,10 +128,8 @@ TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_no_diag_int32)
 	SGMatrix<int32_t> mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
 }
@@ -149,10 +141,8 @@ TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_with_diag_int64)
 	SGMatrix<int64_t> mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
 }
@@ -164,10 +154,8 @@ TEST(MeanEigen3, SGMatrix_asymmetric_eigen3_backend_no_diag_int64)
 	SGMatrix<int64_t> mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
 }
@@ -179,10 +167,8 @@ TEST(MeanEigen3, Eigen3_Matrix_asymmetric_eigen3_backend_with_diag)
 	Eigen::MatrixXd mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, false), 7.5, 1E-15);
 }
@@ -194,12 +180,108 @@ TEST(MeanEigen3, Eigen3_Matrix_asymmetric_eigen3_backend_no_diag)
 	Eigen::MatrixXd mat(m, n);
 
 	for (index_t i = 0; i < m; ++i)
-	{
 		for (index_t j = 0; j < n; ++j)
 			mat(i, j) = i * 10 + i * j + j + 1;
-	}
 
 	EXPECT_NEAR(linalg::mean<linalg::Backend::EIGEN3>(mat, true), 7.75, 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_rowwise_eigen3_backend_with_diag)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<int64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + j * j;
+
+	auto s = linalg::rowwise_mean<linalg::Backend::EIGEN3>(mat);
+
+	EXPECT_NEAR(5/3.0, s[0], 1E-15);
+	EXPECT_NEAR(35/3.0, s[1], 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_Matrix_asymmetric_rowwise_eigen3_backend_with_diag)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	Eigen::MatrixXd mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + j * j;
+
+	auto s = linalg::rowwise_mean<linalg::Backend::EIGEN3>(mat);
+
+	EXPECT_NEAR(5/3.0, s[0], 1E-15);
+	EXPECT_NEAR(35/3.0, s[1], 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_rowwise_eigen3_backend_no_diag_col_more_than_row)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	SGMatrix<int64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + j * j;
+
+	auto s = linalg::rowwise_mean<linalg::Backend::EIGEN3>(mat, true);
+
+	EXPECT_NEAR(2.5, s[0], 1E-15);
+	EXPECT_NEAR(12, s[1], 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_Matrix_symmetric_rowwise_eigen3_backend_no_diag_col_more_than_row)
+{
+	const index_t m = 2;
+	const index_t n = 3;
+	Eigen::MatrixXd mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + j * j;
+
+	auto s = linalg::rowwise_mean<linalg::Backend::EIGEN3>(mat, true);
+
+	EXPECT_NEAR(2.5, s[0], 1E-15);
+	EXPECT_NEAR(12, s[1], 1E-15);
+}
+
+TEST(MeanEigen3, SGMatrix_asymmetric_rowwise_eigen3_backend_no_diag_row_more_than_col)
+{
+	const index_t m = 3;
+	const index_t n = 2;
+	SGMatrix<int64_t> mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + j * j;
+
+	auto s = linalg::rowwise_mean<linalg::Backend::EIGEN3>(mat, true);
+
+	EXPECT_NEAR(1, s[0], 1E-15);
+	EXPECT_NEAR(10, s[1], 1E-15);
+	EXPECT_NEAR(20.5, s[2], 1E-15);
+}
+
+TEST(MeanEigen3, Eigen3_Matrix_asymmetric_rowwise_eigen3_backend_no_diag_row_more_than_col)
+{
+	const index_t m = 3;
+	const index_t n = 2;
+	Eigen::MatrixXd mat(m, n);
+
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j) = i * 10 + j * j;
+
+	auto s = linalg::rowwise_mean<linalg::Backend::EIGEN3>(mat, true);
+
+	EXPECT_NEAR(1, s[0], 1E-15);
+	EXPECT_NEAR(10, s[1], 1E-15);
+	EXPECT_NEAR(20.5, s[2], 1E-15);
 }
 
 #endif // HAVE_LINALG_LIB


### PR DESCRIPTION
Refer #3051 and PR #3070, #3125 
- I didn't implement `colwise_mean` at the same time because I'm not sure how this implement looks like. Apparently I cannot copy `SGVector<T>` to `SGVector<int2float type>` so I just used `for`-loops. Also, I think we are supposed to use EIGEN3 methods, which I have not tried (but used `for`-loop instead). 
- According to #3100, I think we can get rid of `<enum Backend>` generic type? I can re-factor this after `rowwise`/`colwise` are both done.
- There are also `Block` and `symmetric matrix` calculation for `matrixsum`. I am wondering whether we need both for `matrixmean` as while?


- I saw the comparison highlighted the changes I made in PR #3125 (merged). I had no idea why this is happening...