### PR TITLE
Add test for subset functionality on cloned features

### DIFF
--- a/tests/unit/features/DenseFeatures_unittest.cc
+++ b/tests/unit/features/DenseFeatures_unittest.cc
@@ -249,3 +249,51 @@ TEST(DenseFeaturesTest, copy_feature_matrix)
 			EXPECT_NEAR(copy(i, j+offset), data(i, inds[j]), 1E-15);
 	}
 }
+
+TEST(DenseFeaturesTest,subsetClone)
+{
+	// Create data for dense features
+	SGMatrix<float64_t> featMatrix(5,5);
+	for (index_t i=0; i < featMatrix.num_rows * featMatrix.num_cols; ++i)
+		featMatrix.data()[i] = i;
+
+	// Create some subset vectors
+	SGVector<index_t> firstFour(4);
+	for (index_t i=0; i < 4; ++i)
+		firstFour[i] = i;
+
+	SGVector<index_t> firstThree(3);
+	for (index_t i=0; i < 3; ++i)
+		firstThree[i] = i;
+
+	// Create features
+	CDenseFeatures<float64_t> * df_orig = new CDenseFeatures<float64_t>(featMatrix);
+
+	// Add subset
+	df_orig->add_subset(firstFour);
+
+	// Clone with subset
+	CDenseFeatures<float64_t> * df_clone = (CDenseFeatures<float64_t> *) df_orig->clone();
+
+	// Add additional subset on the clone
+	df_clone->add_subset(firstThree);
+
+	// Check the original
+	CSubsetStack * sstack_orig = df_orig->get_subset_stack();
+	EXPECT_EQ(sstack_orig->get_size(), 4);
+	df_orig->remove_subset();
+	EXPECT_FALSE(sstack_orig->has_subsets());
+	SG_UNREF(sstack_orig);
+
+	// Check the clone
+	CSubsetStack * sstack_clone = df_clone->get_subset_stack();
+	EXPECT_EQ(sstack_clone->get_size(), 3);
+	df_clone->remove_subset();
+	EXPECT_EQ(sstack_clone->get_size(), 4);
+	df_clone->remove_subset();
+	EXPECT_FALSE(sstack_clone->has_subsets());
+	SG_UNREF(sstack_clone);
+
+	SG_UNREF(df_clone);
+	SG_UNREF(df_orig);
+}


### PR DESCRIPTION
Test passes (at least when I tried), but uses unallocated memory. With

```
valgrind /home/lk/tmp/shogun/build/bin/shogun-unit-test "--gtest_filter=DenseFeaturesTest.subsetClone"
```

I get an invalid write when adding the second subset on the cloned features (`add_subset()`) and an illegal read when removing one from the stack (`remove_subset()`).

Adding the additional subset on the clone:

