### PR TITLE
Remove duplicate code in LDA/FisherLDA and port the solvers to use linalg (WIP)

### DIFF
--- a/src/shogun/classifier/LDA.h
+++ b/src/shogun/classifier/LDA.h
@@ -172,6 +172,23 @@ class CLDA : public CLinearMachine
 		template <typename ST>
 		bool train_machine_templated(SGVector<int32_t> train_labels, CFeatures * features);
 
+		/**
+		 * Train the machine with the svd-based solver (@see CFisherLDA).
+		 * \warning This method is currently untemplated.
+		 * @param features training data
+		 * @param labels labels for training data
+		 */
+		bool solver_svd(SGVector<int32_t> train_labels, CFeatures* data);
+
+		/**
+		 * Train the machine with the classic method based on the cholesky
+		 * decomposition of the covariance matrix.
+		 * @param features training data
+		 * @param labels labels for training data
+		 */
+		template <typename ST>
+		bool solver_classic(SGVector<int32_t> train_labels, CFeatures* data);
+
 	protected:
 
 		void init();

--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -388,8 +388,23 @@ void SGMatrix<T>::create_diagonal_matrix(T* matrix, T* v,int32_t size)
 }
 
 template <class T>
-float64_t SGMatrix<T>::trace(
-	float64_t* mat, int32_t cols, int32_t rows)
+SGVector<T> SGMatrix<T>::get_column(index_t col) const
+{
+	assert_on_cpu();
+	return SGVector<T>(get_column_vector(col), num_rows, false);
+}
+
+template <class T>
+void SGMatrix<T>::set_column(index_t col, const SGVector<T> vec)
+{
+	assert_on_cpu();
+	ASSERT(!vec.on_gpu())
+	ASSERT(vec.vlen == num_rows)
+	sg_memcpy(&matrix[num_rows * col], vec.vector, sizeof(T) * num_rows);
+}
+
+template <class T>
+float64_t SGMatrix<T>::trace(float64_t* mat, int32_t cols, int32_t rows)
 {
 	float64_t trace=0;
 	for (int64_t i=0; i<rows; i++)

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -132,7 +132,7 @@ template<class T> class SGMatrix : public SGReferencedData
 		/** Empty destructor */
 		virtual ~SGMatrix();
 
-#ifndef SWIG // SWIG should skip this part
+#ifndef SWIG // SWIG should skip this parts
 		/** Get a column vector
 		 * @param col column index
 		 * @return the column vector for index col
@@ -143,6 +143,19 @@ template<class T> class SGMatrix : public SGReferencedData
 			const int64_t c = col;
 			return &matrix[c*num_rows];
 		}
+
+		/** Map a column to a SGVector
+		 * \warning The returned SGVector is non-owning!
+		 * @param col column index
+		 * @return the column vector for index col
+		 */
+		SGVector<T> get_column(index_t col) const;
+
+		/** Copy the content of a vector into a column
+		 * @param col column index
+		 * @param vec vector
+		 */
+		void set_column(index_t col, const SGVector<T> vec);
 
 		/** Get a row vector
 		 *

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -97,10 +97,20 @@ SGVector<T>::SGVector(index_t len, bool ref_counting)
 	m_on_gpu.store(false, std::memory_order_release);
 }
 
-template<class T>
+template <class T>
+SGVector<T>::SGVector(SGMatrix<T> matrix)
+	: SGReferencedData(matrix), vlen(matrix.num_cols * matrix.num_rows),
+	  gpu_ptr(NULL)
+{
+	ASSERT(!matrix.on_gpu())
+	vector = matrix.data();
+	m_on_gpu.store(false, std::memory_order_release);
+}
+
+template <class T>
 SGVector<T>::SGVector(GPUMemoryBase<T>* gpu_vector, index_t len)
- : SGReferencedData(true), vector(NULL), vlen(len),
-   gpu_ptr(std::shared_ptr<GPUMemoryBase<T>>(gpu_vector))
+	: SGReferencedData(true), vector(NULL), vlen(len),
+	  gpu_ptr(std::shared_ptr<GPUMemoryBase<T>>(gpu_vector))
 {
 	m_on_gpu.store(true, std::memory_order_release);
 }

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -65,6 +65,9 @@ template<class T> class SGVector : public SGReferencedData
 		/** Constructor to create new vector in memory */
 		SGVector(index_t len, bool ref_counting=true);
 
+		/** Constructor to create new vector from a SGMatrix */
+		SGVector(SGMatrix<T> matrix);
+
 		/** Construct SGVector from GPU memory.
 		 *
 		 * @param vector GPUMemoryBase pointer

--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -123,6 +123,22 @@ namespace shogun
 #undef BACKEND_GENERIC_ADD_COL_VEC
 
 /**
+ * Wrapper method of add vector to each column of matrix.
+ *
+ * @see linalg::add_vector
+ */
+#define BACKEND_GENERIC_ADD_VECTOR(Type, Container)                            \
+	virtual void add_vector(                                                   \
+	    const SGMatrix<Type>& A, const SGVector<Type>& b,                      \
+	    SGMatrix<Type>& result, Type alpha, Type beta) const                   \
+	{                                                                          \
+		SG_SNOTIMPLEMENTED;                                                    \
+		return;                                                                \
+	}
+		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_VECTOR, SGMatrix)
+#undef BACKEND_GENERIC_ADD_VECTOR
+
+/**
  * Wrapper method of add scalar operation.
  *
  * @see linalg::add_scalar

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -64,6 +64,14 @@ namespace shogun
 		DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGMatrix)
 #undef BACKEND_GENERIC_ADD_COL_VEC
 
+/** Implementation of @see LinalgBackendBase::add_vector */
+#define BACKEND_GENERIC_ADD(Type, Container)                                   \
+	virtual void add_vector(                                                   \
+	    const SGMatrix<Type>& A, const SGVector<Type>& b,                      \
+	    SGMatrix<Type>& result, Type alpha, Type beta) const;
+		DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD, SGMatrix)
+#undef BACKEND_GENERIC_ADD
+
 /** Implementation of @see LinalgBackendBase::add_scalar */
 #define BACKEND_GENERIC_ADD_SCALAR(Type, Container)                            \
 	virtual void add_scalar(Container<Type>& a, Type b) const;
