### PR TITLE
Add to linalg trace, zero, identity, add_col_vec (CPU only)

### DIFF
--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -103,6 +103,22 @@ public:
 	#undef BACKEND_GENERIC_IN_PLACE_ADD
 
 	/**
+	 * Wrapper method of add column vector result = alpha*A.col(i) + beta*b.
+	 *
+	 * @see linalg::add_col_vec
+	 */
+	#define BACKEND_GENERIC_ADD_COL_VEC(Type, Container) \
+	virtual void add_col_vec(const SGMatrix<Type>& A, index_t i, \
+		const SGVector<Type>& b, Container<Type>& result, Type alpha, Type beta) const \
+	{ \
+		SG_SNOTIMPLEMENTED; \
+		return; \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGVector)
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGMatrix)
+	#undef BACKEND_GENERIC_ADD_COL_VEC
+
+	/**
 	 * Wrapper method of Cholesky decomposition.
 	 *
 	 * @see linalg::cholesky_factor
@@ -173,6 +189,20 @@ public:
 	}
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
 	#undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
+
+	/**
+	 * Wrapper method of set matrix to identity.
+	 *
+	 * @see linalg::identity
+	 */
+	#define BACKEND_GENERIC_IDENTITY(Type, Container) \
+	virtual void identity(Container<Type>& I) const \
+	{  \
+		SG_SNOTIMPLEMENTED; \
+		return; \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IDENTITY, SGMatrix)
+	#undef BACKEND_GENERIC_IDENTITY
 
 	/**
 	 * Wrapper method of logistic function f(x) = 1/(1+exp(-x))
@@ -403,6 +433,35 @@ public:
 	}
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_BLOCK_ROWWISE_SUM, SGMatrix)
 	#undef BACKEND_GENERIC_BLOCK_ROWWISE_SUM
+
+	/**
+	 * Wrapper method of trace computation.
+	 *
+	 * @see linalg::trace
+	 */
+	#define BACKEND_GENERIC_TRACE(Type, Container) \
+	virtual Type trace(const Container<Type>& A) const \
+	{  \
+		SG_SNOTIMPLEMENTED; \
+		return 0; \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_TRACE, SGMatrix)
+	#undef BACKEND_GENERIC_TRACE
+
+	/**
+	 * Wrapper method of set vector or matrix to zero.
+	 *
+	 * @see linalg::zero
+	 */
+	#define BACKEND_GENERIC_ZERO(Type, Container) \
+	virtual void zero(Container<Type>& a) const \
+	{  \
+		SG_SNOTIMPLEMENTED; \
+		return; \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ZERO, SGVector)
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ZERO, SGMatrix)
+	#undef BACKEND_GENERIC_ZERO
 
 	/**
 	 * Wrapper method of Transferring data to GPU memory.

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -107,6 +107,17 @@ public:
 	DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_IN_PLACE_ADD, SGMatrix)
 	#undef BACKEND_GENERIC_IN_PLACE_ADD
 
+	/** Implementation of @see LinalgBackendBase::add_col_vec */
+	#define BACKEND_GENERIC_ADD_COL_VEC(Type, Container) \
+	virtual void add_col_vec(const SGMatrix<Type>& A, index_t i, \
+		const SGVector<Type>& b, Container<Type>& result, Type alpha, Type beta) const \
+	{  \
+		add_col_vec_impl(A, i, b, result, alpha, beta); \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGVector)
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGMatrix)
+	#undef BACKEND_GENERIC_ADD_COL_VEC
+
 	/** Implementation of @see LinalgBackendBase::cholesky_factor */
 	#define BACKEND_GENERIC_CHOLESKY_FACTOR(Type, Container) \
 	virtual Container<Type> cholesky_factor(const Container<Type>& A, \
@@ -155,6 +166,15 @@ public:
 	}
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
 	#undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
+
+	/** Implementation of @see LinalgBackendBase::identity */
+	#define BACKEND_GENERIC_IDENTITY(Type, Container) \
+	virtual void identity(Container<Type>& I) const \
+	{  \
+		identity_impl(I); \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IDENTITY, SGMatrix)
+	#undef BACKEND_GENERIC_IDENTITY
 
 	/** Implementation of @see LinalgBackendBase::logistic */
 	#define BACKEND_GENERIC_LOGISTIC(Type, Container) \
@@ -309,6 +329,25 @@ public:
 	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_BLOCK_ROWWISE_SUM, SGMatrix)
 	#undef BACKEND_GENERIC_BLOCK_ROWWISE_SUM
 
