### PR TITLE
add cmake guard for mkl regression cookbook

### DIFF
--- a/cmake/FindMetaExamples.cmake
+++ b/cmake/FindMetaExamples.cmake
@@ -14,5 +14,9 @@ function(find_meta_examples)
 		LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS ${CMAKE_SOURCE_DIR}/examples/meta/src/regression/linear_ridge_regression.sg)
 	ENDIF()
 
+	IF(NOT USE_SVMLIGHT)
+		LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS ${CMAKE_SOURCE_DIR}/examples/meta/src/regression/multiple_kernel_learning.sg)
+	ENDIF()
+
 	SET(META_EXAMPLES ${META_EXAMPLE_LISTINGS} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Fix for [this](http://buildbot.shogun-toolbox.org/builders/nightly_none/builds/1036/steps/compile/logs/stdio).