@@ -371,6 +379,12 @@ namespace shogun
 		void add_col_vec_impl(
 		    const SGMatrix<T>& A, index_t i, const SGVector<T>& b,
 		    SGVector<T>& result, T alpha, T beta) const;
+
+		/** Eigen3 add vector to each column of matrix method */
+		template <typename T>
+		void add_vector_impl(
+		    const SGMatrix<T>& A, const SGVector<T>& b, SGMatrix<T>& result,
+		    T alpha, T beta) const;
 
 		/** Eigen3 vector add scalar method */
 		template <typename T>

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -444,6 +444,36 @@ namespace shogun
 		}
 
 		/**
+		 * Performs the operation result = alpha * A.col(i) + beta * b,
+		 * for each column of A.
+		 * User should pass an appropriately pre-allocated memory matrix
+		 * or pass the operand argument A as a result.
+		 *
+		 * @param A The matrix
+		 * @param b The vector
+		 * @param result The matrix that saves the result
+		 * @param alpha Constant to be multiplied by the matrix
+		 * @param beta Constant to be multiplied by the vector
+		 */
+		template <typename T>
+		void add_vector(
+		    const SGMatrix<T>& A, const SGVector<T>& b, SGMatrix<T>& result,
+		    T alpha = 1, T beta = 1)
+		{
+			REQUIRE(
+			    A.num_rows == b.vlen, "Number of rows of matrix A (%d) doesn't "
+			                          "match length of vector b (%d).\n",
+			    A.num_rows, b.vlen);
+			REQUIRE(
+			    result.num_rows == A.num_rows && result.num_cols == A.num_cols,
+			    "Dimension mismatch! A (%d x %d) vs result (%d x %d).\n",
+			    A.num_rows, A.num_cols, result.num_rows, result.num_cols);
+
+			infer_backend(A, SGMatrix<T>(b))
+			    ->add_vector(A, b, result, alpha, beta);
+		}
+
+		/**
 		 * Adds a scalar to each element of a vector or a matrix in-place.
 		 *
 		 * @param a Vector or matrix

--- a/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
@@ -57,6 +57,16 @@ DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGVector)
 DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGMatrix)
 #undef BACKEND_GENERIC_ADD_COL_VEC
 
+#define BACKEND_GENERIC_ADD_VECTOR(Type, Container)                            \
+	void LinalgBackendEigen::add_vector(                                       \
+	    const SGMatrix<Type>& A, const SGVector<Type>& b,                      \
+	    SGMatrix<Type>& result, Type alpha, Type beta) const                   \
+	{                                                                          \
+		add_vector_impl(A, b, result, alpha, beta);                            \
+	}
+DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_VECTOR, SGMatrix)
+#undef BACKEND_GENERIC_ADD_VECTOR
+
 #define BACKEND_GENERIC_ADD_SCALAR(Type, Container)                            \
 	void LinalgBackendEigen::add_scalar(Container<Type>& a, Type b) const      \
 	{                                                                          \
@@ -164,6 +174,18 @@ void LinalgBackendEigen::add_col_vec_impl(
 	typename SGVector<T>::EigenVectorXtMap result_eig = result;
 
 	result_eig = alpha * A_eig.col(i) + beta * b_eig;
+}
+
+template <typename T>
+void LinalgBackendEigen::add_vector_impl(
+    const SGMatrix<T>& A, const SGVector<T>& b, SGMatrix<T>& result, T alpha,
+    T beta) const
+{
+	typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
+	typename SGVector<T>::EigenVectorXtMap b_eig = b;
+	typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
+
+	result_eig = (alpha * A_eig).colwise() + beta * b_eig;
 }
 
 template <typename T>

--- a/src/shogun/mathematics/linalg/backend/eigen/Decompositions.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/Decompositions.cpp
@@ -120,6 +120,18 @@ void LinalgBackendEigen::eigen_solver_impl(
 	typename SGVector<T>::EigenVectorXtMap eigenvalues_eig = eigenvalues;
 
 	Eigen::EigenSolver<typename SGMatrix<T>::EigenMatrixXt> solver(A_eig);
+
+	/*
+	 * checking for success
+	 *
+	 * 0: Eigen::Success. Decomposition was successful
+	 * 1: Eigen::NumericalIssue. The input contains INF or NaN values or
+	 * overflow occured
+	 */
+	REQUIRE(
+	    solver.info() != Eigen::NumericalIssue,
+	    "The input contains INF or NaN values or overflow occured.\n");
+
 	eigenvalues_eig = solver.eigenvalues().real();
 	eigenvectors_eig = solver.eigenvectors().real();
 }
