### PR TITLE
LinalgRefactor -  SGVector - inplace add

### DIFF
--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -95,6 +95,19 @@ public:
 	#undef BACKEND_GENERIC_ADD
 
 	/**
+	 * Wrapper method of add operation the operation result = alpha*a + beta*b.
+	 *
+	 * @see linalg::add
+	 */
+	#define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container) \
+	virtual void add(Container<Type>& a, Container<Type>& b, Type alpha, Type beta, Container<Type>& result) const \
+	{  \
+		SG_SNOTIMPLEMENTED; \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ADD, SGVector)
+	#undef BACKEND_GENERIC_IN_PLACE_ADD
+
+	/**
 	 * Wrapper method of vector dot-product that works with generic vectors.
 	 *
 	 * @see linalg::dot

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -84,6 +84,15 @@ public:
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD, SGVector)
 	#undef BACKEND_GENERIC_ADD
 
+	/** Implementation of @see LinalgBackendBase::add */
+	#define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container) \
+	virtual void add(Container<Type>& a, Container<Type>& b, Type alpha, Type beta, Container<Type>& result) const \
+	{  \
+		add_impl(a, b, alpha, beta, result); \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ADD, SGVector)
+	#undef BACKEND_GENERIC_IN_PLACE_ADD
+
 	/** Implementation of @see LinalgBackendBase::dot */
 	#define BACKEND_GENERIC_DOT(Type, Container) \
 	virtual Type dot(const Container<Type>& a, const Container<Type>& b) const \
@@ -155,6 +164,17 @@ private:
 
 		c_eig = alpha * a_eig + beta * b_eig;
 		return c;
+	}
+
+	/** Eigen3 vector result = alpha*A + beta*B method */
+	template <typename T>
+	void add_impl(SGVector<T>& a, SGVector<T>& b, T alpha, T beta, SGVector<T>& result) const
+	{
+		typename SGVector<T>::EigenVectorXtMap a_eig = a;
+		typename SGVector<T>::EigenVectorXtMap b_eig = b;
+		typename SGVector<T>::EigenVectorXtMap result_eig = result;
+
+		result_eig = alpha * a_eig + beta * b_eig;
 	}
 
 	/** Eigen3 vector dot-product method */

--- a/src/shogun/mathematics/linalg/LinalgBackendViennacl.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendViennacl.h
@@ -75,6 +75,14 @@ public:
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD, SGVector)
 	#undef BACKEND_GENERIC_ADD
 
+	#define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container) \
+	virtual void add(Container<Type>& a, Container<Type>& b, Type alpha, Type beta, Container<Type>& result) const \
+	{  \
+		add_impl(a, b, alpha, beta, result); \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ADD, SGVector)
+	#undef BACKEND_GENERIC_ADD
+
 	/** Implementation of @see LinalgBackendBase::dot */
 	#define BACKEND_GENERIC_DOT(Type, Container) \
 	virtual Type dot(const Container<Type>& a, const Container<Type>& b) const \
@@ -168,6 +176,18 @@ private:
 
 		c_gpu->data_vector(a.size()) = alpha * a_gpu->data_vector(a.size()) + beta * b_gpu->data_vector(b.size());
 		return SGVector<T>(c_gpu, a.size());
