### PR TITLE
CombinedKernel kernel CombinedFeatures feature mismatch segfault

### DIFF
--- a/src/shogun/features/CombinedFeatures.cpp
+++ b/src/shogun/features/CombinedFeatures.cpp
@@ -48,7 +48,10 @@ CCombinedFeatures::~CCombinedFeatures()
 
 CFeatures* CCombinedFeatures::get_feature_obj(int32_t idx)
 {
-	return (CFeatures*) feature_array->get_element(idx);
+	if (idx>=this->get_num_feature_obj()){
+       SG_SERROR("feature index out of bounds (%d >= %d)\n",
+                  idx, this->get_num_feature_obj());
+    }
 }
 
 void CCombinedFeatures::list_feature_objs()

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -121,9 +121,13 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 		// skip over features - the custom kernel does not need any
 		if (k->get_kernel_type() != K_CUSTOM)
 		{
-			lf = ((CCombinedFeatures*) l)->get_feature_obj(f_idx);
-			rf = ((CCombinedFeatures*) r)->get_feature_obj(f_idx);
-			f_idx++;
+			if (((CCombinedFeatures*) l)->get_num_feature_obj() > f_idx && ((CCombinedFeatures*) r)->get_num_feature_obj() > f_idx)
+            {
+                lf = ((CCombinedFeatures*) l)->get_feature_obj(f_idx);
+                rf = ((CCombinedFeatures*) r)->get_feature_obj(f_idx);
+            }
+
+            f_idx++;
 			if (!lf || !rf)
 			{
 				SG_UNREF(lf);

--- a/src/shogun/kernel/CombinedKernel.h
+++ b/src/shogun/kernel/CombinedKernel.h
@@ -124,7 +124,11 @@ class CCombinedKernel : public CKernel
 		 */
 		inline CKernel* get_kernel(int32_t idx)
 		{
-			return (CKernel*) kernel_array->get_element(idx);
+						if (idx < get_num_kernels()) {
+								return (CKernel*) kernel_array->get_element(idx);
+							} else {
+								return 0;
+							}
 		}
 
 		/** get last kernel


### PR DESCRIPTION
Fixed issues with array index being out of bounds if there was a mismatch between num of kernels and num of features, which would cause a segfault

Introduced a fix that should prevent CCombinedKernel::init from segfaulting when number of feature in CCombinedFeatures is less than the number of kernels in CCombined Kernels. Fixed a potential segfault where CCombinedFeatures does not check if idx is within bounds in CCombinedFeatures::get_feature_obj Fixed a bug where CCombinedKernel expected CCombinedKernel::get_kernel to return 0 if idx is out of bounds, however a segfault would occur instead