### PR TITLE
Cereal serialization - Any

### DIFF
--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -442,6 +442,24 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		void save(CFile* saver);
 
+		template<class Archive>
+		void save(Archive & ar) const
+		{
+			ar(vlen);
+			for (index_t i = 0; i < vlen; ++i)
+				ar(vector[i]);
+		}
+
+		template<class Archive>
+		void load(Archive & ar)
+		{
+			unref();
+			ar(vlen);
+			vector = SG_MALLOC(T, vlen);
+			for (index_t i = 0; i < vlen; ++i)
+				ar(vector[i]);
+		}
+
 		/** Real part of a complex128_t vector */
 		SGVector<float64_t> get_real();
 

--- a/tests/unit/io/CerealObject.h
+++ b/tests/unit/io/CerealObject.h
@@ -1,0 +1,33 @@
+#include <shogun/base/SGObject.h>
+#include <shogun/lib/SGVector.h>
+
+namespace shogun
+{
+
+/** @brief Used to test the SGObject serialization */
+class CCerealObject : public CSGObject
+{
+public:
+    CCerealObject() : CSGObject()
+    {
+        init_params();
+    }
+
+	SGVector<float64_t> data()
+	{
+		return m_vector;
+	}
+
+    const char* get_name() const { return "CerealObject"; }
+
+protected:
+    void init_params()
+    {
+		m_vector = SGVector<float64_t>(5);
+		m_vector.zero();
+		register_param("test_vector", m_vector);
+    }
+
+	SGVector<float64_t> m_vector;
+};
+}

--- a/tests/unit/io/Cereal_unittest.cc
+++ b/tests/unit/io/Cereal_unittest.cc
@@ -1,0 +1,77 @@
+#include <shogun/lib/common.h>
+#include <gtest/gtest.h>
+
+#include <shogun/lib/SGVector.h>
+#include <../tests/unit/io/CerealObject.h>
+#include <cereal/archives/json.hpp>
+
+#include <fstream>
+#include <string>
+
+using namespace shogun;
+
+TEST(Cereal, Json_SGVector_FLOAT64_load_equals_saved)
+{
+	const index_t size = 5;
+	SGVector<float64_t> a(size);
+	SGVector<float64_t> b;
+	a.range_fill(1.0);
+
+	char* filename = std::tmpnam(nullptr);
+
+	try
+	{
+		{
+			std::ofstream os(filename);
+			cereal::JSONOutputArchive archive(os);
+			archive(a);
+		}
+
+		{
+			std::ifstream is(filename);
+			cereal::JSONInputArchive archive(is);
+			archive(b);
+		}
+	}
+	catch (std::exception& e)
+		SG_SINFO("Error code: %s \n", e.what());
+
+	EXPECT_EQ(a.vlen, b.vlen);
+	for (index_t i = 0; i < size; i++)
+		EXPECT_NEAR(a[i], b[i], 1E-15);
+
+	remove(filename);
+}
+
+TEST(Cereal, Json_AnyObject_load_equals_saved)
+{
+	SGVector<float64_t> vec_a(5);
+	SGVector<float64_t> vec_b(5);
+	vec_a.range_fill(0);
+	vec_b.range_fill(1);
+	Any a(vec_a);
+	Any b(vec_b);
+
+	char* filename = std::tmpnam(nullptr);
+
+	try
+	{
+		{
+			std::ofstream os(filename);
+			cereal::JSONOutputArchive archive(os);
+			archive(a);
+		}
+
+		{
+			std::ifstream is(filename);
+			cereal::JSONInputArchive archive(is);
+			archive(b);
+		}
+	}
+	catch (std::exception& e)
+		SG_SINFO("Error code: %s \n", e.what());
+
+	EXPECT_TRUE(a==b);
+
+	remove(filename);
+}


### PR DESCRIPTION
- `SGVector.h` is not updated
- `load` and `save` methods in `SGVector` class will confuse examples in examples/undocumented because they're taking similar params as old save-load methods in `SGVector` class. Most examples will fail with current methods naming. BUT so far I have found that the inheritance serialization only works with the exact "load-save" pairs so I'd keep it like this for now.
- This PR can only be merged once #3226 is finished.