### PR TITLE
Automatically genereated parser files are now stored in the build dir…

### DIFF
--- a/examples/meta/CMakeLists.txt
+++ b/examples/meta/CMakeLists.txt
@@ -7,6 +7,8 @@
 # Generate type list
 # execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/generator/types/get_type_list.sh > ${CMAKE_CURRENT_SOURCE_DIR}/generator/types/typelist)
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/parser_files)
+
 # Run example generation script
 add_custom_target(meta_examples
     COMMAND ${PYTHON_EXECUTABLE}
@@ -16,6 +18,7 @@ add_custom_target(meta_examples
     -t ${CMAKE_CURRENT_SOURCE_DIR}/generator/targets
     -g ${CTAGS_FILE}
     --store-vars
+    --parser_files_dir=${CMAKE_CURRENT_BINARY_DIR}/parser_files
     COMMENT "Generating examples from meta-language"
     DEPENDS ctags)
 

--- a/examples/meta/generator/generate.py
+++ b/examples/meta/generator/generate.py
@@ -31,7 +31,8 @@ def parseCtags(filename):
 
 
 def translateExamples(inputDir, outputDir, targetsDir, ctagsFile,
-                      includedTargets=None, storeVars=False):
+                      includedTargets=None, storeVars=False,
+                      generatedFilesOutputDir=None):
 
     tags = parseCtags(ctagsFile)
     # Load all target dictionaries
@@ -62,7 +63,7 @@ def translateExamples(inputDir, outputDir, targetsDir, ctagsFile,
         # Parse the example file
         filePath = os.path.join(dirRelative, filename)
         with open(os.path.join(inputDir, dirRelative, filename), 'r') as file:
-            ast = parse(file.read(), filePath)
+            ast = parse(file.read(), filePath, generatedFilesOutputDir)
 
         # Translate ast to each target language
         for target in targets:
@@ -117,6 +118,7 @@ if __name__ == "__main__":
         'lua',
     ]
     parser.add_argument('targets', nargs='*', help="Targets to include (one or more of: %s). If not specified all targets are produced." % (' '.join(available_targets)))
+    parser.add_argument("--parser_files_dir", nargs='?', help='Path to directory where generated parser and lexer files should be stored.')
 
     args = parser.parse_args()
 
@@ -137,4 +139,5 @@ if __name__ == "__main__":
 
     translateExamples(inputDir=inputDir, outputDir=outputDir,
                       targetsDir=targetsDir, ctagsFile=ctagsFile,
-                      includedTargets=args.targets, storeVars=storeVars)
+                      includedTargets=args.targets, storeVars=storeVars,
+                      generatedFilesOutputDir=args.parser_files_dir)


### PR DESCRIPTION
…ectory.

`parse.py` and `generate.py` now have the command line option `--parser_files_dir` that allows users to specify where automatically generated parser files should be stored. When running `make meta_examples` the files are stored under `build/examples/meta/parser_files/`. If `parse.py` is run without the new command line argument, the parser is run in unoptimised mode (slower) and no parser files are generated.