### PR TITLE
Rename static method DotFeatures::get_mean -> compute_mean

### DIFF
--- a/src/shogun/distance/MahalanobisDistance.cpp
+++ b/src/shogun/distance/MahalanobisDistance.cpp
@@ -50,7 +50,8 @@ bool CMahalanobisDistance::init(CFeatures* l, CFeatures* r)
 	}
 	else
 	{
-		mean = ((CDenseFeatures<float64_t>*) l)->get_mean((CDotFeatures*) lhs, (CDotFeatures*) rhs);
+		mean = ((CDenseFeatures<float64_t>*)l)
+		           ->compute_mean((CDotFeatures*)lhs, (CDotFeatures*)rhs);
 		icov = CDotFeatures::compute_cov((CDotFeatures*) lhs, (CDotFeatures*) rhs);
 	}
 

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -277,7 +277,8 @@ SGVector<float64_t> CDotFeatures::get_mean()
 	return mean;
 }
 
-SGVector<float64_t> CDotFeatures::get_mean(CDotFeatures* lhs, CDotFeatures* rhs)
+SGVector<float64_t>
+CDotFeatures::compute_mean(CDotFeatures* lhs, CDotFeatures* rhs)
 {
 	ASSERT(lhs && rhs)
 	ASSERT(lhs->get_dim_feature_space() == rhs->get_dim_feature_space())
@@ -368,7 +369,7 @@ SGMatrix<float64_t> CDotFeatures::compute_cov(CDotFeatures* lhs, CDotFeatures* r
 
 	memset(cov.matrix, 0, sizeof(float64_t)*dim*dim);
 
-	SGVector<float64_t>  mean=get_mean(lhs,rhs);
+	SGVector<float64_t> mean = compute_mean(lhs, rhs);
 
 	for (int i = 0; i < 2; i++)
 	{

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -213,7 +213,8 @@ class CDotFeatures : public CFeatures
 		 *
 		 * @return mean returned
 		 */
-		static SGVector<float64_t> get_mean(CDotFeatures* lhs, CDotFeatures* rhs);
+		static SGVector<float64_t>
+		compute_mean(CDotFeatures* lhs, CDotFeatures* rhs);
 
 		/** get covariance
 		 *


### PR DESCRIPTION
Swig doesn't handle mixed static/non-static methods with the same name resulting in the availability of only one of the two.