### PR TITLE
Remove HAVE_LARGEFILE conf. option since it is not used.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,9 +379,6 @@ OPTION(USE_PATHDEBUG "Viterbi path debugging" OFF)
 # big states
 OPTION(USE_BIGSTATES "Big (16bit) state" ON)
 
-# Large file
-OPTION(HAVE_LARGEFILE "Large file support" ON)
-
 #kernelcache to use 4-byte-floating-point values instead of 8-byte-doubles
 OPTION(USE_SHORTREAL_KERNELCACHE "Kernelcache to use 4-byte-floating-point values instead of 8-byte-doubles" ON)
 

--- a/src/shogun/lib/config.h.in
+++ b/src/shogun/lib/config.h.in
@@ -10,7 +10,6 @@
 #cmakedefine HAVE_CURL 1
 #cmakedefine HAVE_JSON 1
 #cmakedefine HAVE_XML 1
-#cmakedefine HAVE_LARGEFILE 1
 #cmakedefine HAVE_DOXYGEN 1
 #cmakedefine HAVE_LAPACK 1
 #cmakedefine HAVE_MVEC 1


### PR DESCRIPTION
Am I missing where this is used?