### PR TITLE
Make CrossValidation emit fold evaluations (WIP)

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -806,6 +806,26 @@ bool CSGObject::type_erased_has(const BaseTag& _tag) const
 	return self->has(_tag);
 }
 
+class CSGObject::ParameterObserverList
+{
+public:
+	void register_param(
+	    const std::string& name, const std::string& type,
+	    const std::string& description)
+	{
+		m_list_obs_params[name] = std::make_pair(type, description);
+	}
+
+	ObsParamsList get_list() const
+	{
+		return m_list_obs_params;
+	}
+
+private:
+	/** List of observable parameters (name, description) */
+	ObsParamsList m_list_obs_params;
+};
+
 void CSGObject::subscribe_to_parameters(ParameterObserverInterface* obs)
 {
 	auto sub =
@@ -833,26 +853,6 @@ void CSGObject::observe_scalar(
 	m_subscriber_params->on_next(tmp);
 }
 
-class CSGObject::ParameterObserverList
-{
-public:
-	void register_param(
-	    const std::string& name, const std::string& type,
-	    const std::string& description)
-	{
-		m_list_obs_params[name] = std::make_pair(type, description);
-	}
-
-	ObsParamsList get_list() const
-	{
-		return m_list_obs_params;
-	}
-
-private:
-	/** List of observable parameters (name, description) */
-	ObsParamsList m_list_obs_params;
-};
-
 void CSGObject::register_observable_param(
     const std::string& name, const std::string& type,
     const std::string& description)
@@ -862,12 +862,11 @@ void CSGObject::register_observable_param(
 
 void CSGObject::list_observable_parameters()
 {
-	SG_INFO("List of observable parameters of object %s\n", get_name());
-	SG_PRINT("------");
+	SG_PRINT("List of %s's observable parameters\n", get_name());
 	for (auto const& x : param_obs_list->get_list())
 	{
 		SG_PRINT(
-		    "%s [%s]: %s\n", x.first.c_str(), x.second.first.c_str(),
+		    "* %s [%s]: %s\n", x.first.c_str(), x.second.first.c_str(),
 		    x.second.second.c_str());
 	}
 }

--- a/src/shogun/evaluation/CrossValidation.h
+++ b/src/shogun/evaluation/CrossValidation.h
@@ -178,7 +178,7 @@ protected:
 	 *
 	 * @return evaluation result of one cross-validation run
 	 */
-	virtual float64_t evaluate_one_run();
+	virtual float64_t evaluate_one_run(int step = 0);
 
 	/** number of evaluation runs for one fold */
 	int32_t m_num_runs;


### PR DESCRIPTION
@karlnapf this patch will lead to a result like this one below. The XValidation algorithm will emit each fold evaluation for each of the xvalidation run (this version doesn't emit the fold indices, because there is no meaningful way to represent them with Tensorboard). 
 
![screenshot from 2017-07-13 16-03-17](https://user-images.githubusercontent.com/3296552/28170804-c0fa4f5e-67e6-11e7-86e5-b433c1016cf0.png)

The data show in the image were generated by [this](https://github.com/shogun-toolbox/shogun/blob/develop/examples/undocumented/libshogun/evaluation_cross_validation_regression.cpp) Shogun's example (with the addition of ParameterObserverScalar).