### PR TITLE
Fix add_col_vec compatibility with eigen 3.3.x

### DIFF
--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -114,8 +114,8 @@ public:
 	{  \
 		add_col_vec_impl(A, i, b, result, alpha, beta); \
 	}
-	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGVector)
-	DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGMatrix)
+	DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGVector)
+	DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_COL_VEC, SGMatrix)
 	#undef BACKEND_GENERIC_ADD_COL_VEC
 
 	/** Implementation of @see LinalgBackendBase::cholesky_factor */


### PR DESCRIPTION
Eigen 3.3.x casts boolean sum to int, this fix removes add_col_vec for booleans, see #3644 #3656.