### PR TITLE
fix modshogun and python warnings

### DIFF
--- a/src/shogun/clustering/KMeansLloydImpl.h
+++ b/src/shogun/clustering/KMeansLloydImpl.h
@@ -29,8 +29,6 @@ class CKMeansLloydImpl
 		 * @param distance distance
 		 * @param max_iter max iterations allowed
 		 * @param mus cluster centers matrix (k columns)
-		 * @param ClList cluster number each data vector belongs (size no_of_vectors)
-		 * @param weights_set no. of points belonging to each cluster (size k)
 		 * @param fixed_centers keep centers fixed or not
 		 */
 		static void Lloyd_KMeans(int32_t k, CDistance* distance, int32_t max_iter, SGMatrix<float64_t> mus,

--- a/src/shogun/lib/external/cdflib.cpp
+++ b/src/shogun/lib/external/cdflib.cpp
@@ -10861,11 +10861,9 @@ void timestamp ( )
 # define TIME_SIZE 40
 
   static char time_buffer[TIME_SIZE];
-  const struct tm *tm;
   time_t now;
 
   now = time ( NULL );
-  tm = localtime ( &now );
 
 
   cout << time_buffer << "\n";

--- a/src/shogun/machine/LinearMachine.h
+++ b/src/shogun/machine/LinearMachine.h
@@ -192,7 +192,7 @@ class CLinearMachine : public CMachine
 		float64_t bias;
 		/** features */
 		CDotFeatures* features;
-		/** If true, bias is computed in ::train method */
+		/** If true, bias is computed in train method */
 		bool m_compute_bias;
 };
 }

--- a/src/shogun/mathematics/linalg/internal/implementation/ElementwiseSquare.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/ElementwiseSquare.h
@@ -128,7 +128,7 @@ struct elementwise_square<Backend::EIGEN3,Matrix>
 	/**
 	 * Method that computes the square of co-efficients of a dense matrix
 	 *
-	 * @param m the matrix whose squared co-efficients matrix has to be computed
+	 * @param mat the matrix whose squared co-efficients matrix has to be computed
 	 * @param result Pre-allocated matrix for the result of the computation
 	 */
 	static void compute(SGMatrix<T> mat, SGMatrix<T> result)

--- a/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
+++ b/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h
@@ -153,7 +153,7 @@ struct mean<Backend::EIGEN3, Matrix>
 	/**
 	 * Method that computes the mean of SGVectors using Eigen3
 	 *
-	 * @param a vector whose mean has to be computed
+	 * @param vec a vector whose mean has to be computed
 	 * @return the vector mean \f$\bar a_i\f$
 	 */
 	static ReturnType compute(SGVector<T> vec)

--- a/src/shogun/neuralnets/RBM.h
+++ b/src/shogun/neuralnets/RBM.h
@@ -301,7 +301,7 @@ public:
 	 * during computation. If not given, a new matrix is allocated and used as
 	 * a buffer.
 	 *
-	 * @param return Approximation to the average pseudo-likelihood over the
+	 * @return Approximation to the average pseudo-likelihood over the
 	 * given batch
 	 */
 	virtual float64_t pseudo_likelihood(SGMatrix<float64_t> visible,

--- a/src/shogun/statistics/NOCCO.h
+++ b/src/shogun/statistics/NOCCO.h
@@ -96,7 +96,7 @@ template<class T> class SGMatrix;
  *	\mathbf R_X^i\cdot \mathbf R_Y^i
  * \f]
  *
- * For performing the independence test, ::PERMUTATION test is used by first
+ * For performing the independence test, PERMUTATION test is used by first
  * randomly shuffling the samples from one of the distributions while keeping
  * the samples from the other distribution in the original order. This way we
  * sample the null distribution and compute p-value and threshold for a given


### PR DESCRIPTION
Fixes following warnings:
```
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/lib/external/cdflib.cpp:10864:20: warning: variable ‘tm’ set but not used [-Wunused-but-set-variable]
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/clustering/KMeansLloydImpl.h:26: warning: argument 'ClList' of command @param is not found in the argument list of shogun::CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance *distance, int32_t max_iter, SGMatrix< float64_t > mus, bool fixed_centers)
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/clustering/KMeansLloydImpl.h:26: warning: argument 'weights_set' of command @param is not found in the argument list of shogun::CKMeansLloydImpl::Lloyd_KMeans(int32_t k, CDistance *distance, int32_t max_iter, SGMatrix< float64_t > mus, bool fixed_centers)
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/statistics/NOCCO.h:96: warning: explicit link request to 'PERMUTATION' could not be resolved
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/neuralnets/RBM.h:295: warning: argument 'return' of command @param is not found in the argument list of shogun::CRBM::pseudo_likelihood(SGMatrix< float64_t > visible, SGMatrix< float64_t > buffer=SGMatrix< float64_t >())
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/mathematics/linalg/internal/implementation/ElementwiseSquare.h:129: warning: argument 'm' of command @param is not found in the argument list of shogun::linalg::implementation::elementwise_square< Backend::EIGEN3, Matrix >::compute(SGMatrix< T > mat, SGMatrix< T > result)
/home/buildslave/deb3_-_modular_interfaces/build/src/shogun/mathematics/linalg/internal/implementation/MeanEigen3.h:167: warning: argument 'a' of command @param is not found in the argument list of shogun::linalg::implementation::mean< Backend::EIGEN3, Matrix >::compute(SGMatrix< T > mat, bool no_diag=false)
```