### PR TITLE
fix invalid use of pre-declared class (#3459)

### DIFF
--- a/src/shogun/CMakeLists.txt
+++ b/src/shogun/CMakeLists.txt
@@ -26,6 +26,9 @@ IF (PROTOBUF_FOUND)
 	ENDFOREACH()
 ENDIF()
 
+list(SORT LIBSHOGUN_SRC)
+list(SORT LIBSHOGUN_HEADERS)
+
 # add target to compile the libshogun sources
 add_library(libshogun OBJECT ${LIBSHOGUN_SRC} base/class_list.cpp)
 set_target_properties(libshogun PROPERTIES

--- a/src/shogun/kernel/Kernel.h
+++ b/src/shogun/kernel/Kernel.h
@@ -30,10 +30,6 @@
 
 namespace shogun
 {
-	class CFile;
-	class CFeatures;
-	class CKernelNormalizer;
-
 #ifdef USE_SHORTREAL_KERNELCACHE
 	/** kernel cache element */
 	typedef float32_t KERNELCACHE_ELEM;

--- a/src/shogun/kernel/normalizer/KernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/KernelNormalizer.h
@@ -13,7 +13,6 @@
 
 #include <shogun/lib/config.h>
 
-#include <shogun/kernel/Kernel.h>
 #include <shogun/base/Parameter.h>
 
 namespace shogun
@@ -117,4 +116,6 @@ class CKernelNormalizer : public CSGObject
 		ENormalizerType m_type;
 };
 }
+
+#include <shogun/kernel/Kernel.h>
 #endif


### PR DESCRIPTION
This should possibly fix #3459.  We don't need the pre-declerations, when all headers are included in proper order.