### PR TITLE
LinalgRefactor - gpu_ptr compatibility in SGMatrix and SGVector

### DIFF
--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -13,6 +13,7 @@
 #ifndef __SGMATRIX_H__
 #define __SGMATRIX_H__
 
+#include <shogun/io/SGIO.h>
 #include <shogun/lib/config.h>
 #include <shogun/lib/common.h>
 #include <shogun/lib/SGReferencedData.h>
@@ -136,6 +137,7 @@ template<class T> class SGMatrix : public SGReferencedData
 		 */
 		T* get_column_vector(index_t col) const
 		{
+			assert_on_cpu();
 			const int64_t c = col;
 			return &matrix[c*num_rows];
 		}
@@ -159,6 +161,7 @@ template<class T> class SGMatrix : public SGReferencedData
 		 */
 		inline const T& operator()(index_t i_row, index_t i_col) const
 		{
+			assert_on_cpu();
 		    const int64_t c = i_col;
 		    return matrix[c*num_rows + i_row];
 		}
@@ -168,6 +171,7 @@ template<class T> class SGMatrix : public SGReferencedData
 		 */
 		inline const T& operator[](index_t index) const
 		{
+			assert_on_cpu();
 			return matrix[index];
 		}
 
@@ -177,6 +181,7 @@ template<class T> class SGMatrix : public SGReferencedData
 		 */
 		inline T& operator()(index_t i_row, index_t i_col)
 		{
+			assert_on_cpu();
 		    const int64_t c = i_col;
 		    return matrix[c*num_rows + i_row];
 		}
@@ -186,6 +191,7 @@ template<class T> class SGMatrix : public SGReferencedData
 		 */
 		inline T& operator[](index_t index)
 		{
+			assert_on_cpu();
 			return matrix[index];
 		}
 
@@ -390,6 +396,16 @@ template<class T> class SGMatrix : public SGReferencedData
 
 		/** overridden to free data */
 		virtual void free_data();
+
+        private:
+		/** Assert whether the data is on GPU
+		 * and raise error if the data is on GPU
+		 */
+		void assert_on_cpu() const
+		{
+			if (on_gpu())
+				SG_SERROR("Direct memory access not possible when data is in GPU memory.\n");
+		}
 
 	public:
 		/** matrix  */

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -130,21 +130,21 @@ SGVector<T>::SGVector(EigenRowVectorXt& vec)
 template <class T>
 SGVector<T>::operator EigenVectorXtMap() const
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	return EigenVectorXtMap(vector, vlen);
 }
 
 template <class T>
 SGVector<T>::operator EigenRowVectorXtMap() const
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	return EigenRowVectorXtMap(vector, vlen);
 }
 
 template<class T>
 void SGVector<T>::zero()
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	if (vector && vlen)
 		set_const(0);
 }
@@ -152,7 +152,7 @@ void SGVector<T>::zero()
 template <>
 void SGVector<complex128_t>::zero()
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	if (vector && vlen)
 		set_const(complex128_t(0.0));
 }
@@ -160,7 +160,7 @@ void SGVector<complex128_t>::zero()
 template<class T>
 void SGVector<T>::set_const(T const_elem)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	for (index_t i=0; i<vlen; i++)
 		vector[i]=const_elem ;
 }
@@ -169,14 +169,14 @@ void SGVector<T>::set_const(T const_elem)
 template<>
 void SGVector<float64_t>::set_const(float64_t const_elem)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	catlas_dset(vlen, const_elem, vector, 1);
 }
 
 template<>
 void SGVector<float32_t>::set_const(float32_t const_elem)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	catlas_sset(vlen, const_elem, vector, 1);
 }
 #endif // HAVE_CATLAS
@@ -184,7 +184,7 @@ void SGVector<float32_t>::set_const(float32_t const_elem)
 template<class T>
 void SGVector<T>::range_fill(T start)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	range_fill_vector(vector, vlen, start);
 }
 
@@ -193,7 +193,7 @@ COMPLEX128_ERROR_ONEARG(range_fill)
 template<class T>
 void SGVector<T>::random(T min_value, T max_value)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	random_vector(vector, vlen, min_value, max_value);
 }
 
