### PR TITLE
Fix buildbot mathematics/ warnings

### DIFF
--- a/src/shogun/mathematics/Statistics.h
+++ b/src/shogun/mathematics/Statistics.h
@@ -173,7 +173,7 @@ public:
 	 *
 	 * Returns the argument \f$x\f$ for which the CDF is equal to \f$y\f$.
 	 *
-	 * @param y CDF value \f$y\f$.
+	 * @param p CDF value \f$y\f$.
 	 * @param a Shape parameter \f$\alpha\f$
 	 * @param b Rate parameter \f$\beta\f$
 	 * @return Argument \f$x\f$ that produces \f$y\f$.
@@ -188,8 +188,7 @@ public:
 	 * \f]
 	 *
 	 * @param x Argument \f$x\f$ to evaluate.
-	 * @param a Shape parameter \f$\alpha\f$
-	 * @param b Rate parameter \f$\beta\f$
+	 * @param std_dev Standard deviation \f$\sigma\f$. Default value is 1.
 	 * @return Gamma CDF at \f$x\f$
 	 */
 	static float64_t normal_cdf(float64_t x, float64_t std_dev=1);
@@ -203,7 +202,7 @@ public:
 	 *
 	 * Returns the argument \f$x\f$ for which CDF is equal to \f$y\f$.
 	 *
-	 * @param y CDF value \f$y\f$.
+	 * @param y0 CDF value \f$y\f$.
 	 * @param mean Mean \f$\mu\f$. Default value is 0.
 	 * @param std_dev Standard deviation \f$\sigma\f$. Default value is 1.
 	 * @return Argument \f$x\f$ that produces \f$y\f$.

--- a/src/shogun/mathematics/linalg/internal/implementation/ElementwiseSquare.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/ElementwiseSquare.h
@@ -128,7 +128,7 @@ struct elementwise_square<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the square of co-efficients of a dense matrix
 	 *
-	 * @param m the matrix whose squared co-efficients matrix has to be computed
+	 * @param mat the matrix whose squared co-efficients matrix has to be computed
 	 * @param result Pre-allocated matrix for the result of the computation
 	 */
 	static void compute(SGMatrix<T> mat, SGMatrix<T> result)

--- a/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
@@ -5,7 +5,6 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
@@ -44,17 +43,19 @@ namespace shogun
 
 namespace linalg
 {
-    
+
 namespace implementation
 {
-    
+
+#ifndef SWIG // SWIG should skip this part
 /**
- * @brief Generic class int2float which converts different types of integer 
+ * @brief Generic class int2float which converts different types of integer
  * into float64 type.
  */
 template <typename inputType>
 struct int2float
 {
+	/** orininal type **/
 	using floatType = inputType;
 };
 
@@ -64,6 +65,7 @@ struct int2float
 template <>
 struct int2float<int32_t>
 {
+	/** float64_t type **/
 	using floatType = float64_t;
 };
 
@@ -73,11 +75,13 @@ struct int2float<int32_t>
 template <>
 struct int2float<int64_t>
 {
+	/** float64_t type **/
 	using floatType = float64_t;
 };
- 
+#endif
+
 /**
- * @brief Generic class mean which provides a static compute method. 
+ * @brief Generic class mean which provides a static compute method.
  */
 template <enum Backend, class Matrix>
 struct mean
@@ -100,7 +104,7 @@ struct mean
 	 * Method that computes the matrix mean
 	 *
 	 * @param a matrix whose mean has to be computed
-	 * @param no_diag if true, diagonal entries are excluded from the mean (default - false) 
+	 * @param no_diag if true, diagonal entries are excluded from the mean (default - false)
 	 * @return the matrix mean \f$\1/N^2\sum_{i,j=1}^N m_{i,j}\f$
 	 */
 	static ReturnType compute(Matrix a, bool no_diag=false);
@@ -130,7 +134,7 @@ struct rowwise_mean
 	/**
 	 * Method that computes the row wise sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose rowwise sum of co-efficients has to be computed
+	 * @param mat the matrix whose rowwise sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @param result Pre-allocated vector for the result of the computation
 	 */
@@ -138,7 +142,7 @@ struct rowwise_mean
 };
 
 /**
- * @brief Specialization of generic mean which works with SGVector and 
+ * @brief Specialization of generic mean which works with SGVector and
  * SGMatrix and uses Eigen3 as backend for computing mean.
  */
 template <class Matrix>
@@ -167,13 +171,13 @@ struct mean<Backend::EIGEN3, Matrix>
 	 * Method that computes the mean of SGMatrix using Eigen3
 	 *
 	 * @param a matrix whose mean has to be computed
-	 * @param no_diag if true, diagonal entries are excluded from the mean (default - false) 
-	 * @return the matrix mean \f$\1/N^2 \sum_{i,j=1}^N m_{i,j}\f$
+	 * @param no_diag if true, diagonal entries are excluded from the mean (default - false)
+	 * @return the matrix mean \f$\1/N^2\sum_{i,j=1}^N m_{i,j}\f$
 	 */
         static ReturnType compute(SGMatrix<T> mat, bool no_diag=false)
 	{
 		REQUIRE(mat.num_rows > 0, "Matrix row number cannot be zero!\n");
-		if (no_diag) 
+		if (no_diag)
 		{
 			if (mat.num_rows > mat.num_cols)
 			{
@@ -186,17 +190,17 @@ struct mean<Backend::EIGEN3, Matrix>
 					/ ReturnType(mat.num_rows * mat.num_cols - mat.num_rows));
 			}
 		}
-		else 
+		else
 		{
 			return (sum<Backend::EIGEN3, SGMatrix<T> >::compute(mat, no_diag)
 				/ ReturnType(mat.num_rows * mat.num_cols));
 		}
-	}     
-}; 
+	}
+};
 
 
 /**
- * @brief Specialization of generic mean which works with SGMatrix  
+ * @brief Specialization of generic mean which works with SGMatrix
  * and uses Eigen3 as backend for computing rowwise mean.
  */
 template <class Matrix>