@@ -136,6 +148,11 @@ void LinalgBackendEigen::eigen_solver_impl(
 
 	Eigen::ComplexEigenSolver<typename SGMatrix<complex128_t>::EigenMatrixXt>
 	    solver(A_eig);
+
+	REQUIRE(
+	    solver.info() != Eigen::NumericalIssue,
+	    "The input contains INF or NaN values or overflow occured.\n");
+
 	eigenvalues_eig = solver.eigenvalues();
 	eigenvectors_eig = solver.eigenvectors();
 }
@@ -151,6 +168,17 @@ void LinalgBackendEigen::eigen_solver_symmetric_impl(
 
 	Eigen::SelfAdjointEigenSolver<typename SGMatrix<T>::EigenMatrixXt> solver(
 	    A_eig);
+
+	/*
+	 * checking for success
+	 *
+	 * 0: Eigen::Success. Eigenvalues computation was successful
+	 * 2: Eigen::NoConvergence. Iterative procedure did not converge.
+	 */
+	REQUIRE(
+	    solver.info() != Eigen::NoConvergence,
+	    "Iterative procedure did not converge!\n");
+
 	eigenvalues_eig = solver.eigenvalues().template cast<T>();
 	eigenvectors_eig = solver.eigenvectors().template cast<T>();
 }

