### PR TITLE
Fixes #3231 Cookbook generation error using Sphinx from PyPI.

### DIFF
--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -13,6 +13,7 @@
 
 find_program(SPHINX_EXECUTABLE
              NAMES sphinx-build sphinx-build2
+             PATH /usr/local/bin
              DOC "Path to sphinx-build executable")
 
 # Handle REQUIRED and QUIET arguments


### PR DESCRIPTION
This fixes #3231 Cookbook generation error using Sphinx from PyPI.

Sphinx installed via PyPI resides in /usr/loca/bin