@@ -202,7 +202,7 @@ COMPLEX128_ERROR_TWOARGS(random)
 template <class T>
 index_t SGVector<T>::find_position_to_insert(T element)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	index_t i;
 	for (i=0; i<vlen; ++i)
 	{
@@ -262,7 +262,7 @@ void SGVector<complex128_t>::range_fill_vector(complex128_t* vec,
 template<class T>
 const T& SGVector<T>::get_element(index_t index)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	REQUIRE(vector && (index>=0) && (index<vlen), "Provided index (%d) must be between 0 and %d.\n", index, vlen);
 	return vector[index];
 }
@@ -270,7 +270,7 @@ const T& SGVector<T>::get_element(index_t index)
 template<class T>
 void SGVector<T>::set_element(const T& p_element, index_t index)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	REQUIRE(vector && (index>=0) && (index<vlen), "Provided index (%d) must be between 0 and %d.\n", index, vlen);
 	vector[index]=p_element;
 }
@@ -278,7 +278,7 @@ void SGVector<T>::set_element(const T& p_element, index_t index)
 template<class T>
 void SGVector<T>::resize_vector(int32_t n)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	vector=SG_REALLOC(T, vector, vlen, n);
 
 	if (n > vlen)
@@ -290,7 +290,7 @@ void SGVector<T>::resize_vector(int32_t n)
 template<class T>
 SGVector<T> SGVector<T>::operator+ (SGVector<T> x)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	REQUIRE(x.vector && vector, "Addition possible for only non-null vectors.\n");
 	REQUIRE(x.vlen == vlen, "Length of the two vectors to be added should be same. [V(%d) + V(%d)]\n", vlen, x.vlen);
 
@@ -302,7 +302,7 @@ SGVector<T> SGVector<T>::operator+ (SGVector<T> x)
 template<class T>
 void SGVector<T>::add(const SGVector<T> x)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	REQUIRE(x.vector && vector, "Addition possible for only non-null vectors.\n");
 	REQUIRE(x.vlen == vlen, "Length of the two vectors to be added should be same. [V(%d) + V(%d)]\n", vlen, x.vlen);
 
@@ -313,7 +313,7 @@ void SGVector<T>::add(const SGVector<T> x)
 template<class T>
 void SGVector<T>::add(const T x)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	REQUIRE(vector, "Addition possible for only non-null vectors.\n");
 	for (int32_t i=0; i<vlen; i++)
 		vector[i]+=x;
@@ -322,7 +322,7 @@ void SGVector<T>::add(const T x)
 template<class T>
 void SGVector<T>::add(const SGSparseVector<T>& x)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	if (x.features)
 	{
 		for (int32_t i=0; i < x.num_feat_entries; i++)
@@ -337,7 +337,7 @@ void SGVector<T>::add(const SGSparseVector<T>& x)
 template<class T>
 void SGVector<T>::display_size() const
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	SG_SPRINT("SGVector '%p' of size: %d\n", vector, vlen)
 }
 
@@ -369,7 +369,7 @@ void SGVector<T>::free_data()
 template<class T>
 bool SGVector<T>::equals(SGVector<T>& other)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	if (other.vlen!=vlen)
 		return false;
 
@@ -838,7 +838,7 @@ int32_t SGVector<complex128_t>::unique(complex128_t* output, int32_t size)
 template <class T>
 SGVector<index_t> SGVector<T>::find(T elem)
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	SGVector<index_t> idx(vlen);
 	index_t k=0;
 
@@ -884,6 +884,7 @@ template<class T> void SGVector<T>::load(CFile* loader)
 	SG_SET_LOCALE_C;
 	SGVector<T> vec;
 	loader->get_vector(vec.vector, vec.vlen);
+	vec.gpu_ptr = nullptr;
 	copy_data(vec);
 	copy_refcount(vec);
 	ref();
