### PR TITLE
Add clang-format file and Travis integration to check PRs' code style.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,44 @@
+#
+# Shogun clang-format configuration file
+#
+Language:        Cpp
+AccessModifierOffset: 0
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+ColumnLimit: 80
+ContinuationIndentWidth: 4
+IndentWidth: 4
+NamespaceIndentation: All
+PenaltyBreakComment: 10000
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 10000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes:    true
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          ForIndentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
       services: docker
       env:
         - CMAKE_OPTIONS="-DOctaveModular=ON -DTRAVIS_DISABLE_UNIT_TESTS=ON -DTRAVIS_DISABLE_LIBSHOGUN_TESTS=ON"
+        - OCTAVE_MODULAR=true
     - compiler: clang
       services: docker
       env:
@@ -68,11 +69,14 @@ matrix:
         - CXX=clang++
 before_install:
   - docker pull shogun/shogun-dev
-  - echo $CC; echo $CXX
-  - docker run -t -d -P -e "JAVA_HOME=/usr/lib/jvm/java-8-oracle" -e "CC=$CC" -e "CXX=$CXX" --name devenv -v $PWD:/opt/shogun shogun/shogun-dev /bin/sh -c "mkdir /opt/shogun/build;bash"
+  - docker run -t -d -P -e "JAVA_HOME=/usr/lib/jvm/java-8-oracle" -e "CC=$CC" -e "CXX=$CXX" -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" -e "TRAVIS_BRANCH=$TRAVIS_BRANCH" -e "TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"  --name devenv -v $PWD:/opt/shogun shogun/shogun-dev /bin/sh -c "mkdir /opt/shogun/build;bash"
 before_script:
   - docker exec -t devenv /bin/sh -c "cd /opt/shogun/build; cmake -DCMAKE_INSTALL_PREFIX=$HOME/shogun-build -DENABLE_TESTING=ON $CMAKE_OPTIONS .."
 script:
+  - |
+    if [ $CC == "gcc" ] && [ -z $OCTAVE_MODULAR ]; then
+      docker exec -t devenv /bin/sh -c "cd /opt/shogun/; ./scripts/check_format.sh"
+    fi
   - docker exec -t devenv /bin/sh -c "cd /opt/shogun/build; make -j2"
   - docker exec -t devenv /bin/sh -c "cd /opt/shogun/build; make install"
   - docker exec -t devenv /bin/sh -c "cd /opt/shogun/build; ctest --output-on-failure -j 2"

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# This script was originally inspired by:
+# https://github.com/root-project/root/blob/master/.travis.yml
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+
+    BASE_COMMIT=$(git rev-parse $TRAVIS_BRANCH)
+
+    echo "-----"
+    echo "Shogun Style Checker"
+    echo "-----"
+    echo "Running clang-format-3.8 against branch $TRAVIS_BRANCH, with hash $BASE_COMMIT"
+
+    COMMIT_FILES=$(git diff --name-only $BASE_COMMIT)
+    RESULT_OUTPUT="$(git clang-format-3.8 --commit $BASE_COMMIT --diff --binary `which clang-format-3.8` $COMMIT_FILES)"
+
+    if [ "$RESULT_OUTPUT" == "no modified files to format" ] \
+        || [ "$RESULT_OUTPUT" == "clang-format-3.8 did not modify any files" ] \
+        || [ "$RESULT_OUTPUT" == "clang-format did not modify any files" ]; then
+          echo "clang-format-3.8 passed. \o/"
+          echo "-----"
+          exit 0
+    else
+        echo "-----"
+        echo "clang-format failed."
+        echo "To reproduce it locally please run: "
+        echo -e "\t1) git checkout $TRAVIS_PULL_REQUEST_BRANCH"
+        echo -e "\t2) git clang-format-3.8 --commit $BASE_COMMIT --diff --binary $(which clang-format-3.8)"
+        echo "To fix the errors automatically please run: "
+        echo -e "\t1) git checkout $TRAVIS_PULL_REQUEST_BRANCH"
+        echo -e "\t2) git clang-format-3.8 --commit $BASE_COMMIT --binary $(which clang-format-3.8)"
+        echo "-----"
+        echo "Style errors found:"
+        echo "$RESULT_OUTPUT"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
This PR is focused on make Travis able to evaluate PRs' code style. The main idea is to create a clang-format file which will define some Shogun's code style guidelines. These guidelines should be followed when writing patches/code.

This patch's `.clang-format` file is a bit skinny. There are only some basic instructions which were modelled by looking at this page:
* https://github.com/shogun-toolbox/shogun/wiki/Code-style

A simple example on how Travis will (should) behave after this patch can be found at this link: 
* https://travis-ci.org/geektoni/clang-format-test/jobs/226336339