### PR TITLE
Set LAPACK's dsyevr as default symmetric eigensolver + fixes

### DIFF
--- a/src/shogun/mathematics/lapack.cpp
+++ b/src/shogun/mathematics/lapack.cpp
@@ -311,7 +311,7 @@ void wrap_dsyevr(char jobz, char uplo, int n, double *a, int lda, int il, int iu
 	double vl,vu;
 	double abstol = 0.0;
 	char I = 'I';
-	int* isuppz = SG_MALLOC(int, n);
+	int* isuppz = SG_MALLOC(int, 2 * (iu - il + 1));
 #ifdef HAVE_ACML
 	DSYEVR(jobz,I,uplo,n,a,lda,vl,vu,il,iu,abstol,m,
 	       eigenvalues,eigenvectors,n,isuppz,info);

--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -250,7 +250,7 @@ namespace shogun
 #define BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC(Type, Container)                \
 	virtual void eigen_solver_symmetric(                                       \
 	    const Container<Type>& A, SGVector<Type>& eigenvalues,                 \
-	    SGMatrix<Type>& eigenvectors) const                                    \
+	    SGMatrix<Type>& eigenvectors, index_t k) const                         \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
 	}

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -127,7 +127,7 @@ namespace shogun
 #define BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC(Type, Container)                \
 	virtual void eigen_solver_symmetric(                                       \
 	    const Container<Type>& A, SGVector<Type>& eigenvalues,                 \
-	    SGMatrix<Type>& eigenvectors) const;
+	    SGMatrix<Type>& eigenvectors, index_t k) const;
 		DEFINE_FOR_NON_INTEGER_PTYPE(
 		    BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC, SGMatrix)
 #undef BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC
@@ -439,7 +439,7 @@ namespace shogun
 		template <typename T>
 		void eigen_solver_symmetric_impl(
 		    const SGMatrix<T>& A, SGVector<T>& eigenvalues,
-		    SGMatrix<T>& eigenvectors) const;
+		    SGMatrix<T>& eigenvectors, index_t k) const;
 
 		/** Eigen3 matrix in-place elementwise product method */
 		template <typename T>
@@ -622,6 +622,20 @@ namespace shogun
 		template <typename T>
 		void zero_impl(SGMatrix<T>& a) const;
 	};
