### PR TITLE
Fix some documentation warnings in python mod build

### DIFF
--- a/src/shogun/classifier/LDA.h
+++ b/src/shogun/classifier/LDA.h
@@ -73,9 +73,9 @@ template <class ST> class CDenseFeatures;
  * solution \f${\bf w}\f$ to be expressed in this basis.
  * \f[{\bf W} := {\bf Q} {\bf{W^\prime}}\f]
  * The between class Matrix is replaced with:
- * \f[{\bf S_b^\prime} \equiv {{\bf Q^T}{\bf S_b } {\bf Q}\f]
+ * \f[{\bf S_b^\prime} \equiv {\bf Q^T}{\bf S_b}{\bf Q}\f]
  * The within class Matrix is replaced with:
- * \f[{\bf S_w^\prime} \equiv {{\bf Q^T}{\bf S_w} {\bf Q}\f]
+ * \f[{\bf S_w^\prime} \equiv {\bf Q^T}{\bf S_w}{\bf Q}\f]
  * In this case {\bf S_w^\prime} is guranteed invertible since {\bf S_w} has
  * been projected down to the basis that spans the data.
  * see: Bayesian Reasoning and Machine Learning, section 16.3.1.

--- a/src/shogun/distance/EuclideanDistance.h
+++ b/src/shogun/distance/EuclideanDistance.h
@@ -38,8 +38,11 @@ namespace shogun
  *  d({\bf x},{\bf x'})= \sum_{i=0}^{n}|{\bf x_i}-{\bf x'_i}|^2
  * \f]
  * 
- * Distance is computed as :  
+ * Distance is computed as :
+ * 
+ * \f[\displaystyle
  * \sqrt{{\bf x}\cdot {\bf x} - 2{\bf x}\cdot {\bf x'} + {\bf x'}\cdot {\bf x'}}
+ * \f]
  *  
  * Squared norms for left hand side and right hand side features can be precomputed.
  * WARNING : Make sure to reset squared norms using reset_squared_norms() when features

--- a/src/shogun/mathematics/Statistics.h
+++ b/src/shogun/mathematics/Statistics.h
@@ -173,7 +173,7 @@ public:
 	 *
 	 * Returns the argument \f$x\f$ for which the CDF is equal to \f$y\f$.
 	 *
-	 * @param y CDF value \f$y\f$.
+	 * @param p CDF value \f$y\f$.
 	 * @param a Shape parameter \f$\alpha\f$
 	 * @param b Rate parameter \f$\beta\f$
 	 * @return Argument \f$x\f$ that produces \f$y\f$.
@@ -188,8 +188,7 @@ public:
 	 * \f]
 	 *
 	 * @param x Argument \f$x\f$ to evaluate.
-	 * @param a Shape parameter \f$\alpha\f$
-	 * @param b Rate parameter \f$\beta\f$
+	 * @param std_dev Standard deviation \f$\sigma\f$. Default value is 1.
 	 * @return Gamma CDF at \f$x\f$
 	 */
 	static float64_t normal_cdf(float64_t x, float64_t std_dev=1);
@@ -203,7 +202,7 @@ public:
 	 *
 	 * Returns the argument \f$x\f$ for which CDF is equal to \f$y\f$.
 	 *
-	 * @param y CDF value \f$y\f$.
+	 * @param y0 CDF value \f$y\f$.
 	 * @param mean Mean \f$\mu\f$. Default value is 0.
 	 * @param std_dev Standard deviation \f$\sigma\f$. Default value is 1.
 	 * @return Argument \f$x\f$ that produces \f$y\f$.

--- a/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
@@ -130,7 +130,7 @@ struct rowwise_mean
 	/**
 	 * Method that computes the row wise sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose rowwise sum of co-efficients has to be computed
+	 * @param mat the matrix whose rowwise sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @param result Pre-allocated vector for the result of the computation
 	 */
@@ -154,7 +154,7 @@ struct mean<Backend::EIGEN3, Matrix>
 	 * Method that computes the mean of SGVectors using Eigen3
 	 *
 	 * @param a vector whose mean has to be computed
-	 * @return the vector mean \f\bar a_i\f$
+	 * @return the vector mean \f$\bar a_i\f$
 	 */
 	static ReturnType compute(SGVector<T> vec)
 	{
@@ -228,7 +228,7 @@ struct rowwise_mean<Backend::EIGEN3, Matrix>
 	/**
 	 * Method that computes the rowwise mean of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose rowwise mean has to be computed
+	 * @param mat the matrix whose rowwise mean has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the mean
 	 * @param result Pre-allocated vector for the result of the computation
 	 */

--- a/src/shogun/mathematics/linalg/internal/implementation/Sum.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/Sum.h
@@ -234,7 +234,7 @@ struct sum<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose sum of co-efficients has to be computed
+	 * @param mat the matrix whose sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @return the sum of co-efficients computed as \f$\sum_{i,j}m_{i,j}\f$
 	 */
@@ -292,7 +292,7 @@ struct sum_symmetric<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the sum of co-efficients of symmetric SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose sum of co-efficients has to be computed
+	 * @param mat the matrix whose sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @return the sum of co-efficients computed as \f$\sum_{i,j}m_{i,j}\f$
 	 */
@@ -400,7 +400,7 @@ struct colwise_sum<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the column wise sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose colwise sum of co-efficients has to be computed
+	 * @param mat the matrix whose colwise sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @param result Pre-allocated vector for the result of the computation
 	 */
@@ -500,7 +500,7 @@ struct rowwise_sum<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the row wise sum of co-efficients of SGMatrix using Eigen3
 	 *
-	 * @param m the matrix whose rowwise sum of co-efficients has to be computed
+	 * @param mat the matrix whose rowwise sum of co-efficients has to be computed
 	 * @param no_diag if true, diagonal entries are excluded from the sum
 	 * @param result Pre-allocated vector for the result of the computation
 	 */

--- a/src/shogun/neuralnets/RBM.h
+++ b/src/shogun/neuralnets/RBM.h
@@ -148,7 +148,7 @@ public:
 	/** Adds a group of visible units to the RBM
 	 *
 	 * @param num_units Number of visible units
-	 * @param visible_unit_type Type of the visible units
+	 * @param unit_type Type of the visible units
 	 */
 	virtual void add_visible_group(int32_t num_units, ERBMVisibleUnitType unit_type);
 

--- a/src/shogun/preprocessor/FisherLDA.h
+++ b/src/shogun/preprocessor/FisherLDA.h
@@ -107,7 +107,7 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 		 * @param features using which the transformation matrix will be formed
 		 * @param labels of the given features which will be used here to find
 		 * the transformation matrix unlike PCA where it is not needed.
-		 * @param dimensions number of dimensions to retain
+		 * @param num_dimensions number of dimensions to retain
 		 */
 		virtual bool fit(CFeatures* features, CLabels* labels, int32_t num_dimensions=0);
 
@@ -122,7 +122,7 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 		virtual SGMatrix<float64_t> apply_to_feature_matrix(CFeatures* features);
 
 		/** apply preprocessor to feature vector
-		 * @param features on which the learned transformation has to be applied.
+		 * @param vector features on which the learned transformation has to be applied.
 		 * @return processed feature vector with reduced dimensions.
 		 */
 		virtual SGVector<float64_t> apply_to_feature_vector(SGVector<float64_t> vector);

--- a/src/shogun/preprocessor/PCA.h
+++ b/src/shogun/preprocessor/PCA.h
@@ -178,7 +178,7 @@ class CPCA: public CDimensionReductionPreprocessor
 		EPCAMemoryMode get_memory_mode() const;
 
 		/** set PCA memory mode to be used
-		 * @param choice between MEM_REALLOCATE and MEM_IN_PLACE
+		 * @param e hoice between MEM_REALLOCATE and MEM_IN_PLACE
 		 */
 		void set_memory_mode(EPCAMemoryMode e);
 

--- a/src/shogun/statistics/NOCCO.h
+++ b/src/shogun/statistics/NOCCO.h
@@ -85,7 +85,7 @@ template<class T> class SGMatrix;
  * the fly it then uses the solution vectors \f$\mathbf x_i\f$ to compute the
  * matrix-matrix product \f$\mathbf C_*=\mathbf G_*\mathbf{GG}_*^{-1}\f$
  * using \f$\mathbf C_{*,(j,i)}=\mathbf G_{*,j}\cdot \mathbf x_i\f$, where
- * $\mathbf G_{*,j}$ is the \f$j^{\text{th}}\f$ row of \f$\mathbf G_*$ (or
+ * \f$\mathbf G_{*,j}\f$ is the \f$j^{\text{th}}\f$ row of \f$\mathbf G_*\f$ (or
  * column, since it is symmetric) and then discarding the vector.
  *
  * The final trace computation is also simplified using the symmetry of the


### PR DESCRIPTION
Fix some warnings from [here](http://buildbot.shogun-toolbox.org/builders/deb3%20-%20modular_interfaces/builds/2853/steps/python%20modular/logs/warnings%20(87)/text).