### PR TITLE
Fix Debug msg that was not continued to debug output

### DIFF
--- a/src/shogun/kernel/string/CommUlongStringKernel.cpp
+++ b/src/shogun/kernel/string/CommUlongStringKernel.cpp
@@ -239,7 +239,7 @@ bool CCommUlongStringKernel::init_optimization(
 		add_to_normal(IDX[i], weights[i]);
 	}
 
-	SG_PRINT("Done.         \n")
+	SG_DEBUG("Done.         \n")
 
 	set_is_initialized(true);
 	return true;


### PR DESCRIPTION
CommUlongStringKernel was producing "Done." messages on the console