### PR TITLE
Register parameters for CMKL and override clone()

### DIFF
--- a/src/shogun/classifier/mkl/MKL.h
+++ b/src/shogun/classifier/mkl/MKL.h
@@ -95,6 +95,8 @@ class CMKL : public CSVM
 		 */
 		virtual ~CMKL();
 
+		virtual CSGObject* clone();
+
 		/** SVM to use as constraint generator in MKL SIP
 		 *
 		 * @param s svm
@@ -399,6 +401,9 @@ class CMKL : public CSVM
 		/** initialize solver such as glpk or cplex */
 		void init_solver();
 
+	private:
+		void register_params();
+
 	protected:
 		/** wrapper SVM */
 		CSVM* svm;
@@ -419,15 +424,14 @@ class CMKL : public CSVM
 
 		/** sub-kernel weights on the L1-term of ElasticnetMKL */
 		float64_t* beta_local;
+		int32_t beta_local_size;
+
 		/** number of mkl steps */
 		int32_t mkl_iterations;
 		/** mkl_epsilon for multiple kernel learning */
 		float64_t mkl_epsilon;
 		/** whether to use mkl wrapper or interleaved opt. */
 		bool interleaved_optimization;
-
-		/** partial objectives (one per kernel) */
-		float64_t* W;
 
 		/** gap between iterations */
 		float64_t w_gap;


### PR DESCRIPTION
Registers MKL class parameters and handles 3rd party lib parameters in `::clone()`. See #3725. I couldn't get shogun to compile with CPLEX enabled, it looks to me as if there are plenty of `#ifdef USE_CPLEX...#endif` blocks in shogun that actually don't compile anymore.