### PR TITLE
Add CLabels::get_subset_stack()

### DIFF
--- a/src/shogun/labels/Labels.cpp
+++ b/src/shogun/labels/Labels.cpp
@@ -56,6 +56,12 @@ void CLabels::remove_all_subsets()
 	m_subset_stack->remove_all_subsets();
 }
 
+CSubsetStack* CLabels::get_subset_stack()
+{
+	SG_REF(m_subset_stack);
+	return m_subset_stack;
+}
+
 float64_t CLabels::get_value(int32_t idx)
 {
 	ASSERT(m_current_values.vector && idx < get_num_labels())

--- a/src/shogun/labels/Labels.h
+++ b/src/shogun/labels/Labels.h
@@ -96,6 +96,11 @@ public:
 	 * Calls subset_changed_post() afterwards */
 	virtual void remove_all_subsets();
 
+	/**
+	 * @return subset stack
+	 */
+	virtual CSubsetStack* get_subset_stack();
+
 	/** set the confidence value for a particular label
 	 *
 	 * @param value value to set


### PR DESCRIPTION
Was available in Features, not in Labels. As far as I can tell it's the only interface to figure out if subsets are currently applied.