### PR TITLE
Fix ROC evaluation to properly access binary labels

### DIFF
--- a/src/shogun/evaluation/ROCEvaluation.cpp
+++ b/src/shogun/evaluation/ROCEvaluation.cpp
@@ -19,15 +19,16 @@ CROCEvaluation::~CROCEvaluation()
 
 float64_t CROCEvaluation::evaluate(CLabels* predicted, CLabels* ground_truth)
 {
-	return evaluate_roc(predicted,ground_truth);
+	REQUIRE(predicted->get_label_type()==LT_BINARY, "ROC evalution requires binary labels.");
+	REQUIRE(ground_truth->get_label_type()==LT_BINARY, "ROC evalution requires binary labels.");
+
+	return evaluate_roc((CBinaryLabels*)predicted,(CBinaryLabels*)ground_truth);
 }
 
-float64_t CROCEvaluation::evaluate_roc(CLabels* predicted, CLabels* ground_truth)
+float64_t CROCEvaluation::evaluate_roc(CBinaryLabels* predicted, CBinaryLabels* ground_truth)
 {
 	ASSERT(predicted && ground_truth)
 	ASSERT(predicted->get_num_labels()==ground_truth->get_num_labels())
-	ASSERT(predicted->get_label_type()==LT_BINARY)
-	ASSERT(ground_truth->get_label_type()==LT_BINARY)
 	ground_truth->ensure_valid();
 
 	// assume threshold as negative infinity
@@ -76,7 +77,7 @@ float64_t CROCEvaluation::evaluate_roc(CLabels* predicted, CLabels* ground_truth
 	// get total numbers of positive and negative labels
 	for(i=0; i<length; i++)
 	{
-		if (ground_truth->get_value(i) >= 0)
+		if (ground_truth->get_label(i) >= 0)
 			pos_count++;
 		else
 			neg_count++;
@@ -106,7 +107,7 @@ float64_t CROCEvaluation::evaluate_roc(CLabels* predicted, CLabels* ground_truth
 
 		m_thresholds[i]=threshold;
 
-		if (ground_truth->get_value(idxs[i]) > 0)
+		if (ground_truth->get_label(idxs[i]) > 0)
 			tp+=1.0;
 		else
 			fp+=1.0;

--- a/src/shogun/evaluation/ROCEvaluation.h
+++ b/src/shogun/evaluation/ROCEvaluation.h
@@ -80,7 +80,7 @@ protected:
 	 * @param ground_truth labels assumed to be correct
 	 * @return auROC
 	 */
-	float64_t evaluate_roc(CLabels* predicted, CLabels* ground_truth);
+	float64_t evaluate_roc(CBinaryLabels* predicted, CBinaryLabels* ground_truth);
 
 protected:
 

--- a/src/shogun/transfer/multitask/MultitaskROCEvaluation.cpp
+++ b/src/shogun/transfer/multitask/MultitaskROCEvaluation.cpp
@@ -58,6 +58,12 @@ void CMultitaskROCEvaluation::set_indices(SGVector<index_t> indices)
 
 float64_t CMultitaskROCEvaluation::evaluate(CLabels* predicted, CLabels* ground_truth)
 {
+	REQUIRE(predicted->get_label_type()==LT_BINARY, "ROC evalution requires binary labels.");
+	REQUIRE(ground_truth->get_label_type()==LT_BINARY, "ROC evalution requires binary labels.");
+
+        CBinaryLabels* predicted_binary = (CBinaryLabels*)predicted;
+        CBinaryLabels* ground_truth_binary = (CBinaryLabels*)ground_truth;
+
 	//SG_SPRINT("Evaluate\n")
 	predicted->remove_all_subsets();
 	ground_truth->remove_all_subsets();
@@ -68,7 +74,7 @@ float64_t CMultitaskROCEvaluation::evaluate(CLabels* predicted, CLabels* ground_
 		//m_tasks_indices[t].display_vector();
 		predicted->add_subset(m_tasks_indices[t]);
 		ground_truth->add_subset(m_tasks_indices[t]);
-		result += evaluate_roc(predicted,ground_truth)/m_tasks_indices[t].vlen;
+		result += evaluate_roc(predicted_binary,ground_truth_binary)/m_tasks_indices[t].vlen;
 		predicted->remove_subset();
 		ground_truth->remove_subset();
 	}


### PR DESCRIPTION
ROC evaluation accesses uninitialized memory via CLabel::get_value() instead of the actual labels via CBinaryLabel::get_label().

I added the typecasts after checking the label type and replaced the function calls.