--- a/src/shogun/preprocessor/FisherLDA.h
+++ b/src/shogun/preprocessor/FisherLDA.h
@@ -36,10 +36,11 @@
 
 #include <shogun/lib/config.h>
 
+#include <shogun/features/Features.h>
+#include <shogun/labels/Labels.h>
 #include <shogun/preprocessor/DimensionReductionPreprocessor.h>
 #include <shogun/preprocessor/Preprocessor.h>
-#include <shogun/labels/Labels.h>
-#include <shogun/features/Features.h>
+#include <vector>
 
 namespace shogun
 {
@@ -98,7 +99,9 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 		 * those basis whose singular values are less than the provided threshold.
 		 * The default one is 0.01.
 		 */
-		CFisherLDA(EFLDAMethod method=AUTO_FLDA, float64_t thresh=0.01);
+		CFisherLDA(
+		    EFLDAMethod method = AUTO_FLDA, float64_t thresh = 0.01,
+		    float64_t gamma = 0);
 
 		/** destructor */
 		virtual ~CFisherLDA();
@@ -150,12 +153,46 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 		void initialize_parameters();
 
 	protected:
+		/** Helper function used by the solvers to center the data and
+		 * to compute the number of data points and the mean for each class.
+		 * @param data matrix containing the data to be processed.
+		 * @param labels_vector vector containing the label for each data point.
+		 * @param C number of classes.
+		 * @param mean_class vector that holds the mean vector for each class.
+		 * @param num_class vector that holds the number of data points for each
+		 * class.
+		 */
+		void center_data_compute_means(
+		    SGMatrix<float64_t>& data, SGVector<float64_t>& labels_vector,
+		    int32_t C, std::vector<SGVector<float64_t>>& mean_class,
+		    std::vector<index_t>& num_class);
 
+		/**
+		 * Train the preprocessor with the canonical variates method.
+		 * @param data training data.
+		 * @param labels_vector vector containing the label for each data point.
+		 * @param C number of classes.
+		 */
+		bool solver_canvar(
+		    SGMatrix<float64_t>& data, SGVector<float64_t>& labels_vector,
+		    int32_t C);
+
+		/**
+		 * Train the preprocessor with the classic method.
+		 * @param data training data.
+		 * @param labels_vector vector containing the label for each data point.
+		 * @param C number of classes.
+		 */
+		bool solver_classic(
+		    SGMatrix<float64_t>& data, SGVector<float64_t>& labels_vector,
+		    int32_t C);
 
 		/** transformation matrix */
 		SGMatrix<float64_t> m_transformation_matrix;
 		/** num dim */
 		int32_t m_num_dim;
+		/** gamma */
+		float64_t m_gamma;
 		/** m_threshold */
 		float64_t m_threshold;
 		/** m_method */

--- a/tests/unit/lib/SGMatrix_unittest.cc
+++ b/tests/unit/lib/SGMatrix_unittest.cc
@@ -614,3 +614,35 @@ TEST(SGMatrixTest, max_single)
 	for (uint64_t i=0; i<mat.size(); ++i)
 		EXPECT_GE(max, mat.matrix[i]);
 }
