### PR TITLE
Use SGVector instead of pointer in KNN solvers and fix the warning when building KNNSolvers

### DIFF
--- a/src/shogun/multiclass/BruteKNNSolver.cpp
+++ b/src/shogun/multiclass/BruteKNNSolver.cpp
@@ -15,7 +15,7 @@ CKNNSolver(k, q, num_classes, min_label, train_labels)
 	nn=NN;
 }
 
-CMulticlassLabels* CBruteKNNSolver::classify_objects(CDistance* distance, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const
+CMulticlassLabels* CBruteKNNSolver::classify_objects(CDistance* knn_distance, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const
 {
 	CMulticlassLabels* output=new CMulticlassLabels(num_lab);
 	//get the k nearest neighbors of each example
@@ -29,7 +29,7 @@ CMulticlassLabels* CBruteKNNSolver::classify_objects(CDistance* distance, const 
 			train_lab[j] = m_train_labels[ NN(j,i) ];
 
 		//get the index of the 'nearest' class
-		index_t out_idx = choose_class(classes, train_lab);
+		index_t out_idx = choose_class(classes.vector, train_lab.vector);
 		//write the label of 'nearest' in the output
 		output->set_label(i, out_idx + m_min_label);
 	}
@@ -37,9 +37,9 @@ CMulticlassLabels* CBruteKNNSolver::classify_objects(CDistance* distance, const 
 	return output;
 }
 
-int32_t* CBruteKNNSolver::classify_objects_k(CDistance* distance, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const
+SGVector<int32_t> CBruteKNNSolver::classify_objects_k(CDistance* knn_distance, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const
 {
-	int32_t* output=SG_MALLOC(int32_t, m_k*num_lab);
+	SGVector<int32_t> output(m_k*num_lab);
 
 	//get the k nearest neighbors of each example
 	SGMatrix<index_t> NN = this->nn;
@@ -50,7 +50,7 @@ int32_t* CBruteKNNSolver::classify_objects_k(CDistance* distance, const int32_t 
 		for (index_t j=0; j<m_k; j++)
 			train_lab[j] = m_train_labels[ NN(j,i) ];
 
-		choose_class_for_multiple_k(output+i, classes, train_lab, num_lab);
+		choose_class_for_multiple_k(output.vector+i, classes.vector, train_lab.vector, num_lab);
 	}
 
 	return output;

--- a/src/shogun/multiclass/BruteKNNSolver.h
+++ b/src/shogun/multiclass/BruteKNNSolver.h
@@ -39,9 +39,9 @@ class CBruteKNNSolver : public CKNNSolver
 		 */
 		CBruteKNNSolver(const int32_t k, const float64_t q, const int32_t num_classes, const int32_t min_label, const SGVector<int32_t> train_labels, const SGMatrix<index_t> NN);
 
-		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const;
+		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const;
 
-		virtual int32_t* classify_objects_k(CDistance* d, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const;
+		virtual SGVector<int32_t> classify_objects_k(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const;
 
 		/** @return object name */
 		const char* get_name() const { return "BruteKNNSolver"; }

--- a/src/shogun/multiclass/CoverTreeKNNSolver.cpp
+++ b/src/shogun/multiclass/CoverTreeKNNSolver.cpp
@@ -11,7 +11,7 @@ using namespace shogun;
 CCoverTreeKNNSolver::CCoverTreeKNNSolver(const int32_t k, const float64_t q, const int32_t num_classes, const int32_t min_label, const SGVector<int32_t> train_labels):
 CKNNSolver(k, q, num_classes, min_label, train_labels) { /* nothing to do */ }
 
-CMulticlassLabels* CCoverTreeKNNSolver::classify_objects(CDistance* distance, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const
+CMulticlassLabels* CCoverTreeKNNSolver::classify_objects(CDistance* knn_distance, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const
 {
 	CMulticlassLabels* output=new CMulticlassLabels(num_lab);
 
@@ -23,20 +23,20 @@ CMulticlassLabels* CCoverTreeKNNSolver::classify_objects(CDistance* distance, co
 	// From the sets of features (lhs and rhs) stored in distance,
 	// build arrays of cover tree points
 	v_array< CJLCoverTreePoint > set_of_points  =
-		parse_points(distance, FC_LHS);
+		parse_points(knn_distance, FC_LHS);
 	v_array< CJLCoverTreePoint > set_of_queries =
-		parse_points(distance, FC_RHS);
+		parse_points(knn_distance, FC_RHS);
 
 	// Build the cover trees, one for the test vectors (rhs features)
 	// and another for the training vectors (lhs features)
-	CFeatures* r = distance->replace_rhs( distance->get_lhs() );
+	CFeatures* r = knn_distance->replace_rhs( knn_distance->get_lhs() );
 	node< CJLCoverTreePoint > top = batch_create(set_of_points);
-	CFeatures* l = distance->replace_lhs(r);
-	distance->replace_rhs(r);
+	CFeatures* l = knn_distance->replace_lhs(r);
+	knn_distance->replace_rhs(r);
 	node< CJLCoverTreePoint > top_query = batch_create(set_of_queries);
 
 	// Get the k nearest neighbors to all the test vectors (batch method)
-	distance->replace_lhs(l);
+	knn_distance->replace_lhs(l);
 	v_array< v_array< CJLCoverTreePoint > > res;
 	k_nearest_neighbor(top, top_query, res, m_k);
 
@@ -62,7 +62,7 @@ if (io->get_loglevel()<= MSG_DEBUG)
 			train_lab[j] = m_train_labels.vector[ res[i][j+1].m_index ];
 
 		// Get the index of the 'nearest' class
-		index_t out_idx = choose_class(classes, train_lab);
+		index_t out_idx = choose_class(classes.vector, train_lab.vector);
 		output->set_label(res[i][0].m_index, out_idx+m_min_label);
 	}
 
@@ -70,30 +70,30 @@ if (io->get_loglevel()<= MSG_DEBUG)
 	return output;
 }
 
-int32_t* CCoverTreeKNNSolver::classify_objects_k(CDistance* distance, int32_t num_lab, int32_t* train_lab,  int32_t* classes) const
+SGVector<int32_t> CCoverTreeKNNSolver::classify_objects_k(CDistance* knn_distance, int32_t num_lab, SGVector<int32_t>& train_lab,  SGVector<int32_t>& classes) const
 {
-	int32_t* output=SG_MALLOC(int32_t, m_k*num_lab);
+	SGVector<int32_t> output(m_k*num_lab);
 
 	//allocation for distances to nearest neighbors
-	float64_t* dists=SG_MALLOC(float64_t, m_k);
+	SGVector<float64_t> dists(m_k);
 
 	// From the sets of features (lhs and rhs) stored in distance,
 	// build arrays of cover tree points
 	v_array< CJLCoverTreePoint > set_of_points  =
-		parse_points(distance, FC_LHS);
+		parse_points(knn_distance, FC_LHS);
 	v_array< CJLCoverTreePoint > set_of_queries =
-		parse_points(distance, FC_RHS);
+		parse_points(knn_distance, FC_RHS);
 
 	// Build the cover trees, one for the test vectors (rhs features)
 	// and another for the training vectors (lhs features)
-	CFeatures* r = distance->replace_rhs( distance->get_lhs() );
+	CFeatures* r = knn_distance->replace_rhs( knn_distance->get_lhs() );
 	node< CJLCoverTreePoint > top = batch_create(set_of_points);
-	CFeatures* l = distance->replace_lhs(r);
-	distance->replace_rhs(r);
+	CFeatures* l = knn_distance->replace_lhs(r);
+	knn_distance->replace_rhs(r);
 	node< CJLCoverTreePoint > top_query = batch_create(set_of_queries);
 
 	// Get the k nearest neighbors to all the test vectors (batch method)
-	distance->replace_lhs(l);
+	knn_distance->replace_lhs(l);
 	v_array< v_array< CJLCoverTreePoint > > res;
 	k_nearest_neighbor(top, top_query, res, m_k);
 
@@ -105,20 +105,18 @@ int32_t* CCoverTreeKNNSolver::classify_objects_k(CDistance* distance, int32_t nu
 		for ( index_t j = 0 ; j < m_k ; ++j )
 		{
 			// The first index in res[i] points to the test vector
-			dists[j]     = distance->distance(res[i][j+1].m_index,
+			dists[j]     = knn_distance->distance(res[i][j+1].m_index,
 						res[i][0].m_index);
 			train_lab[j] = m_train_labels.vector[
 						res[i][j+1].m_index ];
 		}
 
 		// Now we get the indices to the neighbors sorted by distance
-		CMath::qsort_index(dists, train_lab, m_k);
+		CMath::qsort_index(dists.vector, train_lab.vector, m_k);
 
-		choose_class_for_multiple_k(output+res[i][0].m_index, classes,
-				train_lab, num_lab);
+		choose_class_for_multiple_k(output.vector+res[i][0].m_index, classes.vector,
+				train_lab.vector, num_lab);
 	}
-
-	SG_FREE(dists);
 
 	return output;
 }

--- a/src/shogun/multiclass/CoverTreeKNNSolver.h
+++ b/src/shogun/multiclass/CoverTreeKNNSolver.h
@@ -41,9 +41,9 @@ class CCoverTreeKNNSolver : public CKNNSolver
 		 */
 		CCoverTreeKNNSolver(const int32_t k, const float64_t q, const int32_t num_classes, const int32_t min_label, const SGVector<int32_t> train_labels);
 
-		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const;
+		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const;
 
-		virtual int32_t* classify_objects_k(CDistance* d, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const;
+		virtual SGVector<int32_t> classify_objects_k(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const;
 
 		/** @return object name */
 		const char* get_name() const { return "CoverTreeKNNSolver"; }

--- a/src/shogun/multiclass/KDTreeKNNSolver.h
+++ b/src/shogun/multiclass/KDTreeKNNSolver.h
@@ -44,9 +44,9 @@ class CKDTREEKNNSolver : public CKNNSolver
 		 */
 		CKDTREEKNNSolver(const int32_t k, const float64_t q, const int32_t num_classes, const int32_t min_label, const SGVector<int32_t> train_labels, const int32_t leaf_size);
 
-		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const;
+		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const;
 
-		virtual int32_t* classify_objects_k(CDistance* d, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const;
+		virtual SGVector<int32_t> classify_objects_k(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const;
 
 		/** @return object name */
 		const char* get_name() const { return "KDTREEKNNSolver"; }

--- a/src/shogun/multiclass/KDTreeKNNsolver.cpp
+++ b/src/shogun/multiclass/KDTreeKNNsolver.cpp
@@ -17,15 +17,15 @@ CKNNSolver(k, q, num_classes, min_label, train_labels)
 	m_leaf_size=leaf_size;
 }
 
-CMulticlassLabels* CKDTREEKNNSolver::classify_objects(CDistance* distance, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const
+CMulticlassLabels* CKDTREEKNNSolver::classify_objects(CDistance* knn_distance, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const
 {
 	CMulticlassLabels* output=new CMulticlassLabels(num_lab);
-	CFeatures* lhs = distance->get_lhs();
+	CFeatures* lhs = knn_distance->get_lhs();
 	CKDTree* kd_tree = new CKDTree(m_leaf_size);
 	kd_tree->build_tree(dynamic_cast<CDenseFeatures<float64_t>*>(lhs));
 	SG_UNREF(lhs);
 
-	CFeatures* query = distance->get_rhs();
+	CFeatures* query = knn_distance->get_rhs();
 	kd_tree->query_knn(dynamic_cast<CDenseFeatures<float64_t>*>(query), m_k);
 	SGMatrix<index_t> NN = kd_tree->get_knn_indices();
 	for (int32_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
@@ -35,7 +35,7 @@ CMulticlassLabels* CKDTREEKNNSolver::classify_objects(CDistance* distance, const
 			train_lab[j] = m_train_labels[ NN(j,i) ];
 
 		//get the index of the 'nearest' class
-		int32_t out_idx = choose_class(classes, train_lab);
+		int32_t out_idx = choose_class(classes.vector, train_lab.vector);
 		//write the label of 'nearest' in the output
 		output->set_label(i, out_idx + m_min_label);
 	}
@@ -44,19 +44,19 @@ CMulticlassLabels* CKDTREEKNNSolver::classify_objects(CDistance* distance, const
 	return output;
 }
 
-int32_t* CKDTREEKNNSolver::classify_objects_k(CDistance* distance, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const
+SGVector<int32_t> CKDTREEKNNSolver::classify_objects_k(CDistance* knn_distance, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const
 {
-	int32_t* output=SG_MALLOC(int32_t, m_k*num_lab);
+	SGVector<int32_t> output(m_k*num_lab);
 
 	//allocation for distances to nearest neighbors
 	SGVector<float64_t> dists(m_k);
 
-	CFeatures* lhs = distance->get_lhs();
+	CFeatures* lhs = knn_distance->get_lhs();
 	CKDTree* kd_tree = new CKDTree(m_leaf_size);
 	kd_tree->build_tree(dynamic_cast<CDenseFeatures<float64_t>*>(lhs));
 	SG_UNREF(lhs);
 
-	CFeatures* data = distance->get_rhs();
+	CFeatures* data = knn_distance->get_rhs();
 	kd_tree->query_knn(dynamic_cast<CDenseFeatures<float64_t>*>(data), m_k);
 	SGMatrix<index_t> NN = kd_tree->get_knn_indices();
 	for (index_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
@@ -65,11 +65,11 @@ int32_t* CKDTREEKNNSolver::classify_objects_k(CDistance* distance, const int32_t
 		for (index_t j=0; j<m_k; j++)
 		{
 			train_lab[j] = m_train_labels[ NN(j,i) ];
-			dists[j] = distance->distance(NN(j,i), i);
+			dists[j] = knn_distance->distance(NN(j,i), i);
 		}
-		CMath::qsort_index(dists.vector, train_lab, m_k);
+		CMath::qsort_index(dists.vector, train_lab.vector, m_k);
 
-		choose_class_for_multiple_k(output+i, classes, train_lab, num_lab);
+		choose_class_for_multiple_k(output.vector+i, classes.vector, train_lab.vector, num_lab);
 	}
 
 	SG_UNREF(data);

--- a/src/shogun/multiclass/KNNSolver.h
+++ b/src/shogun/multiclass/KNNSolver.h
@@ -71,7 +71,7 @@ class CKNNSolver : public CDistanceMachine
 		 * @param classes vector used to store the histogram
 		 * @return the classified labels
 		 */
-		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const = 0;
+		 virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const = 0;
 
 		/**
 		 * classify all objects, and the implementation will depended on which knn solver been choosen.
@@ -81,7 +81,7 @@ class CKNNSolver : public CDistanceMachine
 		 * @param classes vector used to store the histogram
 		 * @return the classified labels
 		 */
-		virtual int32_t* classify_objects_k(CDistance* d, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const = 0;
+		 virtual SGVector<int32_t> classify_objects_k(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const = 0;
 
 		/** @return object name */
 		virtual const char* get_name() const { return "KNNSolver"; }

--- a/src/shogun/multiclass/LSHKNNSolver.cpp
+++ b/src/shogun/multiclass/LSHKNNSolver.cpp
@@ -23,10 +23,10 @@ CKNNSolver(k, q, num_classes, min_label, train_labels)
 	m_lsh_t=lsh_t;
 }
 
-CMulticlassLabels* CLSHKNNSolver::classify_objects(CDistance* distance, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const
+CMulticlassLabels* CLSHKNNSolver::classify_objects(CDistance* knn_distance, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const
 {
 	CMulticlassLabels* output=new CMulticlassLabels(num_lab);
-	CDenseFeatures<float64_t>* features = dynamic_cast<CDenseFeatures<float64_t>*>(distance->get_lhs());
+	CDenseFeatures<float64_t>* features = dynamic_cast<CDenseFeatures<float64_t>*>(knn_distance->get_lhs());
 	std::vector<falconn::DenseVector<double>> feats;
 	for(int32_t i=0; i < features->get_num_vectors(); i++)
 	{
@@ -50,7 +50,7 @@ CMulticlassLabels* CLSHKNNSolver::classify_objects(CDistance* distance, const in
 	if (m_lsh_t)
 		lsh_table->set_num_probes(m_lsh_t);
 
-	CDenseFeatures<float64_t>* query_features = dynamic_cast<CDenseFeatures<float64_t>*>(distance->get_rhs());
+	CDenseFeatures<float64_t>* query_features = dynamic_cast<CDenseFeatures<float64_t>*>(knn_distance->get_rhs());
 	std::vector<falconn::DenseVector<double>> query_feats;
 
 	SGMatrix<index_t> NN (m_k, query_features->get_num_vectors());
@@ -73,7 +73,7 @@ CMulticlassLabels* CLSHKNNSolver::classify_objects(CDistance* distance, const in
 			train_lab[j] = m_train_labels[ NN(j,i) ];
 
 		//get the index of the 'nearest' class
-		index_t out_idx = choose_class(classes, train_lab);
+		index_t out_idx = choose_class(classes.vector, train_lab.vector);
 		//write the label of 'nearest' in the output
 		output->set_label(i, out_idx + m_min_label);
 	}
@@ -82,7 +82,7 @@ CMulticlassLabels* CLSHKNNSolver::classify_objects(CDistance* distance, const in
 	return output;
 }
 
-int32_t* CLSHKNNSolver::classify_objects_k(CDistance* d, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const
+SGVector<int32_t> CLSHKNNSolver::classify_objects_k(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const
 {
 	SG_NOTIMPLEMENTED
 	return 0;

--- a/src/shogun/multiclass/LSHKNNSolver.h
+++ b/src/shogun/multiclass/LSHKNNSolver.h
@@ -45,9 +45,9 @@ class CLSHKNNSolver : public CKNNSolver
 		 */
 		CLSHKNNSolver(const int32_t k, const float64_t q, const int32_t num_classes, const int32_t min_label, const SGVector<int32_t> train_labels, const int32_t lsh_l, const int32_t lsh_t);
 
-		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const;
+		virtual CMulticlassLabels* classify_objects(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<float64_t>& classes) const;
 
-		virtual int32_t* classify_objects_k(CDistance* d, const int32_t num_lab, int32_t* train_lab, int32_t* classes) const;
+		virtual SGVector<int32_t> classify_objects_k(CDistance* d, const int32_t num_lab, SGVector<int32_t>& train_lab, SGVector<int32_t>& classes) const;
 
 		/** @return object name */
 		const char* get_name() const { return "LSHKNNSolver"; }


### PR DESCRIPTION
This pr is about to fix the warning generated by  **shadow declaration of ‘distance’**  in KNNSolvers. For example, as @vigsterkr pointed out on irc, 

>
> /home/wiking/shogun/src/shogun/multiclass/KDTreeKNNsolver.cpp: In member function ‘virtual shogun::CMulticlassLabels* shogun::CKDTREEKNNSolver::classify_objects(shogun::CDistance*, int32_t, int32_t*, float64_t*) const’:
> /home/wiking/shogun/src/shogun/multiclass/KDTreeKNNsolver.cpp:20:139: warning: declaration of ‘distance’ shadows a member of 'this' [-Wshadow]
> CMulticlassLabels* CKDTREEKNNSolver::classify_objects(CDistance* distance, const int32_t num_lab, int32_t* train_lab, float64_t* classes) const
>

BTW, I guess this pr may conflict with another pr also related with KNN https://github.com/shogun-toolbox/shogun/pull/3641. Please merge that first if it's ok, otherwise I need to rebase it again anyway :)

@vigsterkr  Could you please take a look at this? Thank you! :)