### PR TITLE
Fix CDynamicObjectArray / DynArray parameter handling + Test

### DIFF
--- a/src/shogun/lib/DynamicObjectArray.h
+++ b/src/shogun/lib/DynamicObjectArray.h
@@ -447,11 +447,14 @@ class CDynamicObjectArray : public CSGObject
 		/** register parameters */
 		virtual void init()
 		{
-			m_parameters->add_vector(&m_array.array, &m_array.current_num_elements, "array",
+			m_parameters->add_vector(&m_array.array, &m_array.num_elements, "array",
 									 "Memory for dynamic array.");
 			SG_ADD(&m_array.num_elements,
 							  "num_elements",
-							  "Number of Elements.", MS_NOT_AVAILABLE);
+							  "Number of elements.", MS_NOT_AVAILABLE);
+			SG_ADD(&m_array.current_num_elements,
+							  "current_num_elements",
+							  "Number of currently used elements.", MS_NOT_AVAILABLE);
 			SG_ADD(&m_array.resize_granularity,
 							  "resize_granularity",
 							  "shrink/grow step size.", MS_NOT_AVAILABLE);

--- a/tests/unit/base/DynamicObjectArrayNoTempl_unittest.cc
+++ b/tests/unit/base/DynamicObjectArrayNoTempl_unittest.cc
@@ -1,0 +1,34 @@
+/* This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Written (W) 2017 Leon Kuchenbecker
+ */
+
+#include <shogun/lib/DynamicObjectArray.h>
+#include <shogun/features/Subset.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+TEST(DynamicObjectArray,clone)
+{
+	// Base array
+	CDynamicObjectArray * do_array = new CDynamicObjectArray();
+
+	// Something relatively simple to add
+	CSubset * subset = new CSubset();
+	do_array->append_element(subset);
+
+	// Cloned array
+	CDynamicObjectArray * do_array_clone = (CDynamicObjectArray*) do_array->clone();
+
+	// Expand the cloned array
+	for (size_t i=0; i < 100; ++i)
+		do_array_clone->append_element(new CSubset());
+
+	// Check sizes
+	EXPECT_EQ(do_array->get_num_elements(), 1);
+	EXPECT_EQ(do_array_clone->get_num_elements(), 101);
+
+	SG_UNREF(do_array);
+	SG_UNREF(do_array_clone);
+}


### PR DESCRIPTION
CDynamicObjectArray could not be clone()ed properly (see test).

Changes:
 1. **Register `CDynamicObjectArray` parameters correctly**
 The `DynArray` member `array` was allocated + copied with the actual number of elements rather than the reserved number of elements. The cloned `DynArray` would insert new elements into unallocated space.
 1. **Initialize memory in `DynArray` if pointers are stored**
 Relevant when the `DynArray` holds `SGObject` pointers. The copy logic in `Parameter` checks for null and calls `clone()` on the pointers if not null.
 1. **Test**
 The test inserts many new elements to a `clone()`ed `CDynamicObjectArray`, most likely causing a bad access. In any case, the bad writes can be seen in valgrind. Test checks out fine after patch.