### PR TITLE
LibSVM parameters

### DIFF
--- a/src/shogun/classifier/svm/LibSVM.cpp
+++ b/src/shogun/classifier/svm/LibSVM.cpp
@@ -15,29 +15,39 @@
 using namespace shogun;
 
 CLibSVM::CLibSVM()
-: CSVM(), model(NULL), solver_type(LIBSVM_C_SVC)
+: CSVM(), solver_type(LIBSVM_C_SVC)
 {
+	register_params();
 }
 
 CLibSVM::CLibSVM(LIBSVM_SOLVER_TYPE st)
-: CSVM(), model(NULL), solver_type(st)
+: CSVM(), solver_type(st)
 {
+	register_params();
 }
 
 
 CLibSVM::CLibSVM(float64_t C, CKernel* k, CLabels* lab, LIBSVM_SOLVER_TYPE st)
-: CSVM(C, k, lab), model(NULL), solver_type(st)
+: CSVM(C, k, lab), solver_type(st)
 {
-	problem = svm_problem();
+	register_params();
 }
 
 CLibSVM::~CLibSVM()
 {
 }
 
+void CLibSVM::register_params()
+{
+	SG_ADD((machine_int_t*) &solver_type, "libsvm_solver_type", "LibSVM Solver type", MS_NOT_AVAILABLE);
+}
 
 bool CLibSVM::train_machine(CFeatures* data)
 {
+	svm_problem problem;
+	svm_parameter param;
+	struct svm_model* model = nullptr;
+
 	struct svm_node* x_space;
 
 	ASSERT(m_labels && m_labels->get_num_labels())

--- a/src/shogun/classifier/svm/LibSVM.cpp
+++ b/src/shogun/classifier/svm/LibSVM.cpp
@@ -61,7 +61,7 @@ bool CLibSVM::train_machine(CFeatures* data)
 	if (m_linear_term.vlen>0)
 	{
 		if (m_labels->get_num_labels()!=m_linear_term.vlen)
-            SG_ERROR("Number of training vectors does not match length of linear term\n")
+			SG_ERROR("Number of training vectors does not match length of linear term\n")
 
 		// set with linear term from base class
 		problem.pv = get_linear_term_array();
@@ -77,7 +77,7 @@ bool CLibSVM::train_machine(CFeatures* data)
 
 	problem.y=SG_MALLOC(float64_t, problem.l);
 	problem.x=SG_MALLOC(struct svm_node*, problem.l);
-    problem.C=SG_MALLOC(float64_t, problem.l);
+	problem.C=SG_MALLOC(float64_t, problem.l);
 
 	x_space=SG_MALLOC(struct svm_node, 2*problem.l);
 
@@ -155,7 +155,7 @@ bool CLibSVM::train_machine(CFeatures* data)
 		SG_FREE(problem.x);
 		SG_FREE(problem.y);
 		SG_FREE(problem.pv);
-        SG_FREE(problem.C);
+		SG_FREE(problem.C);
 
 
 		SG_FREE(x_space);

--- a/src/shogun/classifier/svm/LibSVM.h
+++ b/src/shogun/classifier/svm/LibSVM.h
@@ -60,6 +60,9 @@ class CLibSVM : public CSVM
 		/** @return object name */
 		virtual const char* get_name() const { return "LibSVM"; }
 
+	private:
+		void register_params();
+
 	protected:
 		/** train SVM classifier
 		 *
@@ -72,13 +75,6 @@ class CLibSVM : public CSVM
 		virtual bool train_machine(CFeatures* data=NULL);
 
 	protected:
-		/** SVM problem */
-		svm_problem problem;
-		/** SVM param */
-		svm_parameter param;
-		/** SVM model */
-		struct svm_model* model;
-
 		/** solver type */
 		LIBSVM_SOLVER_TYPE solver_type;
 };

--- a/src/shogun/classifier/svm/LibSVMOneClass.cpp
+++ b/src/shogun/classifier/svm/LibSVMOneClass.cpp
@@ -15,22 +15,25 @@
 using namespace shogun;
 
 CLibSVMOneClass::CLibSVMOneClass()
-: CSVM(), model(NULL)
+: CSVM()
 {
 }
 
 CLibSVMOneClass::CLibSVMOneClass(float64_t C, CKernel* k)
-: CSVM(C, k, NULL), model(NULL)
+: CSVM(C, k, NULL)
 {
 }
 
 CLibSVMOneClass::~CLibSVMOneClass()
 {
-	SG_FREE(model);
 }
 
 bool CLibSVMOneClass::train_machine(CFeatures* data)
 {
+	svm_problem problem;
+	svm_parameter param;
+	struct svm_model* model = nullptr;
+
 	ASSERT(kernel)
 	if (data)
 		kernel->init(data, data);

--- a/src/shogun/classifier/svm/LibSVMOneClass.h
+++ b/src/shogun/classifier/svm/LibSVMOneClass.h
@@ -58,15 +58,6 @@ class CLibSVMOneClass : public CSVM
 		 * @return whether training was successful
 		 */
 		virtual bool train_machine(CFeatures* data=NULL);
-
-	protected:
-		/** SVM problem */
-		svm_problem problem;
-		/** SVM parameter */
-		svm_parameter param;
-
-		/** SVM model */
-		struct svm_model* model;
 };
 }
 #endif

--- a/src/shogun/multiclass/MulticlassLibSVM.cpp
+++ b/src/shogun/multiclass/MulticlassLibSVM.cpp
@@ -16,12 +16,12 @@
 using namespace shogun;
 
 CMulticlassLibSVM::CMulticlassLibSVM(LIBSVM_SOLVER_TYPE st)
