### PR TITLE
fix meta example language to allow the "0" literal

### DIFF
--- a/examples/meta/generator/parse.py
+++ b/examples/meta/generator/parse.py
@@ -77,7 +77,7 @@ class FastParser:
         'string': 'BASICTYPE'
     }
 
-    t_NUMERAL = "[0-9]+(\.[0-9]+)?”
+    t_NUMERAL = "[0-9]+(\.[0-9]+)?"
     t_STRINGLITERAL = '"[^"\n]*"'
     t_COMMA = ","
     t_DOT = "\."

--- a/examples/meta/generator/parse.py
+++ b/examples/meta/generator/parse.py
@@ -77,7 +77,7 @@ class FastParser:
         'string': 'BASICTYPE'
     }
 
-    t_NUMERAL = "([1-9][0-9]*(\.[0-9]+)?)|0\.[0-9]+"
+    t_NUMERAL = "[0-9]+(\.[0-9]+)?”
     t_STRINGLITERAL = '"[^"\n]*"'
     t_COMMA = ","
     t_DOT = "\."


### PR DESCRIPTION
@OXPHOS this allows to use
`int variable = 0` in the meta language