### PR TITLE
fix an issue related to enum class for the precise build

### DIFF
--- a/src/shogun/machine/gp/KLDualInferenceMethod.h
+++ b/src/shogun/machine/gp/KLDualInferenceMethod.h
@@ -59,9 +59,9 @@ protected:
 	/** Init before minimization */
 	virtual void init_minimization()
 	{
-		REQUIRE((m_linesearch == ELBFGSLineSearch::BACKTRACKING_ARMIJO) ||
-			(m_linesearch == ELBFGSLineSearch::BACKTRACKING_WOLFE) ||
-			(m_linesearch == ELBFGSLineSearch::BACKTRACKING_STRONG_WOLFE),
+		REQUIRE((m_linesearch == BACKTRACKING_ARMIJO) ||
+			(m_linesearch == BACKTRACKING_WOLFE) ||
+			(m_linesearch == BACKTRACKING_STRONG_WOLFE),
 			"The provided line search method is not supported. Please use backtracking line search methods\n");
 		LBFGSMinimizer::init_minimization();
 	}

--- a/src/shogun/optimization/lbfgs/LBFGSMinimizer.h
+++ b/src/shogun/optimization/lbfgs/LBFGSMinimizer.h
@@ -102,7 +102,7 @@ public:
 	 */
 	virtual void set_lbfgs_parameters(int m = 100,
 		int max_linesearch = 1000,
-		ELBFGSLineSearch linesearch = ELBFGSLineSearch::BACKTRACKING_STRONG_WOLFE,
+		ELBFGSLineSearch linesearch = BACKTRACKING_STRONG_WOLFE,
 		int max_iterations = 1000,
 		float64_t delta = 0.0,
 		int past = 0,

--- a/src/shogun/optimization/lbfgs/lbfgs.h
+++ b/src/shogun/optimization/lbfgs/lbfgs.h
@@ -130,9 +130,9 @@ enum {
  */
 enum {
     /** The default algorithm (MoreThuente method). */
-    LBFGS_LINESEARCH_DEFAULT = ELBFGSLineSearch::MORETHUENTE,
+    LBFGS_LINESEARCH_DEFAULT = MORETHUENTE,
     /** MoreThuente method proposd by More and Thuente. */
-    LBFGS_LINESEARCH_MORETHUENTE = ELBFGSLineSearch::MORETHUENTE,
+    LBFGS_LINESEARCH_MORETHUENTE = MORETHUENTE,
     /**
      * Backtracking method with the Armijo condition.
      *  The backtracking method finds the step length such that it satisfies
@@ -142,9 +142,9 @@ enum {
      *  where x is the current point, d is the current search direction, and
      *  a is the step length.
      */
-    LBFGS_LINESEARCH_BACKTRACKING_ARMIJO = ELBFGSLineSearch::BACKTRACKING_ARMIJO,
+    LBFGS_LINESEARCH_BACKTRACKING_ARMIJO = BACKTRACKING_ARMIJO,
     /** The backtracking method with the defualt (regular Wolfe) condition. */
-    LBFGS_LINESEARCH_BACKTRACKING = ELBFGSLineSearch::BACKTRACKING_WOLFE,
+    LBFGS_LINESEARCH_BACKTRACKING = BACKTRACKING_WOLFE,
     /**
      * Backtracking method with regular Wolfe condition.
      *  The backtracking method finds the step length such that it satisfies
@@ -155,7 +155,7 @@ enum {
      *  where x is the current point, d is the current search direction, and
      *  a is the step length.
      */
-    LBFGS_LINESEARCH_BACKTRACKING_WOLFE = ELBFGSLineSearch::BACKTRACKING_WOLFE,
+    LBFGS_LINESEARCH_BACKTRACKING_WOLFE = BACKTRACKING_WOLFE,
     /**
      * Backtracking method with strong Wolfe condition.
      *  The backtracking method finds the step length such that it satisfies
@@ -166,7 +166,7 @@ enum {
      *  where x is the current point, d is the current search direction, and
      *  a is the step length.
      */
-    LBFGS_LINESEARCH_BACKTRACKING_STRONG_WOLFE = ELBFGSLineSearch::BACKTRACKING_STRONG_WOLFE
+    LBFGS_LINESEARCH_BACKTRACKING_STRONG_WOLFE = BACKTRACKING_STRONG_WOLFE
 };
 
 /**


### PR DESCRIPTION
@karlnapf 
The compiler in the precise build does not support `enum` class.