### PR TITLE
Refactor (Fisher)LDA solvers into separate class

### DIFF
--- a/src/shogun/classifier/LDA.h
+++ b/src/shogun/classifier/LDA.h
@@ -32,7 +32,7 @@ enum ELDAMethod
 	/** Singular Value Decomposition based LDA.
 	*/
 	SVD_LDA = 20,
-	/** Fisher two class discrimiant based LDA.
+	/** Fisher two class discriminant based LDA.
 	*/
 	FLD_LDA = 30
 };
@@ -55,7 +55,8 @@ template <class ST> class CDenseFeatures;
  * is maximized, where
  * \f[S_b := ({\bf m_{+1}} - {\bf m_{-1}})({\bf m_{+1}} - {\bf m_{-1}})^T \f]
  * is the between class scatter matrix and
- * \f[S_w := \sum_{c\in\{-1,+1\}}\sum_{{\bf x}\in X_{c}}({\bf x} - {\bf m_c})({\bf x} - {\bf m_c})^T \f]
+ * \f[S_w := \sum_{c\in\{-1,+1\}}\sum_{{\bf x}\in X_{c}}({\bf x} - {\bf
+ * m_c})({\bf x} - {\bf m_c})^T \f]
  * is the within class scatter matrix with mean \f${\bf m_c} :=
  * \frac{1}{N}\sum_{j=1}^N {\bf x_j^c}\f$ and \f$X_c:=\{x_1^c, \dots, x_N^c\}\f$
  * the set of examples of class c.
@@ -66,10 +67,14 @@ template <class ST> class CDenseFeatures;
  *
  * <em>::SVD_LDA</em> : Singular Valued decomposition method.
  * The above derivation of Fisher's LDA requires the invertibility of the within
- * class matrix. However, this condition gets void when there are fewer data-points
- * than dimensions. A solution is to require that \f${\bf W}\f$ lies only in the subspace
- * spanned by the data. A basis of the data \f${\bf X}\f$ is found using the thin-SVD technique
- * which returns an orthonormal non-square basis matrix \f${\bf Q}\f$. We then require the
+ * class matrix. However, this condition gets void when there are fewer
+ * data-points
+ * than dimensions. A solution is to require that \f${\bf W}\f$ lies only in the
+ * subspace
+ * spanned by the data. A basis of the data \f${\bf X}\f$ is found using the
+ * thin-SVD technique
+ * which returns an orthonormal non-square basis matrix \f${\bf Q}\f$. We then
+ * require the
  * solution \f${\bf w}\f$ to be expressed in this basis.
  * \f[{\bf W} := {\bf Q} {\bf{W^\prime}}\f]
  * The between class Matrix is replaced with:
@@ -80,8 +85,13 @@ template <class ST> class CDenseFeatures;
  * been projected down to the basis that spans the data.
  * see: Bayesian Reasoning and Machine Learning, section 16.3.1.
  *
- * <em>::AUTO_LDA</em> : This mode automagically chooses one of the above modes for
- * the users based on whether N > D (chooses ::FLD_LDA) or N < D(chooses ::SVD_LDA)
+ * <em>::AUTO_LDA</em> : This mode automagically chooses one of the above modes
+ * for
+ * the users based on whether N > D (chooses ::FLD_LDA) or N < D(chooses
+ * ::SVD_LDA)
+ * Note that even if N > D FLD_LDA may fail being the covariance matrix not
+ * invertible,
+ * in such case one should use SVD_LDA.
  * \sa CLinearMachine
  * \sa http://en.wikipedia.org/wiki/Linear_discriminant_analysis
  */
@@ -94,19 +104,33 @@ class CLDA : public CLinearMachine
 		/** constructor
 		 *
 		 * @param gamma gamma
-		 * @param method LDA using Fisher's algorithm or Singular Value Decomposition : ::FLD_LDA/::SVD_LDA/::AUTO_LDA[default]
+		 * @param method LDA using Fisher's algorithm or Singular Value
+		 * Decomposition : ::FLD_LDA/::SVD_LDA/::AUTO_LDA[default]
+		 * @param bdc_svd when using SVD solver switch between
+		 * Bidiagonal Divide and Conquer algorithm (BDC) and
+		 * Jacobi's algorithm, for the differences @see linalg::SVDAlgorithm.
+		 * [default = BDC-SVD]
 		 */
