### PR TITLE
Cereal serialization - Minor updates on unittests and cereal::nvps

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -223,21 +223,21 @@ void CSGObject::save_binary(const char* filename) const
 {
 	std::ofstream os(filename);
 	cereal::BinaryOutputArchive archive(os);
-	archive(*this);
+	archive(cereal::make_nvp(this->get_name(), *this));
 }
 
 void CSGObject::save_json(const char* filename) const
 {
 	std::ofstream os(filename);
 	cereal::JSONOutputArchive archive(os);
-	archive(*this);
+	archive(cereal::make_nvp(this->get_name(), *this));
 }
 
 void CSGObject::save_xml(const char* filename) const
 {
 	std::ofstream os(filename);
 	cereal::XMLOutputArchive archive(os);
-	archive(*this);
+	archive(cereal::make_nvp(this->get_name(), *this));
 }
 
 void CSGObject::load_binary(const char* filename)

--- a/src/shogun/lib/SGReferencedData.cpp
+++ b/src/shogun/lib/SGReferencedData.cpp
@@ -123,7 +123,8 @@ template<class Archive>
 void SGReferencedData::cereal_save(Archive & ar) const
 {
 	if (m_refcount != NULL)
-		ar(cereal::make_nvp("ref_counting", true), m_refcount->ref_count());
+		ar(cereal::make_nvp("ref_counting", true),
+		   cereal::make_nvp("refcount number", m_refcount->ref_count()));
 	else
 		ar(cereal::make_nvp("ref_counting", false));
 }

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -888,7 +888,7 @@ template<class T>
 template<class Archive>
 void SGVector<T>::cereal_save(Archive & ar) const
 {
-	ar(cereal::base_class<SGReferencedData>(this));
+	ar(cereal::make_nvp("ReferencedData", cereal::base_class<SGReferencedData>(this)));
 	ar(cereal::make_nvp("length", vlen));
 	for (index_t i = 0; i < vlen; ++i)
 		ar(vector[i]);

--- a/tests/unit/io/CerealObject.h
+++ b/tests/unit/io/CerealObject.h
@@ -8,23 +8,27 @@ namespace shogun
 class CCerealObject : public CSGObject
 {
 public:
-	CCerealObject() : CSGObject()
+	// Construct CCerealObject from input SGVector
+	CCerealObject(SGVector<float64_t> vec) : CSGObject()
 	{
+		m_vector = vec;
 		init_params();
 	}
 
-	SGVector<float64_t> data()
+	// Default constructor
+	CCerealObject() : CSGObject()
 	{
-		return m_vector;
+		m_vector = SGVector<float64_t>(5);
+		m_vector.set_const(0);
+		init_params();
 	}
 
 	const char* get_name() const { return "CerealObject"; }
 
 protected:
+	// Register m_vector to parameter list with name(tag) "test_vector"
 	void init_params()
 	{
-		m_vector = SGVector<float64_t>(5);
-		m_vector.set_const(0);
 		register_param("test_vector", m_vector);
 	}
 

--- a/tests/unit/io/Cereal_unittest.cc
+++ b/tests/unit/io/Cereal_unittest.cc
@@ -190,15 +190,14 @@ TEST(Cereal, Json_AnyObject_load_equals_saved)
 
 TEST(Cereal, Json_CerealObject_load_equals_saved)
 {
-	CCerealObject obj_save;
-	CCerealObject obj_load;
 	SGVector<float64_t> A(5);
-	SGVector<float64_t> B(5);
 	A.range_fill(0);
+	SGVector<float64_t> B(5);
+	CCerealObject obj_save(A);
+	CCerealObject obj_load;
 
 	std::string filename = std::tmpnam(nullptr);
 
-	obj_save.set("test_vector", A);
 	obj_save.save_json(filename.c_str());
 
 	obj_load.load_json(filename.c_str());


### PR DESCRIPTION
- Improved `CCerealObject` for more concise unittest
- Added `cereal::nvp` to some `save` methods for the readability.

Now the JSON serialization output of `CCerealObject` would be:
```
{
    "CerealObject": {
        "test_vector": {
            "value0": 2,
            "value1": 12,
            "value2": {
                "ReferencedData": {
                    "ref_counting": true,
                    "refcount number": 3
                },
                "length": 5,
                "value0": 0,
                "value1": 1,
                "value2": 2,
                "value3": 3,
                "value4": 4
            }
        }
    }
}
```
@vigsterkr 