### PR TITLE
[PrematureStopping] Convert CSignal::cancel_computations() to cancel_computation().

### DIFF
--- a/src/shogun/classifier/AveragedPerceptron.cpp
+++ b/src/shogun/classifier/AveragedPerceptron.cpp
@@ -62,7 +62,7 @@ bool CAveragedPerceptron::train_machine(CFeatures* data)
 
 	//loop till we either get everything classified right or reach max_iter
 
-	while (!(CSignal::cancel_computations()) && (!converged && iter<max_iter))
+	while (!(cancel_computation()) && (!converged && iter < max_iter))
 	{
 		converged=true;
 		SG_INFO("Iteration Number : %d of max %d\n", iter, max_iter);

--- a/src/shogun/classifier/LPBoost.cpp
+++ b/src/shogun/classifier/LPBoost.cpp
@@ -125,7 +125,7 @@ bool CLPBoost::train_machine(CFeatures* data)
 	int32_t num_hypothesis=0;
 	CTime time;
 
-	while (!(CSignal::cancel_computations()))
+	while (!(cancel_computation()))
 	{
 		int32_t max_dim=0;
 		float64_t violator=find_max_violator(max_dim);

--- a/src/shogun/classifier/Perceptron.cpp
+++ b/src/shogun/classifier/Perceptron.cpp
@@ -67,7 +67,7 @@ bool CPerceptron::train_machine(CFeatures* data)
 
 
 	//loop till we either get everything classified right or reach max_iter
-	while (!(CSignal::cancel_computations()) && (!converged && iter<max_iter))
+	while (!(cancel_computation()) && (!converged && iter < max_iter))
 	{
 		converged=true;
 		for (auto example_idx : features->index_iterator())

--- a/src/shogun/classifier/mkl/MKL.cpp
+++ b/src/shogun/classifier/mkl/MKL.cpp
@@ -477,7 +477,7 @@ bool CMKL::train_machine(CFeatures* data)
 
 
 			mkl_iterations++;
-			if (perform_mkl_step(sumw, suma) || CSignal::cancel_computations())
+			if (perform_mkl_step(sumw, suma) || cancel_computation())
 				break;
 		}
 

--- a/src/shogun/classifier/mkl/MKLMulticlass.cpp
+++ b/src/shogun/classifier/mkl/MKLMulticlass.cpp
@@ -371,7 +371,7 @@ bool CMKLMulticlass::train_machine(CFeatures* data)
 	int32_t numberofsilpiterations=0;
 	bool final=false;
 
-	while (!(CSignal::cancel_computations()) && !final)
+	while (!(cancel_computation()) && !final)
 	{
 
 		//curweights.clear();

--- a/src/shogun/classifier/svm/LibLinear.cpp
+++ b/src/shogun/classifier/svm/LibLinear.cpp
@@ -316,7 +316,7 @@ void CLibLinear::solve_l2r_l1l2_svc(
 
 	auto pb = progress(range(10));
 	CTime start_time;
-	while (iter < max_iterations && !CSignal::cancel_computations())
+	while (iter < max_iterations && !cancel_computation())
 	{
 		if (m_max_train_time > 0 && start_time.cur_time_diff() > m_max_train_time)
 		  break;
@@ -526,7 +526,7 @@ void CLibLinear::solve_l1r_l2_svc(
 
 	auto pb = progress(range(10));
 	CTime start_time;
-	while (iter < max_iterations && !CSignal::cancel_computations())
+	while (iter < max_iterations && !cancel_computation())
 	{
 		if (m_max_train_time > 0 && start_time.cur_time_diff() > m_max_train_time)
 		  break;
@@ -898,7 +898,7 @@ void CLibLinear::solve_l1r_lr(
 
 	auto pb = progress(range(10));
 	CTime start_time;
-	while (iter < max_iterations && !CSignal::cancel_computations())
+	while (iter < max_iterations && !cancel_computation())
 	{
 		if (m_max_train_time > 0 && start_time.cur_time_diff() > m_max_train_time)
 		  break;

--- a/src/shogun/classifier/svm/MPDSVM.cpp
+++ b/src/shogun/classifier/svm/MPDSVM.cpp
@@ -95,7 +95,7 @@ bool CMPDSVM::train_machine(CFeatures* data)
 	}
 
 	// go ...
-	while (niter++ < maxiter && !CSignal::cancel_computations())
+	while (niter++ < maxiter && !cancel_computation())
 	{
 		int32_t maxpidx=-1;
 		float64_t maxpviol = -1;

--- a/src/shogun/classifier/svm/NewtonSVM.cpp
+++ b/src/shogun/classifier/svm/NewtonSVM.cpp
@@ -80,7 +80,7 @@ bool CNewtonSVM::train_machine(CFeatures* data)
 	float64_t obj, *grad=SG_MALLOC(float64_t, x_d+1);
 	float64_t t;
 
-	while(!CSignal::cancel_computations())
+	while (!cancel_computation())
 	{
 		iter++;
 

--- a/src/shogun/classifier/svm/OnlineSVMSGD.cpp
+++ b/src/shogun/classifier/svm/OnlineSVMSGD.cpp
@@ -106,7 +106,7 @@ bool COnlineSVMSGD::train(CFeatures* data)
 		is_log_loss = true;
 
 	int32_t vec_count;
-	for(int32_t e=0; e<epochs && (!CSignal::cancel_computations()); e++)
+	for (int32_t e = 0; e < epochs && (!cancel_computation()); e++)
 	{
 		vec_count=0;
 		count = skip;

--- a/src/shogun/classifier/svm/SGDQN.cpp
+++ b/src/shogun/classifier/svm/SGDQN.cpp
@@ -143,7 +143,7 @@ bool CSGDQN::train(CFeatures* data)
 	if ((loss_type == L_LOGLOSS) || (loss_type == L_LOGLOSSMARGIN))
 		is_log_loss = true;
 
-	for(int32_t e=0; e<epochs && (!CSignal::cancel_computations()); e++)
+	for (int32_t e = 0; e < epochs && (!cancel_computation()); e++)
 	{
 		count = skip;
 		bool updateB=false;

--- a/src/shogun/classifier/svm/SVMLight.cpp
+++ b/src/shogun/classifier/svm/SVMLight.cpp
@@ -647,7 +647,11 @@ int32_t CSVMLight::optimize_to_convergence(int32_t* docs, int32_t* label, int32_
   for (;((iteration<100 || (!mkl_converged && callback) ) || (retrain && (!terminate))); iteration++){
 #else
 
-	  for (;((!CSignal::cancel_computations()) && ((iteration<3 || (!mkl_converged && callback) ) || (retrain && (!terminate)))); iteration++){
+  for (; ((!cancel_computation()) &&
+	      ((iteration < 3 || (!mkl_converged && callback)) ||
+	       (retrain && (!terminate))));
+	   iteration++)
+  {
 #endif
 
 	  if(use_kernel_cache)

--- a/src/shogun/classifier/svm/SVMSGD.cpp
+++ b/src/shogun/classifier/svm/SVMSGD.cpp
@@ -115,7 +115,7 @@ bool CSVMSGD::train_machine(CFeatures* data)
 	if ((loss_type == L_LOGLOSS) || (loss_type == L_LOGLOSSMARGIN))
 		is_log_loss = true;
 
-	for(int32_t e=0; e<epochs && (!CSignal::cancel_computations()); e++)
+	for (int32_t e = 0; e < epochs && (!cancel_computation()); e++)
 	{
 		count = skip;
 		for (int32_t i=0; i<num_vec; i++)

--- a/src/shogun/classifier/vw/VowpalWabbit.cpp
+++ b/src/shogun/classifier/vw/VowpalWabbit.cpp
@@ -164,7 +164,7 @@ bool CVowpalWabbit::train_machine(CFeatures* feat)
 	}
 
 	features->start_parser();
-	while (!(CSignal::cancel_computations()) && (env->passes_complete < env->num_passes))
+	while (!(cancel_computation()) && (env->passes_complete < env->num_passes))
 	{
 		while (features->get_next_example())
 		{

--- a/src/shogun/distance/Distance.cpp
+++ b/src/shogun/distance/Distance.cpp
@@ -333,8 +333,9 @@ SGMatrix<T> CDistance::get_distance_matrix()
 
 					pb.print_progress();
 
-					if (CSignal::cancel_computations())
-						break;
+					// TODO: replace with new signal
+					// if (CSignal::cancel_computations())
+					//	break;
 				}
 			}
 		}

--- a/src/shogun/distributions/HMM.cpp
+++ b/src/shogun/distributions/HMM.cpp
@@ -5586,7 +5586,9 @@ bool CHMM::baum_welch_viterbi_train(BaumWelchViterbiType type)
 	float64_t prob_train=CMath::ALMOST_NEG_INFTY;
 	iteration_count=iterations;
 
-	while (!converged(prob, prob_train) && (!CSignal::cancel_computations()))
+	// TODO: replace with the new signal
+	// while (!converged(prob, prob_train) && (!CSignal::cancel_computations()))
+	while (!converged(prob, prob_train))
 	{
 		CMath::swap(working, estimate);
 		prob=prob_train;

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -87,8 +87,10 @@ void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t sto
 #ifdef WIN32
 		for (int32_t i=t_start; i<t_stop; i++)
 #else
-		for (int32_t i=t_start; i<t_stop &&
-				!CSignal::cancel_computations(); i++)
+		// TODO: replace with the new signal
+		// for (int32_t i=t_start; i<t_stop &&
+		//		!CSignal::cancel_computations(); i++)
+		for (int32_t i = t_start; i < t_stop; i++)
 #endif
 		{
 			if (alphas)
@@ -99,11 +101,6 @@ void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t sto
 		}
 	}
 	pb.complete();
-
-#ifndef WIN32
-		if ( CSignal::cancel_computations() )
-			SG_INFO("prematurely stopped.           \n")
-#endif
 }
 
 void CDotFeatures::dense_dot_range_subset(int32_t* sub_index, int32_t num, float64_t* output, float64_t* alphas, float64_t* vec, int32_t dim, float64_t b)
@@ -136,8 +133,10 @@ void CDotFeatures::dense_dot_range_subset(int32_t* sub_index, int32_t num, float
 #ifdef WIN32
 		for (int32_t i=t_start; i<t_stop; i++)
 #else
-		for (int32_t i=t_start; i<t_stop &&
-				!CSignal::cancel_computations(); i++)
+		// TODO: replace with the new signal
+		// for (int32_t i=t_start; i<t_stop &&
+		//		!CSignal::cancel_computations(); i++)
+		for (int32_t i = t_start; i < t_stop; i++)
 #endif
 		{
 			if (alphas)
@@ -148,11 +147,6 @@ void CDotFeatures::dense_dot_range_subset(int32_t* sub_index, int32_t num, float
 		}
 	}
 	pb.complete();
-
-#ifndef WIN32
-		if ( CSignal::cancel_computations() )
-			SG_INFO("prematurely stopped.           \n")
-#endif
 }
 
 SGMatrix<float64_t> CDotFeatures::get_computed_dot_feature_matrix()

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
@@ -291,11 +291,6 @@ void CHashedWDFeaturesTransposed::dense_dot_range(float64_t* output, int32_t sta
 	}
 #endif
 	SG_FREE(index);
-
-#ifndef WIN32
-		if ( CSignal::cancel_computations() )
-			SG_INFO("prematurely stopped.           \n")
-#endif
 }
 
 void CHashedWDFeaturesTransposed::dense_dot_range_subset(int32_t* sub_index, int num, float64_t* output, float64_t* alphas, float64_t* vec, int32_t dim, float64_t b)
@@ -381,11 +376,6 @@ void CHashedWDFeaturesTransposed::dense_dot_range_subset(int32_t* sub_index, int
 		SG_FREE(threads);
 		SG_FREE(index);
 	}
-#endif
-
-#ifndef WIN32
-		if ( CSignal::cancel_computations() )
-			SG_INFO("prematurely stopped.           \n")
 #endif
 }
 

--- a/src/shogun/kernel/Kernel.cpp
+++ b/src/shogun/kernel/Kernel.cpp
@@ -1302,8 +1302,9 @@ template <class T> void* CKernel::get_kernel_matrix_helper(void* p)
 
 				pb->print_progress();
 
-				if (CSignal::cancel_computations())
-					break;
+				// TODO: replace with the new signal
+				// if (CSignal::cancel_computations())
+				//	break;
 			}
 		}
 

--- a/src/shogun/kernel/string/WeightedDegreePositionStringKernel.cpp
+++ b/src/shogun/kernel/string/WeightedDegreePositionStringKernel.cpp
@@ -1254,26 +1254,28 @@ void CWeightedDegreePositionStringKernel::compute_batch(
 	{
 
 	   auto pb = progress(range(num_feat), *this->io);
-	   for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
-			{
-				init_optimization(num_suppvec, IDX, alphas, j);
-				S_THREAD_PARAM_WDS<DNATrie> params;
-				params.vec=vec;
-				params.result=result;
-				params.weights=weights;
-				params.kernel=this;
-				params.tries=&tries;
-				params.factor=factor;
-				params.j=j;
-				params.start=0;
-				params.end=num_vec;
-				params.length=length;
-				params.max_shift=max_shift;
-				params.shift=shift;
-				params.vec_idx=vec_idx;
-				compute_batch_helper((void*) &params);
+	   // TODO: replace with the new signal
+	   // for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+	   for (int32_t j = 0; j < num_feat; j++)
+	   {
+		   init_optimization(num_suppvec, IDX, alphas, j);
+		   S_THREAD_PARAM_WDS<DNATrie> params;
+		   params.vec = vec;
+		   params.result = result;
+		   params.weights = weights;
+		   params.kernel = this;
+		   params.tries = &tries;
+		   params.factor = factor;
+		   params.j = j;
+		   params.start = 0;
+		   params.end = num_vec;
+		   params.length = length;
+		   params.max_shift = max_shift;
+		   params.shift = shift;
+		   params.vec_idx = vec_idx;
+		   compute_batch_helper((void*)&params);
 
-			    pb.print_progress();
+		   pb.print_progress();
 		    }
 		    pb.complete();
 	}
@@ -1282,7 +1284,9 @@ void CWeightedDegreePositionStringKernel::compute_batch(
 	{
 
 		auto pb = progress(range(num_feat), *this->io);
-		for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+		// TODO: replace with the new signal
+		// for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+		for (int32_t j = 0; j < num_feat; j++)
 		{
 			init_optimization(num_suppvec, IDX, alphas, j);
 			pthread_t* threads = SG_MALLOC(pthread_t, num_threads-1);

--- a/src/shogun/kernel/string/WeightedDegreeStringKernel.cpp
+++ b/src/shogun/kernel/string/WeightedDegreeStringKernel.cpp
@@ -884,8 +884,9 @@ void CWeightedDegreeStringKernel::compute_batch(
 
 	if (num_threads < 2)
 	{
-
-		for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+		// TODO: replace with the new signal
+		// for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+		for (int32_t j = 0; j < num_feat; j++)
 		{
 			init_optimization(num_suppvec, IDX, alphas, j);
 			S_THREAD_PARAM_WD params;
@@ -909,8 +910,9 @@ void CWeightedDegreeStringKernel::compute_batch(
 #ifdef HAVE_PTHREAD
 	else
 	{
-
-		for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+		// TODO: replace with the new signal
+		// for (int32_t j=0; j<num_feat && !CSignal::cancel_computations(); j++)
+		for (int32_t j = 0; j < num_feat; j++)
 		{
 			init_optimization(num_suppvec, IDX, alphas, j);
 			pthread_t* threads = SG_MALLOC(pthread_t, num_threads-1);

--- a/src/shogun/lib/Signal.h
+++ b/src/shogun/lib/Signal.h
@@ -68,15 +68,6 @@ namespace shogun
 		};
 #endif
 
-		/** Cancel computations
-		 *
-		 * @return if computations should be cancelled
-		 */
-		static inline bool cancel_computations()
-		{
-			return false;
-		}
-
 		/** Enable signal handler
 		*/
 		void enable_handler()

--- a/src/shogun/lib/external/gpdtsolve.cpp
+++ b/src/shogun/lib/external/gpdtsolve.cpp
@@ -1311,7 +1311,9 @@ float64_t QPproblem::gpdtsolve(float64_t *solution)
     }
     Cache->Iteration();
     nit = nit+1;
-  } while (!optimal() && !(CSignal::cancel_computations()));
+	// TODO: replace with the new signal
+	//} while (!optimal() && !(CSignal::cancel_computations()));
+  } while (!optimal());
   /* End of the problem resolution loop                                      */
   /***************************************************************************/
 

--- a/src/shogun/lib/external/shogun_libsvm.cpp
+++ b/src/shogun/lib/external/shogun_libsvm.cpp
@@ -35,6 +35,7 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
+#include <shogun/base/init.h>
 #include <shogun/base/progress.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/kernel/Kernel.h>
@@ -50,6 +51,8 @@
 #include <float.h>
 #include <string.h>
 #include <stdarg.h>
+
+#include <rxcpp/rx.hpp>
 
 namespace shogun
 {
@@ -290,7 +293,7 @@ LibSVMKernel::~LibSVMKernel()
 //
 class Solver {
 public:
-	Solver() {};
+	Solver() : m_cancel_computation(false){};
 	virtual ~Solver() {};
 
 	struct SolutionInfo {
@@ -322,6 +325,7 @@ protected:
 	float64_t *G_bar;		// gradient, if we treat free variables as 0
 	int32_t l;
 	bool unshrink;	// XXX
+	std::atomic<bool> m_cancel_computation;
 
 	float64_t get_C(int32_t i)
 	{
@@ -343,9 +347,50 @@ protected:
 	virtual int32_t select_working_set(int32_t &i, int32_t &j, float64_t &gap);
 	virtual float64_t calculate_rho();
 	virtual void do_shrinking();
+
+	/* Custom implementation of signal handling */
+	rxcpp::subscription connect_to_signal_handler();
+	void reset_computation_variables();
+#ifndef SWIG
+	/** @return whether the algorithm needs to be stopped */
+	SG_FORCED_INLINE bool cancel_computation() const
+	{
+		return m_cancel_computation.load();
+	}
+#endif
+	void on_pause()
+	{
+	}
+	void on_next()
+	{
+		m_cancel_computation.store(false);
+	}
+	void on_complete()
+	{
+	}
+
 private:
 	bool be_shrunk(int32_t i, float64_t Gmax1, float64_t Gmax2);
 };
+
+rxcpp::subscription Solver::connect_to_signal_handler()
+{
+	// Subscribe this algorithm to the signal handler
+	auto subscriber = rxcpp::make_subscriber<int>(
+		[this](int i) {
+			if (i == SG_PAUSE_COMP)
+				this->on_pause();
+			else
+				this->on_next();
+		},
+		[this]() { this->on_complete(); });
+	return get_global_signal()->get_observable().subscribe(subscriber);
+}
+
+void Solver::reset_computation_variables()
+{
+	m_cancel_computation.store(false);
+}
 
 void Solver::swap_index(int32_t i, int32_t j)
 {
@@ -403,6 +448,8 @@ void Solver::Solve(
 	const schar *p_y, float64_t *p_alpha, float64_t p_Cp, float64_t p_Cn,
 	float64_t p_eps, SolutionInfo* p_si, int32_t shrinking, bool use_bias)
 {
+	auto sub = connect_to_signal_handler();
+
 	this->l = p_l;
 	this->Q = &p_Q;
 	QD=Q->get_QD();
@@ -443,7 +490,7 @@ void Solver::Solve(
 		}
 		SG_SINFO("Computing gradient for initial set of non-zero alphas\n")
 		//CMath::display_vector(alpha, l, "alphas");
-		for(i=0;i<l && !CSignal::cancel_computations(); i++)
+		for (i = 0; i < l && !cancel_computation(); i++)
 		{
 			if(!is_lower_bound(i))
 			{
@@ -466,7 +513,7 @@ void Solver::Solve(
 	int32_t iter = 0;
 	int32_t counter = CMath::min(l,1000)+1;
 	auto pb = progress(range(10));
-	while (!CSignal::cancel_computations())
+	while (!cancel_computation())
 	{
 		if (Q->max_train_time > 0 && start_time.cur_time_diff() > Q->max_train_time)
 		  break;
@@ -711,6 +758,9 @@ void Solver::Solve(
 	SG_FREE(active_set);
 	SG_FREE(G);
 	SG_FREE(G_bar);
+
+	sub.unsubscribe();
+	reset_computation_variables();
 }
 
 // return 1 if already optimal, return 0 otherwise
@@ -1832,7 +1882,7 @@ void solve_c_svc_weighted(
 		if(prob->y[i] > 0) y[i] = +1; else y[i]=-1;
 	}
 
-	WeightedSolver s = WeightedSolver(prob->C);
+	WeightedSolver s{prob->C};
 	s.Solve(l, SVC_Q(*prob,*param,y), minus_ones, y,
 		alpha, Cp, Cn, param->eps, si, param->shrinking, param->use_bias);
 

--- a/src/shogun/lib/malsar/malsar_joint_feature_learning.cpp
+++ b/src/shogun/lib/malsar/malsar_joint_feature_learning.cpp
@@ -51,7 +51,10 @@ malsar_result_t malsar_joint_feature_learning(
 
 	//internal::set_is_malloc_allowed(false);
 	bool done = false;
-	while (!done && iter <= options.max_iter && !CSignal::cancel_computations())
+	// TODO: replace with the new signal
+	// while (!done && iter <= options.max_iter &&
+	// !CSignal::cancel_computations())
+	while (!done && iter <= options.max_iter)
 	{
 		double alpha = double(t_old - 1)/t;
 

--- a/src/shogun/lib/slep/slep_mc_plain_lr.cpp
+++ b/src/shogun/lib/slep/slep_mc_plain_lr.cpp
@@ -91,7 +91,8 @@ slep_result_t slep_mc_plain_lr(
 	bool done = false;
 	CTime time;
 	//internal::set_is_malloc_allowed(false);
-	while ((!done) && (iter<options.max_iter) && (!CSignal::cancel_computations()))
+	// while ((!done) && (iter<options.max_iter) && (!cancel_computation()))
+	while ((!done) && (iter < options.max_iter))
 	{
 		double beta = (alphap-1)/alpha;
 		// compute search points

--- a/src/shogun/lib/slep/slep_mc_tree_lr.cpp
+++ b/src/shogun/lib/slep/slep_mc_tree_lr.cpp
@@ -93,7 +93,8 @@ slep_result_t slep_mc_tree_lr(
 	bool done = false;
 	CTime time;
 	//internal::set_is_malloc_allowed(false);
-	while ((!done) && (iter<options.max_iter) && (!CSignal::cancel_computations()))
+	// while ((!done) && (iter<options.max_iter) && (!cancel_computation()))
+	while ((!done) && (iter < options.max_iter))
 	{
 		double beta = (alphap-1)/alpha;
 		// compute search points

--- a/src/shogun/lib/slep/slep_solver.cpp
+++ b/src/shogun/lib/slep/slep_solver.cpp
@@ -524,7 +524,8 @@ slep_result_t slep_solver(
 	double alphap = 0.0, alpha = 1.0;
 	double fun_x = 0.0;
 
-	while (!done && iter <= options.max_iter && !CSignal::cancel_computations())
+	// while (!done && iter <= options.max_iter && !cancel_computation())
+	while (!done && iter <= options.max_iter)
 	{
 		beta = (alphap-1.0)/alpha;
 

--- a/src/shogun/machine/KernelMachine.cpp
+++ b/src/shogun/machine/KernelMachine.cpp
@@ -12,7 +12,6 @@
 #include <shogun/base/progress.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/labels/RegressionLabels.h>
-#include <shogun/lib/Signal.h>
 #include <shogun/machine/KernelMachine.h>
 
 #include <shogun/kernel/Kernel.h>
@@ -364,8 +363,8 @@ SGVector<float64_t> CKernelMachine::apply_get_outputs(CFeatures* data)
 #ifdef WIN32
 				for (int32_t vec = start; vec < end; vec++)
 #else
-				for (int32_t vec = start;
-				     vec < end && !CSignal::cancel_computations(); vec++)
+				for (int32_t vec = start; vec < end && !cancel_computation();
+				     vec++)
 #endif
 				{
 					pb.print_progress();
@@ -392,7 +391,7 @@ SGVector<float64_t> CKernelMachine::apply_get_outputs(CFeatures* data)
 		}
 
 #ifndef WIN32
-		if ( CSignal::cancel_computations() )
+		if (cancel_computation())
 			SG_INFO("prematurely stopped.           \n")
 #endif
 	}
@@ -523,8 +522,7 @@ SGVector<float64_t> CKernelMachine::apply_locked_get_output(
 #ifdef WIN32
 		for (int32_t vec = start; vec < end; vec++)
 #else
-		for (int32_t vec = start; vec < end && !CSignal::cancel_computations();
-		     vec++)
+		for (int32_t vec = start; vec < end && !cancel_computation(); vec++)
 #endif
 		{
 			pb.print_progress();
@@ -549,7 +547,7 @@ SGVector<float64_t> CKernelMachine::apply_locked_get_output(
 	}
 
 #ifndef WIN32
-	if ( CSignal::cancel_computations() )
+	if (cancel_computation())
 		SG_INFO("prematurely stopped.\n")
 	else
 #endif

--- a/src/shogun/multiclass/BruteKNNSolver.cpp
+++ b/src/shogun/multiclass/BruteKNNSolver.cpp
@@ -22,7 +22,7 @@ CMulticlassLabels* CBruteKNNSolver::classify_objects(CDistance* knn_distance, co
 	SGMatrix<index_t> NN = this->nn;
 
 	//from the indices to the nearest neighbors, compute the class labels
-	for (index_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
+	for (index_t i = 0; i < num_lab && (!cancel_computation()); i++)
 	{
 		//write the labels of the k nearest neighbors from theirs indices
 		for (index_t j=0; j<m_k; j++)
@@ -44,7 +44,7 @@ SGVector<int32_t> CBruteKNNSolver::classify_objects_k(CDistance* knn_distance, c
 	//get the k nearest neighbors of each example
 	SGMatrix<index_t> NN = this->nn;
 
-	for (index_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
+	for (index_t i = 0; i < num_lab && (!cancel_computation()); i++)
 	{
 		//write the labels of the k nearest neighbors from theirs indices
 		for (index_t j=0; j<m_k; j++)

--- a/src/shogun/multiclass/KDTreeKNNsolver.cpp
+++ b/src/shogun/multiclass/KDTreeKNNsolver.cpp
@@ -28,7 +28,7 @@ CMulticlassLabels* CKDTREEKNNSolver::classify_objects(CDistance* knn_distance, c
 	CFeatures* query = knn_distance->get_rhs();
 	kd_tree->query_knn(dynamic_cast<CDenseFeatures<float64_t>*>(query), m_k);
 	SGMatrix<index_t> NN = kd_tree->get_knn_indices();
-	for (int32_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
+	for (int32_t i = 0; i < num_lab && (!cancel_computation()); i++)
 	{
 		//write the labels of the k nearest neighbors from theirs indices
 		for (int32_t j=0; j<m_k; j++)
@@ -59,7 +59,7 @@ SGVector<int32_t> CKDTREEKNNSolver::classify_objects_k(CDistance* knn_distance, 
 	CFeatures* data = knn_distance->get_rhs();
 	kd_tree->query_knn(dynamic_cast<CDenseFeatures<float64_t>*>(data), m_k);
 	SGMatrix<index_t> NN = kd_tree->get_knn_indices();
-	for (index_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
+	for (index_t i = 0; i < num_lab && (!cancel_computation()); i++)
 	{
 		//write the labels of the k nearest neighbors from theirs indices
 		for (index_t j=0; j<m_k; j++)

--- a/src/shogun/multiclass/KNN.cpp
+++ b/src/shogun/multiclass/KNN.cpp
@@ -129,7 +129,7 @@ SGMatrix<index_t> CKNN::nearest_neighbors()
 	auto pb = progress(range(n), *this->io);
 
 	//for each test example
-	for (int32_t i=0; i<n && (!CSignal::cancel_computations()); i++)
+	for (int32_t i = 0; i < n && (!cancel_computation()); i++)
 	{
 		pb.print_progress();
 
@@ -212,7 +212,7 @@ CMulticlassLabels* CKNN::classify_NN()
 	auto pb = progress(range(num_lab), *this->io);
 
 	// for each test example
-	for (int32_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
+	for (int32_t i = 0; i < num_lab && (!cancel_computation()); i++)
 	{
 		pb.print_progress();
 

--- a/src/shogun/multiclass/LSHKNNSolver.cpp
+++ b/src/shogun/multiclass/LSHKNNSolver.cpp
@@ -65,8 +65,8 @@ CMulticlassLabels* CLSHKNNSolver::classify_objects(CDistance* knn_distance, cons
 		sg_memcpy(NN.get_column_vector(i), indices->data(), sizeof(int32_t)*m_k);
 		delete indices;
 	}
-		
-	for (index_t i=0; i<num_lab && (!CSignal::cancel_computations()); i++)
+
+	for (index_t i = 0; i < num_lab && (!cancel_computation()); i++)
 	{
 		//write the labels of the k nearest neighbors from theirs indices
 		for (index_t j=0; j<m_k; j++)

--- a/src/shogun/multiclass/LaRank.cpp
+++ b/src/shogun/multiclass/LaRank.cpp
@@ -639,8 +639,8 @@ bool CLaRank::train_machine(CFeatures* data)
 
 	auto pb = progress(range(0, 10), *this->io);
 	SG_INFO("Training on %d examples\n", nb_train)
-	while (gap > get_C() && (!CSignal::cancel_computations()) &&
-            n_it < max_iteration)      // stopping criteria
+	while (gap > get_C() && (!cancel_computation()) &&
+	       n_it < max_iteration) // stopping criteria
 	{
 		float64_t tr_err = 0;
 		int32_t ind = step;

--- a/src/shogun/optimization/liblinear/shogun_liblinear.cpp
+++ b/src/shogun/optimization/liblinear/shogun_liblinear.cpp
@@ -513,7 +513,9 @@ void Solver_MCSVM_CS::solve()
 		state->inited = true;
 	}
 
-	while(iter < max_iter && !CSignal::cancel_computations())
+	// TODO: replace with the new signal
+	// while(iter < max_iter && !CSignal::cancel_computations())
+	while (iter < max_iter)
 	{
 		double stopping = -CMath::INFTY;
 		for(i=0;i<active_size;i++)

--- a/src/shogun/optimization/liblinear/tron.cpp
+++ b/src/shogun/optimization/liblinear/tron.cpp
@@ -107,7 +107,9 @@ void CTron::tron(float64_t *w, float64_t max_train_time)
 	CTime start_time;
 	auto pb = progress(range(10));
 
-	while (iter <= max_iter && search && (!CSignal::cancel_computations()))
+	// TODO: replace with new signal
+	// while (iter <= max_iter && search && (!CSignal::cancel_computations()))
+	while (iter <= max_iter && search)
 	{
 		if (max_train_time > 0 && start_time.cur_time_diff() > max_train_time)
 		  break;

--- a/src/shogun/transfer/multitask/LibLinearMTL.cpp
+++ b/src/shogun/transfer/multitask/LibLinearMTL.cpp
@@ -256,7 +256,7 @@ void CLibLinearMTL::solve_l2r_l1l2_svc(const liblinear_problem *prob, double eps
 
 	auto pb = progress(range(10));
 	CTime start_time;
-	while (iter < max_iterations && !CSignal::cancel_computations())
+	while (iter < max_iterations && !cancel_computation())
 	{
 		if (m_max_train_time > 0 && start_time.cur_time_diff() > m_max_train_time)
 			break;


### PR DESCRIPTION
Remove `CSignal::cancel_computations()` and add `TODO` when the class does not inherit directly from CMachine.