### PR TITLE
Javascript support added to meta_examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,9 @@ $RECYCLE.BIN/
 # -*- mode: gitignore; -*-
 # -*- coding: utf-8 -*-
 # vim: set fileencoding=utf-8
+
+# IntelliJ
+.idea/
+
+# VS Code
+.vscode/

--- a/examples/README
+++ b/examples/README
@@ -8,3 +8,31 @@ examples can then be found in the "documented" directory.
 
 Note that in the (un)documented directories a symbolic link to a number of data
 sets contained "data" is required to run the examples.
+
+
+---
+
+What do I need to install to develop examples/meta on OSX?
+
+```
+
+# install the following packages
+brew install cmake ccache ctags swig eigen homebrew/science/nlopt
+
+# change dir to shogun
+cd /path/to/shogun-toolbox/shogun/
+
+# make sure you're on develop branch
+git checkout develop
+
+# create build dir and cd
+mkdir build && cd build/
+
+# cmake
+cmake ..
+
+# ctags and meta_examples
+make ctags
+make meta_examples
+
+```

--- a/examples/meta/generator/generate.py
+++ b/examples/meta/generator/generate.py
@@ -109,13 +109,14 @@ if __name__ == "__main__":
                         action='store_true')
     available_targets = [
         'cpp',
-        'python',
-        'java',
-        'r',
-        'octave',
         'csharp',
-        'ruby',
+        'java',
+        'javascript',
         'lua',
+        'octave',
+        'python',
+        'r',
+        'ruby'
     ]
     parser.add_argument('targets', nargs='*', help="Targets to include (one or more of: %s). If not specified all targets are produced." % (' '.join(available_targets)))
     parser.add_argument("--parser_files_dir", nargs='?', help='Path to directory where generated parser and lexer files should be stored.')

--- a/examples/meta/generator/targets/java.json
+++ b/examples/meta/generator/targets/java.json
@@ -21,7 +21,7 @@
         "ShortRealVector": "DoubleMatrix $name = new DoubleMatrix($arguments)",
         "RealVector": "DoubleMatrix $name = new DoubleMatrix($arguments)",
         "LongRealVector": "DoubleMatrix $name = new DoubleMatrix($arguments)",
-        "BoolMatrix": "DoubleMatrix $name = new DoubleMatrix($arguments)",
+        "BoolMatrix": "DoubleMatrix $name = new DoubleMatrix($n, $m)",
         "CharMatrix": "DoubleMatrix $name = new DoubleMatrix($arguments)",
         "ByteMatrix": "DoubleMatrix $name = new DoubleMatrix($arguments)",
         "WordMatrix": "DoubleMatrix $name = new DoubleMatrix($arguments)",

