### PR TITLE
renaming inference methods in GP

### DIFF
--- a/examples/undocumented/python_modular/multiclass_gp_modular.py
+++ b/examples/undocumented/python_modular/multiclass_gp_modular.py
@@ -45,7 +45,7 @@ except ImportError:
 	exit(0)
 
 parameter_list=[
-    [MultiLaplacianInferenceMethod,traindat,testdat,label_multi_traindat,0,0],
+    [MultiLaplaceInferenceMethod,traindat,testdat,label_multi_traindat,0,0],
 ]
 
 

--- a/examples/undocumented/python_modular/variational_classifier_modular.py
+++ b/examples/undocumented/python_modular/variational_classifier_modular.py
@@ -46,9 +46,9 @@ from modshogun import *
 parameter_list=[
 	[KLCholeskyInferenceMethod,traindat,testdat,label_binary_traindat,0,0,1e-5,1e-2,0],
 	[KLCovarianceInferenceMethod,traindat,testdat,label_binary_traindat,0,0,1e-5,1e-2,0],
-	[KLApproxDiagonalInferenceMethod,traindat,testdat,label_binary_traindat,0,0,1e-5,1e-2,0],
+	[KLDiagonalInferenceMethod,traindat,testdat,label_binary_traindat,0,0,1e-5,1e-2,0],
 	[KLDualInferenceMethod,traindat,testdat,label_binary_traindat,0,0,1e-5,1e-2,0],
-	[SingleLaplacianInferenceMethod,traindat,testdat,label_binary_traindat,0,0],
+	[SingleLaplaceInferenceMethod,traindat,testdat,label_binary_traindat,0,0],
 ]
 def variational_classifier_modular(kl_inference,train_fname=traindat,test_fname=testdat,
 	label_fname=label_binary_traindat,kernel_log_sigma=0,kernel_log_scale=0,noise_factor=1e-5,

--- a/src/interfaces/modular/GaussianProcess.i
+++ b/src/interfaces/modular/GaussianProcess.i
@@ -12,17 +12,17 @@
 %rename(ZeroMean) CZeroMean;
 %rename(ConstMean) CConstMean;
 
-%rename(InferenceMethod) CInferenceMethod;
+%rename(Inference) CInference;
 %rename(ExactInferenceMethod) CExactInferenceMethod;
-%rename(LaplacianInferenceBase) CLaplacianInferenceBase;
-%rename(SparseInferenceBase) CSparseInferenceBase;
-%rename(SingleSparseInferenceBase) CSingleSparseInferenceBase;
-%rename(SingleFITCLaplacianBase) CSingleFITCLaplacianBase;
-%rename(SingleLaplacianInferenceMethod) CSingleLaplacianInferenceMethod;
-%rename(MultiLaplacianInferenceMethod) CMultiLaplacianInferenceMethod;
+%rename(LaplaceInference) CLaplaceInference;
+%rename(SparseInference) CSparseInference;
+%rename(SingleSparseInference) CSingleSparseInference;
+%rename(SingleFITCLaplace) CSingleFITCLaplace;
+%rename(SingleLaplaceInferenceMethod) CSingleLaplaceInferenceMethod;
+%rename(MultiLaplaceInferenceMethod) CMultiLaplaceInferenceMethod;
 %rename(FITCInferenceMethod) CFITCInferenceMethod;
-%rename(SingleFITCLaplacianInferenceMethod) CSingleFITCLaplacianInferenceMethod;
-%rename(SparseVGInferenceMethod) CSparseVGInferenceMethod;
+%rename(SingleFITCLaplaceInferenceMethod) CSingleFITCLaplaceInferenceMethod;
+%rename(VarDTCInferenceMethod) CVarDTCInferenceMethod;
 %rename(EPInferenceMethod) CEPInferenceMethod;
 
 %rename(LikelihoodModel) CLikelihoodModel;
@@ -42,10 +42,10 @@
 %rename(ProbitVGLikelihood) CProbitVGLikelihood;
 %rename(StudentsTVGLikelihood) CStudentsTVGLikelihood;
 
-%rename(KLInferenceMethod) CKLInferenceMethod;
-%rename(KLLowerTriangularInferenceMethod) CKLLowerTriangularInferenceMethod;
+%rename(KLInference) CKLInference;
+%rename(KLLowerTriangularInference) CKLLowerTriangularInference;
 %rename(KLCovarianceInferenceMethod) CKLCovarianceInferenceMethod;
-%rename(KLApproxDiagonalInferenceMethod) CKLApproxDiagonalInferenceMethod;
+%rename(KLDiagonalInferenceMethod) CKLDiagonalInferenceMethod;
 %rename(KLCholeskyInferenceMethod) CKLCholeskyInferenceMethod;
 %rename(KLDualInferenceMethod) CKLDualInferenceMethod;
 
@@ -79,23 +79,23 @@
 %include <shogun/machine/gp/ZeroMean.h>
 %include <shogun/machine/gp/ConstMean.h>
 
-%include <shogun/machine/gp/InferenceMethod.h>
-%include <shogun/machine/gp/LaplacianInferenceBase.h>
-%include <shogun/machine/gp/SparseInferenceBase.h>
-%include <shogun/machine/gp/SingleSparseInferenceBase.h>
-%include <shogun/machine/gp/SingleFITCLaplacianBase.h>
-%include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
-%include <shogun/machine/gp/MultiLaplacianInferenceMethod.h>
+%include <shogun/machine/gp/Inference.h>
+%include <shogun/machine/gp/LaplaceInference.h>
+%include <shogun/machine/gp/SparseInference.h>
+%include <shogun/machine/gp/SingleSparseInference.h>
+%include <shogun/machine/gp/SingleFITCLaplace.h>
+%include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
+%include <shogun/machine/gp/MultiLaplaceInferenceMethod.h>
 %include <shogun/machine/gp/ExactInferenceMethod.h>
-%include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+%include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
 %include <shogun/machine/gp/FITCInferenceMethod.h>
-%include <shogun/machine/gp/SparseVGInferenceMethod.h>
+%include <shogun/machine/gp/VarDTCInferenceMethod.h>
 %include <shogun/machine/gp/EPInferenceMethod.h>
 
-%include <shogun/machine/gp/KLInferenceMethod.h>
-%include <shogun/machine/gp/KLLowerTriangularInferenceMethod.h>
+%include <shogun/machine/gp/KLInference.h>
+%include <shogun/machine/gp/KLLowerTriangularInference.h>
 %include <shogun/machine/gp/KLCovarianceInferenceMethod.h>
-%include <shogun/machine/gp/KLApproxDiagonalInferenceMethod.h>
+%include <shogun/machine/gp/KLDiagonalInferenceMethod.h>
 %include <shogun/machine/gp/KLCholeskyInferenceMethod.h>
 %include <shogun/machine/gp/KLDualInferenceMethod.h>
 

--- a/src/interfaces/modular/GaussianProcess_includes.i
+++ b/src/interfaces/modular/GaussianProcess_includes.i
@@ -22,23 +22,23 @@
  #include <shogun/machine/gp/ZeroMean.h>
  #include <shogun/machine/gp/ConstMean.h>
 
- #include <shogun/machine/gp/InferenceMethod.h>
- #include <shogun/machine/gp/LaplacianInferenceBase.h>
- #include <shogun/machine/gp/SparseInferenceBase.h>
- #include <shogun/machine/gp/SingleFITCLaplacianBase.h>
- #include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
- #include <shogun/machine/gp/SingleSparseInferenceBase.h>
- #include <shogun/machine/gp/MultiLaplacianInferenceMethod.h>
+ #include <shogun/machine/gp/Inference.h>
+ #include <shogun/machine/gp/LaplaceInference.h>
+ #include <shogun/machine/gp/SparseInference.h>
+ #include <shogun/machine/gp/SingleFITCLaplace.h>
+ #include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
+ #include <shogun/machine/gp/SingleSparseInference.h>
+ #include <shogun/machine/gp/MultiLaplaceInferenceMethod.h>
  #include <shogun/machine/gp/ExactInferenceMethod.h>
  #include <shogun/machine/gp/FITCInferenceMethod.h>
- #include <shogun/machine/gp/SparseVGInferenceMethod.h>
- #include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+ #include <shogun/machine/gp/VarDTCInferenceMethod.h>
+ #include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
  #include <shogun/machine/gp/EPInferenceMethod.h>
 
- #include <shogun/machine/gp/KLInferenceMethod.h>
- #include <shogun/machine/gp/KLLowerTriangularInferenceMethod.h>
+ #include <shogun/machine/gp/KLInference.h>
+ #include <shogun/machine/gp/KLLowerTriangularInference.h>
  #include <shogun/machine/gp/KLCovarianceInferenceMethod.h>
- #include <shogun/machine/gp/KLApproxDiagonalInferenceMethod.h>
+ #include <shogun/machine/gp/KLDiagonalInferenceMethod.h>
  #include <shogun/machine/gp/KLCholeskyInferenceMethod.h>
  #include <shogun/machine/gp/KLDualInferenceMethod.h>
 

--- a/src/shogun/classifier/GaussianProcessClassification.cpp
+++ b/src/shogun/classifier/GaussianProcessClassification.cpp
@@ -39,7 +39,7 @@
 #include <shogun/lib/config.h>
 #include <shogun/classifier/GaussianProcessClassification.h>
 #include <shogun/mathematics/Math.h>
-#include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
 
 using namespace shogun;
 
@@ -49,7 +49,7 @@ CGaussianProcessClassification::CGaussianProcessClassification()
 }
 
 CGaussianProcessClassification::CGaussianProcessClassification(
-		CInferenceMethod* method) : CGaussianProcessMachine(method)
+		CInference* method) : CGaussianProcessMachine(method)
 {
 	// set labels
 	m_labels=method->get_labels();
@@ -115,10 +115,10 @@ CBinaryLabels* CGaussianProcessClassification::apply_binary(
 	// features
 	if (!data)
 	{
-		if (m_method->get_inference_type()==INF_FITC_LAPLACIAN_SINGLE)
+		if (m_method->get_inference_type()== INF_FITC_LAPLACE_SINGLE)
 		{
-			CSingleFITCLaplacianInferenceMethod* fitc_method=
-				CSingleFITCLaplacianInferenceMethod::obtain_from_generic(m_method);
+			CSingleFITCLaplaceInferenceMethod* fitc_method=
+				CSingleFITCLaplaceInferenceMethod::obtain_from_generic(m_method);
 			data=fitc_method->get_inducing_features();
 			SG_UNREF(fitc_method);
 		}
@@ -147,10 +147,10 @@ bool CGaussianProcessClassification::train_machine(CFeatures* data)
 	if (data)
 	{
 		// set inducing features for FITC inference method
-		if (m_method->get_inference_type()==INF_FITC_LAPLACIAN_SINGLE)
+		if (m_method->get_inference_type()==INF_FITC_LAPLACE_SINGLE)
 		{
-			CSingleFITCLaplacianInferenceMethod* fitc_method=
-				CSingleFITCLaplacianInferenceMethod::obtain_from_generic(m_method);
+			CSingleFITCLaplaceInferenceMethod* fitc_method=
+				CSingleFITCLaplaceInferenceMethod::obtain_from_generic(m_method);
 			fitc_method->set_inducing_features(data);
 			SG_UNREF(fitc_method);
 		}

--- a/src/shogun/classifier/GaussianProcessClassification.h
+++ b/src/shogun/classifier/GaussianProcessClassification.h
@@ -62,7 +62,7 @@ public:
 	 *
 	 * @param method inference method
 	 */
-	CGaussianProcessClassification(CInferenceMethod* method);
+	CGaussianProcessClassification(CInference* method);
 
 	virtual ~CGaussianProcessClassification();
 

--- a/src/shogun/machine/GaussianProcessMachine.cpp
+++ b/src/shogun/machine/GaussianProcessMachine.cpp
@@ -40,7 +40,7 @@
 #include <shogun/machine/GaussianProcessMachine.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/kernel/Kernel.h>
-#include <shogun/machine/gp/SingleFITCLaplacianBase.h>
+#include <shogun/machine/gp/SingleFITCLaplace.h>
 
 #include <shogun/mathematics/eigen3.h>
 
@@ -52,7 +52,7 @@ CGaussianProcessMachine::CGaussianProcessMachine()
 	init();
 }
 
-CGaussianProcessMachine::CGaussianProcessMachine(CInferenceMethod* method)
+CGaussianProcessMachine::CGaussianProcessMachine(CInference* method)
 {
 	init();
 	set_inference_method(method);
@@ -77,8 +77,8 @@ SGVector<float64_t> CGaussianProcessMachine::get_posterior_means(CFeatures* data
 
 	CFeatures* feat;
 
-	CSingleSparseInferenceBase* sparse_method=
-		dynamic_cast<CSingleSparseInferenceBase *>(m_method);
+	CSingleSparseInference* sparse_method=
+		dynamic_cast<CSingleSparseInference *>(m_method);
 	// use inducing features for sparse inference method
 	if (sparse_method)
 	{
@@ -138,8 +138,8 @@ SGVector<float64_t> CGaussianProcessMachine::get_posterior_variances(
 	CFeatures* feat;
 
 	bool is_sparse=false;
-	CSingleSparseInferenceBase* sparse_method=
-		dynamic_cast<CSingleSparseInferenceBase *>(m_method);
+	CSingleSparseInference* sparse_method=
+		dynamic_cast<CSingleSparseInference *>(m_method);
 	// use inducing features for sparse inference method
 	if (sparse_method)
 	{

--- a/src/shogun/machine/GaussianProcessMachine.h
+++ b/src/shogun/machine/GaussianProcessMachine.h
@@ -40,7 +40,7 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/machine/Machine.h>
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 
 
 namespace shogun
@@ -67,7 +67,7 @@ public:
 	 *
 	 * @param method inference method
 	 */
-	CGaussianProcessMachine(CInferenceMethod* method);
+	CGaussianProcessMachine(CInference* method);
 
 	virtual ~CGaussianProcessMachine();
 
@@ -101,7 +101,7 @@ public:
 	 *
 	 * @return inference method, which is used by Gaussian process machine
 	 */
-	CInferenceMethod* get_inference_method() const
+	CInference* get_inference_method() const
 	{
 		SG_REF(m_method);
 		return m_method;
@@ -111,7 +111,7 @@ public:
 	 *
 	 * @param method inference method
 	 */
-	void set_inference_method(CInferenceMethod* method)
+	void set_inference_method(CInference* method)
 	{
 		SG_REF(method);
 		SG_UNREF(m_method);
@@ -140,7 +140,7 @@ private:
 
 protected:
 	/** inference method */
-	CInferenceMethod* m_method;
+	CInference* m_method;
 };
 }
 #endif /* _GAUSSIANPROCESSMACHINE_H_ */

--- a/src/shogun/machine/gp/EPInferenceMethod.cpp
+++ b/src/shogun/machine/gp/EPInferenceMethod.cpp
@@ -66,7 +66,7 @@ CEPInferenceMethod::CEPInferenceMethod()
 
 CEPInferenceMethod::CEPInferenceMethod(CKernel* kernel, CFeatures* features,
 		CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model)
-		: CInferenceMethod(kernel, features, mean, labels, model)
+		: CInference(kernel, features, mean, labels, model)
 {
 	init();
 }
@@ -88,7 +88,7 @@ void CEPInferenceMethod::init()
 }
 
 CEPInferenceMethod* CEPInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;
@@ -148,7 +148,7 @@ SGMatrix<float64_t> CEPInferenceMethod::get_posterior_covariance()
 
 void CEPInferenceMethod::compute_gradient()
 {
-	CInferenceMethod::compute_gradient();
+	CInference::compute_gradient();
 
 	if (!m_gradient_update)
 	{
@@ -164,7 +164,7 @@ void CEPInferenceMethod::update()
 	SG_DEBUG("entering\n");
 
 	// update kernel and feature matrix
-	CInferenceMethod::update();
+	CInference::update();
 
 	// get number of labels (trainig examples)
 	index_t n=m_labels->get_num_labels();

--- a/src/shogun/machine/gp/EPInferenceMethod.h
+++ b/src/shogun/machine/gp/EPInferenceMethod.h
@@ -37,7 +37,7 @@
 #include <shogun/lib/config.h>
 
 
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 
 namespace shogun
 {
@@ -49,7 +49,7 @@ namespace shogun
  * Approximate Bayesian Inference. PhD thesis, Massachusetts Institute of
  * Technology
  */
-class CEPInferenceMethod : public CInferenceMethod
+class CEPInferenceMethod : public CInference
 {
 public:
 	/** default constructor */
@@ -85,7 +85,7 @@ public:
 	 * @param inference inference method
 	 * @return casted CEPInferenceMethod object
 	 */
-	static CEPInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CEPInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** returns the negative logarithm of the marginal likelihood function:
 	 *
@@ -275,9 +275,9 @@ protected:
 	virtual void update_deriv();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */

--- a/src/shogun/machine/gp/ExactInferenceMethod.cpp
+++ b/src/shogun/machine/gp/ExactInferenceMethod.cpp
@@ -42,13 +42,13 @@
 using namespace shogun;
 using namespace Eigen;
 
-CExactInferenceMethod::CExactInferenceMethod() : CInferenceMethod()
+CExactInferenceMethod::CExactInferenceMethod() : CInference()
 {
 }
 
 CExactInferenceMethod::CExactInferenceMethod(CKernel* kern, CFeatures* feat,
 		CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod) :
-		CInferenceMethod(kern, feat, m, lab, mod)
+		CInference(kern, feat, m, lab, mod)
 {
 }
 
@@ -63,7 +63,7 @@ void CExactInferenceMethod::register_minimizer(Minimizer* minimizer)
 
 void CExactInferenceMethod::compute_gradient()
 {
-	CInferenceMethod::compute_gradient();
+	CInference::compute_gradient();
 
 	if (!m_gradient_update)
 	{
@@ -79,7 +79,7 @@ void CExactInferenceMethod::update()
 {
 	SG_DEBUG("entering\n");
 
-	CInferenceMethod::update();
+	CInference::update();
 	update_chol();
 	update_alpha();
 	m_gradient_update=false;
@@ -90,7 +90,7 @@ void CExactInferenceMethod::update()
 
 void CExactInferenceMethod::check_members() const
 {
-	CInferenceMethod::check_members();
+	CInference::check_members();
 
 	REQUIRE(m_model->get_model_type()==LT_GAUSSIAN,
 		"Exact inference method can only use Gaussian likelihood function\n")
@@ -305,7 +305,7 @@ SGVector<float64_t> CExactInferenceMethod::get_derivative_wrt_inference_method(
 }
 
 CExactInferenceMethod* CExactInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;

--- a/src/shogun/machine/gp/ExactInferenceMethod.h
+++ b/src/shogun/machine/gp/ExactInferenceMethod.h
@@ -35,7 +35,7 @@
 #include <shogun/lib/config.h>
 
 
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 
 namespace shogun
 {
@@ -63,7 +63,7 @@ namespace shogun
  * NOTE: The Gaussian Likelihood Function must be used for this inference
  * method.
  */
-class CExactInferenceMethod: public CInferenceMethod
+class CExactInferenceMethod: public CInference
 {
 public:
 	/** default constructor */
@@ -99,7 +99,7 @@ public:
 	 * @param inference inference method
 	 * @return casted CExactInferenceMethod object
 	 */
-	static CExactInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CExactInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get negative log marginal likelihood
 	 *
@@ -214,9 +214,9 @@ protected:
 	virtual void update_deriv();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */

--- a/src/shogun/machine/gp/FITCInferenceMethod.cpp
+++ b/src/shogun/machine/gp/FITCInferenceMethod.cpp
@@ -39,14 +39,14 @@
 using namespace shogun;
 using namespace Eigen;
 
-CFITCInferenceMethod::CFITCInferenceMethod() : CSingleFITCLaplacianBase()
+CFITCInferenceMethod::CFITCInferenceMethod() : CSingleFITCLaplace()
 {
 	init();
 }
 
 CFITCInferenceMethod::CFITCInferenceMethod(CKernel* kern, CFeatures* feat,
 		CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod, CFeatures* lat)
-		: CSingleFITCLaplacianBase(kern, feat, m, lab, mod, lat)
+		: CSingleFITCLaplace(kern, feat, m, lab, mod, lat)
 {
 	init();
 }
@@ -60,7 +60,7 @@ CFITCInferenceMethod::~CFITCInferenceMethod()
 }
 void CFITCInferenceMethod::compute_gradient()
 {
-	CInferenceMethod::compute_gradient();
+	CInference::compute_gradient();
 
 	if (!m_gradient_update)
 	{
@@ -74,7 +74,7 @@ void CFITCInferenceMethod::update()
 {
 	SG_DEBUG("entering\n");
 
-	CInferenceMethod::update();
+	CInference::update();
 	update_chol();
 	update_alpha();
 	m_gradient_update=false;
@@ -84,7 +84,7 @@ void CFITCInferenceMethod::update()
 }
 
 CFITCInferenceMethod* CFITCInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;
@@ -98,7 +98,7 @@ CFITCInferenceMethod* CFITCInferenceMethod::obtain_from_generic(
 
 void CFITCInferenceMethod::check_members() const
 {
-	CSingleFITCLaplacianBase::check_members();
+	CSingleFITCLaplace::check_members();
 
 	REQUIRE(m_model->get_model_type()==LT_GAUSSIAN,
 			"FITC inference method can only use Gaussian likelihood function\n")

--- a/src/shogun/machine/gp/FITCInferenceMethod.h
+++ b/src/shogun/machine/gp/FITCInferenceMethod.h
@@ -19,7 +19,7 @@
 
 
 #include <shogun/lib/config.h>
-#include <shogun/machine/gp/SingleFITCLaplacianBase.h>
+#include <shogun/machine/gp/SingleFITCLaplace.h>
 
 namespace shogun
 {
@@ -41,7 +41,7 @@ namespace shogun
  * (the time complexity is computed based on the assumption m < n)
  *
  * Warning: the time complexity of method,
- * CSingleFITCLaplacianBase::get_derivative_wrt_kernel(const TParameter* param),
+ * CSingleFITCLaplace::get_derivative_wrt_kernel(const TParameter* param),
  * depends on the implementation of virtual kernel method,
  * CKernel::get_parameter_gradient_diagonal(param, i).
  * The default time complexity of the kernel method can be O(n^2)
@@ -49,7 +49,7 @@ namespace shogun
  * Warning: the the time complexity increases from O(m^2*n) to O(n^2*m) if method
  * CFITCInferenceMethod::get_posterior_covariance() is called
  */
-class CFITCInferenceMethod: public CSingleFITCLaplacianBase
+class CFITCInferenceMethod: public CSingleFITCLaplace
 {
 public:
 	/** default constructor */
@@ -87,7 +87,7 @@ public:
 	 * @param inference inference method
 	 * @return casted CFITCInferenceMethod object
 	 */
-	static CFITCInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CFITCInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get negative log marginal likelihood
 	 *

--- a/src/shogun/machine/gp/Inference.h
+++ b/src/shogun/machine/gp/Inference.h
@@ -31,8 +31,8 @@
  * either expressed or implied, of the Shogun Development Team.
  *
  */
-#ifndef CINFERENCEMETHOD_H_
-#define CINFERENCEMETHOD_H_
+#ifndef CINFERENCE_H_
+#define CINFERENCE_H_
 
 #include <shogun/lib/config.h>
 
@@ -56,10 +56,10 @@ enum EInferenceType
 	INF_EXACT=10,
 	INF_SPARSE=20,
 	INF_FITC_REGRESSION=21,
-	INF_FITC_LAPLACIAN_SINGLE=22,
-	INF_LAPLACIAN=30,
-	INF_LAPLACIAN_SINGLE=31,
-	INF_LAPLACIAN_MULTIPLE=32,
+	INF_FITC_LAPLACE_SINGLE=22,
+	INF_LAPLACE=30,
+	INF_LAPLACE_SINGLE=31,
+	INF_LAPLACE_MULTIPLE=32,
 	INF_EP=40,
 	INF_KL=50,
 	INF_KL_DIAGONAL=51,
@@ -76,13 +76,13 @@ enum EInferenceType
  *
  * It is possible to sample the (true) log-marginal likelihood on the base of
  * any implemented approximation. See
- * CInferenceMethod::get_marginal_likelihood_estimate.
+ * CInference::get_marginal_likelihood_estimate.
  */
-class CInferenceMethod : public CDifferentiableFunction
+class CInference : public CDifferentiableFunction
 {
 public:
 	/** default constructor */
-	CInferenceMethod();
+	CInference();
 
 	/** constructor
 	 *
@@ -92,12 +92,12 @@ public:
 	 * @param labels labels of the features
 	 * @param model likelihood model to use
 	 */
-	CInferenceMethod(CKernel* kernel, CFeatures* features,
+	CInference(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model);
 
-	virtual ~CInferenceMethod();
+	virtual ~CInference();
 
-	/** return what type of inference we are, e.g. exact, FITC, Laplacian, etc.
+	/** return what type of inference we are, e.g. exact, FITC, Laplace, etc.
 	 *
 	 * @return inference type
 	 */
@@ -126,7 +126,7 @@ public:
 	 *
 	 * This is done via a Gaussian approximation to the posterior
 	 * \f$q(f|y, \theta)\approx p(f|y, \theta)\f$, which is computed by the
-	 * underlying CInferenceMethod instance (if implemented, otherwise error),
+	 * underlying CInference instance (if implemented, otherwise error),
 	 * and then using an importance sample estimator
 	 *
 	 * \f[
@@ -411,9 +411,9 @@ protected:
 	virtual void update_train_kernel();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -499,4 +499,4 @@ protected:
 	bool m_gradient_update;
 };
 }
-#endif /* CINFERENCEMETHOD_H_ */
+#endif /* CINFERENCE_H_ */

--- a/src/shogun/machine/gp/KLCholeskyInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLCholeskyInferenceMethod.cpp
@@ -51,14 +51,14 @@ using namespace Eigen;
 namespace shogun
 {
 
-CKLCholeskyInferenceMethod::CKLCholeskyInferenceMethod() : CKLLowerTriangularInferenceMethod()
+CKLCholeskyInferenceMethod::CKLCholeskyInferenceMethod() : CKLLowerTriangularInference()
 {
 	init();
 }
 
 CKLCholeskyInferenceMethod::CKLCholeskyInferenceMethod(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CKLLowerTriangularInferenceMethod(kern, feat, m, lab, mod)
+		: CKLLowerTriangularInference(kern, feat, m, lab, mod)
 {
 	init();
 }
@@ -74,7 +74,7 @@ void CKLCholeskyInferenceMethod::init()
 }
 
 CKLCholeskyInferenceMethod* CKLCholeskyInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;

--- a/src/shogun/machine/gp/KLCholeskyInferenceMethod.h
+++ b/src/shogun/machine/gp/KLCholeskyInferenceMethod.h
@@ -43,7 +43,7 @@
 
 #include <shogun/lib/config.h>
 
-#include <shogun/machine/gp/KLLowerTriangularInferenceMethod.h>
+#include <shogun/machine/gp/KLLowerTriangularInference.h>
 
 namespace shogun
 {
@@ -69,7 +69,7 @@ namespace shogun
  * Note that "Cholesky" means Cholesky represention of the variational co-variance matrix
  * is explicitly used in inference
  */
-class CKLCholeskyInferenceMethod: public CKLLowerTriangularInferenceMethod
+class CKLCholeskyInferenceMethod: public CKLLowerTriangularInference
 {
 public:
 	/** default constructor */
@@ -105,7 +105,7 @@ public:
 	 * @param inference inference method
 	 * @return casted CKLCholeskyInferenceMethod object
 	 */
-	static CKLCholeskyInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CKLCholeskyInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get alpha vector
 	 *

--- a/src/shogun/machine/gp/KLCovarianceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLCovarianceInferenceMethod.cpp
@@ -51,14 +51,14 @@ using namespace Eigen;
 namespace shogun
 {
 
-CKLCovarianceInferenceMethod::CKLCovarianceInferenceMethod() : CKLInferenceMethod()
+CKLCovarianceInferenceMethod::CKLCovarianceInferenceMethod() : CKLInference()
 {
 	init();
 }
 
 CKLCovarianceInferenceMethod::CKLCovarianceInferenceMethod(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CKLInferenceMethod(kern, feat, m, lab, mod)
+		: CKLInference(kern, feat, m, lab, mod)
 {
 	init();
 }
@@ -114,7 +114,7 @@ CKLCovarianceInferenceMethod::~CKLCovarianceInferenceMethod()
 }
 
 CKLCovarianceInferenceMethod* CKLCovarianceInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;

--- a/src/shogun/machine/gp/KLCovarianceInferenceMethod.h
+++ b/src/shogun/machine/gp/KLCovarianceInferenceMethod.h
@@ -43,7 +43,7 @@
 
 #include <shogun/lib/config.h>
 
-#include <shogun/machine/gp/KLInferenceMethod.h>
+#include <shogun/machine/gp/KLInference.h>
 
 namespace shogun
 {
@@ -69,7 +69,7 @@ namespace shogun
  * https://gist.github.com/yorkerlin/b64a015491833562d11a
  *
  */
-class CKLCovarianceInferenceMethod: public CKLInferenceMethod
+class CKLCovarianceInferenceMethod: public CKLInference
 {
 public:
 	/** default constructor */
@@ -105,7 +105,7 @@ public:
 	 * @param inference inference method
 	 * @return casted CKLCovarianceInferenceMethod object
 	 */
-	static CKLCovarianceInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CKLCovarianceInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get alpha vector
 	 *

--- a/src/shogun/machine/gp/KLDiagonalInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDiagonalInferenceMethod.cpp
@@ -39,7 +39,7 @@
  * This code specifically adapted from function in approxKL.m and infKL.m
  */
 
-#include <shogun/machine/gp/KLApproxDiagonalInferenceMethod.h>
+#include <shogun/machine/gp/KLDiagonalInferenceMethod.h>
 
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/Math.h>
@@ -51,39 +51,39 @@ using namespace Eigen;
 namespace shogun
 {
 
-CKLApproxDiagonalInferenceMethod::CKLApproxDiagonalInferenceMethod() : CKLLowerTriangularInferenceMethod()
+CKLDiagonalInferenceMethod::CKLDiagonalInferenceMethod() : CKLLowerTriangularInference()
 {
 	init();
 }
 
-CKLApproxDiagonalInferenceMethod::CKLApproxDiagonalInferenceMethod(CKernel* kern,
+CKLDiagonalInferenceMethod::CKLDiagonalInferenceMethod(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CKLLowerTriangularInferenceMethod(kern, feat, m, lab, mod)
+		: CKLLowerTriangularInference(kern, feat, m, lab, mod)
 {
 	init();
 }
 
-void CKLApproxDiagonalInferenceMethod::init()
+void CKLDiagonalInferenceMethod::init()
 {
 	SG_ADD(&m_InvK, "invK",
 		"The K^{-1} matrix",
 		MS_NOT_AVAILABLE);
 }
 
-CKLApproxDiagonalInferenceMethod* CKLApproxDiagonalInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+CKLDiagonalInferenceMethod* CKLDiagonalInferenceMethod::obtain_from_generic(
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;
 
 	if (inference->get_inference_type()!=INF_KL_DIAGONAL)
-		SG_SERROR("Provided inference is not of type CKLApproxDiagonalInferenceMethod!\n")
+		SG_SERROR("Provided inference is not of type CKLDiagonalInferenceMethod!\n")
 
 	SG_REF(inference);
-	return (CKLApproxDiagonalInferenceMethod*)inference;
+	return (CKLDiagonalInferenceMethod*)inference;
 }
 
-SGVector<float64_t> CKLApproxDiagonalInferenceMethod::get_alpha()
+SGVector<float64_t> CKLDiagonalInferenceMethod::get_alpha()
 {
 	/** Note that m_alpha contains not only the alpha vector defined in the reference
 	 * but also a vector corresponding to the lower triangular of C
@@ -105,11 +105,11 @@ SGVector<float64_t> CKLApproxDiagonalInferenceMethod::get_alpha()
 	return result;
 }
 
-CKLApproxDiagonalInferenceMethod::~CKLApproxDiagonalInferenceMethod()
+CKLDiagonalInferenceMethod::~CKLDiagonalInferenceMethod()
 {
 }
 
-bool CKLApproxDiagonalInferenceMethod::precompute()
+bool CKLDiagonalInferenceMethod::precompute()
 {
 	index_t len=m_mean_vec.vlen;
 	Map<VectorXd> eigen_mean(m_mean_vec.vector, m_mean_vec.vlen);
@@ -130,7 +130,7 @@ bool CKLApproxDiagonalInferenceMethod::precompute()
 	return status;
 }
 
-void CKLApproxDiagonalInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<float64_t> gradient)
+void CKLDiagonalInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<float64_t> gradient)
 {
 	REQUIRE(gradient.vlen==m_alpha.vlen,
 		"The length of gradients (%d) should the same as the length of parameters (%d)\n",
@@ -165,7 +165,7 @@ void CKLApproxDiagonalInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVec
 
 }
 
-float64_t CKLApproxDiagonalInferenceMethod::get_negative_log_marginal_likelihood_helper()
+float64_t CKLDiagonalInferenceMethod::get_negative_log_marginal_likelihood_helper()
 {
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_mu.vlen);
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
@@ -187,7 +187,7 @@ float64_t CKLApproxDiagonalInferenceMethod::get_negative_log_marginal_likelihood
 	return result;
 }
 
-void CKLApproxDiagonalInferenceMethod::update_alpha()
+void CKLDiagonalInferenceMethod::update_alpha()
 {
 	Map<MatrixXd> eigen_K(m_ktrtr.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
 	m_InvK=SGMatrix<float64_t>(m_ktrtr.num_rows, m_ktrtr.num_cols);
@@ -230,7 +230,7 @@ void CKLApproxDiagonalInferenceMethod::update_alpha()
 	nlml_new=optimization();
 }
 
-void CKLApproxDiagonalInferenceMethod::update_Sigma()
+void CKLDiagonalInferenceMethod::update_Sigma()
 {
 	m_Sigma=SGMatrix<float64_t>(m_mu.vlen, m_mu.vlen);
 	Map<MatrixXd> eigen_Sigma(m_Sigma.matrix, m_Sigma.num_rows, m_Sigma.num_cols);
@@ -238,7 +238,7 @@ void CKLApproxDiagonalInferenceMethod::update_Sigma()
 	eigen_Sigma=eigen_s2.asDiagonal();
 }
 
-void CKLApproxDiagonalInferenceMethod::update_InvK_Sigma()
+void CKLDiagonalInferenceMethod::update_InvK_Sigma()
 {
 	m_InvK_Sigma=SGMatrix<float64_t>(m_ktrtr.num_rows, m_ktrtr.num_cols);
 	Map<MatrixXd> eigen_InvK_Sigma(m_InvK_Sigma.matrix, m_InvK_Sigma.num_rows, m_InvK_Sigma.num_cols);

--- a/src/shogun/machine/gp/KLDualInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDualInferenceMethod.cpp
@@ -220,20 +220,20 @@ private:
 };
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 
-CKLDualInferenceMethod::CKLDualInferenceMethod() : CKLInferenceMethod()
+CKLDualInferenceMethod::CKLDualInferenceMethod() : CKLInference()
 {
 	init();
 }
 
 CKLDualInferenceMethod::CKLDualInferenceMethod(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CKLInferenceMethod(kern, feat, m, lab, mod)
+		: CKLInference(kern, feat, m, lab, mod)
 {
 	init();
 }
 
 CKLDualInferenceMethod* CKLDualInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;
@@ -270,7 +270,7 @@ void CKLDualInferenceMethod::check_dual_inference(CLikelihoodModel* mod) const
 void CKLDualInferenceMethod::set_model(CLikelihoodModel* mod)
 {
 	check_dual_inference(mod);
-	CKLInferenceMethod::set_model(mod);
+	CKLInference::set_model(mod);
 }
 
 CDualVariationalGaussianLikelihood* CKLDualInferenceMethod::get_dual_variational_likelihood() const
@@ -284,7 +284,7 @@ void CKLDualInferenceMethod::register_minimizer(Minimizer* minimizer)
 {
 	KLDualInferenceMethodMinimizer* opt=dynamic_cast<KLDualInferenceMethodMinimizer*>(minimizer);
 	REQUIRE(opt,"The minimizer must be an instance of KLDualInferenceMethodMinimizer\n"); 
-	CInferenceMethod::register_minimizer(minimizer);
+	CInference::register_minimizer(minimizer);
 }
 
 

--- a/src/shogun/machine/gp/KLDualInferenceMethod.h
+++ b/src/shogun/machine/gp/KLDualInferenceMethod.h
@@ -37,7 +37,7 @@
 #define _KLDUALINFERENCEMETHOD_H_
 
 #include <shogun/lib/config.h>
-#include <shogun/machine/gp/KLInferenceMethod.h>
+#include <shogun/machine/gp/KLInference.h>
 #include <shogun/machine/gp/DualVariationalGaussianLikelihood.h>
 
 namespace shogun
@@ -59,7 +59,7 @@ namespace shogun
  *
  * For detailed information, please refer to the paper.
  */
-class CKLDualInferenceMethod: public CKLInferenceMethod
+class CKLDualInferenceMethod: public CKLInference
 {
 friend class KLDualInferenceMethodCostFunction;
 public:
@@ -96,7 +96,7 @@ public:
 	 * @param inference inference method
 	 * @return casted CKLDualInferenceMethod object
 	 */
-	static CKLDualInferenceMethod * obtain_from_generic(CInferenceMethod* inference);
+	static CKLDualInferenceMethod * obtain_from_generic(CInference* inference);
 
 	/** get alpha vector
 	 *

--- a/src/shogun/machine/gp/KLInference.h
+++ b/src/shogun/machine/gp/KLInference.h
@@ -38,12 +38,12 @@
  *
  */
 
-#ifndef _KLINFERENCEMETHOD_H_
-#define _KLINFERENCEMETHOD_H_
+#ifndef _KLINFERENCE_H_
+#define _KLINFERENCE_H_
 
 #include <shogun/lib/config.h>
 
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 #include <shogun/machine/gp/VariationalGaussianLikelihood.h>
 
 namespace Eigen
@@ -72,12 +72,12 @@ namespace shogun
  * "Approximations for Binary Gaussian Process Classification."
  * Journal of Machine Learning Research 9.10 (2008).
  */
-class CKLInferenceMethod: public CInferenceMethod
+class CKLInference: public CInference
 {
-friend class KLInferenceMethodCostFunction;
+friend class KLInferenceCostFunction;
 public:
 	/** default constructor */
-	CKLInferenceMethod();
+	CKLInference();
 
 	/** constructor
 	 *
@@ -87,10 +87,10 @@ public:
 	 * @param labels labels of the features
 	 * @param model Likelihood model to use
 	 */
-	CKLInferenceMethod(CKernel* kernel, CFeatures* features,
+	CKLInference(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model);
 
-	virtual ~CKLInferenceMethod();
+	virtual ~CKLInference();
 
 	/** return what type of inference we are
 	 */
@@ -98,9 +98,9 @@ public:
 
 	/** returns the name of the inference method
 	 *
-	 * @return name KLInferenceMethod
+	 * @return name KLInference
 	 */
-	virtual const char* get_name() const { return "KLInferenceMethod"; }
+	virtual const char* get_name() const { return "KLInference"; }
 
 	/** get negative log marginal likelihood
 	 *
@@ -291,9 +291,9 @@ protected:
 	virtual float64_t optimization();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -377,4 +377,4 @@ private:
 	void init();
 };
 }
-#endif /* _KLINFERENCEMETHOD_H_ */
+#endif /* _KLINFERENCE_H_ */

--- a/src/shogun/machine/gp/KLLowerTriangularInference.cpp
+++ b/src/shogun/machine/gp/KLLowerTriangularInference.cpp
@@ -39,7 +39,7 @@
  * This code specifically adapted from function in approxKL.m and infKL.m
  */
 
-#include <shogun/machine/gp/KLLowerTriangularInferenceMethod.h>
+#include <shogun/machine/gp/KLLowerTriangularInference.h>
 
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/Math.h>
@@ -50,19 +50,19 @@ using namespace Eigen;
 namespace shogun
 {
 
-CKLLowerTriangularInferenceMethod::CKLLowerTriangularInferenceMethod() : CKLInferenceMethod()
+CKLLowerTriangularInference::CKLLowerTriangularInference() : CKLInference()
 {
 	init();
 }
 
-CKLLowerTriangularInferenceMethod::CKLLowerTriangularInferenceMethod(CKernel* kern,
+CKLLowerTriangularInference::CKLLowerTriangularInference(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CKLInferenceMethod(kern, feat, m, lab, mod)
+		: CKLInference(kern, feat, m, lab, mod)
 {
 	init();
 }
 
-void CKLLowerTriangularInferenceMethod::init()
+void CKLLowerTriangularInference::init()
 {
 	SG_ADD(&m_InvK_Sigma, "invk_Sigma",
 		"K^{-1}Sigma'",
@@ -83,11 +83,11 @@ void CKLLowerTriangularInferenceMethod::init()
 	m_log_det_Kernel=0;
 }
 
-CKLLowerTriangularInferenceMethod::~CKLLowerTriangularInferenceMethod()
+CKLLowerTriangularInference::~CKLLowerTriangularInference()
 {
 }
 
-SGVector<float64_t> CKLLowerTriangularInferenceMethod::get_diagonal_vector()
+SGVector<float64_t> CKLLowerTriangularInference::get_diagonal_vector()
 {
 	/** The diagonal vector W is NOT used in this KL method
 	 * Therefore, return empty vector
@@ -95,14 +95,14 @@ SGVector<float64_t> CKLLowerTriangularInferenceMethod::get_diagonal_vector()
 	return SGVector<float64_t>();
 }
 
-void CKLLowerTriangularInferenceMethod::update_deriv()
+void CKLLowerTriangularInference::update_deriv()
 {
 	/** get_derivative_related_cov() does the similar job
 	 * Therefore, this function body is empty
 	 */
 }
 
-void CKLLowerTriangularInferenceMethod::update_init()
+void CKLLowerTriangularInference::update_init()
 {
 	Eigen::LDLT<Eigen::MatrixXd> ldlt=update_init_helper();
 	MatrixXd Kernel_D=ldlt.vectorD();
@@ -122,7 +122,7 @@ void CKLLowerTriangularInferenceMethod::update_init()
 	m_mean_vec=m_mean->get_mean_vector(m_features);
 }
 
-MatrixXd CKLLowerTriangularInferenceMethod::solve_inverse(MatrixXd eigen_A)
+MatrixXd CKLLowerTriangularInference::solve_inverse(MatrixXd eigen_A)
 {
 	Map<VectorXi> eigen_Kernel_P(m_Kernel_P.vector, m_Kernel_P.vlen);
 	Map<MatrixXd> eigen_Kernel_LsD(m_Kernel_LsD.matrix, m_Kernel_LsD.num_rows, m_Kernel_LsD.num_cols);
@@ -149,7 +149,7 @@ MatrixXd CKLLowerTriangularInferenceMethod::solve_inverse(MatrixXd eigen_A)
 	return P.transpose()*tmp3;
 }
 
-float64_t CKLLowerTriangularInferenceMethod::get_derivative_related_cov(SGMatrix<float64_t> dK)
+float64_t CKLLowerTriangularInference::get_derivative_related_cov(SGMatrix<float64_t> dK)
 {
 	Map<MatrixXd> eigen_dK(dK.matrix, dK.num_rows, dK.num_cols);
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_mu.vlen);
@@ -163,14 +163,14 @@ float64_t CKLLowerTriangularInferenceMethod::get_derivative_related_cov(SGMatrix
 	return 0.5*(tmp3.array()*eigen_dK.array()).sum();
 }
 
-void CKLLowerTriangularInferenceMethod::update_approx_cov()
+void CKLLowerTriangularInference::update_approx_cov()
 {
 	/** update_Sigma() does the similar job
 	 * Therefore, this function body is empty
 	 */
 }
 
-void CKLLowerTriangularInferenceMethod::update_chol()
+void CKLLowerTriangularInference::update_chol()
 {
 	update_Sigma();
 	update_InvK_Sigma();

--- a/src/shogun/machine/gp/LaplaceInference.cpp
+++ b/src/shogun/machine/gp/LaplaceInference.cpp
@@ -30,7 +30,7 @@
  *
  */
 
-#include <shogun/machine/gp/LaplacianInferenceBase.h>
+#include <shogun/machine/gp/LaplaceInference.h>
 
 
 #include <shogun/mathematics/Math.h>
@@ -43,19 +43,19 @@ using namespace Eigen;
 namespace shogun
 {
 
-CLaplacianInferenceBase::CLaplacianInferenceBase() : CInferenceMethod()
+CLaplaceInference::CLaplaceInference() : CInference()
 {
 	init();
 }
 
-CLaplacianInferenceBase::CLaplacianInferenceBase(CKernel* kern,
+CLaplaceInference::CLaplaceInference(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CInferenceMethod(kern, feat, m, lab, mod)
+		: CInference(kern, feat, m, lab, mod)
 {
 	init();
 }
 
-void CLaplacianInferenceBase::init()
+void CLaplaceInference::init()
 {
 	SG_ADD(&m_dlp, "dlp", "derivative of log likelihood with respect to function location", MS_NOT_AVAILABLE);
 	SG_ADD(&m_mu, "mu", "mean vector of the approximation to the posterior", MS_NOT_AVAILABLE);
@@ -63,13 +63,13 @@ void CLaplacianInferenceBase::init()
 	SG_ADD(&m_W, "W", "the noise matrix", MS_NOT_AVAILABLE);
 }
 
-CLaplacianInferenceBase::~CLaplacianInferenceBase()
+CLaplaceInference::~CLaplaceInference()
 {
 }
 
-void CLaplacianInferenceBase::compute_gradient()
+void CLaplaceInference::compute_gradient()
 {
-	CInferenceMethod::compute_gradient();
+	CInference::compute_gradient();
 
 	if (!m_gradient_update)
 	{
@@ -79,11 +79,11 @@ void CLaplacianInferenceBase::compute_gradient()
 		update_parameter_hash();
 	}
 }
-void CLaplacianInferenceBase::update()
+void CLaplaceInference::update()
 {
 	SG_DEBUG("entering\n");
 
-	CInferenceMethod::update();
+	CInference::update();
 	update_alpha();
 	update_chol();
 	m_gradient_update=false;
@@ -92,7 +92,7 @@ void CLaplacianInferenceBase::update()
 	SG_DEBUG("leaving\n");
 }
 
-SGVector<float64_t> CLaplacianInferenceBase::get_alpha()
+SGVector<float64_t> CLaplaceInference::get_alpha()
 {
 	if (parameter_hash_changed())
 		update();
@@ -102,7 +102,7 @@ SGVector<float64_t> CLaplacianInferenceBase::get_alpha()
 
 }
 
-SGMatrix<float64_t> CLaplacianInferenceBase::get_cholesky()
+SGMatrix<float64_t> CLaplaceInference::get_cholesky()
 {
 	if (parameter_hash_changed())
 		update();
@@ -111,7 +111,7 @@ SGMatrix<float64_t> CLaplacianInferenceBase::get_cholesky()
 
 }
 
-SGMatrix<float64_t> CLaplacianInferenceBase::get_posterior_covariance()
+SGMatrix<float64_t> CLaplaceInference::get_posterior_covariance()
 {
 	compute_gradient();
 

--- a/src/shogun/machine/gp/LaplaceInference.h
+++ b/src/shogun/machine/gp/LaplaceInference.h
@@ -29,13 +29,13 @@
  * either expressed or implied, of the Shogun Development Team.
  *
  */
-#ifndef CLAPLACIANINFERENCEBASE_H_
-#define CLAPLACIANINFERENCEBASE_H_
+#ifndef CLAPLACEINFERENCE_H_
+#define CLAPLACEINFERENCE_H_
 
 #include <shogun/lib/config.h>
 
 
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 
 namespace shogun
 {
@@ -48,11 +48,11 @@ namespace shogun
  * function.
  *
  */
-class CLaplacianInferenceBase: public CInferenceMethod
+class CLaplaceInference: public CInference
 {
 public:
 	/** default constructor */
-	CLaplacianInferenceBase();
+	CLaplaceInference();
 
 	/** constructor
 	 *
@@ -62,22 +62,22 @@ public:
 	 * @param labels labels of the features
 	 * @param model Likelihood model to use
 	 */
-	CLaplacianInferenceBase(CKernel* kernel, CFeatures* features,
+	CLaplaceInference(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model);
 
-	virtual ~CLaplacianInferenceBase();
+	virtual ~CLaplaceInference();
 
 	/** return what type of inference we are
 	 *
-	 * @return inference type Laplacian
+	 * @return inference type Laplace
 	 */
-	virtual EInferenceType get_inference_type() const { return INF_LAPLACIAN; }
+	virtual EInferenceType get_inference_type() const { return INF_LAPLACE; }
 
 	/** returns the name of the inference method
 	 *
-	 * @return name Laplacian
+	 * @return name Laplace
 	 */
-	virtual const char* get_name() const { return "LaplacianInferenceBase"; }
+	virtual const char* get_name() const { return "LaplaceInference"; }
 
 	/** get alpha vector
 	 *
@@ -157,4 +157,4 @@ protected:
 	SGMatrix<float64_t> m_Sigma;
 };
 }
-#endif /* CLAPLACIANINFERENCEBASE_H_ */
+#endif /* CLAPLACEINFERENCE_H_ */

--- a/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
@@ -39,7 +39,7 @@
  * The reference pseudo code is the algorithm 3.3 of the GPML textbook
  */
 
-#include <shogun/machine/gp/MultiLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/MultiLaplaceInferenceMethod.h>
 
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/labels/MulticlassLabels.h>
@@ -98,19 +98,19 @@ public:
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-CMultiLaplacianInferenceMethod::CMultiLaplacianInferenceMethod() : CLaplacianInferenceBase()
+CMultiLaplaceInferenceMethod::CMultiLaplaceInferenceMethod() : CLaplaceInference()
 {
 	init();
 }
 
-CMultiLaplacianInferenceMethod::CMultiLaplacianInferenceMethod(CKernel* kern,
+CMultiLaplaceInferenceMethod::CMultiLaplaceInferenceMethod(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CLaplacianInferenceBase(kern, feat, m, lab, mod)
+		: CLaplaceInference(kern, feat, m, lab, mod)
 {
 	init();
 }
 
-void CMultiLaplacianInferenceMethod::init()
+void CMultiLaplaceInferenceMethod::init()
 {
 	m_iter=20;
 	m_tolerance=1e-6;
@@ -127,13 +127,13 @@ void CMultiLaplacianInferenceMethod::init()
 	SG_ADD(&m_opt_max, "opt_max", "max iterations for Brent's minimization method", MS_NOT_AVAILABLE);
 }
 
-CMultiLaplacianInferenceMethod::~CMultiLaplacianInferenceMethod()
+CMultiLaplaceInferenceMethod::~CMultiLaplaceInferenceMethod()
 {
 }
 
-void CMultiLaplacianInferenceMethod::check_members() const
+void CMultiLaplaceInferenceMethod::check_members() const
 {
-	CInferenceMethod::check_members();
+	CInference::check_members();
 
 	REQUIRE(m_labels->get_label_type()==LT_MULTICLASS,
 		"Labels must be type of CMulticlassLabels\n");
@@ -141,7 +141,7 @@ void CMultiLaplacianInferenceMethod::check_members() const
 		"likelihood model should support multi-classification\n");
 }
 
-SGVector<float64_t> CMultiLaplacianInferenceMethod::get_diagonal_vector()
+SGVector<float64_t> CMultiLaplaceInferenceMethod::get_diagonal_vector()
 {
 	if (parameter_hash_changed())
 		update();
@@ -151,7 +151,7 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_diagonal_vector()
 	return SGVector<float64_t>(m_W);
 }
 
-float64_t CMultiLaplacianInferenceMethod::get_negative_log_marginal_likelihood()
+float64_t CMultiLaplaceInferenceMethod::get_negative_log_marginal_likelihood()
 {
 	if (parameter_hash_changed())
 		update();
@@ -159,7 +159,7 @@ float64_t CMultiLaplacianInferenceMethod::get_negative_log_marginal_likelihood()
 	return m_nlz;
 }
 
-SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_likelihood_model(
+SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_likelihood_model(
 		const TParameter* param)
 {
 	//SoftMax likelihood does not have this kind of derivative
@@ -167,21 +167,21 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_likelihoo
 	return SGVector<float64_t> ();
 }
 
-CMultiLaplacianInferenceMethod* CMultiLaplacianInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+CMultiLaplaceInferenceMethod* CMultiLaplaceInferenceMethod::obtain_from_generic(
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;
 
-	if (inference->get_inference_type()!=INF_LAPLACIAN_MULTIPLE)
-		SG_SERROR("Provided inference is not of type CMultiLaplacianInferenceMethod!\n")
+	if (inference->get_inference_type()!=INF_LAPLACE_MULTIPLE)
+		SG_SERROR("Provided inference is not of type CMultiLaplaceInferenceMethod!\n")
 
 	SG_REF(inference);
-	return (CMultiLaplacianInferenceMethod*)inference;
+	return (CMultiLaplaceInferenceMethod*)inference;
 }
 
 
-void CMultiLaplacianInferenceMethod::update_approx_cov()
+void CMultiLaplaceInferenceMethod::update_approx_cov()
 {
 	//Sigma=K-K*(E-E*R(M*M')^{-1}*R'*E)*K
 	const index_t C=((CMulticlassLabels*)m_labels)->get_num_classes();
@@ -204,11 +204,11 @@ void CMultiLaplacianInferenceMethod::update_approx_cov()
 	eigen_Sigma+=eigen_V.transpose()*eigen_V;
 }
 
-void CMultiLaplacianInferenceMethod::update_chol()
+void CMultiLaplaceInferenceMethod::update_chol()
 {
 }
 
-void CMultiLaplacianInferenceMethod::get_dpi_helper()
+void CMultiLaplaceInferenceMethod::get_dpi_helper()
 {
 	const index_t C=((CMulticlassLabels*)m_labels)->get_num_classes();
 	const index_t n=m_labels->get_num_labels();
@@ -229,7 +229,7 @@ void CMultiLaplacianInferenceMethod::get_dpi_helper()
 	//eigen_dpi_matrix=eigen_dpi_matrix.array().colwise()/tmp_for_dpi.array();
 }
 
-void CMultiLaplacianInferenceMethod::update_alpha()
+void CMultiLaplaceInferenceMethod::update_alpha()
 {
 	float64_t Psi_Old = CMath::INFTY;
 	float64_t Psi_New;
@@ -377,7 +377,7 @@ void CMultiLaplacianInferenceMethod::update_alpha()
 	}
 }
 
-void CMultiLaplacianInferenceMethod::update_deriv()
+void CMultiLaplaceInferenceMethod::update_deriv()
 {
 	const index_t C=((CMulticlassLabels*)m_labels)->get_num_classes();
 	const index_t n=m_labels->get_num_labels();
@@ -388,7 +388,7 @@ void CMultiLaplacianInferenceMethod::update_deriv()
 	eigen_U=eigen_M.triangularView<Upper>().adjoint().solve(eigen_E);
 }
 
-float64_t CMultiLaplacianInferenceMethod::get_derivative_helper(SGMatrix<float64_t> dK)
+float64_t CMultiLaplaceInferenceMethod::get_derivative_helper(SGMatrix<float64_t> dK)
 {
 	Map<MatrixXd> eigen_dK(dK.matrix, dK.num_rows, dK.num_cols);
 	//currently only explicit term is computed
@@ -409,7 +409,7 @@ float64_t CMultiLaplacianInferenceMethod::get_derivative_helper(SGMatrix<float64
 	return result/2.0;
 }
 
-SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_inference_method(
+SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_inference_method(
 		const TParameter* param)
 {
 	REQUIRE(!strcmp(param->m_name, "log_scale"), "Can't compute derivative of "
@@ -428,7 +428,7 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_inference
 	return result;
 }
 
-SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_kernel(
+SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_kernel(
 		const TParameter* param)
 {
 	// create eigen representation of K, Z, dfhat, dlp and alpha
@@ -455,7 +455,7 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_kernel(
 	return result;
 }
 
-SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_mean(
+SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_mean(
 		const TParameter* param)
 {
 	// create eigen representation of K, Z, dfhat and alpha
@@ -489,7 +489,7 @@ SGVector<float64_t> CMultiLaplacianInferenceMethod::get_derivative_wrt_mean(
 	return result;
 }
 
-SGVector<float64_t> CMultiLaplacianInferenceMethod::get_posterior_mean()
+SGVector<float64_t> CMultiLaplaceInferenceMethod::get_posterior_mean()
 {
 	compute_gradient();
 

--- a/src/shogun/machine/gp/MultiLaplaceInferenceMethod.h
+++ b/src/shogun/machine/gp/MultiLaplaceInferenceMethod.h
@@ -39,12 +39,12 @@
  *
  */
 
-#ifndef CMULTILAPLACIANINFERENCEMETHOD_H_
-#define CMULTILAPLACIANINFERENCEMETHOD_H_
+#ifndef CMULTILAPLACEINFERENCEMETHOD_H_
+#define CMULTILAPLACEINFERENCEMETHOD_H_
 
 #include <shogun/lib/config.h>
 
-#include <shogun/machine/gp/LaplacianInferenceBase.h>
+#include <shogun/machine/gp/LaplaceInference.h>
 
 namespace shogun
 {
@@ -66,11 +66,11 @@ namespace shogun
  *
  * The reference pseudo code is the algorithm 3.3 of the GPML textbook
  */
-class CMultiLaplacianInferenceMethod: public CLaplacianInferenceBase
+class CMultiLaplaceInferenceMethod: public CLaplaceInference
 {
 public:
 	/** default constructor */
-	CMultiLaplacianInferenceMethod();
+	CMultiLaplaceInferenceMethod();
 
 	/** constructor
 	 *
@@ -80,31 +80,31 @@ public:
 	 * @param labels labels of the features
 	 * @param model Likelihood model to use
 	 */
-	CMultiLaplacianInferenceMethod(CKernel* kernel, CFeatures* features,
+	CMultiLaplaceInferenceMethod(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model);
 
-	virtual ~CMultiLaplacianInferenceMethod();
+	virtual ~CMultiLaplaceInferenceMethod();
 
 	/** returns the name of the inference method
 	 *
-	 * @return name MultiLaplacian
+	 * @return name MultiLaplace
 	 *
 	 */
-	virtual const char* get_name() const { return "MultiLaplacianInferenceMethod"; }
+	virtual const char* get_name() const { return "MultiLaplaceInferenceMethod"; }
 
 
 	/** return what type of inference we are
 	 *
-	 * @return inference type Laplacian
+	 * @return inference type Laplace
 	 */
-	virtual EInferenceType get_inference_type() const { return INF_LAPLACIAN_MULTIPLE; }
+	virtual EInferenceType get_inference_type() const { return INF_LAPLACE_MULTIPLE; }
 
 	/** helper method used to specialize a base class instance
 	 *
 	 * @param inference inference method
-	 * @return casted CMultiLaplacianInferenceMethod object
+	 * @return casted CMultiLaplaceInferenceMethod object
 	 */
-	static CMultiLaplacianInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CMultiLaplaceInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get negative log marginal likelihood
 	 *
@@ -218,9 +218,9 @@ protected:
 	virtual void update_deriv();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -298,4 +298,4 @@ protected:
 	float64_t m_opt_max;
 };
 }
-#endif /* CMULTILAPLACIANINFERENCEMETHOD_H_ */
+#endif /*  CMULTILAPLACEINFERENCEMETHOD_H_ */

--- a/src/shogun/machine/gp/SingleFITCLaplace.cpp
+++ b/src/shogun/machine/gp/SingleFITCLaplace.cpp
@@ -30,7 +30,7 @@
  */
 
 
-#include <shogun/machine/gp/SingleFITCLaplacianBase.h>
+#include <shogun/machine/gp/SingleFITCLaplace.h>
 
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/eigen3.h>
@@ -39,19 +39,19 @@
 using namespace shogun;
 using namespace Eigen;
 
-CSingleFITCLaplacianBase::CSingleFITCLaplacianBase() : CSingleSparseInferenceBase()
+CSingleFITCLaplace::CSingleFITCLaplace() : CSingleSparseInference()
 {
 	init();
 }
 
-CSingleFITCLaplacianBase::CSingleFITCLaplacianBase(CKernel* kern, CFeatures* feat,
+CSingleFITCLaplace::CSingleFITCLaplace(CKernel* kern, CFeatures* feat,
 		CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod, CFeatures* lat)
-		: CSingleSparseInferenceBase(kern, feat, m, lab, mod, lat)
+		: CSingleSparseInference(kern, feat, m, lab, mod, lat)
 {
 	init();
 }
 
-void CSingleFITCLaplacianBase::init()
+void CSingleFITCLaplace::init()
 {
 	SG_ADD(&m_al, "al", "alpha", MS_NOT_AVAILABLE);
 	SG_ADD(&m_t, "t", "noise", MS_NOT_AVAILABLE);
@@ -61,11 +61,11 @@ void CSingleFITCLaplacianBase::init()
 	SG_ADD(&m_V, "V", "V", MS_NOT_AVAILABLE);
 }
 
-CSingleFITCLaplacianBase::~CSingleFITCLaplacianBase()
+CSingleFITCLaplace::~CSingleFITCLaplace()
 {
 }
 
-SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_related_cov_diagonal()
+SGVector<float64_t> CSingleFITCLaplace::get_derivative_related_cov_diagonal()
 {
 	//time complexity O(m*n)
 	Map<MatrixXd> eigen_W(m_Rvdd.matrix, m_Rvdd.num_rows, m_Rvdd.num_cols);
@@ -78,7 +78,7 @@ SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_related_cov_diagona
 	return res;
 }
 
-float64_t CSingleFITCLaplacianBase::get_derivative_related_cov_helper(
+float64_t CSingleFITCLaplace::get_derivative_related_cov_helper(
 	SGMatrix<float64_t> dKuui, SGVector<float64_t> v, SGMatrix<float64_t> R)
 {
 	//time complexity O(m^2*n)
@@ -101,7 +101,7 @@ float64_t CSingleFITCLaplacianBase::get_derivative_related_cov_helper(
 	return result;
 }
 
-float64_t CSingleFITCLaplacianBase::get_derivative_related_cov(SGVector<float64_t> ddiagKi,
+float64_t CSingleFITCLaplace::get_derivative_related_cov(SGVector<float64_t> ddiagKi,
 	SGMatrix<float64_t> dKuui, SGMatrix<float64_t> dKui)
 {
 	//time complexity O(m^2*n)
@@ -123,7 +123,7 @@ float64_t CSingleFITCLaplacianBase::get_derivative_related_cov(SGVector<float64_
 	return get_derivative_related_cov(ddiagKi, dKuui, dKui, v, R);
 }
 
-float64_t CSingleFITCLaplacianBase::get_derivative_related_cov(SGVector<float64_t> ddiagKi,
+float64_t CSingleFITCLaplace::get_derivative_related_cov(SGVector<float64_t> ddiagKi,
 	SGMatrix<float64_t> dKuui, SGMatrix<float64_t> dKui,
 	SGVector<float64_t> v, SGMatrix<float64_t> R)
 {
@@ -146,7 +146,7 @@ float64_t CSingleFITCLaplacianBase::get_derivative_related_cov(SGVector<float64_
 	return result;
 }
 
-float64_t CSingleFITCLaplacianBase::get_derivative_related_mean(SGVector<float64_t> dmu)
+float64_t CSingleFITCLaplace::get_derivative_related_mean(SGVector<float64_t> dmu)
 {
 	//time complexity O(n)
 	Map<VectorXd> eigen_al(m_al.vector, m_al.vlen);
@@ -154,7 +154,7 @@ float64_t CSingleFITCLaplacianBase::get_derivative_related_mean(SGVector<float64
 	return -eigen_dmu.dot(eigen_al);
 }
 
-SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_wrt_mean(
+SGVector<float64_t> CSingleFITCLaplace::get_derivative_wrt_mean(
 		const TParameter* param)
 {
 	//time complexity O(n)
@@ -176,7 +176,7 @@ SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_wrt_mean(
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_wrt_inducing_noise(
+SGVector<float64_t> CSingleFITCLaplace::get_derivative_wrt_inducing_noise(
 	const TParameter* param)
 {
 	//time complexity O(m^2*n)
@@ -207,7 +207,7 @@ SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_wrt_inducing_noise(
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_related_inducing_features(
+SGVector<float64_t> CSingleFITCLaplace::get_derivative_related_inducing_features(
 	SGMatrix<float64_t> BdK, const TParameter* param)
 {
 	//time complexity depends on the implementation of the provided kernel
@@ -255,7 +255,7 @@ SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_related_inducing_fe
 	return deriv_lat;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianBase::get_derivative_wrt_inducing_features(const TParameter* param)
+SGVector<float64_t> CSingleFITCLaplace::get_derivative_wrt_inducing_features(const TParameter* param)
 {
 	//time complexity depends on the implementation of the provided kernel
 	//time complexity is at least O(max((p*n*m),(m^2*n))), where p is the dimension (#) of features

--- a/src/shogun/machine/gp/SingleFITCLaplace.h
+++ b/src/shogun/machine/gp/SingleFITCLaplace.h
@@ -29,12 +29,12 @@
  *
  */
 
-#ifndef CSINGLEFITCLAPLACIANBASE_H
-#define CSINGLEFITCLAPLACIANBASE_H
+#ifndef CSINGLEFITCLAPLACE_H
+#define CSINGLEFITCLAPLACE_H
 
 
 #include <shogun/lib/config.h>
-#include <shogun/machine/gp/SingleSparseInferenceBase.h>
+#include <shogun/machine/gp/SingleSparseInference.h>
 #include <shogun/lib/Lock.h>
 
 namespace shogun
@@ -59,17 +59,17 @@ namespace shogun
  * in the GPML toolbox.
  *
  * Warning: the time complexity of method,
- * CSingleFITCLaplacianBase::get_derivative_wrt_kernel(const TParameter* param),
+ * CSingleFITCLaplace::get_derivative_wrt_kernel(const TParameter* param),
  * depends on the implementation of virtual kernel method,
  * CKernel::get_parameter_gradient_diagonal(param, i).
  * The default time complexity of the kernel method can be O(n^2)
  *
  */
-class CSingleFITCLaplacianBase: public CSingleSparseInferenceBase
+class CSingleFITCLaplace: public CSingleSparseInference
 {
 public:
 	/** default constructor */
-	CSingleFITCLaplacianBase();
+	CSingleFITCLaplace();
 
 	/** constructor
 	 *
@@ -80,17 +80,17 @@ public:
 	 * @param model likelihood model to use
 	 * @param inducing_features features to use
 	 */
-	CSingleFITCLaplacianBase(CKernel* kernel, CFeatures* features,
+	CSingleFITCLaplace(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model,
 			CFeatures* inducing_features);
 
-	virtual ~CSingleFITCLaplacianBase();
+	virtual ~CSingleFITCLaplace();
 
 	/** returns the name of the inference method
 	 *
-	 * @return name SingleFITCLaplacianBase
+	 * @return name SingleFITCLaplace
 	 */
-	virtual const char* get_name() const { return "SingleFITCLaplacianBase"; }
+	virtual const char* get_name() const { return "SingleFITCLaplace"; }
 
 protected:
 
@@ -255,4 +255,4 @@ private:
 	void init();
 };
 }
-#endif /* CSINGLEFITCLAPLACIANBASE_H */
+#endif /* CSINGLEFITCLAPLACE_H */

--- a/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.cpp
@@ -29,7 +29,7 @@
  *
  */
 
-#include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
 
 #include <shogun/machine/gp/StudentsTLikelihood.h>
 #include <shogun/mathematics/Math.h>
@@ -60,7 +60,7 @@ public:
 	SGVector<float64_t>* m;
 	CLikelihoodModel* lik;
 	CLabels* lab;
-	CSingleFITCLaplacianInferenceMethod *inf;
+	CSingleFITCLaplaceInferenceMethod *inf;
 
 	virtual double operator() (double x)
 	{
@@ -90,12 +90,12 @@ public:
 	}
 };
 
-class SingleFITCLaplacianNewtonOptimizer: public Minimizer
+class SingleFITCLaplaceNewtonOptimizer: public Minimizer
 {
 public:
-	SingleFITCLaplacianNewtonOptimizer() :Minimizer() {  init(); }
-	virtual ~SingleFITCLaplacianNewtonOptimizer() { SG_UNREF(m_obj); }
-	void set_target(CSingleFITCLaplacianInferenceMethod *obj)
+	SingleFITCLaplaceNewtonOptimizer() :Minimizer() {  init(); }
+	virtual ~SingleFITCLaplaceNewtonOptimizer() { SG_UNREF(m_obj); }
+	void set_target(CSingleFITCLaplaceInferenceMethod *obj)
 	{
 		if(obj!=m_obj)
 		{
@@ -240,7 +240,7 @@ private:
 		m_opt_max=10;
 	}
 
-	CSingleFITCLaplacianInferenceMethod *m_obj;
+	CSingleFITCLaplaceInferenceMethod *m_obj;
 
 	/** amount of tolerance for Newton's iterations */
 	float64_t m_tolerance;
@@ -255,12 +255,12 @@ private:
 	float64_t m_opt_max;
 };
 
-class SingleFITCLaplacianInferenceMethodCostFunction: public FirstOrderCostFunction
+class SingleFITCLaplaceInferenceMethodCostFunction: public FirstOrderCostFunction
 {
 public:
-	SingleFITCLaplacianInferenceMethodCostFunction():FirstOrderCostFunction() {  init(); }
-	virtual ~SingleFITCLaplacianInferenceMethodCostFunction() { SG_UNREF(m_obj); }
-	void set_target(CSingleFITCLaplacianInferenceMethod *obj)
+	SingleFITCLaplaceInferenceMethodCostFunction():FirstOrderCostFunction() {  init(); }
+	virtual ~SingleFITCLaplaceInferenceMethodCostFunction() { SG_UNREF(m_obj); }
+	void set_target(CSingleFITCLaplaceInferenceMethod *obj)
 	{
 		if(obj!=m_obj)
 		{
@@ -294,24 +294,24 @@ private:
 	}
 
 	SGVector<float64_t> m_derivatives;
-	CSingleFITCLaplacianInferenceMethod *m_obj;
+	CSingleFITCLaplaceInferenceMethod *m_obj;
 };
 
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-CSingleFITCLaplacianInferenceMethod::CSingleFITCLaplacianInferenceMethod() : CSingleFITCLaplacianBase()
+CSingleFITCLaplaceInferenceMethod::CSingleFITCLaplaceInferenceMethod() : CSingleFITCLaplace()
 {
 	init();
 }
 
-CSingleFITCLaplacianInferenceMethod::CSingleFITCLaplacianInferenceMethod(CKernel* kern, CFeatures* feat,
+CSingleFITCLaplaceInferenceMethod::CSingleFITCLaplaceInferenceMethod(CKernel* kern, CFeatures* feat,
 		CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod, CFeatures* lat)
-		: CSingleFITCLaplacianBase(kern, feat, m, lab, mod, lat)
+		: CSingleFITCLaplace(kern, feat, m, lab, mod, lat)
 {
 	init();
 }
 
-void CSingleFITCLaplacianInferenceMethod::init()
+void CSingleFITCLaplaceInferenceMethod::init()
 {
 	m_Psi=0;
 	m_Wneg=false;
@@ -329,12 +329,12 @@ void CSingleFITCLaplacianInferenceMethod::init()
 	SG_ADD(&m_Psi, "Psi", "the negative log likelihood without constant terms used in Newton's method", MS_NOT_AVAILABLE);
 	SG_ADD(&m_Wneg, "Wneg", "whether W contains negative elements", MS_NOT_AVAILABLE);
 
-	m_minimizer=new SingleFITCLaplacianNewtonOptimizer();
+	m_minimizer=new SingleFITCLaplaceNewtonOptimizer();
 }
 
-void CSingleFITCLaplacianInferenceMethod::compute_gradient()
+void CSingleFITCLaplaceInferenceMethod::compute_gradient()
 {
-	CInferenceMethod::compute_gradient();
+	CInference::compute_gradient();
 
 	if (!m_gradient_update)
 	{
@@ -345,11 +345,11 @@ void CSingleFITCLaplacianInferenceMethod::compute_gradient()
 	}
 }
 
-void CSingleFITCLaplacianInferenceMethod::update()
+void CSingleFITCLaplaceInferenceMethod::update()
 {
 	SG_DEBUG("entering\n");
 
-	CInferenceMethod::update();
+	CInference::update();
 	update_init();
 	update_alpha();
 	update_chol();
@@ -359,7 +359,7 @@ void CSingleFITCLaplacianInferenceMethod::update()
 	SG_DEBUG("leaving\n");
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_diagonal_vector()
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_diagonal_vector()
 {
 	if (parameter_hash_changed())
 		update();
@@ -367,11 +367,11 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_diagonal_vector()
 	return SGVector<float64_t>(m_sW);
 }
 
-CSingleFITCLaplacianInferenceMethod::~CSingleFITCLaplacianInferenceMethod()
+CSingleFITCLaplaceInferenceMethod::~CSingleFITCLaplaceInferenceMethod()
 {
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::compute_mvmZ(SGVector<float64_t> x)
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::compute_mvmZ(SGVector<float64_t> x)
 {
 	//time complexity O(m*n)
 	Map<MatrixXd> eigen_Rvdd(m_Rvdd.matrix, m_Rvdd.num_rows, m_Rvdd.num_cols);
@@ -386,7 +386,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::compute_mvmZ(SGVector<f
 	return res;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::compute_mvmK(SGVector<float64_t> al)
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::compute_mvmK(SGVector<float64_t> al)
 {
 	//time complexity O(m*n)
 	Map<MatrixXd> eigen_V(m_V.matrix, m_V.num_rows, m_V.num_cols);
@@ -401,19 +401,19 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::compute_mvmK(SGVector<f
 	return res;
 }
 
-CSingleFITCLaplacianInferenceMethod* CSingleFITCLaplacianInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+CSingleFITCLaplaceInferenceMethod* CSingleFITCLaplaceInferenceMethod::obtain_from_generic(
+		CInference* inference)
 {
 	REQUIRE(inference!=NULL, "Inference should be not NULL");
 
-	if (inference->get_inference_type()!=INF_FITC_LAPLACIAN_SINGLE)
-		SG_SERROR("Provided inference is not of type CSingleFITCLaplacianInferenceMethod!\n")
+	if (inference->get_inference_type()!=INF_FITC_LAPLACE_SINGLE)
+		SG_SERROR("Provided inference is not of type CSingleFITCLaplaceInferenceMethod!\n")
 
 	SG_REF(inference);
-	return (CSingleFITCLaplacianInferenceMethod*)inference;
+	return (CSingleFITCLaplaceInferenceMethod*)inference;
 }
 
-SGMatrix<float64_t> CSingleFITCLaplacianInferenceMethod::get_chol_inv(SGMatrix<float64_t> mtx)
+SGMatrix<float64_t> CSingleFITCLaplaceInferenceMethod::get_chol_inv(SGMatrix<float64_t> mtx)
 {
 	//time complexity O(m^3), where mtx is a m-by-m matrix
 	REQUIRE(mtx.num_rows==mtx.num_cols, "Matrix must be square\n");
@@ -430,7 +430,7 @@ SGMatrix<float64_t> CSingleFITCLaplacianInferenceMethod::get_chol_inv(SGMatrix<f
 	return res;
 }
 
-float64_t CSingleFITCLaplacianInferenceMethod::get_negative_log_marginal_likelihood()
+float64_t CSingleFITCLaplaceInferenceMethod::get_negative_log_marginal_likelihood()
 {
 	if (parameter_hash_changed())
 		update();
@@ -466,11 +466,11 @@ float64_t CSingleFITCLaplacianInferenceMethod::get_negative_log_marginal_likelih
 	return result;
 }
 
-void CSingleFITCLaplacianInferenceMethod::update_approx_cov()
+void CSingleFITCLaplaceInferenceMethod::update_approx_cov()
 {
 }
 
-void CSingleFITCLaplacianInferenceMethod::update_init()
+void CSingleFITCLaplaceInferenceMethod::update_init()
 {
 	//time complexity O(m^2*n)
 	//m-by-m matrix
@@ -545,10 +545,10 @@ void CSingleFITCLaplacianInferenceMethod::update_init()
 	m_Psi=Psi_New;
 }
 
-void CSingleFITCLaplacianInferenceMethod::update_alpha()
+void CSingleFITCLaplaceInferenceMethod::update_alpha()
 {
 
-	SingleFITCLaplacianNewtonOptimizer *opt=dynamic_cast<SingleFITCLaplacianNewtonOptimizer*>(m_minimizer);
+	SingleFITCLaplaceNewtonOptimizer *opt=dynamic_cast<SingleFITCLaplaceNewtonOptimizer*>(m_minimizer);
 	if (opt)
 	{
 		SG_REF(this);
@@ -560,7 +560,7 @@ void CSingleFITCLaplacianInferenceMethod::update_alpha()
 		FirstOrderMinimizer* minimizer= dynamic_cast<FirstOrderMinimizer*>(m_minimizer);
 		REQUIRE(minimizer, "The provided minimizer is not supported\n");
 
-		SingleFITCLaplacianInferenceMethodCostFunction *cost_fun=new SingleFITCLaplacianInferenceMethodCostFunction();
+		SingleFITCLaplaceInferenceMethodCostFunction *cost_fun=new SingleFITCLaplaceInferenceMethodCostFunction();
 		SG_REF(this);
 		cost_fun->set_target(this);
 		minimizer->set_cost_function(cost_fun);
@@ -588,7 +588,7 @@ void CSingleFITCLaplacianInferenceMethod::update_alpha()
 	eigen_post_alpha=eigen_R0.transpose()*(eigen_V*eigen_al);
 }
 
-void CSingleFITCLaplacianInferenceMethod::update_chol()
+void CSingleFITCLaplaceInferenceMethod::update_chol()
 {
 	//time complexity O(m^2*n)
 	Map<VectorXd> eigen_dg(m_dg.vector, m_dg.vlen);
@@ -685,7 +685,7 @@ void CSingleFITCLaplacianInferenceMethod::update_chol()
 		 ).array().pow(2).colwise().sum().transpose())/2;
 }
 
-void CSingleFITCLaplacianInferenceMethod::update_deriv()
+void CSingleFITCLaplaceInferenceMethod::update_deriv()
 {
 	//time complexity O(m^2*n)
 	Map<MatrixXd> eigen_ktru(m_ktru.matrix, m_ktru.num_rows, m_ktru.num_cols);
@@ -717,7 +717,7 @@ void CSingleFITCLaplacianInferenceMethod::update_deriv()
 	eigen_dfhat=eigen_g.cwiseProduct(eigen_d3lp);
 }
 
-float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_related_cov(SGVector<float64_t> ddiagKi,
+float64_t CSingleFITCLaplaceInferenceMethod::get_derivative_related_cov(SGVector<float64_t> ddiagKi,
 	SGMatrix<float64_t> dKuui, SGMatrix<float64_t> dKui)
 {
 	//time complexity O(m^2*n)
@@ -743,7 +743,7 @@ float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_related_cov(SGVect
 	eigen_v=eigen_ddiagKi-eigen_dA.cwiseProduct(eigen_R0tV).colwise().sum().transpose();
 
 	//explicit term
-	float64_t result=CSingleFITCLaplacianBase::get_derivative_related_cov(ddiagKi, dKuui, dKui, v, dA);
+	float64_t result=CSingleFITCLaplace::get_derivative_related_cov(ddiagKi, dKuui, dKui, v, dA);
 
 	//implicit term
 	Map<VectorXd> eigen_dlp(m_dlp.vector, m_dlp.vlen);
@@ -761,7 +761,7 @@ float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_related_cov(SGVect
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_inference_method(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_derivative_wrt_inference_method(
 		const TParameter* param)
 {
 	REQUIRE(param, "Param not set\n");
@@ -784,7 +784,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_infe
 			len=dim*num_samples;
 		}
 		else if (!m_fully_sparse)
-			return CSingleFITCLaplacianBase::get_derivative_wrt_inference_method(param);
+			return CSingleFITCLaplace::get_derivative_wrt_inference_method(param);
 		else
 			return get_derivative_wrt_inducing_features(param);
 	}
@@ -820,7 +820,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_infe
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_likelihood_model(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_derivative_wrt_likelihood_model(
 		const TParameter* param)
 {
 	SGVector<float64_t> result(1);
@@ -855,7 +855,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_like
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_kernel(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_derivative_wrt_kernel(
 		const TParameter* param)
 {
 	REQUIRE(param, "Param not set\n");
@@ -900,11 +900,11 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_kern
 	return result;
 }
 
-float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_related_mean(SGVector<float64_t> dmu)
+float64_t CSingleFITCLaplaceInferenceMethod::get_derivative_related_mean(SGVector<float64_t> dmu)
 {
 	//time complexity O(m*n)
 	//explicit term
-	float64_t result=CSingleFITCLaplacianBase::get_derivative_related_mean(dmu);
+	float64_t result=CSingleFITCLaplace::get_derivative_related_mean(dmu);
 
 	//implicit term
 	//Zdm = mvmZ(dm,RVdd,t);
@@ -915,7 +915,7 @@ float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_related_mean(SGVec
 	return result;
 }
 
-float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_implicit_term_helper(SGVector<float64_t> d)
+float64_t CSingleFITCLaplaceInferenceMethod::get_derivative_implicit_term_helper(SGVector<float64_t> d)
 {
 	//time complexity O(m*n)
 	Map<VectorXd> eigen_d(d.vector, d.vlen);
@@ -925,7 +925,7 @@ float64_t CSingleFITCLaplacianInferenceMethod::get_derivative_implicit_term_help
 	return eigen_dfhat.dot(eigen_d-eigen_tmp);
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_mean(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_derivative_wrt_mean(
 		const TParameter* param)
 {
 	//time complexity O(m*n)
@@ -947,7 +947,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_mean
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::derivative_helper_when_Wneg(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::derivative_helper_when_Wneg(
 	SGVector<float64_t> res, const TParameter *param)
 {
 	REQUIRE(param, "Param not set\n");
@@ -957,7 +957,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::derivative_helper_when_
 	return res;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_inducing_features(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_derivative_wrt_inducing_features(
 	const TParameter* param)
 {
 	//time complexity depends on the implementation of the provided kernel
@@ -1004,12 +1004,12 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_indu
 	return get_derivative_related_inducing_features(BdK, param);
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_inducing_noise(
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_derivative_wrt_inducing_noise(
 	const TParameter* param)
 {
 	//time complexity O(m^2*n)
 	//explicit term
-	SGVector<float64_t> result=CSingleFITCLaplacianBase::get_derivative_wrt_inducing_noise(param);
+	SGVector<float64_t> result=CSingleFITCLaplace::get_derivative_wrt_inducing_noise(param);
 
 	//implicit term
 	Map<MatrixXd> eigen_B(m_B.matrix, m_B.num_rows, m_B.num_cols);
@@ -1033,7 +1033,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_derivative_wrt_indu
 	return result;
 }
 
-SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_posterior_mean()
+SGVector<float64_t> CSingleFITCLaplaceInferenceMethod::get_posterior_mean()
 {
 	compute_gradient();
 
@@ -1058,7 +1058,7 @@ SGVector<float64_t> CSingleFITCLaplacianInferenceMethod::get_posterior_mean()
 	return res;
 }
 
-SGMatrix<float64_t> CSingleFITCLaplacianInferenceMethod::get_posterior_covariance()
+SGMatrix<float64_t> CSingleFITCLaplaceInferenceMethod::get_posterior_covariance()
 {
 	compute_gradient();
 	//time complexity of the following operations is O(m*n^2)
@@ -1098,7 +1098,7 @@ SGMatrix<float64_t> CSingleFITCLaplacianInferenceMethod::get_posterior_covarianc
 	return SGMatrix<float64_t>(m_Sigma);
 }
 
-float64_t CSingleFITCLaplacianInferenceMethod::get_psi_wrt_alpha()
+float64_t CSingleFITCLaplaceInferenceMethod::get_psi_wrt_alpha()
 {
 	//time complexity O(m*n)
 	Map<VectorXd> eigen_alpha(m_al, m_al.vlen);
@@ -1117,7 +1117,7 @@ float64_t CSingleFITCLaplacianInferenceMethod::get_psi_wrt_alpha()
 	return psi;
 }
 
-void CSingleFITCLaplacianInferenceMethod::get_gradient_wrt_alpha(SGVector<float64_t> gradient)
+void CSingleFITCLaplaceInferenceMethod::get_gradient_wrt_alpha(SGVector<float64_t> gradient)
 {
 	//time complexity O(m*n)
 	Map<VectorXd> eigen_alpha(m_al, m_al.vlen);

--- a/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h
+++ b/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h
@@ -29,12 +29,12 @@
  *
  */
 
-#ifndef CSINGLEFITCLAPLACIANINFERENCEMETHOD_H
-#define CSINGLEFITCLAPLACIANINFERENCEMETHOD_H
+#ifndef CSINGLEFITCLAPLACEINFERENCEMETHOD_H
+#define CSINGLEFITCLAPLACEINFERENCEMETHOD_H
 
 
 #include <shogun/lib/config.h>
-#include <shogun/machine/gp/SingleFITCLaplacianBase.h>
+#include <shogun/machine/gp/SingleFITCLaplace.h>
 
 namespace shogun
 {
@@ -44,25 +44,25 @@ namespace shogun
  * (the time complexity is computed based on the assumption m < n)
  *
  * Warning: the time complexity of method,
- * CSingleFITCLaplacianBase::get_derivative_wrt_kernel(const TParameter* param),
+ * CSingleFITCLaplace::get_derivative_wrt_kernel(const TParameter* param),
  * depends on the implementation of virtual kernel method,
  * CKernel::get_parameter_gradient_diagonal(param, i).
  * The default time complexity of the kernel method can be O(n^2)
  *
  * Warning: the the time complexity increases from O(m^2*n) to O(n^2*m) if method
- * CSingleFITCLaplacianInferenceMethod::get_posterior_covariance() is called
+ * CSingleFITCLaplaceInferenceMethod::get_posterior_covariance() is called
  *
  * This specific implementation was adapted from the infFITC_Laplace.m file in the
  * GPML toolbox.
  */
-class CSingleFITCLaplacianInferenceMethod: public CSingleFITCLaplacianBase
+class CSingleFITCLaplaceInferenceMethod: public CSingleFITCLaplace
 {
 friend class CFITCPsiLine;
-friend class SingleFITCLaplacianNewtonOptimizer; 
-friend class SingleFITCLaplacianInferenceMethodCostFunction;
+friend class SingleFITCLaplaceNewtonOptimizer; 
+friend class SingleFITCLaplaceInferenceMethodCostFunction;
 public:
 	/** default constructor */
-	CSingleFITCLaplacianInferenceMethod();
+	CSingleFITCLaplaceInferenceMethod();
 
 	/** constructor
 	 *
@@ -73,31 +73,31 @@ public:
 	 * @param model Likelihood model to use
 	 * @param inducing_features features to use
 	 */
-	CSingleFITCLaplacianInferenceMethod(CKernel* kernel, CFeatures* features,
+	CSingleFITCLaplaceInferenceMethod(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model,
 			CFeatures* inducing_features);
 
-	virtual ~CSingleFITCLaplacianInferenceMethod();
+	virtual ~CSingleFITCLaplaceInferenceMethod();
 
 	/** returns the name of the inference method
 	 *
-	 * @return name SingleFITCLaplacian
+	 * @return name SingleFITCLaplace
 	 */
-	virtual const char* get_name() const { return "SingleFITCLaplacianInferenceMethod"; }
+	virtual const char* get_name() const { return "SingleFITCLaplaceInferenceMethod"; }
 
 
 	/** return what type of inference we are
 	 *
 	 * @return inference type FITC
 	 */
-	virtual EInferenceType get_inference_type() const { return INF_FITC_LAPLACIAN_SINGLE; }
+	virtual EInferenceType get_inference_type() const { return INF_FITC_LAPLACE_SINGLE; }
 
 	/** helper method used to specialize a base class instance
 	 *
 	 * @param inference inference method
-	 * @return casted CSingleFITCLaplacianInferenceMethod object
+	 * @return casted CSingleFITCLaplaceInferenceMethod object
 	 */
-	static CSingleFITCLaplacianInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CSingleFITCLaplaceInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/**
 	 * @return whether combination of Laplace approximation inference method and
@@ -193,9 +193,9 @@ protected:
 	virtual void update_deriv();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -373,4 +373,4 @@ protected:
 	bool m_Wneg;
 };
 }
-#endif /* CSINGLEFITCLAPLACIANINFERENCEMETHOD_H */
+#endif /* CSINGLEFITCLAPLACEINFERENCEMETHOD_H */

--- a/src/shogun/machine/gp/SingleLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/SingleLaplaceInferenceMethod.cpp
@@ -14,7 +14,7 @@
  * This code specifically adapted from infLaplace.m
  */
 
-#include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
 
 
 #include <shogun/machine/gp/StudentsTLikelihood.h>
@@ -69,12 +69,12 @@ public:
 	}
 };
 
-class SingleLaplacianNewtonOptimizer: public Minimizer
+class SingleLaplaceNewtonOptimizer: public Minimizer
 {
 public:
-	SingleLaplacianNewtonOptimizer() :Minimizer() {  init(); }
-	virtual ~SingleLaplacianNewtonOptimizer() { SG_UNREF(m_obj); }
-	void set_target(CSingleLaplacianInferenceMethod *obj)
+	SingleLaplaceNewtonOptimizer() :Minimizer() {  init(); }
+	virtual ~SingleLaplaceNewtonOptimizer() { SG_UNREF(m_obj); }
+	void set_target(CSingleLaplaceInferenceMethod *obj)
 	{
 		if(obj!=m_obj)
 		{
@@ -180,25 +180,25 @@ public:
 	 *
 	 * @param max maximum for Brent's minimization method
 	 */
-		virtual void set_minimization_max(float64_t max) { m_opt_max=max; }
+	virtual void set_minimization_max(float64_t max) { m_opt_max=max; }
 
-		/** set tolerance for Brent's minimization method
-		 *
-		 * @param tol tolerance for Brent's minimization method
-		 */
-			virtual void set_minimization_tolerance(float64_t tol) { m_opt_tolerance=tol; }
+	/** set tolerance for Brent's minimization method
+	 *
+	 * @param tol tolerance for Brent's minimization method
+	 */
+	virtual void set_minimization_tolerance(float64_t tol) { m_opt_tolerance=tol; }
 
-			/** set max Newton iterations
-			 *
-			 * @param iter max Newton iterations
-			 */
-				virtual void set_newton_iterations(int32_t iter) { m_iter=iter; }
+	/** set max Newton iterations
+	 *
+	 * @param iter max Newton iterations
+	 */
+	virtual void set_newton_iterations(int32_t iter) { m_iter=iter; }
 
-			/** set tolerance for newton iterations
-			 *
-			 * @param tol tolerance for newton iterations to set
-			 */
-				virtual void set_newton_tolerance(float64_t tol) { m_tolerance=tol; }
+	/** set tolerance for newton iterations
+	 *
+	 * @param tol tolerance for newton iterations to set
+	 */
+	virtual void set_newton_tolerance(float64_t tol) { m_tolerance=tol; }
 
 private:
 				void init()
@@ -210,7 +210,7 @@ private:
 		m_opt_max=10;
 	}
 
-	CSingleLaplacianInferenceMethod *m_obj;
+	CSingleLaplaceInferenceMethod *m_obj;
 
 	/** amount of tolerance for Newton's iterations */
 	float64_t m_tolerance;
@@ -225,12 +225,12 @@ private:
 	float64_t m_opt_max;
 };
 
-class SingleLaplacianInferenceMethodCostFunction: public FirstOrderCostFunction
+class SingleLaplaceInferenceMethodCostFunction: public FirstOrderCostFunction
 {
 public: 
-	SingleLaplacianInferenceMethodCostFunction():FirstOrderCostFunction() {  init(); }
-	virtual ~SingleLaplacianInferenceMethodCostFunction() { SG_UNREF(m_obj); }
-	void set_target(CSingleLaplacianInferenceMethod *obj)
+	SingleLaplaceInferenceMethodCostFunction():FirstOrderCostFunction() {  init(); }
+	virtual ~SingleLaplaceInferenceMethodCostFunction() { SG_UNREF(m_obj); }
+	void set_target(CSingleLaplaceInferenceMethod *obj)
 	{
 		if(obj!=m_obj)
 		{
@@ -264,33 +264,33 @@ private:
 	}
 
 	SGVector<float64_t> m_derivatives;
-	CSingleLaplacianInferenceMethod *m_obj;
+	CSingleLaplaceInferenceMethod *m_obj;
 };
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
-CSingleLaplacianInferenceMethod::CSingleLaplacianInferenceMethod() : CLaplacianInferenceBase()
+CSingleLaplaceInferenceMethod::CSingleLaplaceInferenceMethod() : CLaplaceInference()
 {
 	init();
 }
 
-CSingleLaplacianInferenceMethod::CSingleLaplacianInferenceMethod(CKernel* kern,
+CSingleLaplaceInferenceMethod::CSingleLaplaceInferenceMethod(CKernel* kern,
 		CFeatures* feat, CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod)
-		: CLaplacianInferenceBase(kern, feat, m, lab, mod)
+		: CLaplaceInference(kern, feat, m, lab, mod)
 {
 	init();
 }
 
-void CSingleLaplacianInferenceMethod::init()
+void CSingleLaplaceInferenceMethod::init()
 {
 	m_Psi=0;
 	SG_ADD(&m_Psi, "Psi", "posterior log likelihood without constant terms", MS_NOT_AVAILABLE);
 	SG_ADD(&m_sW, "sW", "square root of W", MS_NOT_AVAILABLE);
 	SG_ADD(&m_d2lp, "d2lp", "second derivative of log likelihood with respect to function location", MS_NOT_AVAILABLE);
 	SG_ADD(&m_d3lp, "d3lp", "third derivative of log likelihood with respect to function location", MS_NOT_AVAILABLE);
-	m_minimizer = new SingleLaplacianNewtonOptimizer();
+	m_minimizer = new SingleLaplaceNewtonOptimizer();
 }
 
-SGVector<float64_t> CSingleLaplacianInferenceMethod::get_diagonal_vector()
+SGVector<float64_t> CSingleLaplaceInferenceMethod::get_diagonal_vector()
 {
 	if (parameter_hash_changed())
 		update();
@@ -298,24 +298,24 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_diagonal_vector()
 	return SGVector<float64_t>(m_sW);
 }
 
-CSingleLaplacianInferenceMethod* CSingleLaplacianInferenceMethod::obtain_from_generic(
-		CInferenceMethod* inference)
+CSingleLaplaceInferenceMethod* CSingleLaplaceInferenceMethod::obtain_from_generic(
+		CInference* inference)
 {
 	if (inference==NULL)
 		return NULL;
 
-	if (inference->get_inference_type()!=INF_LAPLACIAN_SINGLE)
-		SG_SERROR("Provided inference is not of type CSingleLaplacianInferenceMethod\n")
+	if (inference->get_inference_type()!=INF_LAPLACE_SINGLE)
+		SG_SERROR("Provided inference is not of type CSingleLaplaceInferenceMethod\n")
 
 	SG_REF(inference);
-	return (CSingleLaplacianInferenceMethod*)inference;
+	return (CSingleLaplaceInferenceMethod*)inference;
 }
 
-CSingleLaplacianInferenceMethod::~CSingleLaplacianInferenceMethod()
+CSingleLaplaceInferenceMethod::~CSingleLaplaceInferenceMethod()
 {
 }
 
-float64_t CSingleLaplacianInferenceMethod::get_negative_log_marginal_likelihood()
+float64_t CSingleLaplaceInferenceMethod::get_negative_log_marginal_likelihood()
 {
 	if (parameter_hash_changed())
 		update();
@@ -356,7 +356,7 @@ float64_t CSingleLaplacianInferenceMethod::get_negative_log_marginal_likelihood(
 	return result;
 }
 
-void CSingleLaplacianInferenceMethod::update_approx_cov()
+void CSingleLaplaceInferenceMethod::update_approx_cov()
 {
 	Map<MatrixXd> eigen_L(m_L.matrix, m_L.num_rows, m_L.num_cols);
 	Map<MatrixXd> eigen_K(m_ktrtr.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
@@ -376,7 +376,7 @@ void CSingleLaplacianInferenceMethod::update_approx_cov()
 	eigen_Sigma=eigen_K*CMath::exp(m_log_scale*2.0)-eigen_V.adjoint()*eigen_V;
 }
 
-void CSingleLaplacianInferenceMethod::update_chol()
+void CSingleLaplaceInferenceMethod::update_chol()
 {
 	// get log probability derivatives
 	m_dlp=m_model->get_log_probability_derivative_f(m_labels, m_mu, 1);
@@ -428,11 +428,11 @@ void CSingleLaplacianInferenceMethod::update_chol()
 	}
 }
 
-void CSingleLaplacianInferenceMethod::update()
+void CSingleLaplaceInferenceMethod::update()
 {
 	SG_DEBUG("entering\n");
 
-	CInferenceMethod::update();
+	CInference::update();
 	update_init();
 	update_alpha();
 	update_chol();
@@ -443,7 +443,7 @@ void CSingleLaplacianInferenceMethod::update()
 }
 
 
-void CSingleLaplacianInferenceMethod::update_init()
+void CSingleLaplaceInferenceMethod::update_init()
 {
 	float64_t Psi_New;
 	float64_t Psi_Def;
@@ -494,10 +494,10 @@ void CSingleLaplacianInferenceMethod::update_init()
 }
 
 
-void CSingleLaplacianInferenceMethod::register_minimizer(Minimizer* minimizer)
+void CSingleLaplaceInferenceMethod::register_minimizer(Minimizer* minimizer)
 {
 	REQUIRE(minimizer, "Minimizer must set\n");
-	if (!dynamic_cast<SingleLaplacianNewtonOptimizer*>(minimizer))
+	if (!dynamic_cast<SingleLaplaceNewtonOptimizer*>(minimizer))
 	{
 		FirstOrderMinimizer* opt= dynamic_cast<FirstOrderMinimizer*>(minimizer);
 		REQUIRE(opt, "The provided minimizer is not supported\n")
@@ -509,9 +509,9 @@ void CSingleLaplacianInferenceMethod::register_minimizer(Minimizer* minimizer)
 	}
 }
 
-void CSingleLaplacianInferenceMethod::update_alpha()
+void CSingleLaplaceInferenceMethod::update_alpha()
 {
-	SingleLaplacianNewtonOptimizer *opt=dynamic_cast<SingleLaplacianNewtonOptimizer*>(m_minimizer);
+	SingleLaplaceNewtonOptimizer *opt=dynamic_cast<SingleLaplaceNewtonOptimizer*>(m_minimizer);
 	if (opt)
 	{
 		SG_REF(this);
@@ -523,7 +523,7 @@ void CSingleLaplacianInferenceMethod::update_alpha()
 		FirstOrderMinimizer* minimizer= dynamic_cast<FirstOrderMinimizer*>(m_minimizer);
 		REQUIRE(minimizer, "The provided minimizer is not supported\n");
 
-		SingleLaplacianInferenceMethodCostFunction *cost_fun=new SingleLaplacianInferenceMethodCostFunction();
+		SingleLaplaceInferenceMethodCostFunction *cost_fun=new SingleLaplaceInferenceMethodCostFunction();
 		SG_REF(this);
 		cost_fun->set_target(this);
 		minimizer->set_cost_function(cost_fun);
@@ -545,7 +545,7 @@ void CSingleLaplacianInferenceMethod::update_alpha()
 	eigen_mu=eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
 }
 
-void CSingleLaplacianInferenceMethod::update_deriv()
+void CSingleLaplaceInferenceMethod::update_deriv()
 {
 	// create eigen representation of W, sW, dlp, d3lp, K, alpha and L
 	Map<VectorXd> eigen_W(m_W.vector, m_W.vlen);
@@ -601,7 +601,7 @@ void CSingleLaplacianInferenceMethod::update_deriv()
 	eigen_dfhat=eigen_g.cwiseProduct(eigen_d3lp);
 }
 
-SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_inference_method(
+SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_inference_method(
 		const TParameter* param)
 {
 	REQUIRE(!strcmp(param->m_name, "log_scale"), "Can't compute derivative of "
@@ -632,7 +632,7 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_inferenc
 	return result;
 }
 
-SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_likelihood_model(
+SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_likelihood_model(
 		const TParameter* param)
 {
 	// create eigen representation of K, Z, g and dfhat
@@ -666,7 +666,7 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_likeliho
 	return result;
 }
 
-SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_kernel(
+SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_kernel(
 		const TParameter* param)
 {
 	// create eigen representation of K, Z, dfhat, dlp and alpha
@@ -708,7 +708,7 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_kernel(
 	return result;
 }
 
-SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_mean(
+SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_mean(
 		const TParameter* param)
 {
 	// create eigen representation of K, Z, dfhat and alpha
@@ -741,7 +741,7 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_derivative_wrt_mean(
 	return result;
 }
 
-SGVector<float64_t> CSingleLaplacianInferenceMethod::get_posterior_mean()
+SGVector<float64_t> CSingleLaplaceInferenceMethod::get_posterior_mean()
 {
 	compute_gradient();
 
@@ -757,7 +757,7 @@ SGVector<float64_t> CSingleLaplacianInferenceMethod::get_posterior_mean()
 }
 
 
-float64_t CSingleLaplacianInferenceMethod::get_psi_wrt_alpha()
+float64_t CSingleLaplaceInferenceMethod::get_psi_wrt_alpha()
 {
 	Eigen::Map<Eigen::VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 	SGVector<float64_t> f(m_alpha.vlen);
@@ -777,7 +777,7 @@ float64_t CSingleLaplacianInferenceMethod::get_psi_wrt_alpha()
 	return psi;
 }
 
-void CSingleLaplacianInferenceMethod::get_gradient_wrt_alpha(SGVector<float64_t> gradient)
+void CSingleLaplaceInferenceMethod::get_gradient_wrt_alpha(SGVector<float64_t> gradient)
 {
 	REQUIRE(gradient.vlen==m_alpha.vlen,
 		"The length of gradients (%d) should the same as the length of parameters (%d)\n",

--- a/src/shogun/machine/gp/SingleLaplaceInferenceMethod.h
+++ b/src/shogun/machine/gp/SingleLaplaceInferenceMethod.h
@@ -12,13 +12,13 @@
  * http://www.gaussianprocess.org/gpml/code/matlab/doc/
  */
 
-#ifndef CSINGLELAPLACIANINFERENCEMETHOD_H_
-#define CSINGLELAPLACIANINFERENCEMETHOD_H_
+#ifndef CSINGLELAPLACEINFERENCEMETHOD_H_
+#define CSINGLELAPLACEINFERENCEMETHOD_H_
 
 #include <shogun/lib/config.h>
 
 
-#include <shogun/machine/gp/LaplacianInferenceBase.h>
+#include <shogun/machine/gp/LaplaceInference.h>
 
 namespace shogun
 {
@@ -38,13 +38,13 @@ namespace shogun
  * This specific implementation was adapted from the infLaplace.m file in the
  * GPML toolbox.
  */
-class CSingleLaplacianInferenceMethod: public CLaplacianInferenceBase
+class CSingleLaplaceInferenceMethod: public CLaplaceInference
 {
-friend class SingleLaplacianNewtonOptimizer; 
-friend class SingleLaplacianInferenceMethodCostFunction;
+friend class SingleLaplaceNewtonOptimizer; 
+friend class SingleLaplaceInferenceMethodCostFunction;
 public:
 	/** default constructor */
-	CSingleLaplacianInferenceMethod();
+	CSingleLaplaceInferenceMethod();
 
 	/** constructor
 	 *
@@ -54,29 +54,29 @@ public:
 	 * @param labels labels of the features
 	 * @param model Likelihood model to use
 	 */
-	CSingleLaplacianInferenceMethod(CKernel* kernel, CFeatures* features,
+	CSingleLaplaceInferenceMethod(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model);
 
-	virtual ~CSingleLaplacianInferenceMethod();
+	virtual ~CSingleLaplaceInferenceMethod();
 
 	/** returns the name of the inference method
 	 *
-	 * @return name SingleLaplacian
+	 * @return name SingleLaplace
 	 */
-	virtual const char* get_name() const { return "SingleLaplacianInferenceMethod"; }
+	virtual const char* get_name() const { return "SingleLaplaceInferenceMethod"; }
 
 	/** return what type of inference we are
 	 *
-	 * @return inference type Laplacian_Single
+	 * @return inference type Laplace_Single
 	 */
-	virtual EInferenceType get_inference_type() const { return INF_LAPLACIAN_SINGLE; }
+	virtual EInferenceType get_inference_type() const { return INF_LAPLACE_SINGLE; }
 
 	/** helper method used to specialize a base class instance
 	 *
 	 * @param inference inference method
-	 * @return casted CSingleLaplacianInferenceMethod object
+	 * @return casted CSingleLaplaceInferenceMethod object
 	 */
-	static CSingleLaplacianInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CSingleLaplaceInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get negative log marginal likelihood
 	 *
@@ -162,9 +162,9 @@ protected:
 	virtual void update_deriv();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -232,4 +232,4 @@ protected:
 	float64_t m_Psi;
 };
 }
-#endif /* CSINGLELAPLACIANINFERENCEMETHOD_H_ */
+#endif /* CSINGLELAPLACEINFERENCEMETHOD_H_ */

--- a/src/shogun/machine/gp/SingleSparseInference.cpp
+++ b/src/shogun/machine/gp/SingleSparseInference.cpp
@@ -29,7 +29,7 @@
  *
  */
 
-#include <shogun/machine/gp/SingleSparseInferenceBase.h>
+#include <shogun/machine/gp/SingleSparseInference.h>
 #ifdef USE_GPL_SHOGUN
 #ifdef HAVE_NLOPT
 #include <shogun/optimization/NLOPTMinimizer.h>
@@ -55,7 +55,7 @@ class SingleSparseInferenceCostFunction: public FirstOrderBoundConstraintsCostFu
 public:
         SingleSparseInferenceCostFunction():FirstOrderBoundConstraintsCostFunction() {  init(); }
         virtual ~SingleSparseInferenceCostFunction() { SG_UNREF(m_obj); }
-        void set_target(CSingleSparseInferenceBase *obj)
+        void set_target(CSingleSparseInference *obj)
 	{
 		if(obj!=m_obj)
 		{
@@ -100,24 +100,24 @@ public:
 	}
 private:
         void init() { m_obj=NULL; }
-        CSingleSparseInferenceBase *m_obj;
+        CSingleSparseInference *m_obj;
 };
 #endif //DOXYGEN_SHOULD_SKIP_THIS
 
-CSingleSparseInferenceBase::CSingleSparseInferenceBase() : CSparseInferenceBase()
+CSingleSparseInference::CSingleSparseInference() : CSparseInference()
 {
 	init();
 }
 
-CSingleSparseInferenceBase::CSingleSparseInferenceBase(CKernel* kern, CFeatures* feat,
+CSingleSparseInference::CSingleSparseInference(CKernel* kern, CFeatures* feat,
 		CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod, CFeatures* lat)
-		: CSparseInferenceBase(kern, feat, m, lab, mod, lat)
+		: CSparseInference(kern, feat, m, lab, mod, lat)
 {
 	init();
 	check_fully_sparse();
 }
 
-void CSingleSparseInferenceBase::init()
+void CSingleSparseInference::init()
 {
 	m_fully_sparse=false;
 	SG_ADD(&m_fully_sparse, "fully_Sparse",
@@ -141,18 +141,18 @@ void CSingleSparseInferenceBase::init()
 	m_upper_bound=SGVector<float64_t>();
 }
 
-void CSingleSparseInferenceBase::set_kernel(CKernel* kern)
+void CSingleSparseInference::set_kernel(CKernel* kern)
 {
-	CInferenceMethod::set_kernel(kern);
+	CInference::set_kernel(kern);
 	check_fully_sparse();
 }
 
-CSingleSparseInferenceBase::~CSingleSparseInferenceBase()
+CSingleSparseInference::~CSingleSparseInference()
 {
 	delete m_lock;
 }
 
-void CSingleSparseInferenceBase::check_fully_sparse()
+void CSingleSparseInference::check_fully_sparse()
 {
 	REQUIRE(m_kernel, "Kernel must be set first\n")
 	if (strstr(m_kernel->get_name(), "SparseKernel")!=NULL)
@@ -164,7 +164,7 @@ void CSingleSparseInferenceBase::check_fully_sparse()
 	}
 }
 
-SGVector<float64_t> CSingleSparseInferenceBase::get_derivative_wrt_inference_method(
+SGVector<float64_t> CSingleSparseInference::get_derivative_wrt_inference_method(
 		const TParameter* param)
 {
 	// the time complexity O(m^2*n) if the TO DO is done
@@ -216,7 +216,7 @@ SGVector<float64_t> CSingleSparseInferenceBase::get_derivative_wrt_inference_met
 	return result;
 }
 
-SGVector<float64_t> CSingleSparseInferenceBase::get_derivative_wrt_kernel(
+SGVector<float64_t> CSingleSparseInference::get_derivative_wrt_kernel(
 	const TParameter* param)
 {
 	REQUIRE(param, "Param not set\n");
@@ -258,7 +258,7 @@ SGVector<float64_t> CSingleSparseInferenceBase::get_derivative_wrt_kernel(
 	return result;
 }
 
-void CSingleSparseInferenceBase::check_bound(SGVector<float64_t> bound, const char* name)
+void CSingleSparseInference::check_bound(SGVector<float64_t> bound, const char* name)
 {
 	if (bound.vlen>1)
 	{
@@ -275,29 +275,29 @@ void CSingleSparseInferenceBase::check_bound(SGVector<float64_t> bound, const ch
 	}
 }
 
-void CSingleSparseInferenceBase::set_lower_bound_of_inducing_features(SGVector<float64_t> bound)
+void CSingleSparseInference::set_lower_bound_of_inducing_features(SGVector<float64_t> bound)
 {
 	check_bound(bound,"lower");
 	m_lower_bound=bound;
 }
-void CSingleSparseInferenceBase::set_upper_bound_of_inducing_features(SGVector<float64_t> bound)
+void CSingleSparseInference::set_upper_bound_of_inducing_features(SGVector<float64_t> bound)
 {
 	check_bound(bound, "upper");
 	m_upper_bound=bound;
 }
 
-void CSingleSparseInferenceBase::set_max_iterations_for_inducing_features(int32_t it)
+void CSingleSparseInference::set_max_iterations_for_inducing_features(int32_t it)
 {
 	REQUIRE(it>0, "Iteration (%d) must be positive\n",it);
 	m_max_ind_iterations=it;
 }
-void CSingleSparseInferenceBase::set_tolearance_for_inducing_features(float64_t tol)
+void CSingleSparseInference::set_tolearance_for_inducing_features(float64_t tol)
 {
 
 	REQUIRE(tol>0, "Tolearance (%f) must be positive\n",tol);
 	m_ind_tolerance=tol;
 }
-void CSingleSparseInferenceBase::enable_optimizing_inducing_features(bool is_optmization)
+void CSingleSparseInference::enable_optimizing_inducing_features(bool is_optmization)
 {
 	m_opt_inducing_features=is_optmization;
 #ifdef USE_GPL_SHOGUN
@@ -316,7 +316,7 @@ void CSingleSparseInferenceBase::enable_optimizing_inducing_features(bool is_opt
 
 }
 
-void CSingleSparseInferenceBase::optimize_inducing_features()
+void CSingleSparseInference::optimize_inducing_features()
 {
 #ifdef USE_GPL_SHOGUN
 #ifdef HAVE_NLOPT

--- a/src/shogun/machine/gp/SingleSparseInference.h
+++ b/src/shogun/machine/gp/SingleSparseInference.h
@@ -30,11 +30,11 @@
  */
 
 
-#ifndef CSINGLESPARSEINFERENCEBASE_H
-#define CSINGLESPARSEINFERENCEBASE_H
+#ifndef CSINGLESPARSEINFERENCE_H
+#define CSINGLESPARSEINFERENCE_H
 
 #include <shogun/lib/config.h>
-#include <shogun/machine/gp/SparseInferenceBase.h>
+#include <shogun/machine/gp/SparseInference.h>
 #include <shogun/lib/Lock.h>
 
 namespace shogun
@@ -44,13 +44,13 @@ class SingleSparseInferenceCostFunction;
 /** @brief The sparse inference base class
  * for classification and regression for 1-D labels (1D regression and binary classification)
  */
-class CSingleSparseInferenceBase: public CSparseInferenceBase
+class CSingleSparseInference: public CSparseInference
 {
 friend class SingleSparseInferenceCostFunction;
 
 public:
 	/** default constructor */
-	CSingleSparseInferenceBase();
+	CSingleSparseInference();
 
 	/** constructor
 	 *
@@ -61,17 +61,17 @@ public:
 	 * @param model likelihood model to use
 	 * @param inducing_features features to use
 	 */
-	CSingleSparseInferenceBase(CKernel* kernel, CFeatures* features,
+	CSingleSparseInference(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model,
 			CFeatures* inducing_features);
 
-	virtual ~CSingleSparseInferenceBase();
+	virtual ~CSingleSparseInference();
 
 	/** returns the name of the inference method
 	 *
-	 * @return name SingleSparseInferenceBase
+	 * @return name SingleSparseInference
 	 */
-	virtual const char* get_name() const { return "SingleSparseInferenceBase"; }
+	virtual const char* get_name() const { return "SingleSparseInference"; }
 
 	/** set kernel
 	 *
@@ -154,9 +154,9 @@ protected:
 
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -227,4 +227,4 @@ private:
 	void init();
 };
 }
-#endif /* CSINGLESPARSEINFERENCEBASE_H */
+#endif /* CSINGLESPARSEINFERENCE_H */

--- a/src/shogun/machine/gp/SparseInference.cpp
+++ b/src/shogun/machine/gp/SparseInference.cpp
@@ -29,7 +29,7 @@
  * either expressed or implied, of the Shogun Development Team.
  *
  */
-#include <shogun/machine/gp/SparseInferenceBase.h>
+#include <shogun/machine/gp/SparseInference.h>
 
 
 #include <shogun/machine/gp/GaussianLikelihood.h>
@@ -40,17 +40,17 @@
 using namespace shogun;
 using namespace Eigen;
 
-CSparseInferenceBase::CSparseInferenceBase() : CInferenceMethod()
+CSparseInference::CSparseInference() : CInference()
 {
 	init();
 }
 
-void CSparseInferenceBase::check_features()
+void CSparseInference::check_features()
 {
 	REQUIRE(m_features, "Input features not set\n")
 }
 
-void CSparseInferenceBase::convert_features()
+void CSparseInference::convert_features()
 {
 	CDotFeatures *feat_type=dynamic_cast<CDotFeatures *>(m_features);
 
@@ -87,15 +87,15 @@ void CSparseInferenceBase::convert_features()
 	SG_UNREF(lat_type);
 }
 
-CSparseInferenceBase::CSparseInferenceBase(CKernel* kern, CFeatures* feat,
+CSparseInference::CSparseInference(CKernel* kern, CFeatures* feat,
 		CMeanFunction* m, CLabels* lab, CLikelihoodModel* mod, CFeatures* lat)
-		: CInferenceMethod(kern, feat, m, lab, mod)
+		: CInference(kern, feat, m, lab, mod)
 {
 	init();
 	set_inducing_features(lat);
 }
 
-void CSparseInferenceBase::init()
+void CSparseInference::init()
 {
 	SG_ADD(&m_inducing_features, "inducing_features", "inducing features",
 			MS_AVAILABLE, GRADIENT_AVAILABLE);
@@ -109,30 +109,30 @@ void CSparseInferenceBase::init()
 	m_inducing_features=SGMatrix<float64_t>();
 }
 
-void CSparseInferenceBase::set_inducing_noise(float64_t noise)
+void CSparseInference::set_inducing_noise(float64_t noise)
 {
 	REQUIRE(noise>0, "Noise (%f) for inducing points must be postive",noise);
 	m_log_ind_noise=CMath::log(noise);
 }
 
-float64_t CSparseInferenceBase::get_inducing_noise()
+float64_t CSparseInference::get_inducing_noise()
 {
 	return CMath::exp(m_log_ind_noise);
 }
 
-CSparseInferenceBase::~CSparseInferenceBase()
+CSparseInference::~CSparseInference()
 {
 }
 
-void CSparseInferenceBase::check_members() const
+void CSparseInference::check_members() const
 {
-	CInferenceMethod::check_members();
+	CInference::check_members();
 
 	REQUIRE(m_inducing_features.num_rows, "Inducing features should not be empty\n")
 	REQUIRE(m_inducing_features.num_cols, "Inducing features should not be empty\n")
 }
 
-SGVector<float64_t> CSparseInferenceBase::get_alpha()
+SGVector<float64_t> CSparseInference::get_alpha()
 {
 	if (parameter_hash_changed())
 		update();
@@ -141,7 +141,7 @@ SGVector<float64_t> CSparseInferenceBase::get_alpha()
 	return result;
 }
 
-SGMatrix<float64_t> CSparseInferenceBase::get_cholesky()
+SGMatrix<float64_t> CSparseInference::get_cholesky()
 {
 	if (parameter_hash_changed())
 		update();
@@ -150,7 +150,7 @@ SGMatrix<float64_t> CSparseInferenceBase::get_cholesky()
 	return result;
 }
 
-void CSparseInferenceBase::update_train_kernel()
+void CSparseInference::update_train_kernel()
 {
 	//time complexity can be O(m*n) if the TO DO is done
 	check_features();

--- a/src/shogun/machine/gp/SparseInference.h
+++ b/src/shogun/machine/gp/SparseInference.h
@@ -30,13 +30,13 @@
  *
  */
 
-#ifndef CSPARSEINFERENCEBASE_H
-#define CSPARSEINFERENCEBASE_H
+#ifndef CSPARSEINFERENCE_H
+#define CSPARSEINFERENCE_H
 
 #include <shogun/lib/config.h>
 
 
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 #include <shogun/features/DenseFeatures.h>
 
 namespace shogun
@@ -68,11 +68,11 @@ namespace shogun
  * the (approximated) negative log marginal likelihood are computed based on \f$\Sigma_{Sparse}\f$.
  *
  */
-class CSparseInferenceBase: public CInferenceMethod
+class CSparseInference: public CInference
 {
 public:
 	/** default constructor */
-	CSparseInferenceBase();
+	CSparseInference();
 
 	/** constructor
 	 *
@@ -83,11 +83,11 @@ public:
 	 * @param model likelihood model to use
 	 * @param inducing_features features to use
 	 */
-	CSparseInferenceBase(CKernel* kernel, CFeatures* features,
+	CSparseInference(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model,
 			CFeatures* inducing_features);
 
-	virtual ~CSparseInferenceBase();
+	virtual ~CSparseInference();
 
 	/** return what type of inference we are
 	 *
@@ -235,9 +235,9 @@ protected:
 	virtual void update_train_kernel();
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
-	 * CInferenceMethod class
+	 * CInference class
 	 *
-	 * @param param parameter of CInferenceMethod class
+	 * @param param parameter of CInference class
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
@@ -277,7 +277,7 @@ protected:
 	/** returns derivative of negative log marginal likelihood wrt
 	 * inducing noise (noise from inducing features) parameter
 	 *
-	 * @param param parameter of given  SparseInferenceBase class
+	 * @param param parameter of given  SparseInference class
 	 *
 	 * In order to enforce symmetrc positive definiteness of the kernel matrix on inducing points,
 	 * \f$\Sigma_{M}\f$, the following ridge trick is used since the matrix is learned from data.
@@ -325,4 +325,4 @@ private:
 	void init();
 };
 }
-#endif /* CSPARSEINFERENCEBASE_H */
+#endif /* CSPARSEINFERENCE_H */

--- a/src/shogun/machine/gp/VarDTCInferenceMethod.h
+++ b/src/shogun/machine/gp/VarDTCInferenceMethod.h
@@ -31,12 +31,12 @@
  * http://www.aueb.gr/users/mtitsias/code/varsgp.tar.gz
  */
 
-#ifndef CSPARSEVGINFERENCEMETHOD_H
-#define CSPARSEVGINFERENCEMETHOD_H
+#ifndef CVARDTCINFERENCEMETHOD_H
+#define CVARDTCINFERENCEMETHOD_H
 
 
 #include <shogun/lib/config.h>
-#include <shogun/machine/gp/SingleSparseInferenceBase.h>
+#include <shogun/machine/gp/SingleSparseInference.h>
 
 namespace shogun
 {
@@ -49,11 +49,11 @@ namespace shogun
  * method.
  *
  */
-class CSparseVGInferenceMethod: public CSingleSparseInferenceBase
+class CVarDTCInferenceMethod: public CSingleSparseInference
 {
 public:
 	/** default constructor */
-	CSparseVGInferenceMethod();
+	CVarDTCInferenceMethod();
 
 	/** constructor
 	 *
@@ -64,17 +64,17 @@ public:
 	 * @param model likelihood model to use
 	 * @param inducing_features features to use
 	 */
-	CSparseVGInferenceMethod(CKernel* kernel, CFeatures* features,
+	CVarDTCInferenceMethod(CKernel* kernel, CFeatures* features,
 			CMeanFunction* mean, CLabels* labels, CLikelihoodModel* model,
 			CFeatures* inducing_features);
 
-	virtual ~CSparseVGInferenceMethod();
+	virtual ~CVarDTCInferenceMethod();
 
 	/** returns the name of the inference method
 	 *
-	 * @return name SparseVG
+	 * @return name VarDTC
 	 */
-	virtual const char* get_name() const { return "SparseVGInferenceMethod"; }
+	virtual const char* get_name() const { return "VarDTCInferenceMethod"; }
 
 	/** return what type of inference we are
 	 *
@@ -85,9 +85,9 @@ public:
 	/** helper method used to specialize a base class instance
 	 *
 	 * @param inference inference method
-	 * @return casted CSparseVGInferenceMethod object
+	 * @return casted CVarDTCInferenceMethod object
 	 */
-	static CSparseVGInferenceMethod* obtain_from_generic(CInferenceMethod* inference);
+	static CVarDTCInferenceMethod* obtain_from_generic(CInference* inference);
 
 	/** get negative log marginal likelihood
 	 *
@@ -267,4 +267,4 @@ private:
 	void init();
 };
 }
-#endif /* CSPARSEVGINFERENCEMETHOD_H */
+#endif /* CVARDTCINFERENCEMETHOD_H */

--- a/src/shogun/regression/GaussianProcessRegression.cpp
+++ b/src/shogun/regression/GaussianProcessRegression.cpp
@@ -24,7 +24,7 @@ CGaussianProcessRegression::CGaussianProcessRegression()
 {
 }
 
-CGaussianProcessRegression::CGaussianProcessRegression(CInferenceMethod* method)
+CGaussianProcessRegression::CGaussianProcessRegression(CInference* method)
 		: CGaussianProcessMachine(method)
 {
 	// set labels

--- a/src/shogun/regression/GaussianProcessRegression.h
+++ b/src/shogun/regression/GaussianProcessRegression.h
@@ -15,14 +15,14 @@
 
 #include <shogun/lib/config.h>
 #include <shogun/machine/GaussianProcessMachine.h>
-#include <shogun/machine/gp/InferenceMethod.h>
+#include <shogun/machine/gp/Inference.h>
 #include <shogun/features/Features.h>
 #include <shogun/labels/Labels.h>
 
 namespace shogun
 {
 
-class CInferenceMethod;
+class CInference;
 class CFeatures;
 class CLabels;
 
@@ -42,7 +42,7 @@ public:
 	 *
 	 * @param method chosen inference method
 	 */
-	CGaussianProcessRegression(CInferenceMethod* method);
+	CGaussianProcessRegression(CInference* method);
 
 	virtual ~CGaussianProcessRegression();
 

--- a/tests/unit/classifier/GaussianProcessClassification_unittest.cc
+++ b/tests/unit/classifier/GaussianProcessClassification_unittest.cc
@@ -45,18 +45,18 @@
 #include <shogun/machine/gp/ConstMean.h>
 #include <shogun/machine/gp/ProbitLikelihood.h>
 #include <shogun/machine/gp/LogitLikelihood.h>
-#include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
 #include <shogun/machine/gp/EPInferenceMethod.h>
 #include <shogun/classifier/GaussianProcessClassification.h>
 #include <shogun/preprocessor/RescaleFeatures.h>
 #include <gtest/gtest.h>
 #include <shogun/mathematics/Math.h>
-#include <shogun/machine/gp/MultiLaplacianInferenceMethod.h>
-#include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/MultiLaplaceInferenceMethod.h>
+#include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
 
 #include <shogun/machine/gp/KLCovarianceInferenceMethod.h>
 #include <shogun/machine/gp/KLCholeskyInferenceMethod.h>
-#include <shogun/machine/gp/KLApproxDiagonalInferenceMethod.h>
+#include <shogun/machine/gp/KLDiagonalInferenceMethod.h>
 #include <shogun/machine/gp/KLDualInferenceMethod.h>
 #include <shogun/machine/gp/LogitVGLikelihood.h>
 #include <shogun/machine/gp/LogitDVGLikelihood.h>
@@ -130,8 +130,8 @@ TEST(GaussianProcessClassification,get_mean_vector)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// train Gaussian process binary classifier
@@ -235,8 +235,8 @@ TEST(GaussianProcessClassification,get_variance_vector)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// train gaussian process classifier
@@ -340,8 +340,8 @@ TEST(GaussianProcessClassification,get_probabilities)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// train gaussian process classifier
@@ -498,7 +498,7 @@ TEST(GaussianProcessClassification,apply_preprocessor_and_binary)
 	SG_UNREF(prediction);
 }
 
-TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_mean_vector)
+TEST(GaussianProcessClassificationUsingSingleLaplaceWithLBFGS,get_mean_vector)
 {
 	float64_t abs_tolerance;
 	float64_t rel_tolerance=1e-2;
@@ -565,9 +565,9 @@ TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_mean_vector)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-	= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+	= new CSingleLaplaceInferenceMethod(kernel,
 		features_train,
 		mean,
 		labels_train,
@@ -680,7 +680,7 @@ TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_mean_vector)
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_variance_vector)
+TEST(GaussianProcessClassificationUsingSingleLaplaceWithLBFGS,get_variance_vector)
 {
 	float64_t abs_tolerance;
 	float64_t rel_tolerance=1e-2;
@@ -747,9 +747,9 @@ TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_variance_vec
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -862,7 +862,7 @@ TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_variance_vec
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_probabilities)
+TEST(GaussianProcessClassificationUsingSingleLaplaceWithLBFGS,get_probabilities)
 {
 	float64_t abs_tolerance;
 	float64_t rel_tolerance=1e-2;
@@ -929,8 +929,8 @@ TEST(GaussianProcessClassificationUsingSingleLaplacianWithLBFGS,get_probabilitie
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train, mean, labels_train, likelihood);
 
 	int m = 100;
@@ -2021,7 +2021,7 @@ TEST(GaussianProcessClassificationUsingKLCholesky, get_probabilities)
 	SG_UNREF(gpc);
 	}
 
-TEST(GaussianProcessClassificationUsingKLApproxDiagonal,get_mean_vector)
+TEST(GaussianProcessClassificationUsingKLDiagonal,get_mean_vector)
 {
 	float64_t abs_tolerance;
 	float64_t rel_tolerance=1e-2;
@@ -2088,8 +2088,8 @@ TEST(GaussianProcessClassificationUsingKLApproxDiagonal,get_mean_vector)
 	// probit likelihood
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
-	CKLApproxDiagonalInferenceMethod* inf
-	= new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf
+	= new CKLDiagonalInferenceMethod(kernel,
 		features_train,
 		mean,
 		labels_train,
@@ -2185,7 +2185,7 @@ TEST(GaussianProcessClassificationUsingKLApproxDiagonal,get_mean_vector)
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingKLApproxDiagonal, get_variance_vector)
+TEST(GaussianProcessClassificationUsingKLDiagonal, get_variance_vector)
 {
 	float64_t abs_tolerance;
 	float64_t rel_tolerance=1e-2;
@@ -2252,8 +2252,8 @@ TEST(GaussianProcessClassificationUsingKLApproxDiagonal, get_variance_vector)
 	// probit likelihood
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
-	CKLApproxDiagonalInferenceMethod* inf
-	= new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf
+	= new CKLDiagonalInferenceMethod(kernel,
 		features_train,
 		mean,
 		labels_train,
@@ -2348,7 +2348,7 @@ TEST(GaussianProcessClassificationUsingKLApproxDiagonal, get_variance_vector)
 	SG_UNREF(gpc);
 	}
 
-TEST(GaussianProcessClassificationUsingKLApproxDiagonal, get_probabilities)
+TEST(GaussianProcessClassificationUsingKLDiagonal, get_probabilities)
 {
 	float64_t abs_tolerance;
 	float64_t rel_tolerance=1e-2;
@@ -2415,8 +2415,8 @@ TEST(GaussianProcessClassificationUsingKLApproxDiagonal, get_probabilities)
 	// probit likelihood
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
-	CKLApproxDiagonalInferenceMethod* inf
-	= new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf
+	= new CKLDiagonalInferenceMethod(kernel,
 		features_train,
 		mean,
 		labels_train,
@@ -3000,7 +3000,7 @@ TEST(GaussianProcessClassificationUsingKLDual, get_probabilities)
 	SG_UNREF(gpc);
 	}
 
-TEST(GaussianProcessClassificationUsingMultiLaplacian,get_mean_vector)
+TEST(GaussianProcessClassificationUsingMultiLaplace,get_mean_vector)
 {
 
 	float64_t abs_tolerance;
@@ -3080,7 +3080,7 @@ TEST(GaussianProcessClassificationUsingMultiLaplacian,get_mean_vector)
 	CZeroMean* mean=new CZeroMean();
 
 	CSoftMaxLikelihood* likelihood=new CSoftMaxLikelihood();
-	CMultiLaplacianInferenceMethod* inf=new CMultiLaplacianInferenceMethod(kernel,
+	CMultiLaplaceInferenceMethod* inf=new CMultiLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	const float64_t scale=CMath::sqrt(497.3965463400368);
@@ -3144,7 +3144,7 @@ TEST(GaussianProcessClassificationUsingMultiLaplacian,get_mean_vector)
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingMultiLaplacian,get_variance_vector)
+TEST(GaussianProcessClassificationUsingMultiLaplace,get_variance_vector)
 {
 
 	float64_t abs_tolerance;
@@ -3224,7 +3224,7 @@ TEST(GaussianProcessClassificationUsingMultiLaplacian,get_variance_vector)
 	CZeroMean* mean=new CZeroMean();
 
 	CSoftMaxLikelihood* likelihood=new CSoftMaxLikelihood();
-	CMultiLaplacianInferenceMethod* inf=new CMultiLaplacianInferenceMethod(kernel,
+	CMultiLaplaceInferenceMethod* inf=new CMultiLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	const float64_t scale=CMath::sqrt(497.3965463400368);
@@ -3289,7 +3289,7 @@ TEST(GaussianProcessClassificationUsingMultiLaplacian,get_variance_vector)
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingMultiLaplacian,apply_multiclass)
+TEST(GaussianProcessClassificationUsingMultiLaplace,apply_multiclass)
 {
 	index_t n=5;
 
@@ -3336,7 +3336,7 @@ TEST(GaussianProcessClassificationUsingMultiLaplacian,apply_multiclass)
 	CZeroMean* mean=new CZeroMean();
 
 	CSoftMaxLikelihood* likelihood=new CSoftMaxLikelihood();
-	CMultiLaplacianInferenceMethod* inf=new CMultiLaplacianInferenceMethod(kernel,
+	CMultiLaplaceInferenceMethod* inf=new CMultiLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	const float64_t scale=CMath::sqrt(5.114014937226176);
@@ -3360,7 +3360,7 @@ TEST(GaussianProcessClassificationUsingMultiLaplacian,apply_multiclass)
 
 
 #ifdef HAVE_LINALG_LIB
-TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_mean_vector)
+TEST(GaussianProcessClassificationUsingSingleFITCLaplace,get_mean_vector)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -3427,7 +3427,7 @@ TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_mean_vector)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP regression with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -3474,7 +3474,7 @@ TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_mean_vector)
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_variance_vector)
+TEST(GaussianProcessClassificationUsingSingleFITCLaplace,get_variance_vector)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -3541,7 +3541,7 @@ TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_variance_vector)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP regression with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -3587,7 +3587,7 @@ TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_variance_vector)
 	SG_UNREF(gpc);
 }
 
-TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_probabilities)
+TEST(GaussianProcessClassificationUsingSingleFITCLaplace,get_probabilities)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -3654,7 +3654,7 @@ TEST(GaussianProcessClassificationUsingSingleFITCLaplacian,get_probabilities)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP regression with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;

--- a/tests/unit/machine/gp/InferenceMethod_unittest.cc
+++ b/tests/unit/machine/gp/InferenceMethod_unittest.cc
@@ -15,7 +15,7 @@
 #include <shogun/labels/BinaryLabels.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/kernel/GaussianKernel.h>
-#include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
 #include <shogun/machine/gp/EPInferenceMethod.h>
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/LogitLikelihood.h>
@@ -44,7 +44,7 @@ TEST(InferenceMethod,get_marginal_likelihood_estimate_logit_laplace)
 	CGaussianKernel* kernel=new CGaussianKernel(10, 8);
 	CZeroMean* mean=new CZeroMean();
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 	inf->set_scale(2.0);
 

--- a/tests/unit/machine/gp/KLDiagonalInferenceMethod_unittest.cc
+++ b/tests/unit/machine/gp/KLDiagonalInferenceMethod_unittest.cc
@@ -36,7 +36,7 @@
 #include <shogun/kernel/GaussianKernel.h>
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/GaussianLikelihood.h>
-#include <shogun/machine/gp/KLApproxDiagonalInferenceMethod.h>
+#include <shogun/machine/gp/KLDiagonalInferenceMethod.h>
 #include <shogun/machine/gp/LogitVGLikelihood.h>
 #include <shogun/machine/gp/ProbitVGLikelihood.h>
 #include <shogun/machine/gp/StudentsTVGLikelihood.h>
@@ -45,7 +45,7 @@
 
 using namespace shogun;
 
-TEST(KLApproxDiagonalInferenceMethod,get_cholesky_t_likelihood)
+TEST(KLDiagonalInferenceMethod,get_cholesky_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -78,7 +78,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_cholesky_t_likelihood)
 	CStudentsTVGLikelihood* likelihood=new CStudentsTVGLikelihood(1, 3);
 
 	// specify GP regression with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -157,7 +157,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_cholesky_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_cholesky_logit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_cholesky_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -196,7 +196,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_cholesky_logit_likelihood)
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -277,7 +277,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_cholesky_logit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_cholesky_probit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_cholesky_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -316,7 +316,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_cholesky_probit_likelihood)
 	CProbitVGLikelihood* likelihood=new CProbitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -394,7 +394,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_cholesky_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_t_likelihood)
+TEST(KLDiagonalInferenceMethod,get_posterior_mean_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -427,7 +427,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_t_likelihood)
 	CStudentsTVGLikelihood* likelihood=new CStudentsTVGLikelihood(1, 3);
 
 	// specify GP regression with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -461,7 +461,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_t_likelihood)
+TEST(KLDiagonalInferenceMethod,get_posterior_covariance_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -494,7 +494,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_t_likelihood)
 	CStudentsTVGLikelihood* likelihood=new CStudentsTVGLikelihood(1, 3);
 
 	// specify GP regression with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -571,7 +571,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_logit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_posterior_mean_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -610,7 +610,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_logit_likelihood)
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -643,7 +643,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_logit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_logit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_posterior_covariance_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -682,7 +682,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_logit_likelihood)
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -760,7 +760,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_logit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_probit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_posterior_mean_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -800,7 +800,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_probit_likelihood)
 	CProbitVGLikelihood* likelihood=new CProbitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -834,7 +834,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_mean_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_probit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_posterior_covariance_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -873,7 +873,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_probit_likelihood)
 	CProbitVGLikelihood* likelihood=new CProbitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -952,7 +952,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_posterior_covariance_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_t_likelihood)
+TEST(KLDiagonalInferenceMethod,get_negative_marginal_likelihood_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -985,7 +985,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_t_likeliho
 	CStudentsTVGLikelihood* likelihood=new CStudentsTVGLikelihood(1, 3);
 
 	// specify GP regression with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -1005,7 +1005,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_t_likeliho
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_logit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_negative_marginal_likelihood_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -1044,7 +1044,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_logit_like
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -1064,7 +1064,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_logit_like
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_probit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_negative_marginal_likelihood_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -1103,7 +1103,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_probit_lik
 	CProbitVGLikelihood* likelihood=new CProbitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	//Reference result is generated from the Matlab code, which can be found at
@@ -1123,7 +1123,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_negative_marginal_likelihood_probit_lik
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_t_likelihood)
+TEST(KLDiagonalInferenceMethod,get_marginal_likelihood_derivatives_t_likelihood)
 {
 	// create some easy regression data: 1d noisy sine wave
 	index_t ntr=5;
@@ -1157,7 +1157,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_t_likel
 	CStudentsTVGLikelihood* lik=new CStudentsTVGLikelihood(0.25, 3);
 
 	// specify GP regression with exact inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 		features_train,	mean, labels_train, lik);
 
 	// build parameter dictionary
@@ -1208,7 +1208,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_t_likel
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_logit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_marginal_likelihood_derivatives_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -1247,7 +1247,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_logit_l
 	CLogitVGLikelihood* likelihood=new CLogitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	// build parameter dictionary
@@ -1287,7 +1287,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_logit_l
 	SG_UNREF(inf);
 }
 
-TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_probit_likelihood)
+TEST(KLDiagonalInferenceMethod,get_marginal_likelihood_derivatives_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -1326,7 +1326,7 @@ TEST(KLApproxDiagonalInferenceMethod,get_marginal_likelihood_derivatives_probit_
 	CProbitVGLikelihood* likelihood=new CProbitVGLikelihood();
 
 	// specify GP classification with KL inference
-	CKLApproxDiagonalInferenceMethod* inf=new CKLApproxDiagonalInferenceMethod(kernel,
+	CKLDiagonalInferenceMethod* inf=new CKLDiagonalInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	// build parameter dictionary

--- a/tests/unit/machine/gp/SingleFITCInference_unittest.cc
+++ b/tests/unit/machine/gp/SingleFITCInference_unittest.cc
@@ -43,7 +43,7 @@
 
 using namespace shogun;
 
-TEST(SingleFITCInferenceBase,set_kernel)
+TEST(SingleFITCInference,set_kernel)
 {
 	// create some easy regression data with inducing features:
 	// y approximately equals to x^sin(x)

--- a/tests/unit/machine/gp/SingleFITCLaplaceInferenceMethodWithLBFGS_unittest.cc
+++ b/tests/unit/machine/gp/SingleFITCLaplaceInferenceMethodWithLBFGS_unittest.cc
@@ -38,7 +38,7 @@
 #include <shogun/machine/gp/ConstMean.h>
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/GaussianARDSparseKernel.h>
-#include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
 #include <shogun/optimization/lbfgs/LBFGSMinimizer.h>
 #include <shogun/machine/gp/LogitLikelihood.h>
 #include <shogun/mathematics/Math.h>
@@ -46,7 +46,7 @@
 
 using namespace shogun;
 
-TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_cholesky)
+TEST(SingleFITCLaplaceInferenceMethodWithLBFGS,get_cholesky)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -112,7 +112,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_cholesky)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	LBFGSMinimizer* opt=new LBFGSMinimizer();
@@ -156,7 +156,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_cholesky)
 	SG_UNREF(inf);
 }
 
-TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_alpha)
+TEST(SingleFITCLaplaceInferenceMethodWithLBFGS,get_alpha)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -222,7 +222,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_alpha)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	LBFGSMinimizer* opt=new LBFGSMinimizer();
@@ -252,7 +252,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_alpha)
 }
 
 
-TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_negative_log_marginal_likelihood)
+TEST(SingleFITCLaplaceInferenceMethodWithLBFGS,get_negative_log_marginal_likelihood)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -311,7 +311,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_negative_log_marginal_likel
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP regression with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	LBFGSMinimizer* opt=new LBFGSMinimizer();
@@ -335,7 +335,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_negative_log_marginal_likel
 	SG_UNREF(inf);
 }
 
-TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives)
+TEST(SingleFITCLaplaceInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -394,7 +394,7 @@ TEST(SingleFITCLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivat
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP regression with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	LBFGSMinimizer* opt=new LBFGSMinimizer();

--- a/tests/unit/machine/gp/SingleFITCLaplaceInferenceMethod_unittest.cc
+++ b/tests/unit/machine/gp/SingleFITCLaplaceInferenceMethod_unittest.cc
@@ -37,14 +37,14 @@
 #include <shogun/kernel/GaussianKernel.h>
 #include <shogun/machine/gp/ConstMean.h>
 #include <shogun/machine/gp/GaussianARDSparseKernel.h>
-#include <shogun/machine/gp/SingleFITCLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h>
 #include <shogun/machine/gp/LogitLikelihood.h>
 #include <shogun/mathematics/Math.h>
 #include <gtest/gtest.h>
 
 using namespace shogun;
 
-TEST(SingleFITCLaplacianInferenceMethod,get_cholesky)
+TEST(SingleFITCLaplaceInferenceMethod,get_cholesky)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -111,7 +111,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_cholesky)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -151,7 +151,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_cholesky)
 	SG_UNREF(inf);
 }
 
-TEST(SingleFITCLaplacianInferenceMethod,get_alpha)
+TEST(SingleFITCLaplaceInferenceMethod,get_alpha)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -218,7 +218,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_alpha)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -245,7 +245,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_alpha)
 }
 
 
-TEST(SingleFITCLaplacianInferenceMethod,get_negative_log_marginal_likelihood)
+TEST(SingleFITCLaplaceInferenceMethod,get_negative_log_marginal_likelihood)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -312,7 +312,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_negative_log_marginal_likelihood)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -333,7 +333,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_negative_log_marginal_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleFITCLaplacianInferenceMethod,get_marginal_likelihood_derivatives)
+TEST(SingleFITCLaplaceInferenceMethod,get_marginal_likelihood_derivatives)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -400,7 +400,7 @@ TEST(SingleFITCLaplacianInferenceMethod,get_marginal_likelihood_derivatives)
 	CLogitLikelihood* lik=new CLogitLikelihood();
 
 	// specify GP with FITC inference
-	CSingleFITCLaplacianInferenceMethod* inf=new CSingleFITCLaplacianInferenceMethod(kernel, features_train,
+	CSingleFITCLaplaceInferenceMethod* inf=new CSingleFITCLaplaceInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, latent_features_train);
 
 	float64_t ind_noise=1e-6;

--- a/tests/unit/machine/gp/SingleLaplaceInferenceMethodWithLBFGS_unittest.cc
+++ b/tests/unit/machine/gp/SingleLaplaceInferenceMethodWithLBFGS_unittest.cc
@@ -37,7 +37,7 @@
 #include <shogun/labels/BinaryLabels.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/kernel/GaussianKernel.h>
-#include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/GaussianLikelihood.h>
 #include <shogun/machine/gp/StudentsTLikelihood.h>
@@ -49,7 +49,7 @@
 
 using namespace shogun;
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_probit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_cholesky_probit_likelihood)
 {
 	float64_t rel_tolerance = 1e-2;
 	float64_t abs_tolerance;
@@ -88,9 +88,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_probit_likelihood)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -164,7 +164,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_probit_likelihood)
 }
 
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_probit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_alpha_probit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -204,9 +204,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_probit_likelihood)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -255,7 +255,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_probit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_negative_marginal_likelihood_probit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -295,9 +295,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_pr
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -333,7 +333,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_pr
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_probit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_probit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -373,9 +373,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -429,7 +429,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_posterior_mean_probit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_posterior_mean_probit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -469,9 +469,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_posterior_mean_probit_likelihoo
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -519,7 +519,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_posterior_mean_probit_likelihoo
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_posterior_covariance_probit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_posterior_covariance_probit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -559,9 +559,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_posterior_covariance_probit_lik
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -633,7 +633,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_posterior_covariance_probit_lik
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_logit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_cholesky_logit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -674,9 +674,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_logit_likelihood)
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -748,7 +748,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_logit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_logit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_alpha_logit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -789,9 +789,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_logit_likelihood)
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -840,7 +840,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_logit_likelihood)
 }
 
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_logit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_negative_marginal_likelihood_logit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -881,9 +881,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_lo
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -920,7 +920,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_lo
 }
 
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_logit_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_logit_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -961,9 +961,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1018,7 +1018,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 }
 
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_cholesky_gaussian_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -1053,9 +1053,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_gaussian_likelihood)
 	// Gaussian likelihood with sigma = 1 (by default)
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood();
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1127,7 +1127,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_gaussian_likelihood)
 	// clean up
 	SG_UNREF(inf);
 }
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_alpha_gaussian_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -1162,9 +1162,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_gaussian_likelihood)
 	// Gaussian likelihood with sigma = 1 (by default)
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood();
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1211,7 +1211,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_gaussian_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_negative_marginal_likelihood_gaussian_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -1246,9 +1246,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_ga
 	// Gaussian likelihood with sigma = 1 (by default)
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood();
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1284,7 +1284,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_ga
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_gaussian_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-2;
@@ -1321,9 +1321,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 	// Gaussian likelihood with sigma = 0.25
 	CGaussianLikelihood* lik=new CGaussianLikelihood(0.25);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1384,7 +1384,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 }
 
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_t_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_cholesky_t_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-1;
@@ -1419,9 +1419,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_t_likelihood)
 	// Student's-T likelihood with sigma = 1, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(1, 3);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1493,7 +1493,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_cholesky_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_t_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_alpha_t_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-1;
@@ -1528,9 +1528,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_t_likelihood)
 	// Student's-T likelihood with sigma = 1, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(1, 3);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1577,7 +1577,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_alpha_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_t_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_negative_marginal_likelihood_t_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-1;
@@ -1612,9 +1612,9 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_t_
 	// Student's-T likelihood with sigma = 1, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(1, 3);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,
@@ -1650,7 +1650,7 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_negative_marginal_likelihood_t_
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_t_likelihood)
+TEST(SingleLaplaceInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives_t_likelihood)
 {
 
 	float64_t rel_tolerance = 1e-1;
@@ -1687,8 +1687,8 @@ TEST(SingleLaplacianInferenceMethodWithLBFGS,get_marginal_likelihood_derivatives
 	CStudentsTLikelihood* lik=new CStudentsTLikelihood(0.25, 3);
 
 	// specify GP regression with exact inference
-	CSingleLaplacianInferenceMethod* inf
-		= new CSingleLaplacianInferenceMethod(kernel,
+	CSingleLaplaceInferenceMethod* inf
+		= new CSingleLaplaceInferenceMethod(kernel,
 			features_train,
 			mean,
 			labels_train,

--- a/tests/unit/machine/gp/SingleLaplaceInferenceMethod_unittest.cc
+++ b/tests/unit/machine/gp/SingleLaplaceInferenceMethod_unittest.cc
@@ -13,7 +13,7 @@
 #include <shogun/labels/BinaryLabels.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/kernel/GaussianKernel.h>
-#include <shogun/machine/gp/SingleLaplacianInferenceMethod.h>
+#include <shogun/machine/gp/SingleLaplaceInferenceMethod.h>
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/GaussianLikelihood.h>
 #include <shogun/machine/gp/StudentsTLikelihood.h>
@@ -23,7 +23,7 @@
 
 using namespace shogun;
 
-TEST(SingleLaplacianInferenceMethod,get_cholesky_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_cholesky_gaussian_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -55,8 +55,8 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_gaussian_likelihood)
 	// Gaussian likelihood with sigma = 1 (by default)
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood();
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior cholesky with result from GPML package:
@@ -102,7 +102,7 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_gaussian_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_cholesky_t_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_cholesky_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -134,8 +134,8 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_t_likelihood)
 	// Student's-T likelihood with sigma = 1, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(1, 3);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior cholesky with result from GPML package:
@@ -181,7 +181,7 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_cholesky_logit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_cholesky_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -219,8 +219,8 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_logit_likelihood)
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior cholesky with result from GPML package:
@@ -266,7 +266,7 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_logit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_cholesky_probit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_cholesky_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -303,8 +303,8 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_probit_likelihood)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior cholesky with result from GPML package:
@@ -350,7 +350,7 @@ TEST(SingleLaplacianInferenceMethod,get_cholesky_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_alpha_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_alpha_gaussian_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -382,8 +382,8 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_gaussian_likelihood)
 	// Gaussian likelihood with sigma = 1 (by default)
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood();
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior alpha with result from GPML package:
@@ -405,7 +405,7 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_gaussian_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_alpha_t_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_alpha_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -437,8 +437,8 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_t_likelihood)
 	// Student's-T likelihood with sigma = 1, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(1, 3);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior alpha with result from GPML package:
@@ -460,7 +460,7 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_t_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_alpha_logit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_alpha_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -498,8 +498,8 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_logit_likelihood)
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior alpha with result from GPML package:
@@ -521,7 +521,7 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_logit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_alpha_probit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_alpha_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -558,8 +558,8 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_probit_likelihood)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior alpha with result from GPML package:
@@ -581,7 +581,7 @@ TEST(SingleLaplacianInferenceMethod,get_alpha_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_negative_marginal_likelihood_gaussian_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -613,8 +613,8 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_gaussian_li
 	// Gaussian likelihood with sigma = 1 (by default)
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood();
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior negative marginal likelihood with
@@ -629,7 +629,7 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_gaussian_li
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_t_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_negative_marginal_likelihood_t_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -661,8 +661,8 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_t_likelihoo
 	// Student's-T likelihood with sigma = 1, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(1, 3);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior negative marginal likelihood with
@@ -677,7 +677,7 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_t_likelihoo
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_logit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_negative_marginal_likelihood_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -715,8 +715,8 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_logit_likel
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior negative marginal likelihood with
@@ -731,7 +731,7 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_logit_likel
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_probit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_negative_marginal_likelihood_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -768,8 +768,8 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_probit_like
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, likelihood);
 
 	// comparison of posterior negative marginal likelihood with
@@ -784,7 +784,7 @@ TEST(SingleLaplacianInferenceMethod,get_negative_marginal_likelihood_probit_like
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_gaussian_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_marginal_likelihood_derivatives_gaussian_likelihood)
 {
 	// create some easy regression data:
 	// y approximately equals to 1/5*sin(10*x) + sqrt(x)
@@ -818,8 +818,8 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_gaussian
 	// Gaussian likelihood with sigma = 0.25
 	CGaussianLikelihood* lik=new CGaussianLikelihood(0.25);
 
-	// specify GP regression with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP regression with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, lik);
 
 	// build parameter dictionary
@@ -855,7 +855,7 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_gaussian
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_t_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_marginal_likelihood_derivatives_t_likelihood)
 {
 	// create some easy regression data: 1d noisy sine wave
 	index_t ntr=5;
@@ -889,7 +889,7 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_t_likeli
 	CStudentsTLikelihood* lik=new CStudentsTLikelihood(0.25, 3);
 
 	// specify GP regression with exact inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 		features_train,	mean, labels_train, lik);
 
 	// build parameter dictionary
@@ -930,7 +930,7 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_t_likeli
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_logit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_marginal_likelihood_derivatives_logit_likelihood)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -968,8 +968,8 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_logit_li
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	// build parameter dictionary
@@ -1001,7 +1001,7 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_logit_li
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_logit_likelihood2)
+TEST(SingleLaplaceInferenceMethod,get_marginal_likelihood_derivatives_logit_likelihood2)
 {
 	// create some easy classification data:
 	// y=sign(sqrt(x1.^2+x2.^2)-1)
@@ -1039,8 +1039,8 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_logit_li
 	// logit likelihood
 	CLogitLikelihood* likelihood=new CLogitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	inf->set_scale(3.0);
@@ -1073,7 +1073,7 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_logit_li
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_probit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_marginal_likelihood_derivatives_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -1110,8 +1110,8 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_probit_l
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	// build parameter dictionary
@@ -1143,7 +1143,7 @@ TEST(SingleLaplacianInferenceMethod,get_marginal_likelihood_derivatives_probit_l
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_posterior_mean_probit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_posterior_mean_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -1180,8 +1180,8 @@ TEST(SingleLaplacianInferenceMethod,get_posterior_mean_probit_likelihood)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	// comparison of the mode with result from GPML package
@@ -1196,7 +1196,7 @@ TEST(SingleLaplacianInferenceMethod,get_posterior_mean_probit_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SingleLaplacianInferenceMethod,get_posterior_covariance_probit_likelihood)
+TEST(SingleLaplaceInferenceMethod,get_posterior_covariance_probit_likelihood)
 {
 	// create some easy random classification data
 	index_t n=5;
@@ -1233,8 +1233,8 @@ TEST(SingleLaplacianInferenceMethod,get_posterior_covariance_probit_likelihood)
 	// probit likelihood
 	CProbitLikelihood* likelihood=new CProbitLikelihood();
 
-	// specify GP classification with SingleLaplacian inference
-	CSingleLaplacianInferenceMethod* inf=new CSingleLaplacianInferenceMethod(kernel,
+	// specify GP classification with SingleLaplace inference
+	CSingleLaplaceInferenceMethod* inf=new CSingleLaplaceInferenceMethod(kernel,
 			features_train,	mean, labels_train, likelihood);
 
 	SGMatrix<float64_t> approx_cov=inf->get_posterior_covariance();

--- a/tests/unit/machine/gp/VarDTCInferenceMethod_unittest.cc
+++ b/tests/unit/machine/gp/VarDTCInferenceMethod_unittest.cc
@@ -34,7 +34,7 @@
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/kernel/GaussianKernel.h>
-#include <shogun/machine/gp/SparseVGInferenceMethod.h>
+#include <shogun/machine/gp/VarDTCInferenceMethod.h>
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/ConstMean.h>
 #include <shogun/machine/gp/GaussianLikelihood.h>
@@ -45,7 +45,7 @@
 using namespace shogun;
 
 
-TEST(SparseVGInferenceMethod,get_negative_log_marginal_likelihood)
+TEST(VarDTCInferenceMethod,get_negative_log_marginal_likelihood)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -99,7 +99,7 @@ TEST(SparseVGInferenceMethod,get_negative_log_marginal_likelihood)
 	CGaussianLikelihood* lik=new CGaussianLikelihood(sigma);
 
 	// specify GP regression with FITC inference
-	CSparseVGInferenceMethod* inf=new CSparseVGInferenceMethod(kernel, features_train,
+	CVarDTCInferenceMethod* inf=new CVarDTCInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, inducing_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -122,7 +122,7 @@ TEST(SparseVGInferenceMethod,get_negative_log_marginal_likelihood)
 	SG_UNREF(inf);
 }
 
-TEST(SparseVGInferenceMethod,get_marginal_likelihood_derivatives)
+TEST(VarDTCInferenceMethod,get_marginal_likelihood_derivatives)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -176,7 +176,7 @@ TEST(SparseVGInferenceMethod,get_marginal_likelihood_derivatives)
 	CGaussianLikelihood* lik=new CGaussianLikelihood(sigma);
 
 	// specify GP regression with FITC inference
-	CSparseVGInferenceMethod* inf=new CSparseVGInferenceMethod(kernel, features_train,
+	CVarDTCInferenceMethod* inf=new CVarDTCInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, inducing_features_train);
 
 	float64_t ind_noise=1e-6;
@@ -224,7 +224,7 @@ TEST(SparseVGInferenceMethod,get_marginal_likelihood_derivatives)
 }
 
 #ifdef HAVE_LINALG_LIB
-TEST(SparseVGInferenceMethod,get_marginal_likelihood_derivative_wrt_inducing_features)
+TEST(VarDTCInferenceMethod,get_marginal_likelihood_derivative_wrt_inducing_features)
 {
 	float64_t rel_tolerance=1e-5;
 	float64_t abs_tolerance;
@@ -280,7 +280,7 @@ TEST(SparseVGInferenceMethod,get_marginal_likelihood_derivative_wrt_inducing_fea
 	CGaussianLikelihood* lik=new CGaussianLikelihood(sigma);
 
 	// specify GP regression with FITC inference
-	CSparseVGInferenceMethod* inf=new CSparseVGInferenceMethod(kernel, features_train,
+	CVarDTCInferenceMethod* inf=new CVarDTCInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, inducing_features_train);
 
 	float64_t ind_noise=1e-6;

--- a/tests/unit/regression/GaussianProcessRegression_unittest.cc
+++ b/tests/unit/regression/GaussianProcessRegression_unittest.cc
@@ -43,7 +43,7 @@
 #include <shogun/machine/gp/ZeroMean.h>
 #include <shogun/machine/gp/GaussianLikelihood.h>
 #include <gtest/gtest.h>
-#include <shogun/machine/gp/SparseVGInferenceMethod.h>
+#include <shogun/machine/gp/VarDTCInferenceMethod.h>
 
 using namespace shogun;
 
@@ -489,7 +489,7 @@ TEST(GaussianProcessRegression,apply_regression_scaled_kernel)
 	SG_UNREF(gpr);
 }
 
-TEST(GaussianProcessRegression,sparse_vg_regression)
+TEST(GaussianProcessRegression,var_dtc_regression)
 {
 	index_t n=6;
 	index_t dim=2;
@@ -544,7 +544,7 @@ TEST(GaussianProcessRegression,sparse_vg_regression)
 	CGaussianLikelihood* lik=new CGaussianLikelihood(sigma);
 
 	// specify GP regression with FITC inference
-	CSparseVGInferenceMethod* inf=new CSparseVGInferenceMethod(kernel, features_train,
+	CVarDTCInferenceMethod* inf=new CVarDTCInferenceMethod(kernel, features_train,
 		mean, labels_train, lik, inducing_features_train);
 
 	float64_t ind_noise=1e-6;


### PR DESCRIPTION
@karlnapf 
inference methods are renamed so that they are more user-friendly.