### PR TITLE
Fixes #3261 Error in LaTeX formula for TanimotoDistance.

### DIFF
--- a/src/shogun/distance/TanimotoDistance.h
+++ b/src/shogun/distance/TanimotoDistance.h
@@ -26,7 +26,7 @@ namespace shogun
  * \f[\displaystyle
  *  d(\bf{x},\bf{x'}) = \frac{\sum_{i=1}^{n}x_{i}x'_{i}}{
  *  \sum_{i=1}^{n}x_{i}x_{i}x'_{i}x'_{i}-x_{i}x'_{i}}
- *  /quad x,x' /in R^{n}
+ *  \quad x,x' \in R^{n}
  * \f]
  *
  * @see <a href="http://en.wikipedia.org/wiki/Jaccard_index">Wikipedia:


### PR DESCRIPTION
This fixes #3261 Error in LaTeX formula for TanimotoDistance.