+
+/*
+ * Eigen's symmetric eigensolver uses a slower algorithm in comparison
+ * to LAPACK's dsyevr, so if LAPACK is available we use it for float64 type.
+ * This should be removed if eventually Eigen will provide a faster
+ * symmetric eigensolver (@see
+ * http://eigen.tuxfamily.org/bz/show_bug.cgi?id=522).
+ */
+#ifdef HAVE_LAPACK
+	template <>
+	void LinalgBackendEigen::eigen_solver_symmetric_impl<float64_t>(
+	    const SGMatrix<float64_t>& A, SGVector<float64_t>& eigenvalues,
+	    SGMatrix<float64_t>& eigenvectors, index_t k) const;
+#endif
 }
 
 #endif // LINALG_BACKEND_EIGEN_H__

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -623,7 +623,7 @@ namespace shogun
 		}
 
 		/**
-		 * Compute the eigenvalues and eigenvectors of a symmetric matrix.
+		 * Compute the top-k eigenvalues and eigenvectors of a symmetric matrix.
 		 *
 		 * User should pass an appropriately pre-allocated memory vector
 		 * to store the eigenvalues and an appropriately pre-allocated memory
@@ -631,33 +631,45 @@ namespace shogun
 		 *
 		 * @param A The matrix whose eigenvalues and eigenvectors are to be
 		 * computed
-		 * @param eigenvalues Eigenvalues result vector
+		 * @param eigenvalues Eigenvalues result vector in ascending order
 		 * @param eigenvectors Eigenvectors result matrix
+		 * @param k number of top eigenvalues to be computed
+		 * [default = 0: all eigenvalues]
 		 */
 		template <typename T>
 		void eigen_solver_symmetric(
 		    const SGMatrix<T>& A, SGVector<T>& eigenvalues,
-		    SGMatrix<T>& eigenvectors)
+		    SGMatrix<T>& eigenvectors, index_t k = 0)
 		{
+
 			REQUIRE(
 			    A.num_rows == A.num_cols, "Matrix A (%d x% d) is not square!\n",
 			    A.num_rows, A.num_cols);
+
+			if (k == 0)
+				k = A.num_rows;
+			REQUIRE(
+			    k > 0 && k <= A.num_rows,
+			    "Invalid value of k (%d), it must be in the range 1-%d.", k,
+			    A.num_rows)
+
 			REQUIRE(
 			    A.num_rows == eigenvectors.num_rows,
 			    "Number of rows of A (%d) doesn't match eigenvectors' matrix "
 			    "(%d).\n",
 			    A.num_rows, eigenvectors.num_rows);
 			REQUIRE(
-			    A.num_cols == eigenvectors.num_cols,
-			    "Number of columns of A (%d) doesn't match eigenvectors' "
-			    "matrix (%d).\n",
-			    A.num_cols, eigenvectors.num_cols);
+			    k == eigenvectors.num_cols, "Number of requested eigenvectors "
+			                                "(%d) doesn't match the number "
+			                                "of result matrix columns (%d).\n",
+			    k, eigenvectors.num_cols);
 			REQUIRE(
-			    A.num_cols == eigenvalues.vlen,
-			    "Length of eigenvalues' vector doesn't match matrix A");
+			    k == eigenvalues.vlen, "Length of result vector doesn't "
+			                           "match the number of requested "
+			                           "eigenvalues");
 
 			infer_backend(A)->eigen_solver_symmetric(
-			    A, eigenvalues, eigenvectors);
+			    A, eigenvalues, eigenvectors, k);
 		}
 
 		/** Performs the operation C = A .* B where ".*" denotes elementwise

--- a/src/shogun/mathematics/linalg/backend/eigen/Decompositions.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/Decompositions.cpp
@@ -45,26 +45,6 @@ using namespace shogun;
 DEFINE_FOR_NON_INTEGER_PTYPE(BACKEND_GENERIC_CHOLESKY_FACTOR, SGMatrix)
 #undef BACKEND_GENERIC_CHOLESKY_FACTOR
 
-#define BACKEND_GENERIC_EIGEN_SOLVER(Type, Container)                          \
-	void LinalgBackendEigen::eigen_solver(                                     \
-	    const Container<Type>& A, SGVector<Type>& eigenvalues,                 \
-	    SGMatrix<Type>& eigenvectors) const                                    \
-	{                                                                          \
-		eigen_solver_impl(A, eigenvalues, eigenvectors);                       \
-	}
-DEFINE_FOR_NON_INTEGER_PTYPE(BACKEND_GENERIC_EIGEN_SOLVER, SGMatrix)
-#undef BACKEND_GENERIC_EIGEN_SOLVER
-
-#define BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC(Type, Container)                \
-	void LinalgBackendEigen::eigen_solver_symmetric(                           \
-	    const Container<Type>& A, SGVector<Type>& eigenvalues,                 \
-	    SGMatrix<Type>& eigenvectors) const                                    \
-	{                                                                          \
-		eigen_solver_symmetric_impl(A, eigenvalues, eigenvectors);             \
-	}
-DEFINE_FOR_NON_INTEGER_PTYPE(BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC, SGMatrix)
-#undef BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC
-
 #define BACKEND_GENERIC_SVD(Type, Container)                                   \
 	void LinalgBackendEigen::svd(                                              \
 	    const Container<Type>& A, SGVector<Type> s, Container<Type> U,         \
@@ -109,79 +89,6 @@ SGMatrix<T> LinalgBackendEigen::cholesky_factor_impl(
 	    "Matrix is not Hermitian positive definite!\n");
 
 	return c;
-}
-
-template <typename T>
-void LinalgBackendEigen::eigen_solver_impl(
-    const SGMatrix<T>& A, SGVector<T>& eigenvalues,
-    SGMatrix<T>& eigenvectors) const
-{
-	typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
-	typename SGMatrix<T>::EigenMatrixXtMap eigenvectors_eig = eigenvectors;
-	typename SGVector<T>::EigenVectorXtMap eigenvalues_eig = eigenvalues;
-
-	Eigen::EigenSolver<typename SGMatrix<T>::EigenMatrixXt> solver(A_eig);
-
-	/*
-	 * checking for success
-	 *
-	 * 0: Eigen::Success. Decomposition was successful
-	 * 1: Eigen::NumericalIssue. The input contains INF or NaN values or
-	 * overflow occured
-	 */
-	REQUIRE(
-	    solver.info() != Eigen::NumericalIssue,
-	    "The input contains INF or NaN values or overflow occured.\n");
-
-	eigenvalues_eig = solver.eigenvalues().real();
-	eigenvectors_eig = solver.eigenvectors().real();
-}
-
-void LinalgBackendEigen::eigen_solver_impl(
-    const SGMatrix<complex128_t>& A, SGVector<complex128_t>& eigenvalues,
-    SGMatrix<complex128_t>& eigenvectors) const
-{
-	typename SGMatrix<complex128_t>::EigenMatrixXtMap A_eig = A;
-	typename SGMatrix<complex128_t>::EigenMatrixXtMap eigenvectors_eig =
-	    eigenvectors;
-	typename SGVector<complex128_t>::EigenVectorXtMap eigenvalues_eig =
-	    eigenvalues;
-
-	Eigen::ComplexEigenSolver<typename SGMatrix<complex128_t>::EigenMatrixXt>
-	    solver(A_eig);
-
-	REQUIRE(
-	    solver.info() != Eigen::NumericalIssue,
-	    "The input contains INF or NaN values or overflow occured.\n");
-
-	eigenvalues_eig = solver.eigenvalues();
-	eigenvectors_eig = solver.eigenvectors();
-}
-
-template <typename T>
-void LinalgBackendEigen::eigen_solver_symmetric_impl(
-    const SGMatrix<T>& A, SGVector<T>& eigenvalues,
-    SGMatrix<T>& eigenvectors) const
-{
-	typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
-	typename SGMatrix<T>::EigenMatrixXtMap eigenvectors_eig = eigenvectors;
-	typename SGVector<T>::EigenVectorXtMap eigenvalues_eig = eigenvalues;
-
-	Eigen::SelfAdjointEigenSolver<typename SGMatrix<T>::EigenMatrixXt> solver(
-	    A_eig);
-
-	/*
-	 * checking for success
-	 *
-	 * 0: Eigen::Success. Eigenvalues computation was successful
-	 * 2: Eigen::NoConvergence. Iterative procedure did not converge.
-	 */
-	REQUIRE(
-	    solver.info() != Eigen::NoConvergence,
-	    "Iterative procedure did not converge!\n");
-
-	eigenvalues_eig = solver.eigenvalues().template cast<T>();
-	eigenvectors_eig = solver.eigenvectors().template cast<T>();
 }
 
 template <typename T>