-		CLDA(float64_t gamma=0, ELDAMethod method=AUTO_LDA);
+		CLDA(
+		    float64_t gamma = 0, ELDAMethod method = AUTO_LDA,
+		    bool bdc_svd = true);
 
 		/** constructor
 		 *
 		 * @param gamma gamma
 		 * @param traindat training features
 		 * @param trainlab labels for training features
-		 * @param method LDA using Fisher's algorithm or Singular Value Decomposition : ::FLD_LDA/::SVD_LDA/::AUTO_LDA[default]
-
+		 * @param method LDA using Fisher's algorithm or Singular Value
+		 * Decomposition : ::FLD_LDA/::SVD_LDA/::AUTO_LDA[default]
+		 * @param bdc_svd when using SVD solver switch between
+		 * Bidiagonal Divide and Conquer algorithm (BDC-SVD) and
+		 * Jacobi's algorithm, for the differences @see linalg::SVDAlgorithm.
+		 * [default = BDC-SVD]
 		 */
-		CLDA(float64_t gamma, CDenseFeatures<float64_t>* traindat, CLabels* trainlab, ELDAMethod method=AUTO_LDA);
+		CLDA(
+		    float64_t gamma, CDenseFeatures<float64_t>* traindat,
+		    CLabels* trainlab, ELDAMethod method = AUTO_LDA,
+		    bool bdc_svd = true);
 		virtual ~CLDA();
 
 		/** set gamma
@@ -170,15 +194,15 @@ class CLDA : public CLinearMachine
 		 * @see train_machine
 		 */
 		template <typename ST>
-		bool train_machine_templated(SGVector<int32_t> train_labels, CFeatures * features);
+		bool train_machine_templated();
 
 		/**
 		 * Train the machine with the svd-based solver (@see CFisherLDA).
-		 * \warning This method is currently untemplated.
 		 * @param features training data
 		 * @param labels labels for training data
 		 */
-		bool solver_svd(SGVector<int32_t> train_labels, CFeatures* data);
+		template <typename ST>
+		bool solver_svd();
 
 		/**
 		 * Train the machine with the classic method based on the cholesky
@@ -187,7 +211,7 @@ class CLDA : public CLinearMachine
 		 * @param labels labels for training data
 		 */
 		template <typename ST>
-		bool solver_classic(SGVector<int32_t> train_labels, CFeatures* data);
+		bool solver_classic();
 
 	protected:
 
@@ -197,6 +221,8 @@ class CLDA : public CLinearMachine
 		float64_t m_gamma;
 		/** LDA mode */
 		ELDAMethod m_method;
+		/** use bdc-svd algorithm */
+		bool m_bdc_svd;
 };
 }
 #endif//ifndef

--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -25,6 +25,15 @@ CMulticlassLabels::CMulticlassLabels(CFile* loader) : CDenseLabels(loader)
 	init();
 }
 
+CMulticlassLabels::CMulticlassLabels(CBinaryLabels* labels)
+    : CDenseLabels(labels->get_num_labels())
+{
+	init();
+
+	for (index_t i = 0; i < labels->get_num_labels(); ++i)
+		m_labels[i] = (labels->get_label(i) == 1 ? 1 : 0);
+}
+
 CMulticlassLabels::~CMulticlassLabels()
 {
 }

--- a/src/shogun/labels/MulticlassLabels.h
+++ b/src/shogun/labels/MulticlassLabels.h
@@ -57,6 +57,14 @@ class CMulticlassLabels : public CDenseLabels
 		 */
 		CMulticlassLabels(CFile* loader);
 
