### PR TITLE
Add non-owning Any policy

### DIFF
--- a/tests/unit/lib/Any_unittest.cc
+++ b/tests/unit/lib/Any_unittest.cc
@@ -91,3 +91,13 @@ TEST(Any, recall_type)
 	EXPECT_THROW(recall_type<float64_t>(any), std::logic_error);
 	EXPECT_THROW(recall_type<int32_t>(empty_any), std::logic_error);
 }
+
+TEST(Any, non_owning)
+{
+	int32_t value = 783;
+	auto any = Any::non_owning(&value);
+	EXPECT_THROW(recall_type<bool>(any), std::logic_error);
+	EXPECT_EQ(recall_type<int32_t>(any), value);
+	value = 532;
+	EXPECT_EQ(recall_type<int32_t>(any), value);
+}


### PR DESCRIPTION
This would enable us to implement SG_ADD so that
parameters are used through map
and member variables at the same time.