### PR TITLE
Cereal serialization - SGVector

### DIFF
--- a/examples/meta/CMakeLists.txt
+++ b/examples/meta/CMakeLists.txt
@@ -8,6 +8,7 @@
 # execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/generator/types/get_type_list.sh > ${CMAKE_CURRENT_SOURCE_DIR}/generator/types/typelist)
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/parser_files)
+include_directories(${CEREAL_INCLUDE_DIRS})
 
 # Run example generation script
 add_custom_target(meta_examples

--- a/src/shogun/lib/SGReferencedData.h
+++ b/src/shogun/lib/SGReferencedData.h
@@ -10,12 +10,11 @@
 #define __SGREFERENCED_DATA_H__
 
 #include <shogun/lib/config.h>
-
 #include <shogun/lib/common.h>
+#include <shogun/lib/RefCount.h>
 
 namespace shogun
 {
-class RefCount;
 
 /** @brief shogun reference count managed data */
 class SGReferencedData
@@ -42,6 +41,31 @@ class SGReferencedData
 		 * @return reference count
 		 */
 		int32_t ref_count();
+
+		template<class Archive>
+		void cereal_save(Archive & ar) const
+		{
+			if (m_refcount != NULL)
+				ar(cereal::make_nvp("ref_counting", true), m_refcount->ref_count());
+			else
+				ar(cereal::make_nvp("ref_counting", false));
+		}
+
+		template<class Archive>
+		void cereal_load(Archive & ar)
+		{
+			bool ref_counting;
+			ar(ref_counting);
+
+			if (ref_counting)
+			{
+				int32_t temp;
+				ar(temp);
+				m_refcount = new RefCount(temp);
+			}
+			else
+				m_refcount = NULL;
+		}
 
 	protected:
 		/** copy refcount */

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -474,6 +474,28 @@ template<class T> class SGVector : public SGReferencedData
 		 * @return matrix
 		 */
 		static void convert_to_matrix(T*& matrix, index_t nrows, index_t ncols, const T* vector, int32_t vlen, bool fortran_order);
+
+		template<class Archive>
+		void cereal_save(Archive & ar) const
+		{
+			ar(cereal::base_class<SGReferencedData>(this));
+			ar(cereal::make_nvp("length", vlen));
+			for (index_t i = 0; i < vlen; ++i)
+				ar(vector[i]);
+		}
+
+		template<class Archive>
+		void cereal_load(Archive & ar)
+		{
+			unref();
+			ar(cereal::base_class<SGReferencedData>(this));
+
+			ar(vlen);
+			vector = SG_MALLOC(T, vlen);
+			for (index_t i = 0; i < vlen; ++i)
+				ar(vector[i]);
+		}
+
 #endif // #ifndef SWIG // SWIG should skip this part
 	protected:
 		/** needs to be overridden to copy data */

--- a/src/shogun/lib/common.h
+++ b/src/shogun/lib/common.h
@@ -15,6 +15,19 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
+#include <cereal/macros.hpp>
+#ifdef CEREAL_SAVE_FUNCTION_NAME
+#undef CEREAL_SAVE_FUNCTION_NAME
+#endif
+#define CEREAL_SAVE_FUNCTION_NAME cereal_save
+
+#ifdef CEREAL_LOAD_FUNCTION_NAME
+#undef CEREAL_LOAD_FUNCTION_NAME
+#endif
+#define CEREAL_LOAD_FUNCTION_NAME cereal_load
+#include <cereal/cereal.hpp>
+#include <cereal/types/polymorphic.hpp>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>

--- a/tests/meta/CMakeLists.txt
+++ b/tests/meta/CMakeLists.txt
@@ -15,6 +15,8 @@ IF (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/generated_results)
 	EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_BINARY_DIR}/examples/meta" "${CMAKE_CURRENT_BINARY_DIR}/generated_results")
 ENDIF()
 
+include_directories(${CEREAL_INCLUDE_DIRS})
+
 # compile tester c++ binary
 ADD_EXECUTABLE(meta_example_integration_tester ${CMAKE_CURRENT_SOURCE_DIR}/tester.cpp)
 ADD_DEPENDENCIES(meta_example_integration_tester shogun)

--- a/tests/unit/io/Cereal_unittest.cc
+++ b/tests/unit/io/Cereal_unittest.cc
@@ -1,0 +1,79 @@
+#include <shogun/lib/common.h>
+#include <gtest/gtest.h>
+
+#include <shogun/lib/SGVector.h>
+#include <cereal/archives/json.hpp>
+
+#include <shogun/io/SGIO.h>
+#include <cstring>
+#include <fstream>
+
+using namespace shogun;
+
+TEST(Cereal, Json_SGVector_FLOAT64_load_equals_saved)
+{
+	const index_t size = 5;
+	SGVector<float64_t> a(size);
+	SGVector<float64_t> b;
+	a.range_fill(1.0);
+
+	std::string filename = std::tmpnam(nullptr);
+
+	try
+	{
+		{
+			std::ofstream os(filename.c_str());
+			cereal::JSONOutputArchive archive(os);
+			archive(a);
+		}
+
+		{
+			std::ifstream is(filename.c_str());
+			cereal::JSONInputArchive archive(is);
+			archive(b);
+		}
+	}
+	catch (std::exception& e)
+		SG_SINFO("Error code: %s \n", e.what());
+
+	EXPECT_EQ(a.size(), b.size());
+	EXPECT_EQ(a.ref_count(), b.ref_count());
+	for (index_t i = 0; i < size; i++)
+		EXPECT_NEAR(a[i], b[i], 1E-15);
+
+	remove(filename.c_str());
+}
+
+TEST(Cereal, Json_SGVector_load_equals_saved_refcounting_false)
+{
+	const index_t size = 5;
+	SGVector<float64_t> a(size, false);
+	SGVector<float64_t> b;
+	a.range_fill(1.0);
+
+	std::string filename = std::tmpnam(nullptr);
+
+	try
+	{
+		{
+			std::ofstream os(filename.c_str());
+			cereal::JSONOutputArchive archive(os);
+			archive(a);
+		}
+
+		{
+			std::ifstream is(filename.c_str());
+			cereal::JSONInputArchive archive(is);
+			archive(b);
+		}
+	}
+	catch (std::exception& e)
+		SG_SINFO("Error code: %s \n", e.what());
+
+	EXPECT_EQ(a.size(), b.size());
+	EXPECT_EQ(-1, b.ref_count());
+	for (index_t i = 0; i < size; i++)
+		EXPECT_NEAR(a[i], b[i], 1E-15);
+
+	remove(filename.c_str());
+}


### PR DESCRIPTION
I cannot directly add methods to SGVector because `Math.h` calls `SGVector.load()` during compiling and somehow it confuses cereal `load` and the old `load`, and leads to error.

In `CerealTest.h`, **only line 467 - 483** are cereal serialization. others are just copy-paste and name refactor from `SGVector.h`.
`CerealTest.cpp` is just the name refactor version of `SGVector.cpp`.
`Cereal_unittests.cc` is the save/load test case.

@vigsterkr 