### PR TITLE
Fixes #3211 Invalid use of incomplete type ‘struct shogun::TParameter’

### DIFF
--- a/src/shogun/evaluation/GradientResult.h
+++ b/src/shogun/evaluation/GradientResult.h
@@ -15,6 +15,7 @@
 
 #include <shogun/evaluation/EvaluationResult.h>
 #include <shogun/lib/Map.h>
+#include <shogun/base/Parameter.h>
 
 namespace shogun
 {


### PR DESCRIPTION
Fixes #3211 Invalid use of incomplete type ‘struct shogun::TParameter’