+		/**
+		 * Convert binary labels to multiclass labels,
+		 * namely -1 is mapped to 0 and 1 to 1.
+		 *
+		 * @param labels Binary labels
+		 */
+		CMulticlassLabels(CBinaryLabels* labels);
+
 		/** destructor */
 		~CMulticlassLabels();
 

--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -41,6 +41,7 @@
 #include <shogun/lib/config.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/GPUMemoryBase.h>
+#include <shogun/mathematics/linalg/LinalgEnums.h>
 #include <shogun/mathematics/linalg/internal/Block.h>
 
 namespace shogun
@@ -638,7 +639,7 @@ namespace shogun
 #define BACKEND_GENERIC_SVD(Type, Container)                                   \
 	virtual void svd(                                                          \
 	    const Container<Type>& A, SGVector<Type> s, SGMatrix<Type> U,          \
-	    bool thin_U) const                                                     \
+	    bool thin_U, linalg::SVDAlgorithm alg) const                           \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
 	}

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -37,6 +37,7 @@
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/linalg/LinalgBackendBase.h>
+#include <shogun/mathematics/linalg/LinalgEnums.h>
 #include <shogun/mathematics/linalg/LinalgMacros.h>
 
 namespace shogun
@@ -316,7 +317,7 @@ namespace shogun
 #define BACKEND_GENERIC_SVD(Type, Container)                                   \
 	virtual void svd(                                                          \
 	    const Container<Type>& A, SGVector<Type> s, Container<Type> U,         \
-	    bool thin_U) const;
+	    bool thin_U, linalg::SVDAlgorithm alg) const;
 		DEFINE_FOR_NON_INTEGER_PTYPE(BACKEND_GENERIC_SVD, SGMatrix)
 #undef BACKEND_GENERIC_SVD
 
@@ -592,8 +593,8 @@ namespace shogun
 		/** Eigen3 compute svd method */
 		template <typename T>
 		void svd_impl(
-		    const SGMatrix<T>& A, SGVector<T>& s, SGMatrix<T>& U,
-		    bool thin_U) const;
+		    const SGMatrix<T>& A, SGVector<T>& s, SGMatrix<T>& U, bool thin_U,
+		    linalg::SVDAlgorithm alg) const;
 
 		/** Eigen3 compute trace method */
 		template <typename T>

--- a/src/shogun/mathematics/linalg/LinalgEnums.h
+++ b/src/shogun/mathematics/linalg/LinalgEnums.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef LINALG_ENUMS_H__
+#define LINALG_ENUMS_H__
+
+namespace shogun
+{
+
+	namespace linalg
+	{
+
+		/**
+		 * Enum for choosing the algorithm used to calculate SVD.
+		 * The <em>bidiagonal divide and conquer</em> algorithm
+		 * is faster on large matrices but it's available with
+		 * Eigen >= 3.3, furthermore it may produce inaccurate
+		 * results when compiled with unsafe math optimization.
+		 * For more details see:
+		 * https://eigen.tuxfamily.org/dox/classEigen_1_1BDCSVD.html
+		 * https://eigen.tuxfamily.org/dox/classEigen_1_1JacobiSVD.html
+		 */
+		enum class SVDAlgorithm
+		{
+			BidiagonalDivideConquer,
+			Jacobi
+		};
+	}
+}
+
+#endif // LINALG_ENUMS_H__

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -34,6 +34,7 @@
 #define LINALG_NAMESPACE_H_
 
 #include <shogun/mathematics/linalg/LinalgBackendBase.h>
+#include <shogun/mathematics/linalg/LinalgEnums.h>
 #include <shogun/mathematics/linalg/SGLinalg.h>
 
 namespace shogun