```
==49516== Invalid write of size 8
==49516==    at 0xB853C1: shogun::DynArray<shogun::CSGObject*>::set_element(shogun::CSGObject*, int) (DynArray.h:204)
==49516==    by 0xB85457: shogun::DynArray<shogun::CSGObject*>::append_element(shogun::CSGObject*) (DynArray.h:246)
==49516==    by 0xB844CA: shogun::CDynamicObjectArray::append_element(shogun::CSGObject*) (DynamicObjectArray.h:287)
==49516==    by 0x7698A99: shogun::CSubsetStack::add_subset(shogun::SGVector<int>) (SubsetStack.cpp:145)
==49516==    by 0x75DD893: shogun::CFeatures::add_subset(shogun::SGVector<int>) (Features.cpp:312)
==49516==    by 0xC27A63: DenseFeaturesTest_subsetClone_Test::TestBody() (DenseFeatures_unittest.cc:279)
==49516==    by 0x10A5B5C: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2402)
==49516==    by 0x10A0889: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2438)
==49516==    by 0x1086901: testing::Test::Run() (gtest.cc:2475)
==49516==    by 0x108717F: testing::TestInfo::Run() (gtest.cc:2656)
==49516==    by 0x10877CC: testing::TestCase::Run() (gtest.cc:2774)
==49516==    by 0x108E370: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4649)
==49516==  Address 0xff5ddc8 is 0 bytes after a block of size 8 alloc'd
==49516==    at 0x4C28C20: malloc (vg_replace_malloc.c:296)
==49516==    by 0x791F769: shogun::sg_malloc(unsigned long) (memory.cpp:205)
==49516==    by 0xC4E1D8: char* shogun::sg_generic_malloc<char>(unsigned long) (memory.h:79)
==49516==    by 0x719485C: shogun::TParameter::copy(shogun::TParameter*) (Parameter.cpp:3844)
==49516==    by 0x7199403: shogun::CSGObject::clone_parameters(shogun::CSGObject*) (SGObject.cpp:789)
==49516==    by 0x71990D0: shogun::CSGObject::clone() (SGObject.cpp:760)
==49516==    by 0x7192E5C: shogun::TParameter::copy_ptype(shogun::EPrimitiveType, void*, void*) (Parameter.cpp:3481)
==49516==    by 0x7193A02: shogun::TParameter::copy_stype(shogun::EStructType, shogun::EPrimitiveType, void*, void*) (Parameter.cpp:3647)
==49516==    by 0x719462D: shogun::TParameter::copy(shogun::TParameter*) (Parameter.cpp:3814)
==49516==    by 0x7199403: shogun::CSGObject::clone_parameters(shogun::CSGObject*) (SGObject.cpp:789)
==49516==    by 0x71990D0: shogun::CSGObject::clone() (SGObject.cpp:760)
==49516==    by 0x7192E5C: shogun::TParameter::copy_ptype(shogun::EPrimitiveType, void*, void*) (Parameter.cpp:3481)
```
And removing it again:
```
==49516== Invalid read of size 8
==49516==    at 0xC0C716: shogun::DynArray<shogun::CSGObject*>::get_element(int) const (DynArray.h:144)
==49516==    by 0xC6DCB9: shogun::CDynamicObjectArray::delete_element(int) (DynamicObjectArray.h:347)
==49516==    by 0x7698BDD: shogun::CSubsetStack::remove_subset() (SubsetStack.cpp:166)
==49516==    by 0x75DD99C: shogun::CFeatures::remove_subset() (Features.cpp:324)
==49516==    by 0xC27DDE: DenseFeaturesTest_subsetClone_Test::TestBody() (DenseFeatures_unittest.cc:291)
==49516==    by 0x10A5B5C: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2402)
==49516==    by 0x10A0889: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2438)
==49516==    by 0x1086901: testing::Test::Run() (gtest.cc:2475)
==49516==    by 0x108717F: testing::TestInfo::Run() (gtest.cc:2656)
==49516==    by 0x10877CC: testing::TestCase::Run() (gtest.cc:2774)
==49516==    by 0x108E370: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4649)
==49516==    by 0x10A69E2: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2402)
==49516==  Address 0xff5ddc8 is 0 bytes after a block of size 8 alloc'd
==49516==    at 0x4C28C20: malloc (vg_replace_malloc.c:296)
==49516==    by 0x791F769: shogun::sg_malloc(unsigned long) (memory.cpp:205)
==49516==    by 0xC4E1D8: char* shogun::sg_generic_malloc<char>(unsigned long) (memory.h:79)
==49516==    by 0x719485C: shogun::TParameter::copy(shogun::TParameter*) (Parameter.cpp:3844)
==49516==    by 0x7199403: shogun::CSGObject::clone_parameters(shogun::CSGObject*) (SGObject.cpp:789)
==49516==    by 0x71990D0: shogun::CSGObject::clone() (SGObject.cpp:760)
==49516==    by 0x7192E5C: shogun::TParameter::copy_ptype(shogun::EPrimitiveType, void*, void*) (Parameter.cpp:3481)
==49516==    by 0x7193A02: shogun::TParameter::copy_stype(shogun::EStructType, shogun::EPrimitiveType, void*, void*) (Parameter.cpp:3647)
==49516==    by 0x719462D: shogun::TParameter::copy(shogun::TParameter*) (Parameter.cpp:3814)
==49516==    by 0x7199403: shogun::CSGObject::clone_parameters(shogun::CSGObject*) (SGObject.cpp:789)
==49516==    by 0x71990D0: shogun::CSGObject::clone() (SGObject.cpp:760)
==49516==    by 0x7192E5C: shogun::TParameter::copy_ptype(shogun::EPrimitiveType, void*, void*) (Parameter.cpp:3481)
```

I can't figure out why. It would be really great if somebody who knows more about this could look into it.

Issue hidden in a PR 📦  ;-)