### PR TITLE
explicitly mentioned eigen3 backend in Cholesky_unittest and a minor change in Cholesky.h

### DIFF
--- a/src/shogun/mathematics/linalg/internal/implementation/Cholesky.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/Cholesky.h
@@ -64,7 +64,7 @@ struct cholesky
 	 * @param lower - whether to compute the upper or lower triangular Cholesky factorization (default:lower)
 	 * @return the upper or lower triangular Cholesky factorization
 	 */
-	static SGMatrix<T> compute(Matrix A, bool lower);
+	static ReturnType compute(Matrix A, bool lower);
 
 };
 
@@ -88,12 +88,12 @@ struct cholesky<Backend::EIGEN3, Matrix>
 	 * @param lower - whether to compute the upper or lower triangular Cholesky factorization (default:lower)
 	 * @return the upper or lower triangular Cholesky factorization
 	 */
-	static SGMatrix<T> compute(SGMatrix<T> A, bool lower)
+	static ReturnType compute(SGMatrix<T> A, bool lower)
 	{
 		//creating eigen3 dense matrices
 		Eigen::Map<MatrixXt> map_A(A.matrix, A.num_rows, A.num_cols);
 
-		SGMatrix<T> cho(A.num_rows,A.num_cols);
+		ReturnType cho(A.num_rows,A.num_cols);
 		cho.set_const(0.0);
 		Eigen::Map<MatrixXt> map_cho(cho.matrix, cho.num_rows, cho.num_cols);
 

--- a/tests/unit/mathematics/linalg/Cholesky_unittest.cc
+++ b/tests/unit/mathematics/linalg/Cholesky_unittest.cc
@@ -40,7 +40,7 @@
 using namespace shogun;
 using namespace Eigen;
 
-TEST(LLTLinearSolver, compute_cholesky_lower)
+TEST(LLTLinearSolver, compute_cholesky_lower_eigen3)
 {
 	const index_t size=2;
 	SGMatrix<float64_t> m(size, size);
@@ -51,7 +51,7 @@ TEST(LLTLinearSolver, compute_cholesky_lower)
 	m(1,1)=2.5;
 
 	//lower triangular cholesky decomposition
-	SGMatrix<float64_t> L=linalg::cholesky(m);
+	SGMatrix<float64_t> L=linalg::cholesky<linalg::Backend::EIGEN3>(m);
 
 	Map<MatrixXd> map_A(m.matrix,m.num_rows,m.num_cols);
 	Map<MatrixXd> map_L(L.matrix,L.num_rows,L.num_cols);
@@ -59,7 +59,7 @@ TEST(LLTLinearSolver, compute_cholesky_lower)
 		0.0, 1E-15);
 }
 
-TEST(LLTLinearSolver, compute_cholesky_upper)
+TEST(LLTLinearSolver, compute_cholesky_upper_eigen3)
 {
 	const index_t size=2;
 	SGMatrix<float64_t> m(size, size);
@@ -70,13 +70,12 @@ TEST(LLTLinearSolver, compute_cholesky_upper)
 	m(1,1)=2.5;
 
 	//upper triangular cholesky decomposition
-	SGMatrix<float64_t> U=linalg::cholesky(m,false);
+	SGMatrix<float64_t> U=linalg::cholesky<linalg::Backend::EIGEN3>(m,false);
 
 	Map<MatrixXd> map_A(m.matrix,m.num_rows,m.num_cols);
 	Map<MatrixXd> map_U(U.matrix,U.num_rows,U.num_cols);
 	EXPECT_NEAR((map_A-map_U.transpose()*map_U).norm(),
 		0.0, 1E-15);
 }
-
 
 #endif // defined(HAVE_LINALG_LIB)


### PR DESCRIPTION
fix for the failing build with viennacl backend : http://buildbot.shogun-toolbox.org/builders/trusty%20-%20libshogun%20-%20viennacl/builds/616

I have also opened issue #3156 regarding the general handling of viennacl backend by methods that don't have their viennacl backends implemented in linalg yet.

also, a minor change for the compute method to use the general ReturnType instead of SGMatrix