+
+TEST(SGMatrixTest, get_column)
+{
+	const index_t n_rows = 6, n_cols = 8;
+	const index_t col = 4;
+
+	SGMatrix<float64_t> mat(n_rows, n_cols);
+	for (index_t i = 0; i < n_rows * n_cols; ++i)
+		mat[i] = CMath::randn_double();
+
+	auto vec = mat.get_column_vector(col);
+
+	for (index_t i = 0; i < n_rows; ++i)
+		EXPECT_EQ(mat(i, col), vec[i]);
+}
+
+TEST(SGMatrixTest, set_column)
+{
+	const index_t n_rows = 6, n_cols = 8;
+	const index_t col = 4;
+
+	SGMatrix<float64_t> mat(n_rows, n_cols);
+	SGVector<float64_t> vec(n_rows);
+
+	for (index_t i = 0; i < n_rows; ++i)
+		vec[i] = CMath::randn_double();
+
+	mat.set_column(col, vec);
+
+	for (index_t i = 0; i < n_rows; ++i)
+		EXPECT_EQ(mat(i, col), vec[i]);
+}

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -38,6 +38,20 @@ TEST(SGVectorTest,ctor)
 
 }
 
+TEST(SGVectorTest, ctor_from_matrix)
+{
+	const index_t n_rows = 5, n_cols = 4;
+
+	SGMatrix<float64_t> mat(n_rows, n_cols);
+	for (index_t i = 0; i < mat.size(); ++i)
+		mat[i] = CMath::randn_double();
+
+	auto vec = SGVector<float64_t>(mat);
+
+	for (index_t i = 0; i < n_rows * n_cols; ++i)
+		EXPECT_EQ(mat[i], vec[i]);
+}
+
 TEST(SGVectorTest,setget)
 {
 	SGVector<index_t> v(4);

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -155,8 +155,9 @@ TEST(LinalgBackendEigen, SGMatrix_add_col_vec_allocated)
 	add_col_vec(A, col, b, result, alpha, beta);
 
 	for (index_t i = 0; i < nrows; ++i)
-		EXPECT_NEAR(result.get_element(i, col),
-		            alpha*A.get_element(i, col)+beta*b[i], 1e-15);
+		EXPECT_NEAR(
+		    result.get_element(i, col),
+		    alpha * A.get_element(i, col) + beta * b[i], 1e-15);
 }
 
 TEST(LinalgBackendEigen, SGMatrix_add_col_vec_in_place)
@@ -185,6 +186,31 @@ TEST(LinalgBackendEigen, SGMatrix_add_col_vec_in_place)
 			else
 				EXPECT_EQ(A.get_element(i,j), a);
 		}
+}
+
+TEST(LinalgBackendEigen, add_vector)
+{
+	const float64_t alpha = 0.7;
+	const float64_t beta = -1.2;
+	const index_t nrows = 2, ncols = 3;
+
+	SGMatrix<float64_t> A(nrows, ncols);
+	SGMatrix<float64_t> result(nrows, ncols);
+	SGVector<float64_t> b(nrows);
+
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 0.5 * i;
+	for (index_t j = 0; j < ncols; ++j)
+		for (index_t i = 0; i < nrows; ++i)
+		{
+			A(i, j) = i + j * ncols;
+			result(i, j) = alpha * A(i, j) + beta * b[i];
+		}
+
+	add_vector(A, b, A, alpha, beta);
+
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(A[i], result[i], 1e-15);
 }
 
 TEST(LinalgBackendEigen, SGVector_add_scalar)


### PR DESCRIPTION
Starting point to discuss this task. #3482 

Both classes implement two solvers: canonvar (svd based) whose code is very similar in the two implementations except for the regularization parameter in LDA (this PR drops the LDA's solver), and the classic method using covariance matrix, LDA directly computes a solution for the binary classification problem while FisherLDA computes related eigenvectors, so this code isn't strictly _duplicated_ but of course one could use the latter to solve the former with some modification to FisherLDA (i.e. bias computation, but then it should be aware of treating the classification case differently).

A couple of other points:
- LDA supports a regularization parameter in both methods, so FisherLDA should too if we want to use its canonvar solver.
- LDA's solver is templated (float32/64/max)