### PR TITLE
Add cosine-distance meta example

### DIFF
--- a/doc/cookbook/source/examples/distance/cosine.rst
+++ b/doc/cookbook/source/examples/distance/cosine.rst
@@ -1,0 +1,39 @@
+==================
+Cosine	 Distance
+==================
+
+The Cosine distance for real valued features is the similarity between two vectors by finding their angle.
+
+.. math::
+
+    d({\bf x},{\bf x'})= 1-\frac{{\bf x^\top x'}}{\sqrt{\sum_{i=1}^{d}{\bf {x_i}^2}\sum_{i=1}^{d}{\bf {x'_i}^2}}}
+
+where :math:`\bf x` and :math:`\bf x'` are :math:`d` dimensional feature vectors.
+
+-------
+Example
+-------
+
+Imagine we have files with data. We create CDenseFeatures (here 64 bit floats aka RealFeatures) as
+
+.. sgexample:: cosine.sg:create_features
+
+We create an instance of :sgclass:`CCosineDistance` by passing it :sgclass:`CDenseFeatures`.
+
+.. sgexample:: cosine.sg:create_instance
+
+The distance matrix can be extracted as follows:
+
+.. sgexample:: cosine.sg:extract_distance
+
+We can use the same instance with new :sgclass:`CDenseFeatures` to compute asymmetrical distance as follows:
+
+.. sgexample:: cosine.sg:refresh_distance
+
+----------
+References
+----------
+:wiki:`Cosine_distance`
+
+.. bibliography:: ../../references.bib
+    :filter: docname in docnames

--- a/examples/meta/src/distance/cosine.sg
+++ b/examples/meta/src/distance/cosine.sg
@@ -1,0 +1,20 @@
+CSVFile f_feats_a("../../data/fm_train_real.dat")
+CSVFile f_feats_b("../../data/fm_test_real.dat")
+
+#![create_features]
+RealFeatures features_a(f_feats_a)
+RealFeatures features_b(f_feats_b)
+#![create_features]
+
+#![create_instance]
+CosineDistance distance(features_a, features_a)
+#![create_instance]
+
+#![extract_distance]
+RealMatrix distance_matrix_aa = distance.get_distance_matrix()
+#![extract_distance]
+
+#![refresh_distance]
+distance.init(features_a, features_b)
+RealMatrix distance_matrix_ab = distance.get_distance_matrix()
+#![refresh_distance]


### PR DESCRIPTION
Added **cosine.sg** and **cosine.rst** to create meta examples for distance-cosine and generated cookbook for distance-cosine.