### PR TITLE
Clean up SGObject import and DirectorKernel methods

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -32,8 +32,6 @@ class RefCount;
 class SGIO;
 class Parallel;
 class Parameter;
-class ParameterMap;
-class SGParamInfo;
 class CSerializableFile;
 
 template <class T, class K> class CMap;

--- a/src/shogun/kernel/DirectorKernel.h
+++ b/src/shogun/kernel/DirectorKernel.h
@@ -339,60 +339,6 @@ IGNORE_IN_CLASSLIST class CDirectorKernel: public CKernel
 		}
 
 	protected:
-		/** creates a new TParameter instance, which contains migrated data from
-		 * the version that is provided. The provided parameter data base is used
-		 * for migration, this base is a collection of all parameter data of the
-		 * previous version.
-		 * Migration is done FROM the data in param_base TO the provided param info
-		 * Migration is always one version step.
-		 * Method has to be implemented in subclasses, if no match is found, base
-		 * method has to be called.
-		 *
-		 * If there is an element in the param_base which equals the target,
-		 * a copy of the element is returned. This represents the case when nothing
-		 * has changed and therefore, the migrate method is not overloaded in a
-		 * subclass
-		 *
-		 * @param param_base set of TParameter instances to use for migration
-		 * @param target parameter info for the resulting TParameter
-		 * @return a new TParameter instance with migrated data from the base of the
-		 * type which is specified by the target parameter
-		 */
-		virtual TParameter* migrate(DynArray<TParameter*>* param_base,
-				const SGParamInfo* target)
-		{
-			return CSGObject::migrate(param_base, target);
-		}
-
-		/** This method prepares everything for a one-to-one parameter migration.
-		 * One to one here means that only ONE element of the parameter base is
-		 * needed for the migration (the one with the same name as the target).
-		 * Data is allocated for the target (in the type as provided in the target
-		 * SGParamInfo), and a corresponding new TParameter instance is written to
-		 * replacement. The to_migrate pointer points to the single needed
-		 * TParameter instance needed for migration.
-		 * If a name change happened, the old name may be specified by old_name.
-		 * In addition, the m_delete_data flag of to_migrate is set to true.
-		 * So if you want to migrate data, the only thing to do after this call is
-		 * converting the data in the m_parameter fields.
-		 * If unsure how to use - have a look into an example for this.
-		 * (base_migration_type_conversion.cpp for example)
-		 *
-		 * @param param_base set of TParameter instances to use for migration
-		 * @param target parameter info for the resulting TParameter
-		 * @param replacement (used as output) here the TParameter instance which is
-		 * returned by migration is created into
-		 * @param to_migrate the only source that is used for migration
-		 * @param old_name with this parameter, a name change may be specified
-		 *
-		 */
-		virtual void one_to_one_migration_prepare(DynArray<TParameter*>* param_base,
-				const SGParamInfo* target, TParameter*& replacement,
-				TParameter*& to_migrate, char* old_name=NULL)
-		{
-			return CSGObject::one_to_one_migration_prepare(param_base, target,
-					replacement, to_migrate, old_name);
-		}
 		/** Can (optionally) be overridden to pre-initialize some member
 		 *  variables which are not PARAMETER::ADD'ed.  Make sure that at
 		 *  first the overridden method BASE_CLASS::LOAD_SERIALIZABLE_PRE


### PR DESCRIPTION
Classes `ParameterMap` and `SGParamInfo` have been removed.

Methods `CSGObject::migrate()` and `CSGObject::one_to_one_migration_prepare()` have been removed.
