### PR TITLE
Move sg_memcpy out ifdef TRACE_MEMORY_ALLOCS.

### DIFF
--- a/src/shogun/lib/memory.h
+++ b/src/shogun/lib/memory.h
@@ -19,6 +19,18 @@
 #include <new>
 #include <cstring>
 
+/* memcpy wrapper to enable clean moves to different memcpy backends */
+namespace shogun
+{
+
+template <class InputIt, class OutputIt>
+SG_FORCED_INLINE void* sg_memcpy(InputIt dest, OutputIt src, size_t count)
+{
+	return std::memcpy(static_cast<void*>(dest), static_cast<const void*>(src), count);
+}
+
+}  // namespace shogun
+
 /* wrappers for malloc, free, realloc, calloc */
 
 /* overload new() / delete */
@@ -96,13 +108,6 @@ template <class T> void sg_generic_free(T* ptr)
 {
 	sg_free(ptr);
 }
-
-template <class InputIt, class OutputIt>
-SG_FORCED_INLINE void* sg_memcpy(InputIt dest, OutputIt src, size_t count)
-{
-	return std::memcpy(static_cast<void*>(dest), static_cast<const void*>(src), count);
-}
-
 #endif //TRACE_MEMORY_ALLOCS
 #ifdef TRACE_MEMORY_ALLOCS
 /** @brief memory block */


### PR DESCRIPTION
This way sg_memcpy is also defined when TRACE_MEMORY_ALLOCS=OFF.