### PR TITLE
Discover generated serialization tests

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -35,6 +35,8 @@ function (add_unit_test_executable EXECUTABLE TARGET SRC)
 	ADD_CUSTOM_TARGET(${TARGET}
 			COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE}
 			DEPENDS ${EXECUTABLE})
+
+	shogun_discover_tests(${EXECUTABLE})
 endfunction ()
 
 # Generate automatic unittest from jinja2 templates
@@ -117,8 +119,6 @@ add_unit_test_executable(shogun-unit-test unit-tests "${UNITTEST_SRC}")
 
 LIST(APPEND SERIALIZATION_UNITTEST base/main_unittest.cc)
 add_unit_test_executable(shogun-serialization-unit-test serialization-unit-tests "${SERIALIZATION_UNITTEST}")
-
-shogun_discover_tests(shogun-unit-test)
 
 # Add unittests to the dependencies of modular interfaces to make sure nothing
 # will infer with them being build single-threaded.


### PR DESCRIPTION
Following #3735 serialization tests were not discovered by cmake, I don't think this was the intended behaviour (travis still builds the tests but doesn't run them, see this build https://travis-ci.org/shogun-toolbox/shogun/jobs/213507345#L5782), this should fix it.