--- a/src/shogun/mathematics/linalg/backend/eigen/EigenSolvers.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/EigenSolvers.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2016, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors: 2016 Pan Deng, Soumyajit De, Heiko Strathmann, Viktor Gal
+ */
+
+#include <shogun/mathematics/lapack.h>
+#include <shogun/mathematics/linalg/LinalgBackendEigen.h>
+#include <shogun/mathematics/linalg/LinalgMacros.h>
+
+using namespace shogun;
+
+#define BACKEND_GENERIC_EIGEN_SOLVER(Type, Container)                          \
+	void LinalgBackendEigen::eigen_solver(                                     \
+	    const Container<Type>& A, SGVector<Type>& eigenvalues,                 \
+	    SGMatrix<Type>& eigenvectors) const                                    \
+	{                                                                          \
+		eigen_solver_impl(A, eigenvalues, eigenvectors);                       \
+	}
+DEFINE_FOR_NON_INTEGER_PTYPE(BACKEND_GENERIC_EIGEN_SOLVER, SGMatrix)
+#undef BACKEND_GENERIC_EIGEN_SOLVER
+
+#define BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC(Type, Container)                \
+	void LinalgBackendEigen::eigen_solver_symmetric(                           \
+	    const Container<Type>& A, SGVector<Type>& eigenvalues,                 \
+	    SGMatrix<Type>& eigenvectors, index_t k) const                         \
+	{                                                                          \
+		eigen_solver_symmetric_impl(A, eigenvalues, eigenvectors, k);          \
+	}
+DEFINE_FOR_NON_INTEGER_PTYPE(BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC, SGMatrix)
+#undef BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC
+
+#undef DEFINE_FOR_ALL_PTYPE
+#undef DEFINE_FOR_REAL_PTYPE
+#undef DEFINE_FOR_NON_INTEGER_PTYPE
+#undef DEFINE_FOR_NUMERIC_PTYPE
+
+template <typename T>
+void LinalgBackendEigen::eigen_solver_impl(
+    const SGMatrix<T>& A, SGVector<T>& eigenvalues,
+    SGMatrix<T>& eigenvectors) const
+{
+	typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
+	typename SGMatrix<T>::EigenMatrixXtMap eigenvectors_eig = eigenvectors;
+	typename SGVector<T>::EigenVectorXtMap eigenvalues_eig = eigenvalues;
+
+	Eigen::EigenSolver<typename SGMatrix<T>::EigenMatrixXt> solver(A_eig);
+
+	/*
+	 * checking for success
+	 *
+	 * 0: Eigen::Success. Decomposition was successful
+	 * 1: Eigen::NumericalIssue. The input contains INF or NaN values or
+	 * overflow occured
+	 */
+	REQUIRE(
+	    solver.info() != Eigen::NumericalIssue,
+	    "The input contains INF or NaN values or overflow occured.\n");
+
+	eigenvalues_eig = solver.eigenvalues().real();
+	eigenvectors_eig = solver.eigenvectors().real();
+}
+
+void LinalgBackendEigen::eigen_solver_impl(
+    const SGMatrix<complex128_t>& A, SGVector<complex128_t>& eigenvalues,
+    SGMatrix<complex128_t>& eigenvectors) const
+{
+	typename SGMatrix<complex128_t>::EigenMatrixXtMap A_eig = A;
+	typename SGMatrix<complex128_t>::EigenMatrixXtMap eigenvectors_eig =
+	    eigenvectors;
+	typename SGVector<complex128_t>::EigenVectorXtMap eigenvalues_eig =
+	    eigenvalues;
+
+	Eigen::ComplexEigenSolver<typename SGMatrix<complex128_t>::EigenMatrixXt>
+	    solver(A_eig);
+
+	REQUIRE(
+	    solver.info() != Eigen::NumericalIssue,
+	    "The input contains INF or NaN values or overflow occured.\n");
+
+	eigenvalues_eig = solver.eigenvalues();
+	eigenvectors_eig = solver.eigenvectors();
+}
+
+template <typename T>
+void LinalgBackendEigen::eigen_solver_symmetric_impl(
+    const SGMatrix<T>& A, SGVector<T>& eigenvalues, SGMatrix<T>& eigenvectors,
+    index_t k) const
+{
+	typename SGMatrix<T>::EigenMatrixXtMap A_eig = A;
+	typename SGMatrix<T>::EigenMatrixXtMap eigenvectors_eig = eigenvectors;
+	typename SGVector<T>::EigenVectorXtMap eigenvalues_eig = eigenvalues;
+
+	Eigen::SelfAdjointEigenSolver<typename SGMatrix<T>::EigenMatrixXt> solver(
+	    A_eig);
+
+	/*
+	 * checking for success
+	 *
+	 * 0: Eigen::Success. Eigenvalues computation was successful
+	 * 2: Eigen::NoConvergence. Iterative procedure did not converge.
+	 */
+	REQUIRE(
+	    solver.info() != Eigen::NoConvergence,
+	    "Iterative procedure did not converge!\n");
+
+	eigenvalues_eig = solver.eigenvalues().tail(k).template cast<T>();
+	eigenvectors_eig = solver.eigenvectors().rightCols(k).template cast<T>();
+}
+
+#ifdef HAVE_LAPACK
+template <>
+void LinalgBackendEigen::eigen_solver_symmetric_impl<float64_t>(
+    const SGMatrix<float64_t>& A, SGVector<float64_t>& eigenvalues,
+    SGMatrix<float64_t>& eigenvectors, index_t k) const
+{
+	int32_t status = 0;
+	int32_t n = A.num_rows;
+
+	// dsyevr requires a vector of length n even if you want just k eigenvalues
+	SGVector<float64_t>::EigenVectorXt ev_eig(n);
+	wrap_dsyevr(
+	    'V', 'U', n, A.matrix, n, n - k + 1, n, ev_eig.data(),
+	    eigenvectors.matrix, &status);
+
+	typename SGVector<float64_t>::EigenVectorXtMap eigenvalues_eig =
+	    eigenvalues;
+	eigenvalues_eig = ev_eig.head(k);
+
+	/*
+	 * checking for success
+	 *
+	 * status == 0: successful exit
+	 * status < 0: the i-th argument had an illegal value
+	 * status > 0: internal error
+	 */
+	REQUIRE(!(status < 0), "The %d-th argument han an illegal value.", -status)
+	REQUIRE(!(status > 0), "Internal error.")
+}
+#endif

