### PR TITLE
add REQUIRE that covariances were stored during training in get_cov m…

### DIFF
--- a/src/shogun/multiclass/QDA.h
+++ b/src/shogun/multiclass/QDA.h
@@ -138,6 +138,8 @@ class CQDA : public CNativeMulticlassMachine
 		 */
 		inline SGMatrix< float64_t > get_cov(int32_t c) const
 		{
+			REQUIRE(m_store_covs, "Covariance matrices were not stored. "
+					"Please activate to access them subsequently.\n");
 			return SGMatrix< float64_t >(m_covs.get_matrix(c), m_dim, m_dim, false);
 		}
 


### PR DESCRIPTION
…ethod

addresses an issue as experienced by @OXPHOS 