### PR TITLE
Fix TParameter copy

### DIFF
--- a/src/shogun/base/Parameter.cpp
+++ b/src/shogun/base/Parameter.cpp
@@ -3844,7 +3844,7 @@ bool TParameter::copy(TParameter* target)
 				*(char**)target->m_parameter=SG_MALLOC(char, num_bytes);
 				/* check whether ptype is SGOBJECT, if yes we need to initialize
 				   the memory with NULL for the way copy_ptype handles it */
-				if (m_datatype.m_ptype==PT_SGOBJECT)
+				if (m_datatype.m_ptype==PT_SGOBJECT || m_datatype.m_stype==ST_STRING)
 					memset(*(void**)target->m_parameter, 0, num_bytes);
 
 				/* use length of source */
@@ -3860,7 +3860,7 @@ bool TParameter::copy(TParameter* target)
 			SG_SDEBUG("length_y: %d\n", *m_datatype.m_length_y)
 			for (index_t i=0; i<*m_datatype.m_length_y; ++i)
 			{
-				SG_SDEBUG("copying element %d which is %d byes from start\n",
+				SG_SDEBUG("copying element %d which is %d bytes from start\n",
 						i, x);
 
 				void* pointer_a=&((*(char**)m_parameter)[x]);
@@ -3874,7 +3874,7 @@ bool TParameter::copy(TParameter* target)
 					return false;
 				}
 
-				x=x+(m_datatype.sizeof_ptype());
+				x=x+(m_datatype.sizeof_stype());
 			}
 
 			break;

--- a/tests/unit/features/StringFeatures_unittest.cc
+++ b/tests/unit/features/StringFeatures_unittest.cc
@@ -14,12 +14,8 @@
 
 using namespace shogun;
 
-TEST(StringFeaturesTest,copy_subset)
+SGStringList<char> generateRandomData(index_t num_strings=10, index_t max_string_length=20, index_t min_string_length=10)
 {
-	index_t num_strings=10;
-	index_t max_string_length=20;
-	index_t min_string_length=max_string_length/2;
-
 	SGStringList<char> strings(num_strings, max_string_length);
 
 	//SG_SPRINT("original string data:\n");
@@ -45,6 +41,12 @@ TEST(StringFeaturesTest,copy_subset)
 
 		strings.strings[i]=current;
 	}
+	return strings;
+}
+
+TEST(StringFeaturesTest,copy_subset)
+{
+	SGStringList<char> strings = generateRandomData();
 
 	/* create num_feautres 2-dimensional vectors */
 	CStringFeatures<char>* f=new CStringFeatures<char>(strings, ALPHANUM);
@@ -105,4 +107,31 @@ TEST(StringFeaturesTest,copy_subset)
 
 	SG_UNREF(f);
 	SG_UNREF(subset_copy);
+}
+
+TEST(StringFeaturesTest,clone)
+{
+	SGStringList<char> strings = generateRandomData();
+
+	CStringFeatures<char>* f=new CStringFeatures<char>(strings, ALPHANUM);
+	CStringFeatures<char>* f_clone = (CStringFeatures<char> *) f->clone();
+
+	for (index_t i=0; i<f->get_num_vectors(); ++i)
+	{
+		index_t a_len;
+		index_t b_len;
+		bool a_free;
+		bool b_free;
+
+		char * a_vec = f->get_feature_vector(i, a_len, a_free);
+		char * b_vec = f_clone->get_feature_vector(i, b_len, b_free);
+
+		EXPECT_EQ(a_len, b_len);
+		EXPECT_EQ(a_free, b_free);
+		for (index_t j = 0; j < a_len; ++j)
+			EXPECT_EQ(a_vec[j], b_vec[j]);
+	}
+
+	SG_UNREF(f);
+	SG_UNREF(f_clone);
 }


### PR DESCRIPTION
`StringFeatures<T>` contain an `SGString<T>*` parameter that caused `::clone()` on the features to fail.

IMHO this fixes `TParameter::copy()`, however, I'm not familiar with this code, so please check (see inline comments)