### PR TITLE
LinalgRefacotr - add linalg::logistic

### DIFF
--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -175,6 +175,19 @@ public:
 	#undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
 
 	/**
+	 * Wrapper method of logistic function f(x) = 1/(1+exp(-x))
+	 *
+	 * @see linalg::logistic
+	 */
+	#define BACKEND_GENERIC_LOGISTIC(Type, Container) \
+	virtual void logistic(Container<Type>& a, Container<Type>& result) const \
+	{  \
+		SG_SNOTIMPLEMENTED; \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_LOGISTIC, SGMatrix)
+	#undef BACKEND_GENERIC_LOGISTIC
+
+	/**
 	 * Wrapper method of matrix product method.
 	 *
 	 * @see linalg::matrix_prod

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -156,6 +156,15 @@ public:
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
 	#undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
 
+	/** Implementation of @see LinalgBackendBase::logistic */
+	#define BACKEND_GENERIC_LOGISTIC(Type, Container) \
+	virtual void logistic(Container<Type>& a, Container<Type>& result) const \
+	{  \
+		logistic_impl(a, result); \
+	}
+	DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_LOGISTIC, SGMatrix)
+	#undef BACKEND_GENERIC_LOGISTIC
+
 	/** Implementation of @see LinalgBackendBase::matrix_prod */
 	#define BACKEND_GENERIC_IN_PLACE_MATRIX_PROD(Type, Container) \
 	virtual void matrix_prod(SGMatrix<Type>& a, Container<Type>& b,\
@@ -397,6 +406,19 @@ private:
 		typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
 
 		result_eig = a_eig.array() * b_eig.array();
+	}
+
+	/** Eigen3 logistic method. Calculates f(x) = 1/(1+exp(-x)) */
+	template <typename T>
+	void logistic_impl(SGMatrix<T>& a, SGMatrix<T>& result) const
+	{
+		typename SGMatrix<T>::EigenMatrixXtMap a_eig = a;
+		typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
+
+		result_eig = (T)1 / (1 + ((-1 * a_eig).array()).exp());
+
+		//for (int32_t i=0; i<a.num_rows*a.num_cols; i++)
+		//	result_eig[i] = 1.0/(1+CMath::exp(-1*a_eig[i]));
 	}
 
 	/** Eigen3 matrix block in-place elementwise product method */

--- a/src/shogun/mathematics/linalg/LinalgSpecialPurposes.h
+++ b/src/shogun/mathematics/linalg/LinalgSpecialPurposes.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors: 2017 Pan Deng, 2014 Khaled Nasr
+ */
+
+#ifndef LINALG_SPECIAL_PURPOSE_H_
+#define LINALG_SPECIAL_PURPOSE_H_
+
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+/** Applies the elementwise logistic function f(x) = 1/(1+exp(-x)) to a matrix
+ *  This method returns the result in-place.
+ *
+ * @param a The input matrix
+ * @param result The output matrix
+ */
+template <typename T>
+void logistic(SGMatrix<T>& a, SGMatrix<T>& result)
+{
+	REQUIRE((a.num_rows == result.num_rows),
+		"Number of rows of matrix a (%d) must match matrix result (%d).\n",
+		a.num_rows, result.num_rows);
+	REQUIRE((a.num_cols == result.num_cols),
+		"Number of columns of matrix result (%d) must match matrix result (%d).\n",
+		a.num_cols, result.num_cols);
+
+	infer_backend(a, result)->logistic(a, result);
+}
+
+}
+
+}
+
+#endif //LINALG_SPECIAL_PURPOSE_H_

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -1,5 +1,7 @@
 #include <shogun/lib/config.h>
+#include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <shogun/mathematics/linalg/LinalgSpecialPurposes.h>
 #include <gtest/gtest.h>
 #include <shogun/lib/ShogunException.h>
 
@@ -235,6 +237,20 @@ TEST(LinalgBackendEigen, SGMatrix_block_elementwise_product)
 	for (index_t i = 0; i < 2; ++i)
 		for (index_t j = 0; j < 2; ++j)
 			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+}
+
+TEST(LinalgBackendEigen, logistic)
+{
+	SGMatrix<float64_t> A(3,3);
+	SGMatrix<float64_t> B(3,3);
+
+	for (index_t i = 0; i < 9; ++i)
+		A[i] = i;
+
+	linalg::logistic(A, B);
+
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(1.0/(1+CMath::exp(-1*A[i])), B[i], 1e-15);
 }
 
 TEST(LinalgBackendEigen, SGMatrix_SGVector_matrix_prod)

--- a/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
@@ -1,6 +1,8 @@
 #include <shogun/lib/config.h>
 #include <shogun/lib/SGVector.h>
+#include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <shogun/mathematics/linalg/LinalgSpecialPurposes.h>
 #include <gtest/gtest.h>
 
 #ifdef HAVE_VIENNACL
@@ -181,6 +183,26 @@ TEST(LinalgBackendViennaCL, SGMatrix_elementwise_product_in_place)
 
 	for (index_t i = 0; i < 9; ++i)
 		EXPECT_NEAR(C[i]*B[i], A[i], 1e-15);
+}
+
+TEST(LinalgBackendViennaCL, logistic)
+{
+	SGMatrix<float64_t> A(3,3), A_gpu;
+	SGMatrix<float64_t> B(3,3), B_gpu;
+
+	for (index_t i = 0; i < 9; ++i)
+		A[i] = i;
+
+	to_gpu(A, A_gpu);
+	to_gpu(B, B_gpu);
+
+	logistic(A_gpu, B_gpu);
+
+	from_gpu(A_gpu, A);
+	from_gpu(B_gpu, B);
+
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(1.0/(1+CMath::exp(-1*A[i])), B[i], 1e-15);
 }
 
 TEST(LinalgBackendViennaCL, SGMatrix_SGVector_matrix_prod)


### PR DESCRIPTION
I am going to split the current `LinalgNameSpace` into `SpecialPurpose`, `BasicOps` and `LinearSolver`, while keeping `LinalgNameSpace` as the interface for all, if no one objects.