@@ -900,6 +901,7 @@ template<class T> void SGVector<T>::save(CFile* saver)
 {
 	REQUIRE(saver, "Requires a valid 'c FILE pointer'\n");
 
+	assert_on_cpu();
 	SG_SET_LOCALE_C;
 	saver->set_vector(vector, vlen);
 	SG_RESET_LOCALE;
@@ -913,7 +915,7 @@ void SGVector<complex128_t>::save(CFile* saver)
 
 template <class T> SGVector<float64_t> SGVector<T>::get_real()
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	SGVector<float64_t> real(vlen);
 	for (int32_t i=0; i<vlen; i++)
 		real[i]=CMath::real(vector[i]);
@@ -922,7 +924,7 @@ template <class T> SGVector<float64_t> SGVector<T>::get_real()
 
 template <class T> SGVector<float64_t> SGVector<T>::get_imag()
 {
-	assert_on_gpu();
+	assert_on_cpu();
 	SGVector<float64_t> imag(vlen);
 	for (int32_t i=0; i<vlen; i++)
 		imag[i]=CMath::imag(vector[i]);

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -138,7 +138,7 @@ template<class T> class SGVector : public SGReferencedData
 		/** Data pointer */
 		inline T* data() const
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector;
 		}
 
@@ -213,7 +213,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline const T& operator[](uint64_t index) const
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -224,7 +224,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline const T& operator[](int64_t index) const
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -235,7 +235,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline const T& operator[](uint32_t index) const
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -246,7 +246,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline const T& operator[](int32_t index) const
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -257,7 +257,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline T& operator[](uint64_t index)
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -268,7 +268,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline T& operator[](int64_t index)
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -279,7 +279,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline T& operator[](uint32_t index)
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -290,7 +290,7 @@ template<class T> class SGVector : public SGReferencedData
 		 */
 		inline T& operator[](int32_t index)
 		{
-			assert_on_gpu();
+			assert_on_cpu();
 			return vector[index];
 		}
 
@@ -521,7 +521,7 @@ template<class T> class SGVector : public SGReferencedData
 		/** Assert whether the data is on GPU
 		 * and raise error if the data is on GPU
 		 */
-		void assert_on_gpu() const
+		void assert_on_cpu() const
 		{
 			if (on_gpu())
 				SG_SERROR("Direct memory access not possible when data is in GPU memory.\n");

--- a/tests/unit/lib/SGMatrix_unittest.cc
+++ b/tests/unit/lib/SGMatrix_unittest.cc
@@ -2,8 +2,13 @@
 #include <shogun/lib/SGVector.h>
 #include <shogun/mathematics/Math.h>
 #include <gtest/gtest.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 #include <shogun/mathematics/eigen3.h>
+
+#ifdef HAVE_VIENNACL
+#include <shogun/mathematics/linalg/LinalgBackendViennaCL.h>
+#endif
 
 using namespace shogun;
 
@@ -165,6 +170,35 @@ TEST(SGMatrixTest,equals_different_size)
 
 	EXPECT_FALSE(a.equals(b));
 }
+
+#ifdef HAVE_VIENNACL
+TEST(SGMatrixTest,pointer_equal_equal)
+{
+	sg_linalg->set_gpu_backend(new LinalgBackendViennaCL());
+
+	SGMatrix<float64_t> a(3,2);
+	a.zero();
+	auto a_gpu = linalg::to_gpu(a);
+	SGMatrix<float64_t> b_gpu(a_gpu);
+
+	EXPECT_TRUE(a_gpu == b_gpu);
+}
+
+TEST(SGMatrixTest,pointer_equal_different)
+{
+	sg_linalg->set_gpu_backend(new LinalgBackendViennaCL());
+
+	SGMatrix<float64_t> a(3,2);
+	a.zero();
+	auto a_gpu = linalg::to_gpu(a);
+
+	SGMatrix<float64_t> b(3,2);
+	b.zero();
+	auto b_gpu = linalg::to_gpu(b);
+
+	EXPECT_FALSE(a_gpu == b_gpu);
+}
+#endif
 
 TEST(SGMatrixTest,get_diagonal_vector_square_matrix)
 {


### PR DESCRIPTION
- add `assert_on_gpu()` 
- add `on_gpu()` check for elementwise (static) methods

However, the `gpu_ptr` is not serialized. I assume it's users' responsibility to transfer the data back to CPU before serialization. If so, I can add warnings or errors msg to `SGMatrix` serialization methods.