+	}
+
+	/** ViennaCL vector result = alpha*A + beta*B method */
+	template <typename T>
+	void add_impl(SGVector<T>& a, SGVector<T>& b, T alpha, T beta, SGVector<T>& result) const
+	{
+		GPUMemoryViennaCL<T>* a_gpu = cast_to_viennacl(a);
+		GPUMemoryViennaCL<T>* b_gpu = cast_to_viennacl(b);
+		GPUMemoryViennaCL<T>* result_gpu = cast_to_viennacl(result);
+
+		result_gpu->data_vector(a.size()) =
+			alpha * a_gpu->data_vector(a.size()) + beta * b_gpu->data_vector(b.size());
 	}
 
 	/** ViennaCL vector dot-product method. */

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -113,6 +113,29 @@ Container<T> add(const Container<T>& a, const Container<T>& b, T alpha=1, T beta
 }
 
 /**
+ * Performs the operation result = alpha*a + beta*b.
+ *
+ * @param a first vector
+ * @param b second vector
+ * @param result the vector that saves the result
+ * @param alpha constant to be multiplied by the first vector
+ * @param beta constant to be multiplied by the second vector
+ */
+template <typename T>
+void add(SGVector<T>& a, SGVector<T>& b, SGVector<T>& result, T alpha=1, T beta=1)
+{
+	REQUIRE(a.vlen == b.vlen, "Length of vector a (%d) doesn't match vector b (%d).\n", a.vlen, b.vlen);
+	REQUIRE(result.vlen == b.vlen, "Length of vector result (%d) doesn't match vector a (%d).\n", result.vlen, a.vlen);
+
+	REQUIRE(!(result.on_gpu()^a.on_gpu()),
+		"Cannot operate with vector result on_gpu (%d) and vector a on_gpu (%d).\n", result.on_gpu(), a.on_gpu());
+	REQUIRE(!(result.on_gpu()^b.on_gpu()),
+		"Cannot operate with vector result on_gpu (%d) and vector b on_gpu (%d).\n", result.on_gpu(), b.on_gpu());
+
+	infer_backend(a, b)->add(a, b, alpha, beta, result);
+}
+
+/**
  * Vector dot-product that works with generic vectors.
  *
  * @param a first vector

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -26,6 +26,26 @@ TEST(LinalgBackendEigen, SGVector_add)
 		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
 }
 
+TEST(LinalgBackendEigen, add_in_place)
+{
+	const float64_t alpha = 0.3;
+	const float64_t beta = -1.5;
+
+	SGVector<float64_t> A(9), B(9), C(9);
+
+	for (index_t i = 0; i < 9; ++i)
+	{
+		A[i] = i;
+		B[i] = 0.5*i;
+		C[i] = i;
+	}
+
+	add(A, B, A, alpha, beta);
+
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
+}
+
 TEST(LinalgBackendEigen, SGVector_dot)
 {
 	const index_t size = 3;

--- a/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
@@ -34,6 +34,32 @@ TEST(LinalgBackendViennaCL, SGVector_add)
 		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
 }
 
+TEST(LinalgBackendViennaCL, add_in_place)
+{
+	sg_linalg->set_gpu_backend(new LinalgBackendViennaCL());
+
+	const float32_t alpha = 0.3;
+	const float32_t beta = -1.5;
+
+	SGVector<float32_t> A(9), B(9), C(9);
+	SGVector<float32_t> A_gpu, B_gpu;
+
+	for (index_t i = 0; i < 9; ++i)
+	{
+		A[i] = i;
+		B[i] = 0.5*i;
+		C[i] = i;
+	}
+	A_gpu = to_gpu(A);
+	B_gpu = to_gpu(B);
+
+	add(A_gpu, B_gpu, A_gpu, alpha, beta);
+	A = from_gpu(A_gpu);
+
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
+}
+
 TEST(LinalgBackendViennaCL, SGVector_dot)
 {
 	sg_linalg->set_gpu_backend(new LinalgBackendViennaCL());


### PR DESCRIPTION
Ref #3387

- I was trying to merge `void add` and `SGVector<T> add` into one method by doing ` template <typename T> auto add(SGVector<T>& a, SGVector<T>& b, T alpha=1, T beta=1, bool inplace=false) -> decltype((!inplace, SGVector<T>>))`, but I got error `expected ')' -> decltype((!inplace, SGVector<T>>))`. Not sure whether this is a solvable problem or whether there's other way to do it @vigsterkr 

- `TEST(LinalgBackendViennaCL, add_in_place)` is working well(`EXPECT_NEAR` are true), but I got error: `shogun-unit-test(9457,0x7fff7166a300) malloc: *** error for object 0x7f8a138c3590: pointer being freed was not allocated` at the end. I don't know which object was freed twice. 

- I think `add(A, B, alpha, beta, inplace=T)`  is more concise than `add(A, B, A, alpha, beta)` for in-place addition mentioned in [the gist](https://gist.github.com/karlnapf/28e1ea447d3d625f2205d303599fa4ff). If so, the manual allocating case would be kinda awkward. But my question is do we really need that? @karlnapf 