### PR TITLE
Create test environments in main()

### DIFF
--- a/tests/unit/base/main_unittest.cc
+++ b/tests/unit/base/main_unittest.cc
@@ -4,7 +4,7 @@
 #include <shogun/io/SGIO.h>
 
 #include "environments/LinearTestEnvironment.h"
-#include "environments/MutiLabelTestEnvironment.h"
+#include "environments/MultiLabelTestEnvironment.h"
 
 using namespace shogun;
 using ::testing::Test;
@@ -54,6 +54,9 @@ void FailurePrinter::OnTestEnd(const TestInfo& test_info)
 		_listener->OnTestEnd(test_info);
 }
 
+LinearTestEnvironment* linear_test_env;
+MultiLabelTestEnvironment* multilabel_test_env;
+
 int main(int argc, char** argv)
 {
 	::testing::InitGoogleTest(&argc, argv);
@@ -69,10 +72,15 @@ int main(int argc, char** argv)
 		listeners.Append(new FailurePrinter(default_printer));
 	}
 
+	linear_test_env = new LinearTestEnvironment();
+	::testing::AddGlobalTestEnvironment(linear_test_env);
+
+	multilabel_test_env = new MultiLabelTestEnvironment();
+	::testing::AddGlobalTestEnvironment(multilabel_test_env);
+
 	init_shogun_with_defaults();
 	sg_io->set_loglevel(MSG_WARN);
-	::testing::AddGlobalTestEnvironment(new LinearTestEnvironment());
-	::testing::AddGlobalTestEnvironment(new MutiLabelTestEnvironment());
+
 	int ret = RUN_ALL_TESTS();
 	exit_shogun();
 

--- a/tests/unit/classifier/svm/SVMOcas_unittest.cc
+++ b/tests/unit/classifier/svm/SVMOcas_unittest.cc
@@ -9,13 +9,15 @@
 
 using namespace shogun;
 
+extern LinearTestEnvironment* linear_test_env;
+
 #ifdef USE_GPL_SHOGUN
 #ifdef HAVE_LAPACK
 TEST(SVMOcasTest,train)
 {
 	CMath::init_random(5);
 	std::shared_ptr<GaussianCheckerboard> mockData =
-	    LinearTestEnvironment::instance().getBinaryLabelData();
+	    linear_test_env->getBinaryLabelData();
 
 	CDenseFeatures<float64_t>* train_feats = mockData->get_features_train();
 	CDenseFeatures<float64_t>* test_feats = mockData->get_features_test();

--- a/tests/unit/environments/LinearTestEnvironment.h
+++ b/tests/unit/environments/LinearTestEnvironment.h
@@ -43,16 +43,10 @@ using ::testing::Environment;
 class LinearTestEnvironment : public ::testing::Environment
 {
 public:
-	LinearTestEnvironment()
+	virtual void SetUp()
 	{
 		mBinaryLabelData = std::shared_ptr<GaussianCheckerboard>(
 		    new GaussianCheckerboard(100, 2, 2));
-	}
-
-	static LinearTestEnvironment& instance()
-	{
-		static LinearTestEnvironment mInstance;
-		return mInstance;
 	}
 
 	std::shared_ptr<GaussianCheckerboard> getBinaryLabelData() const

--- a/tests/unit/environments/MultiLabelTestEnvironment.h
+++ b/tests/unit/environments/MultiLabelTestEnvironment.h
@@ -30,8 +30,8 @@
  * Authors: 2016 MikeLing, Viktor Gal, Sergey Lisitsyn, Heiko Strathmann
  */
 
-#ifndef MUTILABELTESTENVIRONMENT_HPP
-#define MUTILABELTESTENVIRONMENT_HPP
+#ifndef MULTILABELTESTENVIRONMENT_HPP
+#define MULTILABELTESTENVIRONMENT_HPP
 
 #include "GaussianCheckerboard.h"
 #include <gtest/gtest.h>
@@ -40,19 +40,13 @@
 using namespace shogun;
 using namespace std;
 using ::testing::Environment;
-class MutiLabelTestEnvironment : public ::testing::Environment
+class MultiLabelTestEnvironment : public ::testing::Environment
 {
 public:
-	MutiLabelTestEnvironment()
+	virtual void SetUp()
 	{
 		mMulticlassFixture = std::shared_ptr<GaussianCheckerboard>(
 		    new GaussianCheckerboard(100, 3, 3));
-	}
-
-	static MutiLabelTestEnvironment& instance()
-	{
-		static MutiLabelTestEnvironment mInstance;
-		return mInstance;
 	}
 
 	std::shared_ptr<GaussianCheckerboard> getMulticlassFixture() const

--- a/tests/unit/multiclass/MulticlassOCAS_unittest.cc
+++ b/tests/unit/multiclass/MulticlassOCAS_unittest.cc
@@ -1,4 +1,4 @@
-#include "environments/MutiLabelTestEnvironment.h"
+#include "environments/MultiLabelTestEnvironment.h"
 #include <shogun/evaluation/MulticlassAccuracy.h>
 #include <shogun/features/DataGenerator.h>
 #include <shogun/features/DenseFeatures.h>
@@ -10,13 +10,15 @@
 
 using namespace shogun;
 
+extern MultiLabelTestEnvironment* multilabel_test_env;
+
 #ifdef HAVE_LAPACK
 TEST(MulticlassOCASTest,train)
 {
   CMath::init_random(5);
   float64_t C = 1.0;
   std::shared_ptr<GaussianCheckerboard> mockData =
-	  MutiLabelTestEnvironment::instance().getMulticlassFixture();
+	  multilabel_test_env->getMulticlassFixture();
 
   CDenseFeatures<float64_t>* train_feats = mockData->get_features_train();
   CDenseFeatures<float64_t>* test_feats = mockData->get_features_test();


### PR DESCRIPTION
Previous version used singleton and created useless environment instances in `main()`, also I don't think that you can use that type of singleton with gtest environments since `AddGlobalEnvironment()` frees its memory.
In this patch I used global vars as suggested in gtest guide but of course it could be done differently.

Note: envs should be created after `init_shogun_with_defaults()`? But SVMOcas test fails (rand initialization?)

(+ fix typo in `MutiLabelTestEnvironment`)