@@ -1146,6 +1147,19 @@ namespace shogun
 		}
 
 		/**
+		 * Method that computes the euclidean norm of a vector.
+		 *
+		 * @param a SGVector
+		 * @return The vector norm
+		 */
+		template <typename T>
+		T norm(const SGVector<T>& a)
+		{
+			REQUIRE(a.size() > 0, "Vector cannot be empty!\n");
+			return CMath::sqrt(dot(a, a));
+		}
+
+		/**
 		 * Solve the linear equations \f$Ax=b\f$ through the
 		 * QR decomposition of A.
 		 *
@@ -1393,11 +1407,15 @@ namespace shogun
 		 * @param U The matrix that stores the resulting unitary matrix U
 		 * @param thin_U Whether to compute the full or thin matrix U
 		 * (default:thin)
+		 * @param alg Whether to compute the svd through bidiagonal divide
+		 * and conquer algorithm or Jacobi's algorithm (@see SVDAlgorithm)
+		 * (default: bidiagonal divide and conquer)
 		 */
 		template <typename T>
 		void
 		svd(const SGMatrix<T>& A, SGVector<T>& s, SGMatrix<T>& U,
-		    bool thin_U = true)
+		    bool thin_U = true,
+		    SVDAlgorithm alg = SVDAlgorithm::BidiagonalDivideConquer)
 		{
 			auto r = CMath::min(A.num_cols, A.num_rows);
 			REQUIRE(
@@ -1425,7 +1443,7 @@ namespace shogun
 			                   "smaller dimension (%d).\n",
 			    s.vlen, r);
 
-			infer_backend(A)->svd(A, s, U, thin_U);
+			infer_backend(A)->svd(A, s, U, thin_U, alg);
 		}
 
 		/**

--- a/src/shogun/preprocessor/FisherLDA.h
+++ b/src/shogun/preprocessor/FisherLDA.h
@@ -92,16 +92,23 @@ namespace shogun
 class CFisherLDA: public CDimensionReductionPreprocessor
 {
 	public:
-
 		/** standard constructor
-		 * @param method LDA based on : ::CLASSIC_FLDA/::CANVAR_FLDA/::AUTO_FLDA[default]
-		 * @param thresh threshold value for ::CANVAR_FLDA only. This is used to reject
-		 * those basis whose singular values are less than the provided threshold.
+		 * @param method LDA based on :
+		 * ::CLASSIC_FLDA/::CANVAR_FLDA/::AUTO_FLDA[default]
+		 * @param thresh threshold value for ::CANVAR_FLDA only. This is used to
+		 * reject
+		 * those basis whose singular values are less than the provided
+		 * threshold.
 		 * The default one is 0.01.
+		 * @param gamma regularization parameter
+		 * @param bdc_svd when using SVD solver switch between
+		 * Bidiagonal Divide and Conquer algorithm (BDC) and
+		 * Jacobi's algorithm, for the differences @see linalg::SVDAlgorithm.
+		 * [default = BDC-SVD]
 		 */
 		CFisherLDA(
 		    EFLDAMethod method = AUTO_FLDA, float64_t thresh = 0.01,
-		    float64_t gamma = 0);
+		    float64_t gamma = 0, bool bdc_svd = true);
 
 		/** destructor */
 		virtual ~CFisherLDA();
@@ -153,39 +160,21 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 		void initialize_parameters();
 
 	protected:
-		/** Helper function used by the solvers to center the data and
-		 * to compute the number of data points and the mean for each class.
-		 * @param data matrix containing the data to be processed.
-		 * @param labels_vector vector containing the label for each data point.
-		 * @param C number of classes.
-		 * @param mean_class vector that holds the mean vector for each class.
-		 * @param num_class vector that holds the number of data points for each
-		 * class.
-		 */
-		void center_data_compute_means(
-		    SGMatrix<float64_t>& data, SGVector<float64_t>& labels_vector,
-		    int32_t C, std::vector<SGVector<float64_t>>& mean_class,
-		    std::vector<index_t>& num_class);
-
 		/**
 		 * Train the preprocessor with the canonical variates method.
-		 * @param data training data.
-		 * @param labels_vector vector containing the label for each data point.
-		 * @param C number of classes.
+		 * @param features training data.
+		 * @param labels multiclass labels.
 		 */
 		bool solver_canvar(
-		    SGMatrix<float64_t>& data, SGVector<float64_t>& labels_vector,
-		    int32_t C);
+		    CDenseFeatures<float64_t>* features, CMulticlassLabels* labels);
 
 		/**
 		 * Train the preprocessor with the classic method.
-		 * @param data training data.
-		 * @param labels_vector vector containing the label for each data point.
-		 * @param C number of classes.
+		 * @param features training data.
+		 * @param labels multiclass labels.
 		 */
 		bool solver_classic(
-		    SGMatrix<float64_t>& data, SGVector<float64_t>& labels_vector,
-		    int32_t C);
+		    CDenseFeatures<float64_t>* features, CMulticlassLabels* labels);
 
 		/** transformation matrix */
 		SGMatrix<float64_t> m_transformation_matrix;
