### PR TITLE
Implement CParameterCombination::obtain_from_generic()

### DIFF
--- a/examples/undocumented/python_modular/modelselection_parameter_tree_modular.py
+++ b/examples/undocumented/python_modular/modelselection_parameter_tree_modular.py
@@ -91,7 +91,8 @@ def modelselection_parameter_tree_modular (dummy):
     #	root.print_tree()
     combinations=root.get_combinations()
     #	for i in range(combinations.get_num_elements()):
-    #		combinations.get_element(i).print_tree()
+    #		params = ParameterCombination.obtain_from_generic(combinations.get_element(i))
+    #		params.print_tree()
 
     return
 

--- a/src/shogun/modelselection/ParameterCombination.h
+++ b/src/shogun/modelselection/ParameterCombination.h
@@ -222,10 +222,16 @@ public:
 	static CParameterCombination* obtain_from_generic(
 			CSGObject* param_combination)
 	{
-		if (!param_combination)
+		if (param_combination)
+		{
+			CParameterCombination* casted = dynamic_cast<CParameterCombination*>(param_combination);
+			REQUIRE(casted, "CParameterCombination::obtain_from_generic(): Error, provided object"
+					" of class \"%s\" is not a subclass of CParameterCombination!\n",
+					param_combination->get_name());
+			return casted;
+		}
+		else
 			return NULL;
-
-		return dynamic_cast<CParameterCombination*>(param_combination);
 	}
 
 	/** returns total length of the parameters in combination

--- a/src/shogun/modelselection/ParameterCombination.h
+++ b/src/shogun/modelselection/ParameterCombination.h
@@ -225,8 +225,8 @@ public:
 		if (param_combination)
 		{
 			CParameterCombination* casted = dynamic_cast<CParameterCombination*>(param_combination);
-			REQUIRE(casted, "CParameterCombination::obtain_from_generic(): Error, provided object"
-					" of class \"%s\" is not a subclass of CParameterCombination!\n",
+			REQUIRE(casted, "Error, provided object of class \"%s\" is not a subclass of"
+					" CParameterCombination!\n",
 					param_combination->get_name());
 			return casted;
 		}

--- a/src/shogun/modelselection/ParameterCombination.h
+++ b/src/shogun/modelselection/ParameterCombination.h
@@ -215,6 +215,19 @@ public:
 		return "ParameterCombination";
 	}
 
+	/** helper method used to specialize a base class instance
+	 *
+	 * @param param_combination its dynamic type must be CParameterCombination
+	 */
+	static CParameterCombination* obtain_from_generic(
+			CSGObject* param_combination)
+	{
+		if (!param_combination)
+			return NULL;
+
+		return dynamic_cast<CParameterCombination*>(param_combination);
+	}
+
 	/** returns total length of the parameters in combination
 	 *
 	 * @return total length of the parameters in combination


### PR DESCRIPTION
Iterating through parameter combinations in python as indicated in `modelselection_parameter_tree_modular.py` doesn't work since `get_element()` returns a `CSGObject` pointer.

This patch adds an `obtain_from_generic()` function to `CParamterCombination` that performs the type cast. The example was adopted.