### PR TITLE
Meta-language: Cleaner import statements for enums in java

### DIFF
--- a/examples/meta/generator/targets/java.json
+++ b/examples/meta/generator/targets/java.json
@@ -4,7 +4,6 @@
         "IncludeAllClasses": true, 
         "IncludeEnums": true,
         "DependencyListElement": "import org.shogun.$typeName;",
-        "DependencyListElementEnum": "import static org.shogun.$typeName.$value;",
         "DependencyListSeparator": "\n"
     },
     "Statement": "$statement;\n",
@@ -77,7 +76,7 @@
         "MethodCall": "$object.$method($arguments)",
         "StaticCall": "$typeName.$method($arguments)",
         "Identifier": "$identifier",
-        "Enum":"$value"
+        "Enum":"$typeName.$value"
     },
     "Element": {
         "Access": {


### PR DESCRIPTION
Part of making enum typed variables work in the meta language. We want the statement `LIBLINEAR_SOLVER_TYPE myVar = enum LIBLINEAR_SOLVER_TYPE.L2R_L2LOSS_SVC` to translate and work in all languages.

Related to #3390