@@ -197,6 +186,8 @@ class CFisherLDA: public CDimensionReductionPreprocessor
 		float64_t m_threshold;
 		/** m_method */
 		int32_t m_method;
+		/** m_bdc_svd */
+		bool m_bdc_svd;
 		/** mean vector */
 		SGVector<float64_t> m_mean_vector;
 		/** eigenvalues vector */

--- a/src/shogun/solver/LDACanVarSolver.h
+++ b/src/shogun/solver/LDACanVarSolver.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2017, Shogun Toolbox Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef LDA_CAN_VAR_SOLVER_H_
+#define LDA_CAN_VAR_SOLVER_H_
+
+#include <shogun/mathematics/linalg/LinalgEnums.h>
+#include <shogun/solver/LDASolver.h>
+
+namespace shogun
+{
+
+	template <typename T>
+	class LDACanVarSolver : public LDASolver<T>
+	{
+	protected:
+		/** Between covariance matrix */
+		SGMatrix<T> m_between_cov;
+		/** Number of dimensions in the projected space */
+		index_t m_num_dim;
+		/** Singular values threshold in svd */
+		float64_t m_threshold;
+		/** eigenvectors matrix */
+		SGMatrix<T> m_eigenvectors;
+		/** eigenvalues vector */
+		SGVector<T> m_eigenvalues;
+		/** use bdc-svd algorithm */
+		bool m_bdc_svd;
+
+		/**
+		 * Compute between class covariance matrix.
+		 */
+		virtual void compute_between_cov();
+
+		/**
+		 * Compute the eigenvectors through the canonical variates algorithm.
+		 */
+		virtual void canvar();
+
+	public:
+		LDACanVarSolver(
+		    CDenseFeatures<T>* features, CMulticlassLabels* labels,
+		    index_t num_dim, float64_t gamma = 0.0, bool bdc_svd = true,
+		    float64_t threshold = 0.01)
+		    : LDASolver<T>(features, labels, gamma)
+		{
+			m_num_dim = num_dim;
+			m_threshold = threshold;
+			m_bdc_svd = bdc_svd;
+
+			compute_between_cov();
+			canvar();
+		}
+
+		/** @returns eigenvectors to project features into the transformed space
+		 */
+		SGMatrix<T> get_eigenvectors();
+
+		/** @returns eigenvalues */
+		SGVector<T> get_eigenvalues();
+	};
+
+	template <typename T>
+	void LDACanVarSolver<T>::compute_between_cov()
+	{
+		index_t num_features = this->m_features->get_num_features();
+		index_t num_class = this->m_labels->get_num_classes();
+
+		m_between_cov = SGMatrix<T>(num_features, num_class);
+		linalg::zero(m_between_cov);
+		for (index_t i = 0; i < num_class; ++i)
+		{
+			auto col = m_between_cov.get_column(i);
+			linalg::add(this->m_class_mean[i], this->m_mean, col, (T)1, (T)-1);
+			linalg::scale(col, col, (T)sqrt(this->m_class_count[i]));
+		}
+	}
+
+	template <typename T>
+	void LDACanVarSolver<T>::canvar()
+	{
+		index_t num_features = this->m_features->get_num_features();
+		index_t num_vectors = this->m_features->get_num_vectors();
+
+		index_t r = CMath::min(num_vectors, num_features);
+		SGMatrix<T> U(num_features, r);
+		SGVector<T> singularValues(r);
+
+		// thin U SVD
+		linalg::SVDAlgorithm svd_alg =
+		    m_bdc_svd ? linalg::SVDAlgorithm::BidiagonalDivideConquer
+		              : linalg::SVDAlgorithm::Jacobi;
+		linalg::svd(
+		    this->m_features->get_feature_matrix(), singularValues, U, true,
+		    svd_alg);
+
+		// basis to represent the solution
+		SGMatrix<T> Q;
+		// keep only the directions s.t. singular value > threshold
+		if (num_features > num_vectors)
+		{
+			index_t j = 0;
+			for (index_t i = 0; i < num_vectors; ++i)
+				if (singularValues[i] > m_threshold)
+					++j;
+				else
+					break;
+			Q = SGMatrix<T>(U.matrix, num_features, j, false);
+		}
+		else
+			Q = U;
+
+		// modified between scatter (Sb)
+		auto aux = linalg::matrix_prod(Q, m_between_cov, true, false);
+		m_between_cov = linalg::matrix_prod(aux, aux, false, true);
+		// modified within scatter (Sw)
+		aux = linalg::matrix_prod(Q, this->m_within_cov, true, false);
+		this->m_within_cov = linalg::matrix_prod(aux, Q);
+
+		// To find svd(inverse(Sw)' * Sb * inverse(Sw))
+		// solve Sb = (Sw' * X) * Sw
+		// 1. get chol(Sw)
+		// 2. solve chol(Sw)' * Y = Sb
+		// 3. solve chol(Sw) * X = Y
+		// 4. compute svd(X)
+		auto chol = linalg::cholesky_factor(this->m_within_cov);
+		SGMatrix<T> W(m_between_cov.num_rows, m_between_cov.num_cols);
+		SGVector<T> eigenvalues(m_between_cov.num_rows);
+		linalg::svd(
+		    linalg::triangular_solver(
+		        chol, linalg::transpose_matrix(
+		                  linalg::triangular_solver(chol, m_between_cov))),
+		    eigenvalues, W, true, svd_alg);
+
+		m_eigenvectors = SGMatrix<T>(num_features, m_num_dim);
+		linalg::zero(m_eigenvectors);
+		m_eigenvalues = SGVector<T>(m_num_dim);
+
+		auto Wt = linalg::matrix_prod(Q, W);
+		for (index_t i = 0; i < m_num_dim; ++i)
+		{
+			m_eigenvectors.set_column(i, Wt.get_column(i));
+			m_eigenvalues[i] = eigenvalues[i];
+		}
+	}
+
+	template <typename T>
+	SGMatrix<T> LDACanVarSolver<T>::get_eigenvectors()
+	{
+		return m_eigenvectors;
+	}
+
+	template <typename T>
+	SGVector<T> LDACanVarSolver<T>::get_eigenvalues()
+	{
+		return m_eigenvalues;
+	}
+}
+
+#endif // LDA_CAN_VAR_SOLVER_H_

