### PR TITLE
Fixed the reset_stream bug caused by InputParser::exit_parser

### DIFF
--- a/src/shogun/features/streaming/StreamingDenseFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingDenseFeatures.cpp
@@ -67,6 +67,8 @@ template<class T> void CStreamingDenseFeatures<T>::reset_stream()
 	if (seekable)
 	{
 		((CStreamingFileFromDenseFeatures<T>*)working_file)->reset_stream();
+		if (parser.is_running())
+			parser.end_parser();
 		parser.exit_parser();
 		parser.init(working_file, has_labels, 1);
 		parser.set_free_vector_after_release(false);

--- a/src/shogun/features/streaming/StreamingVwFeatures.cpp
+++ b/src/shogun/features/streaming/StreamingVwFeatures.cpp
@@ -66,6 +66,8 @@ void CStreamingVwFeatures::reset_stream()
 	if (working_file->is_seekable())
 	{
 		working_file->reset_stream();
+		if (parser.is_running())
+			parser.end_parser();
 		parser.exit_parser();
 		parser.init(working_file, has_labels, parser.get_ring_size());
 		parser.set_free_vector_after_release(false);


### PR DESCRIPTION
  The method exit_parser calls the destructor of the std::thread
  object (assuming C++11 is present). A thread join or detatch
  must be performed before this. So, added a check before calling
  exit_parser in StreamingDenseFeatures and StreamingVwFeatures
  whether the parser is in running state. If it is, then added a
  call to end_parser() before calling exit_parser(), which does
  the thread join.