### PR TITLE
Workaround for #3140 Compilation error using newer Eigen library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ include(ShogunUtils)
 
 ############# minimum library versions ###################
 SET(EIGEN_VERSION_MINIMUM 3.1.2)
+add_definitions(-DEIGEN_VERSION_MINIMUM="${EIGEN_VERSION_MINIMUM}")
+
 SET(VIENNACL_VERSION_MINIMUM 1.5.0)
 
 # Store system's or distribution's C[XX]FLAGS.
@@ -566,6 +568,9 @@ IF(NOT EIGEN3_FOUND)
 	include(external/Eigen3)
 	LIST(APPEND SYSTEM_INCLUDES ${EIGEN_INCLUDE_DIR})
 ELSE()
+	IF("${EIGEN3_VERSION}" VERSION_GREATER "${EIGEN_VERSION_MINIMUM}" AND "${EIGEN3_VERSION}" VERSION_LESS "3.2.6")
+	        add_definitions(-DEIGEN_VERSION_DEPENDABLE=1)
+	ENDIF()
 	LIST(APPEND SYSTEM_INCLUDES ${EIGEN_INCLUDE_DIR})
 ENDIF()
 

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/DenseMatrixExactLog.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/DenseMatrixExactLog.cpp
@@ -11,7 +11,7 @@
 
 #include <shogun/mathematics/eigen3.h>
 
-#if EIGEN_VERSION_AT_LEAST(3,1,0)
+#if EIGEN_VERSION_AT_LEAST(3,1,0) && (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION == 2 && EIGEN_MINOR_VERSION < 6 )
 #include <unsupported/Eigen/MatrixFunctions>
 #endif // EIGEN_VERSION_AT_LEAST(3,1,0)
 
@@ -47,7 +47,7 @@ CDenseMatrixExactLog::~CDenseMatrixExactLog()
 	SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 }
 
-#if EIGEN_VERSION_AT_LEAST(3,1,0)
+#if EIGEN_VERSION_AT_LEAST(3,1,0) && (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION == 2 && EIGEN_MINOR_VERSION < 6 )
 void CDenseMatrixExactLog::precompute()
 {
 	SG_DEBUG("Entering...\n");

--- a/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/DenseMatrixExactLog.cpp
+++ b/src/shogun/mathematics/linalg/ratapprox/logdet/opfunc/DenseMatrixExactLog.cpp
@@ -11,9 +11,9 @@
 
 #include <shogun/mathematics/eigen3.h>
 
-#if EIGEN_VERSION_AT_LEAST(3,1,0) && (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION == 2 && EIGEN_MINOR_VERSION < 6 )
+#if EIGEN_VERSION_DEPENDABLE
 #include <unsupported/Eigen/MatrixFunctions>
-#endif // EIGEN_VERSION_AT_LEAST(3,1,0)
+#endif // EIGEN_VERSION_DEPENDABLE
 
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGMatrix.h>
@@ -47,7 +47,7 @@ CDenseMatrixExactLog::~CDenseMatrixExactLog()
 	SG_GCDEBUG("%s destroyed (%p)\n", this->get_name(), this)
 }
 
-#if EIGEN_VERSION_AT_LEAST(3,1,0) && (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION == 2 && EIGEN_MINOR_VERSION < 6 )
+#if EIGEN_VERSION_DEPENDABLE
 void CDenseMatrixExactLog::precompute()
 {
 	SG_DEBUG("Entering...\n");
@@ -75,9 +75,9 @@ void CDenseMatrixExactLog::precompute()
 #else
 void CDenseMatrixExactLog::precompute()
 {
-	SG_WARNING("Eigen3.1.0 or later required!\n")
+	SG_WARNING("Eigen " EIGEN_VERSION_MINIMUM " or later required!\n")
 }
-#endif // EIGEN_VERSION_AT_LEAST(3,1,0)
+#endif // EIGEN_VERSION_DEPENDABLE
 
 CJobResultAggregator* CDenseMatrixExactLog::submit_jobs(SGVector<float64_t>
 	sample)


### PR DESCRIPTION
This pull request is a workaround for #3140 causing a compilation error, when using Eigen 3.3 versions.
It adds an additional check to verify that the Eigen version is between 3.1.0 and 3.2.5. (excluding >= 3.2.6)
