### PR TITLE
Add KernelMachines to generated serialization tests

### DIFF
--- a/src/shogun/regression/KRRNystrom.cpp
+++ b/src/shogun/regression/KRRNystrom.cpp
@@ -58,7 +58,7 @@ less than number of data points (%d)\n", m_num_rkhs_basis, n);
 
 void CKRRNystrom::init()
 {
-	m_num_rkhs_basis=100;
+	m_num_rkhs_basis=0;
 }
 
 SGVector<int32_t> CKRRNystrom::subsample_indices()
@@ -78,6 +78,13 @@ SGVector<int32_t> CKRRNystrom::subsample_indices()
 bool CKRRNystrom::solve_krr_system()
 {
 	int32_t n=kernel->get_num_vec_lhs();
+
+	if (m_num_rkhs_basis == 0)
+	{
+		set_num_rkhs_basis((int32_t)CMath::ceil(n/2.0));
+		SG_SWARNING("Number of sampled rows not set, default is half (%d) "
+					"of the number of data points (%d)\n", m_num_rkhs_basis, n);
+	}
 
 	SGVector<float64_t> y=((CRegressionLabels*)m_labels)->get_labels();
 	if (y==NULL)

--- a/tests/unit/base/trained_model_serialization_unittest.cc.jinja2
+++ b/tests/unit/base/trained_model_serialization_unittest.cc.jinja2
@@ -4,12 +4,14 @@
  */
 
 #include <gtest/gtest.h>
+#include <shogun/kernel/GaussianKernel.h>
 #include <shogun/machine/Machine.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/labels/Labels.h>
 #include <shogun/labels/BinaryLabels.h>
 #include <shogun/labels/RegressionLabels.h>
 #include <shogun/io/SerializableAsciiFile.h>
+#include <shogun/io/SerializableHdf5File.h>
 #include <shogun/io/CSVFile.h>
 #include <shogun/io/SGIO.h>
 #include "environments/LinearTestEnvironment.h"
@@ -67,8 +69,34 @@ protected:
 	CLabels *train_labels;
 };
 
-{% macro test(class) -%}
-TEST_F(TrainedModelSerializationTest, {{class}})
+bool serialize_machine(CMachine* machine, std::string &filename)
+{
+	std::string class_name = machine->get_name();
+	filename = "shogun-unittest-trained-model-serialization-" + class_name + ".XXXXXX";
+	generate_temp_filename(const_cast<char*>(filename.c_str()));
+
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename.c_str(), 'w');
+	bool save_success=machine->save_serializable(file);
+	file->close();
+	SG_FREE(file);
+
+	return save_success;
+}
+
+bool deserialize_machine(CMachine *machine, std::string filename)
+{
+	CSerializableHdf5File *file=new CSerializableHdf5File(filename.c_str(), 'r');
+	bool load_success=machine->load_serializable(file);
+
+	file->close();
+	SG_FREE(file);
+	int delete_success=unlink(filename.c_str());
+
+	return load_success && (delete_success == 0);
+}
+
+{% macro linear_machine_test(class) -%}
+TEST_F(TrainedModelSerializationTest, LinearMachine_{{class}})
 {
 	auto machine=new {{class}}();
 	load_data(machine->get_machine_problem_type());
@@ -85,30 +113,16 @@ TEST_F(TrainedModelSerializationTest, {{class}})
 
 	CLabels* predictions=machine->apply(test_feats);
 
-	std::string class_name("{{class}}");
-	std::string filename = "shogun-unittest-trained-model-serialization-" + class_name + ".XXXXXX";
-	generate_temp_filename(const_cast<char*>(filename.c_str()));
+	std::string filename;
+	ASSERT_TRUE(serialize_machine(machine, filename));
 
-	CSerializableAsciiFile *file=new CSerializableAsciiFile(filename.c_str(), 'w');
-	bool save_success=machine->save_serializable(file);
-	file->close();
-	SG_FREE(file);
-	ASSERT_TRUE(save_success);
-
-	file=new CSerializableAsciiFile(filename.c_str(), 'r');
 	auto deserialized_machine=new {{class}}();
-	bool load_success=deserialized_machine->load_serializable(file);
-	file->close();
-	SG_FREE(file);
-	ASSERT_TRUE(load_success);
+	ASSERT_TRUE(deserialize_machine(deserialized_machine, filename));
 
 	CLabels* deserialized_predictions=deserialized_machine->apply(test_feats);
 
 	float64_t accuracy=1e-13;
 	ASSERT(predictions->equals(deserialized_predictions, accuracy, true))
-
-	int delete_success=unlink(filename.c_str());
-	ASSERT_EQ(0, delete_success);
 
 	SG_FREE(machine);
 	SG_FREE(deserialized_machine);
@@ -117,7 +131,50 @@ TEST_F(TrainedModelSerializationTest, {{class}})
 }
 {%- endmacro %}
 
-{% for name, attrs in classes.items() %}
+{% macro kernel_machine_test(class) -%}
+TEST_F(TrainedModelSerializationTest, KernelMachine_{{class}})
+{
+	auto machine=new {{class}}();
+	load_data(machine->get_machine_problem_type());
+
+	CGaussianKernel *kernel = new CGaussianKernel(2.0);
+	kernel->init(train_feats, train_feats);
+	machine->set_kernel(kernel);
+	machine->set_labels(train_labels);
+
+	bool train_success=machine->train();
+	ASSERT_TRUE(train_success);
+
+	CLabels* predictions=machine->apply(test_feats);
+
+	std::string filename;
+	ASSERT_TRUE(serialize_machine(machine, filename));
+
+	auto deserialized_machine=new {{class}}();
+	ASSERT_TRUE(deserialize_machine(deserialized_machine, filename));
+
+	CLabels* deserialized_predictions=deserialized_machine->apply(test_feats);
+
+	float64_t accuracy=1e-13;
+	ASSERT(predictions->equals(deserialized_predictions, accuracy, true))
+
+	SG_FREE(machine);
+	SG_FREE(deserialized_machine);
+	SG_FREE(predictions);
+	SG_FREE(deserialized_predictions);
+}
+{%- endmacro %}
+
+{%
+set macros = {
+	'CLinearMachine': linear_machine_test,
+	'CKernelMachine': kernel_machine_test}
+%}
+{% for name, attrs in machines.items() %}
+{% for base in bases %}
+{% if base in attrs['ancestors'] and not name in ignores[base] %}
 #include <{{attrs['include']}}>
-{{ test(name) }}
+{{ macros[base](name) }}
+{% endif %}
+{% endfor %}
 {% endfor %}


### PR DESCRIPTION
Machines that are failing: CDomainAdaptationSVM, CMKLRegression, CKRRNystrom, CMKLClassification, CMKLOneClass, CSVM, CLibSVMOneClass.

~Most of them should be failing to due custom initialization needed, I'll check if that's the case.~

KRRNystrom was failing due to wrong inizialization, I made a small modification to the solver.
LibSVMOneClass was failing due to serialization inaccuracy, switching to hdf5 format solves it.
The other ones need custom initialization (MKL, DomainAdaptation) and the generic SVM class doesn't implement a solver.