### PR TITLE
Make DoubleMatrix type available within cookbooks.

### DIFF
--- a/examples/meta/generator/targets/cpp.json
+++ b/examples/meta/generator/targets/cpp.json
@@ -45,7 +45,8 @@
         "ShortRealMatrix": "SGMatrix<float32_t>",
         "RealMatrix": "SGMatrix<float64_t>",
         "LongRealMatrix": "SGMatrix<floatmax_t>",
-        "ComplexMatrix": "SGMatrix<complex128_t>"
+        "ComplexMatrix": "SGMatrix<complex128_t>",
+        "DoubleMatrix": "SGMatrix<float64_t>"
     },
     "Expr": {
         "StringLiteral": "\"$literal\"",


### PR DESCRIPTION
This adds the DoubleMatrix type and makes it available within cookbooks.