### PR TITLE
Meta csharp bool vector

### DIFF
--- a/examples/meta/generator/targets/csharp.json
+++ b/examples/meta/generator/targets/csharp.json
@@ -5,7 +5,6 @@
     "Init": {
         "Construct": "$typeName $name = new $typeName($arguments)",
         "Copy": "$typeName $name = $expr",
-        "BoolVector": "var $name = new bool[$arguments]",
         "CharVector": "var $name = new char[$arguments]",
         "ByteVector": "var $name = new byte[$arguments]",
         "WordVector": "var $name = new ushort[$arguments]",
@@ -36,7 +35,6 @@
         "int": "int",
         "float": "float",
         "real": "double",
-        "BoolVector": "bool[]",
         "CharVector": "char[]",
         "ByteVector": "byte[]",
         "WordVector": "ushort[]",
@@ -78,11 +76,13 @@
     "Element": {
         "Access": {
             "Vector": "$identifier[$indices]",
-            "Matrix": "$identifier[$indices]"
+            "Matrix": "$identifier[$indices]",
+            "BoolVector": "$identifier.get_element($indices)"
         },
         "Assign": {
             "Vector": "$identifier[$indices] = $expr",
-            "Matrix": "$identifier[$indices] = $expr"
+            "Matrix": "$identifier[$indices] = $expr",
+            "BoolVector": "$identifier.set_element($expr, $indices)"
         },
         "ZeroIndexed": true
     },

--- a/examples/meta/generator/targets/doc.js
+++ b/examples/meta/generator/targets/doc.js
@@ -189,7 +189,17 @@
         },
 
         // Keywords: $number
-        "NumberLiteral": "$number",
+        "IntLiteral": "$number",
+
+        /** 64bit float. Keywords:
+         * $number
+         */
+        "RealLiteral": "$number",
+
+        /** 32bit float. Keywords:
+         * $number
+         */
+        "FloatLiteral": "${number}f",
 
         /** Keywords:
          * $object: name of the object
@@ -223,7 +233,10 @@
              * $indices: single index or pair of indices
              */
             "Vector": "$identifier.get($indices)",
-            "Matrix": "$identifier.get($indices)"
+            "Matrix": "$identifier.get($indices)",
+
+            // Rules for specific vector/matrix types can also be specified
+            "BoolVector": "$identifier.bool_getter($indices)"
         },
         "Assign": {
             /** Keywords:
@@ -232,7 +245,10 @@
              * $expr: expression to assign to matrix/vector element
              */
             "Vector": "$identifier.put($indices, $expr)",
-            "Matrix": "$identifier.put($indices, $expr)"
+            "Matrix": "$identifier.put($indices, $expr)",
+
+            // Rules for specific vector/matrix types can also be specified
+            "BoolVector": "$identifier.bool_setter($indices, $expr)"
         },
 
         /** Is the target language zero-indexed?


### PR DESCRIPTION
Adds interface for translations of element getters/setters on specific vector and matrix types. E.g. a `BoolVector` can now have a separate translation rule from all other vector types.

This change requires the translation code to keep track of the type of initialised objects. I have therefore also added some basic type checking assertions on assignments and method calls. This may help catch typos etc when writing meta examples.