--- a/tests/unit/preprocessor/KernelPCA_unittest.cc
+++ b/tests/unit/preprocessor/KernelPCA_unittest.cc
@@ -51,9 +51,8 @@ TEST(KernelPCA, apply_to_feature_matrix)
 	SGMatrix<float64_t> embedding = kpca->apply_to_feature_matrix(test_feats);
 
 	// allow embedding with opposite sign
-	auto s = CMath::sign(embedding[0] * resdata[0]);
-	for (index_t i = 0; i < target_dim * num_test_vectors; ++i)
-		EXPECT_NEAR(embedding[i], s * resdata[i], 1E-6);
+	for (index_t i = 0; i < num_test_vectors * target_dim; ++i)
+		EXPECT_NEAR(CMath::abs(embedding[i]), CMath::abs(resdata[i]), 1E-6);
 
 	SG_FREE(kpca);
 }
@@ -77,9 +76,8 @@ TEST(KernelPCA, apply_to_feature_vector)
 	SGVector<float64_t> embedding = kpca->apply_to_feature_vector(test_vector);
 
 	// allow embedding with opposite sign
-	auto s = CMath::sign(embedding[0] * resdata[0]);
 	for (index_t i = 0; i < target_dim; ++i)
-		EXPECT_NEAR(embedding[i], s * resdata[i], 1E-6);
+		EXPECT_NEAR(CMath::abs(embedding[i]), CMath::abs(resdata[i]), 1E-6);
 
 	SG_FREE(kpca);
 }


### PR DESCRIPTION
Linag (Eigen):
- set LAPACK's dsyevr as default symmetric eigensolver if available;
- add option to compute only the top-k eigenvalues in symmetric eigensolver;
- split decompositions and eigensolvers implementations.

KernelPCA:
- compute just the needed (top-k) eigenvectors;
- fix sign correctness in unittest.

Fix wrap_dsyevr memory allocation.