### PR TITLE
Modular support for nystrom class

### DIFF
--- a/src/interfaces/modular/Regression.i
+++ b/src/interfaces/modular/Regression.i
@@ -12,6 +12,7 @@
 /* Remove C Prefix */
 %rename(Regression) CRegression;
 %rename(KernelRidgeRegression) CKernelRidgeRegression;
+%rename(KRRNystrom) CKRRNystrom;
 %rename(LinearRidgeRegression) CLinearRidgeRegression;
 %rename(LeastSquaresRegression) CLeastSquaresRegression;
 %rename(LeastAngleRegression) CLeastAngleRegression;
@@ -28,6 +29,7 @@
 /* Include Class Headers to make them visible from within the target language */
 %include <shogun/regression/Regression.h>
 %include <shogun/regression/KernelRidgeRegression.h>
+%include <shogun/regression/KRRNystrom.h>
 %include <shogun/regression/LinearRidgeRegression.h>
 %include <shogun/regression/LeastSquaresRegression.h>
 %include <shogun/regression/LeastAngleRegression.h>

--- a/src/interfaces/modular/Regression_includes.i
+++ b/src/interfaces/modular/Regression_includes.i
@@ -4,6 +4,7 @@
  #include <shogun/machine/KernelMachine.h>
  #include <shogun/regression/GaussianProcessRegression.h>
  #include <shogun/regression/KernelRidgeRegression.h>
+ #include <shogun/regression/KRRNystrom.h>
  #include <shogun/regression/LinearRidgeRegression.h>
  #include <shogun/regression/LeastSquaresRegression.h>
  #include <shogun/regression/LeastAngleRegression.h>


### PR DESCRIPTION
Had to place SWIG lines after KernelRidgeRegression, since it is a parent class.