### PR TITLE
Fixes #3254 Cookbook generation crashes using empty meta example files.

### DIFF
--- a/examples/meta/generator/parse.py
+++ b/examples/meta/generator/parse.py
@@ -25,7 +25,7 @@ class FastParser:
         """
 
         # Add trailing endline if missing
-        if programString[-1] != "\n":
+        if len(programString) and programString[-1] != "\n":
             programString += "\n"
 
         # Parse program and add FilePath key to object


### PR DESCRIPTION
This Fixes #3254 Cookbook generation crashes using empty meta example files.