### PR TITLE
Split number literals into int, real (64bit float), and float literals

### DIFF
--- a/examples/meta/generator/parse.py
+++ b/examples/meta/generator/parse.py
@@ -43,7 +43,9 @@ class FastParser:
     # Lexer specification
     # ---------------------------------------
     tokens = (
-        "NUMERAL",
+        "INTLITERAL",
+        "REALLITERAL",
+        "FLOATLITERAL",
         "STRINGLITERAL",
         "BOOLLITERAL",
         "BASICTYPE",
@@ -99,7 +101,9 @@ class FastParser:
         'ComplexMatrix': 'SHOGUNSGTYPE'
     }
 
-    t_NUMERAL = "[0-9]+(\.[0-9]+)?"
+    t_INTLITERAL = "[0-9]+"
+    t_REALLITERAL = "[0-9]+\.[0-9]+"
+    t_FLOATLITERAL = "[0-9]+\.[0-9]+f"
     t_STRINGLITERAL = '"[^"\n]*"'
     t_COMMA = ","
     t_DOT = "\."
@@ -208,8 +212,8 @@ class FastParser:
 
     def p_indexList(self, p):
         """
-        indexList : numeral
-                   | numeral COMMA indexList
+        indexList : int
+                  | int COMMA indexList
         """
         p[0] = [p[1]]
         if len(p) > 2:
@@ -233,9 +237,17 @@ class FastParser:
         "bool : BOOLLITERAL"
         p[0] = {"BoolLiteral": p[1]}
 
-    def p_numeral(self, p):
-        "numeral : NUMERAL"
-        p[0] = {"NumberLiteral": p[1]}
+    def p_int(self, p):
+        "int : INTLITERAL"
+        p[0] = {"IntLiteral": p[1]}
+
+    def p_real(self, p):
+        "real : REALLITERAL"
+        p[0] = {"RealLiteral": p[1]}
+
+    def p_float(self, p):
+        "float : FLOATLITERAL"
+        p[0] = {"FloatLiteral": p[1][:-1]}
 
     def p_expr(self, p):
         """
@@ -245,7 +257,9 @@ class FastParser:
              | elementAccess
              | string
              | bool
-             | numeral
+             | int
+             | real
+             | float
              | identifier
         """
         p[0] = {"Expr": p[1]}

--- a/examples/meta/generator/targets/cpp.json
+++ b/examples/meta/generator/targets/cpp.json
@@ -78,7 +78,9 @@
             "True": "true",
             "False": "false"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "${number}f",
         "MethodCall": "$object->$method($arguments)",
         "StaticCall": "C$typeName::$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/csharp.json
+++ b/examples/meta/generator/targets/csharp.json
@@ -67,7 +67,9 @@
             "True": "true",
             "False": "false"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "${number}f",
         "MethodCall": "$object.$method($arguments)",
         "StaticCall": "$typeName.$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/java.json
+++ b/examples/meta/generator/targets/java.json
@@ -4,6 +4,7 @@
         "IncludeAllClasses": true, 
         "IncludeEnums": true,
         "DependencyListElement": "import org.shogun.$typeName;",
+        "DependencyListElementEnum": "import static org.shogun.$typeName.$value;",
         "DependencyListSeparator": "\n"
     },
     "Statement": "$statement;\n",
@@ -72,11 +73,13 @@
             "True": "true",
             "False": "false"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "${number}f",
         "MethodCall": "$object.$method($arguments)",
         "StaticCall": "$typeName.$method($arguments)",
         "Identifier": "$identifier",
-        "Enum":"$typeName.$value"
+        "Enum":"$value"
     },
     "Element": {
         "Access": {

--- a/examples/meta/generator/targets/lua.json
+++ b/examples/meta/generator/targets/lua.json
@@ -16,7 +16,9 @@
             "True": "True",
             "False": "False"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "$number",
         "MethodCall": "$object:$method($arguments)",
         "StaticCall": "$typeName:$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/octave.json
+++ b/examples/meta/generator/targets/octave.json
@@ -36,7 +36,9 @@
             "True": "true",
             "False": "false"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "$number",
         "MethodCall": "$object.$method($arguments)",
         "StaticCall": "$typeName.$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/python.json
+++ b/examples/meta/generator/targets/python.json
@@ -44,7 +44,9 @@
             "True": "True",
             "False": "False"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "$number",
         "MethodCall": "$object.$method($arguments)",
         "StaticCall": "$typeName.$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/r.json
+++ b/examples/meta/generator/targets/r.json
@@ -16,7 +16,9 @@
             "True": "TRUE",
             "False": "FALSE"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "$number",
         "MethodCall": "$object$$$method($arguments)",
         "StaticCall": "$typeName$$$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/ruby.json
+++ b/examples/meta/generator/targets/ruby.json
@@ -38,7 +38,9 @@
             "True": "1",
             "False": "0"
         },
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "$number",
         "MethodCall": "$object.$method $arguments",
         "StaticCall": "Modshogun::$typeName.$method $arguments",
         "Identifier": "$identifier",

--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -158,7 +158,7 @@ class Translator:
             "Expr": {"StringLiteral": "{}.dat".format(programName)}
         }
         # 'w'
-        storageFilemode = {"Expr": {"NumberLiteral": "119"}}
+        storageFilemode = {"Expr": {"IntLiteral": "119"}}
         storageComment = {"Comment": " Serialize output for integration testing (automatically generated)"}
         storageInit = {"Init": [{"ObjectType": "WrappedObjectArray"},
                                 {"Identifier": storage},
@@ -363,7 +363,7 @@ class Translator:
                 {"MethodCall": [identifierAST, identifierAST, argumentListAST]}
                 {"BoolLiteral": "False"}
                 {"StringLiteral": "train.dat"}
-                {"NumberLiteral": 4}
+                {"IntLiteral": 4}
                 {"Identifier": "feats_test"}
                 etc.
         """
@@ -410,8 +410,16 @@ class Translator:
             template = Template(self.targetDict["Expr"]["StringLiteral"])
             return template.substitute(literal=expr[key])
 
-        elif key == "NumberLiteral":
-            template = Template(self.targetDict["Expr"]["NumberLiteral"])
+        elif key == "IntLiteral":
+            template = Template(self.targetDict["Expr"]["IntLiteral"])
+            return template.substitute(number=expr[key])
+
+        elif key == "RealLiteral":
+            template = Template(self.targetDict["Expr"]["RealLiteral"])
+            return template.substitute(number=expr[key])
+
+        elif key == "FloatLiteral":
+            template = Template(self.targetDict["Expr"]["FloatLiteral"])
             return template.substitute(number=expr[key])
 
         elif key == "Identifier":
@@ -507,17 +515,12 @@ class Translator:
     def translateIndexList(self, indexList):
         """ Translate index list AST
         Args:
-            indexList: object like [NumberLiteralAST, NumberLiteralAST, ..]
+            indexList: object like [IntLiteralAST, IntLiteralAST, ..]
         """
         addOne = not self.targetDict["Element"]["ZeroIndexed"]
         translation = ""
-        for idx, numberLiteral in enumerate(indexList):
-            try:
-                index = int(numberLiteral["NumberLiteral"])
-            except ValueError:
-                raise TranslationFailure("Indices of element access must be "
-                                         "integers.\n Error in literal: " +
-                                         str(numberLiteral["NumberLiteral"]))
+        for idx, intLiteral in enumerate(indexList):
+            index = int(intLiteral["IntLiteral"])
 
             if addOne:
                 index += 1


### PR DESCRIPTION
We need to specify precision of floating point literals because C# is very strict about downcasting these.

Fixes problem in #3390