--- a/src/shogun/solver/LDASolver.h
+++ b/src/shogun/solver/LDASolver.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2017, Shogun Toolbox Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef LDA_SOLVER_H_
+#define LDA_SOLVER_H_
+
+#include <shogun/base/SGObject.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/labels/MulticlassLabels.h>
+#include <shogun/lib/config.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <vector>
+
+namespace shogun
+{
+
+	template <typename T>
+	class LDASolver
+	{
+	protected:
+		CDenseFeatures<T>* m_features;
+		CMulticlassLabels* m_labels;
+		// Regularization parameter
+		float64_t m_gamma;
+		// Vector that holds the mean of each class
+		std::vector<SGVector<T>> m_class_mean;
+		// Vector of number of data points of each class
+		std::vector<index_t> m_class_count;
+		// Total mean vector
+		SGVector<T> m_mean;
+		// Within covariance matrix
+		SGMatrix<T> m_within_cov;
+
+		/**
+		 * Compute the total mean and for each class the number of data points
+		 * and its mean.
+		 */
+		virtual void compute_means();
+
+		/**
+		 * Compute within class covariance matrix.
+		 */
+		virtual void compute_within_cov();
+
+	public:
+		LDASolver(
+		    CDenseFeatures<T>* features, CMulticlassLabels* labels,
+		    float64_t gamma = 0.0)
+		{
+			m_features = features;
+			m_labels = labels;
+			m_gamma = gamma;
+
+			SG_REF(m_features)
+			SG_REF(m_labels)
+
+			compute_means();
+			compute_within_cov();
+		}
+
+		~LDASolver()
+		{
+			SG_UNREF(m_features)
+			SG_UNREF(m_labels)
+		}
+
+		/** @return the vector of classes' mean */
+		std::vector<SGVector<T>> get_class_mean();
+
+		/** @return the number of data points of each class */
+		std::vector<index_t> get_class_count();
+
+		/** @return the total mean */
+		SGVector<T> get_mean();
+
+		/** @return the within covariance matrix */
+		SGMatrix<T> get_within_cov();
+	};
+
+	template <typename T>
+	void LDASolver<T>::compute_means()
+	{
+		index_t num_class = m_labels->get_num_classes();
+		auto data = m_features->get_feature_matrix();
+
+		m_class_mean = std::vector<SGVector<T>>(num_class);
+		m_class_count = std::vector<index_t>(num_class);
+		for (index_t i = 0; i < num_class; ++i)
+		{
+			m_class_mean[i] = SGVector<T>(data.num_rows);
+			linalg::zero(m_class_mean[i]);
+		}
+		m_mean = SGVector<T>(data.num_rows);
+		linalg::zero(m_mean);
+
+		// calculate the total mean and the classes' mean.
+		for (index_t i = 0; i < data.num_cols; ++i)
+		{
+			index_t c = (index_t)m_labels->get_label(i);
+			++m_class_count[c];
+			linalg::add_col_vec(data, i, m_class_mean[c], m_class_mean[c]);
+		}
+		for (index_t i = 0; i < num_class; ++i)
+		{
+			linalg::add(m_mean, m_class_mean[i], m_mean);
+			linalg::scale(
+			    m_class_mean[i], m_class_mean[i], 1 / (T)m_class_count[i]);
+		}
+		linalg::scale(m_mean, m_mean, 1 / (T)data.num_cols);
+	}
+
+	template <typename T>
+	void LDASolver<T>::compute_within_cov()
+	{
+		index_t num_features = m_features->get_num_features();
+		index_t num_vectors = m_features->get_num_vectors();
+		index_t num_class = m_labels->get_num_classes();
+
+		auto data = m_features->get_feature_matrix().clone();
+
+		// Center data with respect to each data point's class
+		for (index_t i = 0; i < data.num_cols; ++i)
+			linalg::add_col_vec(
+			    data, i, m_class_mean[m_labels->get_label(i)], data, (T)1.0,
+			    (T)-1.0);
+
+		// holds the feature matrix for each class
+		std::vector<SGMatrix<T>> centered_class(num_class);
+		std::vector<index_t> centered_class_col(num_class);
+
+		m_within_cov = SGMatrix<T>(num_features, num_features);
+		linalg::zero(m_within_cov);
+		for (auto i = 0; i < num_class; ++i)
+		{
+			centered_class[i] = SGMatrix<T>(num_features, m_class_count[i]);
+			linalg::zero(centered_class[i]);
+		}
+		for (index_t i = 0; i < num_vectors; ++i)
+		{
+			index_t c = (index_t)m_labels->get_label(i);
+			centered_class[c].set_column(
+			    centered_class_col[c], data.get_column(i));
+			++centered_class_col[c];
+		}
+		for (index_t i = 0; i < num_class; ++i)
+		{
+			auto tmp = linalg::matrix_prod(
+			    centered_class[i], centered_class[i], false, true);
+			linalg::add(
+			    m_within_cov, tmp, m_within_cov, (T)1.0,
+			    ((T)m_class_count[i] / (m_class_count[i] - 1)));
+		}
+
+		if (m_gamma > 0.0)
+		{
+			T trace = linalg::trace(m_within_cov);
+			SGMatrix<T> id(num_features, num_features);
+			linalg::identity(id);
+			linalg::add(
+			    m_within_cov, id, m_within_cov, (T)(1.0 - m_gamma),
+			    trace * ((T)m_gamma) / num_features);
+		}
+	}
+
+	template <typename T>
+	std::vector<SGVector<T>> LDASolver<T>::get_class_mean()
+	{
+		return m_class_mean;
+	}
+
+	template <typename T>
+	std::vector<index_t> LDASolver<T>::get_class_count()
+	{
+		return m_class_count;
+	}
+
+	template <typename T>
+	SGVector<T> LDASolver<T>::get_mean()
+	{
+		return m_mean;
+	}
+
+	template <typename T>
+	SGMatrix<T> LDASolver<T>::get_within_cov()
+	{
+		return m_within_cov;
+	}
+}
+
+#endif // LDA_SOLVER_H_

