### PR TITLE
Fix literal types of meta examples

### DIFF
--- a/examples/meta/src/binary_classifier/kernel_svm.sg
+++ b/examples/meta/src/binary_classifier/kernel_svm.sg
@@ -11,7 +11,7 @@ BinaryLabels labels_test(f_labels_test)
 #![create_features]
 
 #![set_parameters]
-real C = 1
+real C = 1.0
 real epsilon = 0.001
 GaussianKernel gauss_kernel(features_train, features_train, 15)
 #![set_parameters]

--- a/examples/meta/src/binary_classifier/linear_svm.sg
+++ b/examples/meta/src/binary_classifier/linear_svm.sg
@@ -11,7 +11,7 @@ BinaryLabels labels_test(f_labels_test)
 #![create_features]
 
 #![set_parameters]
-real C = 1
+real C = 1.0
 real epsilon = 0.001
 #![set_parameters]
 

--- a/examples/meta/src/gaussian_processes/gaussian_process_classifier.sg
+++ b/examples/meta/src/gaussian_processes/gaussian_process_classifier.sg
@@ -12,7 +12,7 @@ MulticlassLabels labels_test(f_labels_test)
 #![create_features]
 
 #![create_appropriate_kernel_and_mean_function]
-GaussianKernel kernel(2)
+GaussianKernel kernel(2.0)
 ConstMean mean_function()
 #![create_appropriate_kernel_and_mean_function]
 

--- a/examples/meta/src/gaussian_processes/gaussian_process_regression.sg
+++ b/examples/meta/src/gaussian_processes/gaussian_process_regression.sg
@@ -11,7 +11,7 @@ RegressionLabels labels_test(f_labels_test)
 #![create_features]
 
 #![create_appropriate_kernel_and_mean_function]
-real width = 1
+real width = 1.0
 GaussianKernel kernel(features_train, features_train, width)
 ZeroMean mean_function()
 #![create_appropriate_kernel_and_mean_function]

--- a/examples/meta/src/meta_api/matrix_types.sg
+++ b/examples/meta/src/meta_api/matrix_types.sg
@@ -24,8 +24,8 @@ long_int_matrix[1,0]=1
 long_int_matrix[0,0]=long_int_matrix[1,0]
 
 ShortRealMatrix short_real_matrix(2,1)
-short_real_matrix[0,0]=0
-short_real_matrix[1,0]=1
+short_real_matrix[0,0]=0.0f
+short_real_matrix[1,0]=1.0f
 short_real_matrix[0,0]=short_real_matrix[1,0]
 
 RealMatrix real_matrix(2,1)

--- a/examples/meta/src/meta_api/vector_types.sg
+++ b/examples/meta/src/meta_api/vector_types.sg
@@ -24,8 +24,8 @@ long_int_vector[1]=1
 long_int_vector[0]=long_int_vector[1]
 
 ShortRealVector short_real_vector(2)
-short_real_vector[0]=0
-short_real_vector[1]=1
+short_real_vector[0]=0.0f
+short_real_vector[1]=1.0f
 short_real_vector[0]=short_real_vector[1]
 
 RealVector real_vector(2)

--- a/examples/meta/src/multiclass_classifier/svm.sg
+++ b/examples/meta/src/multiclass_classifier/svm.sg
@@ -11,7 +11,7 @@ MulticlassLabels labels_test(f_labels_test)
 #![create_features]
 
 #![set_parameters]
-real C = 1
+real C = 1.0
 real epsilon = 0.0001
 GaussianKernel gauss_kernel(features_train, features_train, 15)
 #![set_parameters]

--- a/examples/meta/src/neural_nets/feedforward_net_regression.sg
+++ b/examples/meta/src/neural_nets/feedforward_net_regression.sg
@@ -30,7 +30,7 @@ network.initialize_neural_network()
 #![set_parameters]
 network.set_l2_coefficient(0.1)
 network.set_max_num_epochs(40)
-network.set_epsilon(0)
+network.set_epsilon(0.0)
 network.set_gd_learning_rate(0.1)
 network.set_gd_momentum(0.9)
 #![set_parameters]

--- a/examples/meta/src/regression/kernel_ridge_regression.sg
+++ b/examples/meta/src/regression/kernel_ridge_regression.sg
@@ -11,7 +11,7 @@ RegressionLabels labels_test(f_labels_test)
 #![create_features]
 
 #![create_appropriate_kernel]
-real width = 1
+real width = 1.0
 GaussianKernel kernel(features_train, features_train, width)
 #![create_appropriate_kernel]
 

--- a/examples/meta/src/regression/multiple_kernel_learning.sg
+++ b/examples/meta/src/regression/multiple_kernel_learning.sg
@@ -12,8 +12,8 @@ RegressionLabels labels_test(f_labels_test)
 
 #![create_kernel]
 PolyKernel poly_kernel(10,2)
-GaussianKernel gauss_kernel_1(2)
-GaussianKernel gauss_kernel_2(3)
+GaussianKernel gauss_kernel_1(2.0)
+GaussianKernel gauss_kernel_2(3.0)
 #![create_kernel]
 
 #![create_combined_train]

--- a/examples/meta/src/regression/support_vector_regression.sg
+++ b/examples/meta/src/regression/support_vector_regression.sg
@@ -11,12 +11,12 @@ RegressionLabels labels_test(f_labels_test)
 #![create_features]
 
 #![create_appropriate_kernel]
-real width = 1
+real width = 1.0
 GaussianKernel kernel(width)
 #![create_appropriate_kernel]
 
 #![create_instance]
-real svm_c = 1
+real svm_c = 1.0
 real svr_param = 0.1
 LibSVR svr(svm_c, svr_param, kernel, labels_train, enum LIBSVR_SOLVER_TYPE.LIBSVR_EPSILON_SVR)
 #![create_instance]


### PR DESCRIPTION
These changes were originally part of #3410

I have split this into another PR since it's a slightly tricky merge. This PR will only pass once  #3410 and shogun-toolbox/shogun-data#121 are merged. Note that merging the new integration test data will temporarily make the tests fail until this PR is merged.