### PR TITLE
Fix `make cookbook` when certain cookbooks are guarded

### DIFF
--- a/cmake/FindMetaExamples.cmake
+++ b/cmake/FindMetaExamples.cmake
@@ -15,40 +15,85 @@ function(is_set CONFIG_FILE FLAG)
 	endif()
 endfunction()
 
-function(find_meta_examples)
-	read_config_header(${shogun_INCLUDE_DIR}/shogun/lib/config.h)
-	is_set(${SHOGUN_CONFIG} HAVE_NLOPT)
-	is_set(${SHOGUN_CONFIG} USE_GPL_SHOGUN)
-	is_set(${SHOGUN_CONFIG} HAVE_LAPACK)
-	is_set(${SHOGUN_CONFIG} USE_SVMLIGHT)
+function(get_excluded_meta_examples)
+    read_config_header(${shogun_INCLUDE_DIR}/shogun/lib/config.h)
+    is_set(${SHOGUN_CONFIG} HAVE_NLOPT)
+    is_set(${SHOGUN_CONFIG} USE_GPL_SHOGUN)
+    is_set(${SHOGUN_CONFIG} HAVE_LAPACK)
+    is_set(${SHOGUN_CONFIG} USE_SVMLIGHT)
 
-	FILE(GLOB_RECURSE META_EXAMPLE_LISTINGS ${CMAKE_SOURCE_DIR}/examples/meta/src/*.sg)
-
-	# temporary hacks to exclude certain meta examples that have dependencies
-	IF(NOT HAVE_NLOPT)
-		LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS
-			${CMAKE_SOURCE_DIR}/examples/meta/src/gaussian_processes/gaussian_process_regression.sg)
-	ENDIF()
+    IF(NOT HAVE_NLOPT)
+        LIST(APPEND EXCLUDED_META_EXAMPLES
+            gaussian_processes/gaussian_process_regression.sg)
+    ENDIF()
 
 	IF(NOT USE_GPL_SHOGUN)
-		LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS
-			${CMAKE_SOURCE_DIR}/examples/meta/src/gaussian_processes/gaussian_process_regression.sg
-			${CMAKE_SOURCE_DIR}/examples/meta/src/multiclass_classifier/multiclass_logisticregression.sg
+		LIST(APPEND EXCLUDED_META_EXAMPLES
+			gaussian_processes/gaussian_process_regression.sg
+			multiclass_classifier/multiclass_logisticregression.sg
 			)
 	ENDIF()
 
 	IF(NOT HAVE_LAPACK)
-		LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS
-			${CMAKE_SOURCE_DIR}/examples/meta/src/regression/linear_ridge_regression.sg
-			${CMAKE_SOURCE_DIR}/examples/meta/src/clustering/gmm.sg
-			${CMAKE_SOURCE_DIR}/examples/meta/src/distance/mahalanobis.sg
+		LIST(APPEND EXCLUDED_META_EXAMPLES
+			regression/linear_ridge_regression.sg
+			clustering/gmm.sg
+			distance/mahalanobis.sg
 			)
 	ENDIF()
 
 	IF(NOT USE_SVMLIGHT)
-		LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS
-			${CMAKE_SOURCE_DIR}/examples/meta/src/regression/multiple_kernel_learning.sg)
+		LIST(APPEND EXCLUDED_META_EXAMPLES
+			regression/multiple_kernel_learning.sg)
 	ENDIF()
 
+    SET(EXCLUDED_META_EXAMPLES ${EXCLUDED_META_EXAMPLES} PARENT_SCOPE)
+
+endfunction()
+
+# Remove meta example that cannot be built because of missing dependencies
+function(find_meta_examples)
+
+	FILE(GLOB_RECURSE META_EXAMPLE_LISTINGS ${CMAKE_SOURCE_DIR}/examples/meta/src/*.sg)
+    get_excluded_meta_examples()
+
+    FOREACH(META_EXAMPLE ${EXCLUDED_META_EXAMPLES})
+        LIST(REMOVE_ITEM META_EXAMPLE_LISTINGS ${CMAKE_SOURCE_DIR}/examples/meta/src/${META_EXAMPLE})
+    ENDFOREACH()
+
 	SET(META_EXAMPLES ${META_EXAMPLE_LISTINGS} PARENT_SCOPE)
+endfunction()
+
+# Get the cookbook pages we want to exclude from build
+function(find_excluded_cookbook_pages)
+
+    get_excluded_meta_examples()
+
+    FOREACH(META_EXAMPLE ${EXCLUDED_META_EXAMPLES})
+        # This is made since some meta example does not have
+        # a cookbook page.
+        STRING(REPLACE ".sg" ".rst" META_EXAMPLE ${META_EXAMPLE})
+        IF (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/source/examples/${META_EXAMPLE})
+            LIST(APPEND EXCLUDED_COOKBOOK_PAGES examples/${META_EXAMPLE})
+        ENDIF()
+    ENDFOREACH()
+
+    # Check to ensure we have cookbook pages to exclude
+    IF(EXCLUDED_COOKBOOK_PAGES)
+        # Generate a string with all the meta examples separated by commas.
+        # This is made since Sphinx's exclude_patterns option wants
+        # the list's items separated by commas, but cmake's lists use
+        # semicolons instead.
+        # See: https://cmake.org/cmake/help/v3.3/command/list.html
+        # See: http://www.sphinx-doc.org/en/stable/invocation.html#id2
+        SET(TEMP "${EXCLUDED_COOKBOOK_PAGES}")
+        STRING(REPLACE ".rst" ".rst," TEMP ${TEMP})
+        string(REGEX REPLACE ".rst,$" ".rst" TEMP ${TEMP})
+
+        SET(EXCLUDED_COOKBOOK_PAGES ${TEMP} PARENT_SCOPE)
+    ELSE()
+        SET(EXCLUDED_COOKBOOK_PAGES "" PARENT_SCOPE)
+    ENDIF()
+
+
 endfunction()

--- a/doc/cookbook/CMakeLists.txt
+++ b/doc/cookbook/CMakeLists.txt
@@ -1,5 +1,7 @@
 #PROJECT(sphinxdoc)
 #cmake_minimum_required(VERSION 2.8.8)
+include(FindMetaExamples)
+find_excluded_cookbook_pages()
 
 # configured documentation tools and intermediate build results
 set(BINARY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_build")
@@ -56,6 +58,7 @@ add_custom_target(cookbook_sphinx_linkcheck
     -c "${BINARY_BUILD_DIR}"
     -d "${SPHINX_CACHE_DIR}"
     -D generated_examples_path="${CMAKE_BINARY_DIR}/examples/meta/"
+    -D exclude_patterns="${EXCLUDED_COOKBOOK_PAGES}"
     "${BINARY_BUILD_DIR}"
     "${SPHINX_HTML_DIR}"
     COMMENT "Cookbook Sphinx validating external links"
@@ -69,6 +72,7 @@ add_custom_target(cookbook
     -c "${BINARY_BUILD_DIR}"
     -d "${SPHINX_CACHE_DIR}"
     -D generated_examples_path="${CMAKE_BINARY_DIR}/examples/meta/"
+    -D exclude_patterns="${EXCLUDED_COOKBOOK_PAGES}"
     "${BINARY_BUILD_DIR}"
     "${SPHINX_HTML_DIR}"
     COMMENT "Cookbook Sphinx building HTML"


### PR DESCRIPTION
This should fix issue #3520. These changes fix also ``` make cookbook_sphinx_linkcheck```.

The command ```make cookbook``` still gives me warnings, though, but I don't understand if they are caused by my changes or if they were already there.
See warnings here: http://pastebin.com/chxfGvaq