### PR TITLE
Switch-based untemplated matrix prototype

### DIFF
--- a/src/shogun/lib/Matrix.cpp
+++ b/src/shogun/lib/Matrix.cpp
@@ -1,0 +1,1 @@
+#include <shogun/lib/Matrix.h>

--- a/src/shogun/lib/Matrix.h
+++ b/src/shogun/lib/Matrix.h
@@ -1,0 +1,57 @@
+#ifndef MATRIX_H__
+#define MATRIX_H__
+
+#include <shogun/lib/common.h>
+#include <shogun/lib/DataType.h>
+#include <shogun/lib/SGMatrix.h>
+
+namespace shogun
+{
+
+class Matrix {
+
+	void *m_data;
+	EPrimitiveType m_ptype;
+	index_t m_rows, m_cols;
+
+	template <typename T>
+	static EPrimitiveType ptype();
+
+public:
+	template <typename T>
+	Matrix(T *data, index_t rows, index_t cols)  :
+		m_data(data), m_rows(rows), m_cols(cols)
+	{
+		m_ptype = ptype<T>();
+	}
+
+	template <typename T>
+	operator SGMatrix<T>() const
+	{
+		return SGMatrix<T>(static_cast<T*>(m_data), m_rows, m_cols, false);
+	}
+
+	EPrimitiveType ptype() const
+	{
+		return m_ptype;
+	}
+
+	template <typename T>
+	T* raw_data()
+	{
+		return static_cast<T*>(m_data);
+	}
+};
+
+template <>
+inline EPrimitiveType Matrix::ptype<float32_t>() { return PT_FLOAT32; }
+
+template <>
+inline EPrimitiveType Matrix::ptype<float64_t>() { return PT_FLOAT64; }
+
+template <>
+inline EPrimitiveType Matrix::ptype<floatmax_t>() { return PT_FLOATMAX; }
+
+}
+
+#endif // MATRIX_H_

--- a/src/shogun/mathematics/linalg/LinalgNamespaceMatrix.cpp
+++ b/src/shogun/mathematics/linalg/LinalgNamespaceMatrix.cpp
@@ -1,0 +1,43 @@
+#include <shogun/lib/DataType.h>
+#include <shogun/mathematics/linalg/LinalgNamespaceMatrix.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
+
+#define DEFINE_SWITCH(PTYPE, FUNC, ...) \
+switch (PTYPE) \
+{ \
+	case PT_FLOAT32: \
+		FUNC<float32_t>(__VA_ARGS__); \
+		break; \
+	case PT_FLOAT64: \
+		FUNC<float64_t>(__VA_ARGS__); \
+		break; \
+	case PT_FLOATMAX: \
+		FUNC<floatmax_t>(__VA_ARGS__); \
+		break; \
+	default: \
+		SG_SERROR("Unsupported data type\n"); \
+}
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+template <typename T>
+static inline void add_templated(const Matrix& a, const Matrix& b, Matrix& result)
+{
+	SGMatrix<T> a_sg(a), b_sg(b), result_sg(result);
+	add(a_sg, b_sg, result_sg);
+}
+
+void add(const Matrix& a, const Matrix& b, Matrix& result)
+{
+	DEFINE_SWITCH(a.ptype(), add_templated, a, b, result);
+}
+
+}
+
+}
+
+#undef DEFINE_SWITCH

--- a/src/shogun/mathematics/linalg/LinalgNamespaceMatrix.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespaceMatrix.h
@@ -1,0 +1,20 @@
+
+#ifndef LINALG_MATRIX_NAMESPACE_H_
+#define LINALG_MATRIX_NAMESPACE_H_
+
+#include <shogun/lib/Matrix.h>
+
+namespace shogun
+{
+
+namespace linalg
+{
+
+void add(const Matrix& a, const Matrix& b, Matrix& result);
+
+}
+
+}
+
+
+#endif //LINALG_MATRIX_NAMESPACE_H_

--- a/tests/unit/mathematics/linalg/operations/Eigen3_matrix_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_matrix_operations_unittest.cc
@@ -1,0 +1,31 @@
+#include <shogun/lib/config.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/linalg/LinalgNamespaceMatrix.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+using namespace linalg;
+
+template <typename T>
+class LinalgBackendEigenMatrix : public ::testing::Test {};
+
+typedef ::testing::Types<float32_t, float64_t, floatmax_t> PTypes;
+TYPED_TEST_CASE(LinalgBackendEigenMatrix, PTypes);
+
+TYPED_TEST(LinalgBackendEigenMatrix, add)
+{
+	const index_t nrows = 2, ncols = 3;
+
+	TypeParam A_data[] = {0, 1, 2, 3, 4, 5};
+	TypeParam B_data[] = {1, 2, 3, 4, 5, 6};
+	TypeParam result_data[] = {0, 0, 0, 0, 0, 0};
+
+	Matrix A(A_data, nrows, ncols);
+	Matrix B(B_data, nrows, ncols);
+	Matrix result(result_data, nrows, ncols);
+
+	add(A, B, result);
+
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(A_data[i]+B_data[i], result.raw_data<TypeParam>()[i], 1e-15);
+}


### PR DESCRIPTION
First prototype of untemplated linalg, barebone Matrix class.

A few points:
- do we offer operators `[i]`, `(i,j)` and similar methods? If so, how to handle the return type?
- some linalg functions take scalars of the matrix's type, i.e. `add(SGMatrix<T> a, SGMatrix<T> b, SGMatrix<T> result, T alpha, T beta)`
- Matrix's memory management, just like SGMatrix?