### PR TITLE
Fix `make unit-tests` and replace mktemp inside unit tests with a custom method

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -81,7 +81,7 @@ set_target_properties (discover_gtest_tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY_
 # collect the unittests
 FILE(GLOB_RECURSE UNITTEST_SRC *_unittest.cc)
 
-ADD_EXECUTABLE(shogun-unit-test ${UNITTEST_SRC} ${TEMPLATE_GENERATED_UNITTEST})
+ADD_EXECUTABLE(shogun-unit-test ${UNITTEST_SRC} ${TEMPLATE_GENERATED_UNITTEST} utils/Utils.cpp)
 add_dependencies(shogun-unit-test GoogleMock shogun::shogun)
 target_include_directories(shogun-unit-test PRIVATE ${source_dir}/googlemock/include ${INCLUDES} ${source_dir}/googletest/include)
 target_link_libraries(shogun-unit-test PRIVATE shogun_deps gmock gtest ${SANITIZER_LIBRARY})
@@ -107,7 +107,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
 ADD_CUSTOM_TARGET(unit-tests
-	COMMAND ${CMAKE_CURRENT_BINARY_DIR}/shogun-unit-test
+	COMMAND ${CMAKE_BINARY_DIR}/bin/shogun-unit-test
 	DEPENDS shogun-unit-test)
 
 shogun_discover_tests(shogun-unit-test)

--- a/tests/unit/features/StreamingDenseFeatures_unittest.cc
+++ b/tests/unit/features/StreamingDenseFeatures_unittest.cc
@@ -7,13 +7,15 @@
  * Written (W) 2013 Viktor Gal
  */
 
-#include <shogun/features/streaming/StreamingDenseFeatures.h>
-#include <shogun/io/CSVFile.h>
-#include <shogun/io/streaming/StreamingAsciiFile.h>
 #ifndef _WIN32
 #include <unistd.h>
 #endif
 #include <gtest/gtest.h>
+
+#include <shogun/features/streaming/StreamingDenseFeatures.h>
+#include <shogun/io/CSVFile.h>
+#include <shogun/io/streaming/StreamingAsciiFile.h>
+#include "../utils/Utils.h"
 
 using namespace shogun;
 
@@ -22,7 +24,7 @@ TEST(StreamingDenseFeaturesTest, example_reading_from_file)
 	index_t n=20;
 	index_t dim=2;
 	std::string tmp_name = "StreamingDenseFeatures_reading.XXXXXX";
-	char* fname = mktemp(const_cast<char*>(tmp_name.c_str()));
+	char* fname = mktemp_cst(const_cast<char*>(tmp_name.c_str()));
 
 	SGMatrix<float64_t> data(dim,n);
 	for (index_t i=0; i<dim*n; ++i)

--- a/tests/unit/features/StreamingSparseFeatures_unittest.cc
+++ b/tests/unit/features/StreamingSparseFeatures_unittest.cc
@@ -15,13 +15,14 @@
 #include <shogun/io/streaming/StreamingAsciiFile.h>
 #include <shogun/features/streaming/StreamingSparseFeatures.h>
 #include <shogun/io/LibSVMFile.h>
+#include "../utils/Utils.h"
 
 using namespace shogun;
 
 TEST(StreamingSparseFeaturesTest, parse_file)
 {
   std::string tmp_name = "StreamingSparseFeatures_parse_file.XXXXXX";
-  const char* fname = mktemp(const_cast<char*>(tmp_name.c_str()));
+  const char* fname = mktemp_cst(const_cast<char*>(tmp_name.c_str()));
 
   int32_t max_num_entries=20;
   int32_t max_label_value=1;

--- a/tests/unit/io/SerializationAscii_unittest.cc.jinja2
+++ b/tests/unit/io/SerializationAscii_unittest.cc.jinja2
@@ -6,6 +6,7 @@
 #include <shogun/base/SGObject.h>
 #include <shogun/base/class_list.h>
 #include <shogun/io/SerializableAsciiFile.h>
+#include "utils/Utils.h"
 #include <unistd.h>
 #include <gtest/gtest.h>
 
@@ -22,7 +23,7 @@ TEST(SerializationAscii, {{class}})
 {
 	std::string class_name("{{class}}");
 	std::string file_template = "/tmp/shogun-unittest-serialization-ascii-" + class_name + ".XXXXXX";
-	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
+	char* filename = mktemp_cst(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), PT_NOT_GENERIC);
 	ASSERT_TRUE(object != NULL);
 
@@ -64,7 +65,7 @@ TEST(SerializationAscii,{{class}}_{{type}})
 {
 	std::string class_name("{{class}}");
 	std::string file_template = "/tmp/shogun-unittest-serialization-ascii-" + class_name + "_{{type}}" + ".XXXXXX";
-	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
+	char* filename = mktemp_cst(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), {{type}});
 	ASSERT_TRUE(object != NULL);
 
@@ -96,4 +97,3 @@ TEST(SerializationAscii,{{class}}_{{type}})
 }
 {% endfor %}
 {% endfor %}
-

--- a/tests/unit/io/SerializationXML_unittest.cc.jinja2
+++ b/tests/unit/io/SerializationXML_unittest.cc.jinja2
@@ -6,6 +6,7 @@
 #include <shogun/base/SGObject.h>
 #include <shogun/base/class_list.h>
 #include <shogun/io/SerializableXmlFile.h>
+#include "utils/Utils.h"
 #include <unistd.h>
 #include <gtest/gtest.h>
 
@@ -24,7 +25,7 @@ TEST(SerializationXML, {{class}})
 {
 	std::string class_name("{{class}}");
 	std::string file_template = "/tmp/shogun-unittest-serialization-xml-" + class_name + ".XXXXXX";
-	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
+	char* filename = mktemp_cst(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), PT_NOT_GENERIC);
 	ASSERT_TRUE(object != NULL);
 
@@ -66,7 +67,7 @@ TEST(SerializationXML,{{class}}_{{type}})
 {
 	std::string class_name("{{class}}");
 	std::string file_template = "/tmp/shogun-unittest-serialization-xml-" + class_name + "_{{type}}" + ".XXXXXX";
-	char* filename = mktemp(const_cast<char*>(file_template.c_str()));
+	char* filename = mktemp_cst(const_cast<char*>(file_template.c_str()));
 	CSGObject* object = new_sgserializable(class_name.c_str(), {{type}});
 	ASSERT_TRUE(object != NULL);
 

--- a/tests/unit/utils/Utils.cpp
+++ b/tests/unit/utils/Utils.cpp
@@ -1,0 +1,70 @@
+/*
+* BSD 3-Clause License
+*
+* Copyright (c) 2017, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* * Redistributions of source code must retain the above copyright notice, this
+*   list of conditions and the following disclaimer.
+*
+* * Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*
+* * Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Written (W) 2017 Giovanni De Toni
+*
+*/
+#include <string>
+#include <cstdlib>
+#include <cstring>
+#include <cstdlib>
+#include <algorithm>
+#include "Utils.h"
+
+char * mktemp_cst(char * __template)
+{
+
+	/* If the string is null*/
+	if (__template == NULL)
+		return NULL;
+
+	/* Method to generate a random char */
+	auto random = [] {
+        const char chars[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+        const size_t size = (sizeof(chars) - 1);
+        return chars[ rand() % size ];
+    };
+
+	/* Check that __template has an alterable pattern */
+	char * pos = strstr(__template,"XXXXXX");
+
+	if (pos == NULL)
+		return NULL;
+
+	std::string pattern(6,0);
+	std::generate_n(pattern.begin(), 6, random);
+	strncpy(pos, pattern.c_str(), 6);
+
+    return __template;
+}

--- a/tests/unit/utils/Utils.h
+++ b/tests/unit/utils/Utils.h
@@ -1,0 +1,49 @@
+/*
+* BSD 3-Clause License
+*
+* Copyright (c) 2017, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* * Redistributions of source code must retain the above copyright notice, this
+*   list of conditions and the following disclaimer.
+*
+* * Redistributions in binary form must reproduce the above copyright notice,
+*   this list of conditions and the following disclaimer in the documentation
+*   and/or other materials provided with the distribution.
+*
+* * Neither the name of the copyright holder nor the names of its
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* Written (W) 2017 Giovanni De Toni
+*
+*/
+#ifndef __UTILS_H__
+#define __UTILS_H__
+
+/*
+* Simple implementation of mktemp method to prevent compilation warnings,
+* since the original is not safe to use.
+* This method is not safe either, but we get rid of those annoying messages.
+*
+* For more information see:
+* http://man7.org/linux/man-pages/man3/mktemp.3.html
+* https://www.gnu.org/software/libc/manual/html_node/Temporary-Files.html
+*/
+char * mktemp_cst(char * __template);
+
+#endif


### PR DESCRIPTION
* ```make unit-tests``` was pointing to a wrong location of ```shogun-unit-test```
* Replaced mktemp with mktemp_cst to avoid many compiler warnings (see https://travis-ci.org/shogun-toolbox/shogun/jobs/202296293), since mktemp is not safe to use (and there is no way to suppress them, apparently).