### PR TITLE
LinalgRefactor - minor fix on linalg::max unittest

### DIFF
--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -148,7 +148,7 @@ TEST(LinalgBackendEigen, SGVector_max)
 
 	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
 
-	for (int32_t i=0; i<9; i++)
+	for (index_t i = 0; i < A.size(); ++i)
 		A[i] = a[i];
 
 	EXPECT_NEAR(8, max(A), 1e-15);
@@ -159,7 +159,7 @@ TEST(LinalgBackendEigen, SGMatrix_max)
 	const index_t nrows = 2, ncols = 3;
 	SGMatrix<float64_t> A(nrows, ncols);
 
-	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
+	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 12};
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = a[i];

--- a/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
@@ -204,7 +204,7 @@ TEST(LinalgBackendViennaCL, SGVector_max)
 	SGVector<float32_t> A_gpu;
 
 	float32_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
-	for (index_t i = 0; i < 9; ++i)
+	for (index_t i = 0; i < A.size(); ++i)
 		A[i] = a[i];
 
 	A_gpu = to_gpu(A);
@@ -219,8 +219,8 @@ TEST(LinalgBackendViennaCL, SGMatrix_max)
 	SGMatrix<float32_t> A(nrows, ncols);
 	SGMatrix<float32_t> A_gpu;
 
-	float32_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
-	for (index_t i = 0; i < 9; ++i)
+	float32_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 12};
+	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = a[i];
 
 	A_gpu = to_gpu(A);


### PR DESCRIPTION
The old Viennacl SGMatrix max test may cause segmentation fault