-: CMulticlassSVM(new CMulticlassOneVsOneStrategy()), model(NULL), solver_type(st)
+: CMulticlassSVM(new CMulticlassOneVsOneStrategy()), solver_type(st)
 {
 }
 
 CMulticlassLibSVM::CMulticlassLibSVM(float64_t C, CKernel* k, CLabels* lab)
-: CMulticlassSVM(new CMulticlassOneVsOneStrategy(), C, k, lab), model(NULL), solver_type(LIBSVM_C_SVC)
+: CMulticlassSVM(new CMulticlassOneVsOneStrategy(), C, k, lab), solver_type(LIBSVM_C_SVC)
 {
 }
 
@@ -29,8 +29,17 @@ CMulticlassLibSVM::~CMulticlassLibSVM()
 {
 }
 
+void CMulticlassLibSVM::register_params()
+{
+	SG_ADD((machine_int_t*) &solver_type, "libsvm_solver_type", "LibSVM solver type", MS_NOT_AVAILABLE);
+}
+
 bool CMulticlassLibSVM::train_machine(CFeatures* data)
 {
+	svm_problem problem;
+	svm_parameter param;
+	struct svm_model* model = nullptr;
+
 	struct svm_node* x_space;
 
 	problem = svm_problem();

--- a/src/shogun/multiclass/MulticlassLibSVM.h
+++ b/src/shogun/multiclass/MulticlassLibSVM.h
@@ -59,15 +59,10 @@ class CMulticlassLibSVM : public CMulticlassSVM
 		 */
 		virtual bool train_machine(CFeatures* data=NULL);
 
+	private:
+		void register_params();
+
 	protected:
-		/** SVM problem */
-		svm_problem problem;
-		/** SVM parameter */
-		svm_parameter param;
-
-		/** SVM model */
-		struct svm_model* model;
-
 		/** solver type */
 		LIBSVM_SOLVER_TYPE solver_type;
 };

--- a/src/shogun/multiclass/ScatterSVM.h
+++ b/src/shogun/multiclass/ScatterSVM.h
@@ -110,23 +110,19 @@ class CScatterSVM : public CMulticlassSVM
 #endif //USE_SVMLIGHT
 		virtual bool train_testrule12();
 
+		void register_params();
+
 	protected:
 		/** type of scatter SVM */
 		SCATTER_TYPE scatter_type;
 
-		/** SVM problem */
-		svm_problem problem;
-		/** SVM param */
-		svm_parameter param;
-
-		/** SVM model */
-		struct svm_model* model;
-
 		/** norm of w_c */
 		float64_t* norm_wc;
+		int32_t norm_wc_len;
 
 		/** norm of w_cw */
 		float64_t* norm_wcw;
+		int32_t norm_wcw_len;
 
 		/** ScatterSVM rho */
 		float64_t rho;

--- a/src/shogun/regression/svr/LibSVR.cpp
+++ b/src/shogun/regression/svr/LibSVR.cpp
@@ -1,5 +1,5 @@
 /*
- * This program is free software; you can redistribute it and/or modify
+
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
@@ -18,7 +18,7 @@ using namespace shogun;
 CLibSVR::CLibSVR()
 : CSVM()
 {
-	model=NULL;
+	register_params();
 	solver_type=LIBSVR_EPSILON_SVR;
 }
 
@@ -26,8 +26,7 @@ CLibSVR::CLibSVR(float64_t C, float64_t svr_param, CKernel* k, CLabels* lab,
 		LIBSVR_SOLVER_TYPE st)
 : CSVM()
 {
-	model=NULL;
-
+	register_params();
 	set_C(C,C);
 
 	switch (st)
@@ -50,7 +49,11 @@ CLibSVR::CLibSVR(float64_t C, float64_t svr_param, CKernel* k, CLabels* lab,
 
 CLibSVR::~CLibSVR()
 {
-	SG_FREE(model);
+}
+
+void CLibSVR::register_params()
+{
+	SG_ADD((machine_int_t*) &solver_type, "libsvr_solver_type", "LibSVR Solver type", MS_NOT_AVAILABLE);
 }
 
 EMachineType CLibSVR::get_classifier_type()
@@ -60,6 +63,10 @@ EMachineType CLibSVR::get_classifier_type()
 
 bool CLibSVR::train_machine(CFeatures* data)
 {
+	svm_problem problem;
+	svm_parameter param;
+	struct svm_model* model = nullptr;
+
 	ASSERT(kernel)
 	ASSERT(m_labels && m_labels->get_num_labels())
 	ASSERT(m_labels->get_label_type() == LT_REGRESSION)

--- a/src/shogun/regression/svr/LibSVR.h
+++ b/src/shogun/regression/svr/LibSVR.h
@@ -98,6 +98,9 @@ class CLibSVR : public CSVM
 		/** @return object name */
 		virtual const char* get_name() const { return "LibSVR"; }
 
+	private:
+		void register_params();
+
 	protected:
 		/** train regression
 		 *
@@ -109,14 +112,6 @@ class CLibSVR : public CSVM
 		 */
 		virtual bool train_machine(CFeatures* data=NULL);
 	protected:
-		/** SVM problem */
-		svm_problem problem;
-		/** SVM parameter */
-		svm_parameter param;
-
-		/** SVM model */
-		struct svm_model* model;
-
 		/** solver type */
 		LIBSVR_SOLVER_TYPE solver_type;
 };


### PR DESCRIPTION
This patch registers members of LibSVM related classes as parameters or moves them out of the class scope. See #3725.