+	/** Implementation of @see LinalgBackendBase::trace */
+	#define BACKEND_GENERIC_TRACE(Type, Container) \
+	virtual Type trace(const Container<Type>& A) const \
+	{  \
+		return trace_impl(A); \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_TRACE, SGMatrix)
+	#undef BACKEND_GENERIC_TRACE
+
+	/** Implementation of @see LinalgBackendBase::zero */
+	#define BACKEND_GENERIC_ZERO(Type, Container) \
+	virtual void zero(Container<Type>& a) const \
+	{  \
+		zero_impl(a); \
+	}
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ZERO, SGVector)
+	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ZERO, SGMatrix)
+	#undef BACKEND_GENERIC_ZERO
+
 	#undef DEFINE_FOR_ALL_PTYPE
 
 private:
@@ -332,6 +371,30 @@ private:
 		typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
 
 		result_eig = alpha * a_eig + beta * b_eig;
+	}
+
+	/** Eigen3 add column vector method */
+	template <typename T>
+	void add_col_vec_impl(const SGMatrix<T>& A, index_t i, const SGVector<T>& b,
+	                      SGMatrix<T>& result, T alpha, T beta) const
+	{
+		typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
+		typename SGVector<T>::EigenVectorXtMap b_eig = b;
+		typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
+
+		result_eig.col(i) = alpha * A_eig.col(i) + beta * b_eig;
+	}
+
+	/** Eigen3 add column vector method */
+	template <typename T>
+	void add_col_vec_impl(const SGMatrix<T>& A, index_t i, const SGVector<T>& b,
+	                      SGVector<T>& result, T alpha, T beta) const
+	{
+		typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
+		typename SGVector<T>::EigenVectorXtMap b_eig = b;
+		typename SGVector<T>::EigenVectorXtMap result_eig = result;
+
+		result_eig = alpha * A_eig.col(i) + beta * b_eig;
 	}
 
 	/** Eigen3 Cholesky decomposition */
@@ -406,6 +469,14 @@ private:
 		typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
 
 		result_eig = a_eig.array() * b_eig.array();
+	}
+
+	/** Eigen3 set matrix to identity method */
+	template <typename T>
+	void identity_impl(SGMatrix<T>& I) const
+	{
+		typename SGMatrix<T>::EigenMatrixXtMap I_eig = I;
+		I_eig.setIdentity();
 	}
 
 	/** Eigen3 logistic method. Calculates f(x) = 1/(1+exp(-x)) */
@@ -703,6 +774,30 @@ private:
 		}
 
 		return result;