@@ -228,7 +232,7 @@ struct rowwise_mean<Backend::EIGEN3, Matrix>
 	/**
 	 * Method that computes the rowwise mean of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose rowwise mean has to be computed
+	 * @param mat the matrix whose rowwise mean has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the mean
 	 * @param result Pre-allocated vector for the result of the computation
 	 */
@@ -242,23 +246,23 @@ struct rowwise_mean<Backend::EIGEN3, Matrix>
 
 		if (!no_diag)
 			for (index_t i = 0; i < m.rows(); ++i)
-				result[i] = temp[i] / ReturnDataType(m.cols()); 
+				result[i] = temp[i] / ReturnDataType(m.cols());
 		else if (m.rows() <= m.cols())
 			for (index_t i = 0; i < m.rows(); ++i)
-				result[i] = temp[i] / ReturnDataType(m.cols() - 1); 
+				result[i] = temp[i] / ReturnDataType(m.cols() - 1);
 		else
 		{
-			for (index_t i = 0; i < m.cols(); ++i) 
+			for (index_t i = 0; i < m.cols(); ++i)
 				result[i] = temp[i] / ReturnDataType(m.cols() - 1);
 			for (index_t i = m.cols(); i < m.rows(); ++i)
 				result[i] = temp[i] / ReturnDataType(m.cols());
-		}       
+		}
 	}
 
 };
-    
+
 }
-             
+
 }
 
 }

--- a/src/shogun/mathematics/linalg/internal/implementation/Sum.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/Sum.h
@@ -234,7 +234,7 @@ struct sum<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose sum of co-efficients has to be computed
+	 * @param mat the matrix whose sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @return the sum of co-efficients computed as \f$\sum_{i,j}m_{i,j}\f$
 	 */
@@ -292,7 +292,7 @@ struct sum_symmetric<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the sum of co-efficients of symmetric SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose sum of co-efficients has to be computed
+	 * @param mat the matrix whose sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @return the sum of co-efficients computed as \f$\sum_{i,j}m_{i,j}\f$
 	 */
@@ -500,7 +500,7 @@ struct rowwise_sum<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the row wise sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose rowwise sum of co-efficients has to be computed
+	 * @param mat the matrix whose rowwise sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @param result Pre-allocated vector for the result of the computation
 	 */


### PR DESCRIPTION
Is this the correct way to do it? - 

Fixed documentation warnings in `mathematics/` in http://buildbot.shogun-toolbox.org/builders/deb3%20-%20modular_interfaces/builds/2853