--- a/examples/meta/generator/targets/javascript.json
+++ b/examples/meta/generator/targets/javascript.json
@@ -1,0 +1,66 @@
+{
+    "Program": "var shogun = require('shogun-node');\nvar ndarray = require('ndarray');\n\n$dependencies\n\n$program",
+    "Dependencies": {
+        "IncludeAllClasses": true,
+        "IncludeEnums": true,
+        "DependencyListElement": "var $typeName = shogun.$typeName;",
+        "DependencyListSeparator": "\n"
+    },
+    "Statement": "$statement;\n",
+    "Comment": "// $comment\n",
+    "Init": {
+        "Construct": "var $name = new $typeName($arguments)",
+        "Copy": "var $name = $expr",
+        "BoolVector": "var $name = new Array($arguments)",
+        "CharVector": "var $name = new UInt8Array($arguments)",
+        "ByteVector": "var $name = new UInt8Array($arguments)",
+        "WordVector": "var $name = new UInt16Array($arguments)",
+        "IntVector": "var $name = new Int32Array($arguments)",
+        "LongIntVector": "var $name = new Array($arguments)",
+        "ULongIntVector": "var $name = new Array($arguments)",
+        "ShortRealVector": "var $name = new Float32Array($arguments)",
+        "RealVector": "var $name = new Float64Array($arguments)",
+
+        "BoolMatrix": "var $name = ndarray(new Array($n*$m), [$n, $m])",
+        "CharMatrix": "var $name = ndarray(new UInt8Array($n*$m), [$n, $m])",
+        "ByteMatrix": "var $name = ndarray(new UInt8Array($n*$m), [$n, $m])",
+        "WordMatrix": "var $name = ndarray(new UInt16Array($n*$m), [$n, $m])",
+        "IntMatrix": "var $name = ndarray(new Int32Array($n*$m), [$n, $m])",
+        "LongIntMatrix": "var $name = ndarray(new Array($n*$m), [$n, $m])",
+        "ULongIntMatrix": "var $name = ndarray(new Array($n*$m), [$n, $m])",
+        "ShortRealMatrix": "var $name = ndarray(new Float32Array($n*$m), [$n, $m])",
+        "RealMatrix": "var $name = ndarray(new Float64Array($n*$m), [$n, $m])"
+    },
+    "Assign": "$identifier = $expr",
+    "Type": {
+        "Default": "$typeName"
+    },
+    "Expr": {
+        "StringLiteral": "\"$literal\"",
+        "BoolLiteral": {
+            "True": "true",
+            "False": "false"
+        },
+        "IntLiteral": "$number",
+        "RealLiteral": "$number",
+        "FloatLiteral": "$number",
+        "MethodCall": "$object.$method($arguments)",
+        "StaticCall": "$typeName.$method($arguments)",
+        "Identifier": "$identifier",
+        "Enum": "$typeName.$value"
+    },
+    "Element": {
+        "Access": {
+            "Vector": "$identifier[$indices]",
+            "Matrix": "$identifier.get($indices)"
+        },
+        "Assign": {
+            "Vector": "$identifier[$indices] = $expr",
+            "Matrix": "$identifier.set($indices, $expr)"
+        },
+        "ZeroIndexed": true
+    },
+    "Print": "console.log($expr)",
+    "OutputDirectoryName": "javascript",
+    "FileExtension": ".js"
+}

--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -123,6 +123,7 @@ class Translator:
                                    varsToStore)
 
         targetProgram = ""
+
         for line in program["Program"]:
             try:
                 if "Statement" in line:
@@ -343,7 +344,16 @@ class Translator:
             # Optional custom SGType construction
             if typeKey == "ShogunSGType"\
                and init[0][typeKey] in self.targetDict["Init"]:
-                template = Template(self.targetDict["Init"][init[0][typeKey]])
+                origExpr = self.targetDict["Init"][init[0][typeKey]]
+                template = Template(origExpr)
+
+                if 'Matrix' in typeString\
+                    and '$n' in origExpr and '$m' in origExpr:
+                    argsList = initialisation["ArgumentList"]
+                    return template.substitute(name=nameString,
+                                               typeName=typeString,
+                                               n=self.translateArgumentList(argsList[0]),
+                                               m=self.translateArgumentList(argsList[1]))
 
             argsString = self.translateArgumentList(initialisation["ArgumentList"])
             return template.substitute(name=nameString,
@@ -576,7 +586,7 @@ if __name__ == "__main__":
     parser.add_argument("-t",
                         "--target",
                         nargs='?',
-                        help="Translation target. Possible values: cpp, python, java, r, octave, csharp, ruby, lua. (default: python)")
+                        help="Translation target. Possible values: cpp, python, java, javascript, r, octave, csharp, ruby, lua. (default: python)")
     parser.add_argument("path",
                         nargs='?',
                         help="Path to input file. If not specified input is read from stdin")


### PR DESCRIPTION
Added .gitignore entries for IntelliJ and VSCode;
Javascript (ES2015) meta description, for *Vector and *Matrix inits;
scijs ndarray dependency added;
meta def + translate.py prepared to handle <, >-type matrix definitions;