+	}
+
+	/** Eigen3 compute trace method */
+	template <typename T>
+	T trace_impl(const SGMatrix<T>& A) const
+	{
+		typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
+		return A_eig.trace();
+	}
+
+	/** Eigen3 set vector to zero method */
+	template <typename T>
+	void zero_impl(SGVector<T>& a) const
+	{
+		typename SGVector<T>::EigenVectorXtMap a_eig = a;
+		a_eig.setZero();
+	}
+
+	/** Eigen3 set matrix to zero method */
+	template <typename T>
+	void zero_impl(SGMatrix<T>& a) const
+	{
+		typename SGMatrix<T>::EigenMatrixXtMap a_eig = a;
+		a_eig.setZero();
 	}
 
 #undef DEFINE_FOR_ALL_PTYPE

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -350,6 +350,58 @@ Container<T> add(Container<T>& a, Container<T>& b, T alpha=1, T beta=1)
 }
 
 /**
+ * Performs the operation result.col(i) = alpha * A.col(i) + beta * b.
+ * User should pass an appropriately pre-allocated memory matrix
+ * Or pass the operand argument A as a result.
+ *
+ * @param A The matrix
+ * @param b The vector
+ * @param result The matrix that saves the result
+ * @param alpha Constant to be multiplied by the matrix
+ * @param beta Constant to be multiplied by the vector
+ */
+template <typename T>
+void add_col_vec(const SGMatrix<T>& A, index_t i, const SGVector<T>& b,
+                 SGMatrix<T>& result, T alpha=1, T beta=1)
+{
+	REQUIRE(A.num_rows == b.vlen,
+	        "Number of rows of matrix A (%d) doesn't match length of vector b (%d).\n",
+	        A.num_rows, b.vlen);
+	REQUIRE(result.num_rows == A.num_rows,
+	        "Number of rows of result (%d) doesn't match matrix A (%d).\n",
+	        result.num_rows, A.num_rows);
+	REQUIRE(i >= 0 && i < A.num_cols, "Index i (%d) is out of range (0-%d)", i, A.num_cols-1);
+
+	infer_backend(A, SGMatrix<T>(b))->add_col_vec(A, i, b, result, alpha, beta);
+}
+
+/**
+ * Performs the operation result = alpha * A.col(i) + beta * b.
+ * User should pass an appropriately pre-allocated vector
+ * Or pass the operand argument b as a result.
+ *
+ * @param A The matrix
+ * @param b The vector
+ * @param result The vector that saves the result
+ * @param alpha Constant to be multiplied by the matrix
+ * @param beta Constant to be multiplied by the vector
+ */
+template <typename T>
+void add_col_vec(
+	const SGMatrix<T>& A, index_t i, const SGVector<T>& b,
+	SGVector<T>& result, T alpha=1, T beta=1)
+{
+	REQUIRE(A.num_rows == b.vlen,
+	        "Number of rows of matrix A (%d) doesn't match length of vector b (%d).\n",
+	        A.num_rows, b.vlen);
+	REQUIRE(result.vlen == b.vlen,
+	        "Length of result (%d) doesn't match vector b (%d).\n", result.vlen, b.vlen);
+	REQUIRE(i >= 0 && i < A.num_cols, "Index i (%d) is out of range (0-%d)", i,  A.num_cols-1);
+
+	infer_backend(A, SGMatrix<T>(b))->add_col_vec(A, i, b, result, alpha, beta);
+}
+
+/**
  * Performs the operation A = alpha * x * y' + A
  *
  * @param alpha scaling factor for vector x
@@ -519,6 +571,18 @@ SGMatrix<T> element_prod(SGMatrix<T>& a, SGMatrix<T>& b)
 	element_prod(a, b, result);
 
 	return result;
+}
+
+/**
+ * Method that writes the identity into a square matrix.
+ *
+ * @param a The square matrix to be set
+ */
+template <typename T>
+void identity(SGMatrix<T>& I)
+{
+	REQUIRE(I.num_rows == I.num_cols, "Matrix is not square!\n");
+	infer_backend(I)->identity(I);
 }
 
 /** Performs the operation of a matrix multiplies a vector \f$x = Ab\f$.
@@ -977,6 +1041,30 @@ template <typename T>
 SGVector<T> rowwise_sum(const Block<SGMatrix<T>>& a, bool no_diag=false)
 {
 	return sg_linalg->get_cpu_backend()->rowwise_sum(a, no_diag);
+}
+
+/**
+ * Method that computes the trace of square matrix.
+ *
+ * @param A The matrix whose trace has to be computed
+ * @return The trace of the matrix
+ */
+template <typename T>
+T trace(const SGMatrix<T>& A)
+{
+	REQUIRE(A.num_rows == A.num_cols, "Matrix is not square!\n");
+	return infer_backend(A)->trace(A);
+}
+
+/**
+ * Method that fills with zero a vector or a matrix.
+ *
+ * @param a The vector or the matrix to be set
+ */
+template <typename T, template<typename> class Container>
+void zero(Container<T>& a)
+{
+	infer_backend(a)->zero(a);
 }
 
 }

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -93,6 +93,100 @@ TEST(LinalgBackendEigen, SGMatrix_add_in_place)
 		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
 }
 
