### PR TITLE
Fix CAlphabet::Clone + unit test

### DIFF
--- a/src/shogun/features/Alphabet.cpp
+++ b/src/shogun/features/Alphabet.cpp
@@ -832,6 +832,14 @@ void CAlphabet::translate_from_single_order_reversed(ST* obs, int32_t sequence_l
 	}
 }
 
+CSGObject * CAlphabet::clone()
+{
+	CAlphabet * alph_clone = (CAlphabet *) CSGObject::clone();
+	alph_clone->init_map_table();
+	alph_clone->copy_histogram(this);
+	return alph_clone;
+}
+
 template <class ST>
 void CAlphabet::translate_from_single_order(ST* obs, int32_t sequence_length, int32_t start, int32_t p_order, int32_t max_val, int32_t gap)
 {

--- a/src/shogun/features/Alphabet.h
+++ b/src/shogun/features/Alphabet.h
@@ -306,6 +306,8 @@ class CAlphabet : public CSGObject
 		template <class ST>
 		static void translate_from_single_order_reversed(ST* obs, int32_t sequence_length, int32_t start, int32_t p_order, int32_t max_val, int32_t gap);
 
+		CSGObject * clone();
+
 	private:
 		/** Do basic initialisations like default settings
 		 * and registering parameters */

--- a/tests/unit/features/Alphabet_unittest.cc
+++ b/tests/unit/features/Alphabet_unittest.cc
@@ -1,0 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Written (W) 2017 Leon Kuchenbecker
+ */
+
+#include <shogun/features/Alphabet.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(AlphabetTest, test_clone)
+{
+    CAlphabet * alph = new CAlphabet(PROTEIN);
+    CAlphabet * alph_clone = (CAlphabet *) alph->clone();
+
+    EXPECT_EQ(alph->get_num_symbols(), alph_clone->get_num_symbols());
+    EXPECT_EQ(alph->get_num_symbols_in_histogram(), alph_clone->get_num_symbols_in_histogram());
+
+    SG_UNREF(alph);
+    SG_UNREF(alph_clone);
+}


### PR DESCRIPTION
Seems like `CAlphabet` couldn't be cloned properly. Another bug that surfaced with the all the cloning happening now with parallel xval, for me in the case of `CCommWordStringKernel`.

There are some remarks about this in the serialization section [here](https://github.com/shogun-toolbox/shogun/blob/develop/src/shogun/features/Alphabet.cpp#L721).

Please check.