--- a/tests/unit/classifier/LDA_unittest.cc
+++ b/tests/unit/classifier/LDA_unittest.cc
@@ -27,11 +27,12 @@
 * of the authors and should not be interpreted as representing official policies,
 * either expressed or implied, of the Shogun Development Team.
 */
-#include <shogun/features/DenseFeatures.h>
-#include <shogun/features/DataGenerator.h>
-#include <shogun/labels/BinaryLabels.h>
-#include <shogun/classifier/LDA.h>
 #include <gtest/gtest.h>
+#include <shogun/classifier/LDA.h>
+#include <shogun/features/DataGenerator.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/labels/BinaryLabels.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -162,13 +163,15 @@ void check_eigenvectors_fld()
 
 	FLD_test<float64_t>(projection_FLD, w_FLD);
 
+	// normalize 'w' since the magnitude is irrelevant
+	w_FLD = linalg::scale(w_FLD, 1.0 / linalg::norm(w_FLD));
 	// comparing our 'w' against 'w' a.k.a EigenVec of the scipy implementation
 	// of Fisher 2 Class LDA here:
 	// http://wiki.scipy.org/Cookbook/LinearClassification
 	float64_t epsilon=0.00000001;
-	EXPECT_NEAR(5.31296094, w_FLD[0], epsilon);
-	EXPECT_NEAR(40.45747764, w_FLD[1], epsilon);
-	EXPECT_NEAR(10.81046958, w_FLD[2], epsilon);
+	EXPECT_NEAR(0.12586205, w_FLD[0], epsilon);
+	EXPECT_NEAR(0.95842245, w_FLD[1], epsilon);
+	EXPECT_NEAR(0.25609597, w_FLD[2], epsilon);
 }
 
 TEST(LDA, DISABLED_CheckProjection_FLD)


### PR DESCRIPTION
This includes:
- refactor LDA binary classification and dimension reduction solvers in two separate classes: `LDASolver`, centers data w.r.t. class, compute within cov matrix (shared by bin. class. and dim. red. llt/eigen solvers); `LDACanVarSolver`, inherits from `LDASolver` and computes the solution through canonical variates algorithm (shared by bin class. and dim. red. canvar solvers)
- fix bias calculation in LDA #3886 
- option to compute SVD by bidiagonalization divide and conquer algorithm (with Eigen >= 3.3)
- MulticlassLabels constructor from BinaryLabels (I know there is already some work going on labels, so let me know if there is a better way)
- LDA benchmarks: https://gist.github.com/micmn/d4b51bf39676621afca563b55bdb9a98 :dancer:

Certainly some docs are missing, I'll double check. 