+TEST(LinalgBackendEigen, SGVector_add_col_vec_allocated)
+{
+	const float64_t alpha = 0.7;
+	const float64_t beta = -1.2;
+	const index_t nrows = 2, ncols = 3;
+	const index_t col = 1;
+
+	SGMatrix<float64_t> A(nrows, ncols);
+	SGVector<float64_t> b(nrows);
+	SGVector<float64_t> result(nrows);
+
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 0.5*i;
+
+	add_col_vec(A, col, b, result, alpha, beta);
+
+	for (index_t i = 0; i < nrows; ++i)
+		EXPECT_NEAR(result[i], alpha*A.get_element(i, col)+beta*b[i], 1e-15);
+}
+
+TEST(LinalgBackendEigen, SGVector_add_col_vec_in_place)
+{
+	const float64_t alpha = 0.6;
+	const float64_t beta = -1.3;
+	const index_t nrows = 2, ncols = 3;
+	const index_t col = 1;
+
+	SGMatrix<float64_t> A(nrows, ncols);
+	SGVector<float64_t> b(nrows);
+
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 0.5*i;
+
+	add_col_vec(A, col, b, b, alpha, beta);
+
+	for (index_t i = 0; i < nrows; ++i)
+		EXPECT_NEAR(b[i], alpha*A.get_element(i, col)+beta*0.5*i, 1e-15);
+}
+
+TEST(LinalgBackendEigen, SGMatrix_add_col_vec_allocated)
+{
+	const float64_t alpha = 0.8;
+	const float64_t beta = -1.4;
+	const index_t nrows = 2, ncols = 3;
+	const index_t col = 1;
+
+	SGMatrix<float64_t> A(nrows, ncols);
+	SGVector<float64_t> b(nrows);
+	SGMatrix<float64_t> result(nrows, ncols);
+
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 0.5*i;
+
+	add_col_vec(A, col, b, result, alpha, beta);
+
+	for (index_t i = 0; i < nrows; ++i)
+		EXPECT_NEAR(result.get_element(i, col),
+		            alpha*A.get_element(i, col)+beta*b[i], 1e-15);
+}
+
+TEST(LinalgBackendEigen, SGMatrix_add_col_vec_in_place)
+{
+	const float64_t alpha = 0.9;
+	const float64_t beta = -1.7;
+	const index_t nrows = 2, ncols = 3;
+	const index_t col = 1;
+
+	SGMatrix<float64_t> A(nrows, ncols);
+	SGVector<float64_t> b(nrows);
+
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 0.5*i;
+
+	add_col_vec(A, col, b, A, alpha, beta);
+
+	for (index_t i = 0; i < nrows; ++i)
+		for (index_t j = 0; j < ncols; ++j)
+		{
+			float64_t a = i+j*nrows;
+			if (j == col)
+				EXPECT_NEAR(A.get_element(i, j), alpha*a+beta*b[i], 1e-15);
+			else
+				EXPECT_EQ(A.get_element(i,j), a);
+		}
+}
+
 TEST(LinalgBackendEigen, SGMatrix_cholesky_llt_lower)
 {
 	const index_t size=2;
@@ -237,6 +331,17 @@ TEST(LinalgBackendEigen, SGMatrix_block_elementwise_product)
 	for (index_t i = 0; i < 2; ++i)
 		for (index_t j = 0; j < 2; ++j)
 			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+}
+
+TEST(LinalgBackendEigen, SGMatrix_identity)
+{
+	const index_t n = 4;
+	SGMatrix<float64_t> A(n, n);
+	identity(A);
+
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = 0; j < n; ++j)
+			EXPECT_EQ(A.get_element(i, j), (i==j));
 }
 
 TEST(LinalgBackendEigen, logistic)
@@ -928,4 +1033,39 @@ TEST(LinalgBackendEigen, SGMatrix_block_rowwise_sum)
 			sum += mat(i, j);
 		EXPECT_NEAR(sum, result[i], 1E-15);
 	}
+}
+
+TEST(LinalgBackendEigen, SGMatrix_trace)
+{
+	const index_t n = 4;
+
+	SGMatrix<float64_t> A(n, n);
+	for (index_t i = 0; i < n*n; ++i)
+		A[i] = i;
+
+	float64_t tr = 0;
+	for (index_t i = 0; i < n; ++i)
+		tr += A.get_element(i, i);
+
+	EXPECT_NEAR(trace(A), tr, 1e-15);
+}
+
+TEST(LinalgBackendEigen, SGVector_zero)
+{
+	const index_t n = 16;
+	SGVector<float64_t> a(n);
+	zero(a);
+
+	for (index_t i = 0; i < n; ++i)
+		EXPECT_EQ(a[i], 0);
+}
+
+TEST(LinalgBackendEigen, SGMatrix_zero)
+{
+	const index_t nrows = 3, ncols = 4;
+	SGMatrix<float64_t> A(nrows, ncols);
+	zero(A);
+
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_EQ(A[i], 0);
 }


### PR DESCRIPTION
Operations needed by #3826, linalg + eigen implementation.

~~This is a work in progress: tests, docs, dimension checks etc are missing.~~

PS: if I run `check_format.sh` it wants to rewrite almost completely `LinalgBackendEigen.h`, see https://gist.github.com/micmn/8565fdbb0bcb1e2b1867a934f8f0fbce#file-style-diff-L193