### PR TITLE
Fix from #3956: Setting multiclass confidence scores in function instead of the constructor

### DIFF
--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -20,29 +20,6 @@ CMulticlassLabels::CMulticlassLabels(const SGVector<float64_t> src) : CDenseLabe
 	set_labels(src);
 }
 
-CMulticlassLabels::CMulticlassLabels(const SGMatrix<float64_t> confidences)
-    : CDenseLabels()
-{
-	init();
-	int32_t n_classes = confidences.num_cols;
-
-	SGVector<float64_t> labels(confidences.num_rows);
-	labels.zero();
-	set_labels(labels);
-
-	allocate_confidences_for(n_classes);
-
-	for (int32_t i = 0; i < confidences.num_rows; ++i)
-	{
-		auto confidences_i = confidences.get_row_vector(i);
-		auto y_pred =
-		    CMath::arg_max(confidences_i.vector, 1, confidences_i.vlen);
-
-		set_label(i, y_pred);
-		set_multiclass_confidences(i, confidences_i);
-	}
-}
-
 CMulticlassLabels::CMulticlassLabels(CFile* loader) : CDenseLabels(loader)
 {
 	init();
@@ -64,6 +41,27 @@ CMulticlassLabels::~CMulticlassLabels()
 void CMulticlassLabels::init()
 {
 	m_multiclass_confidences=SGMatrix<float64_t>();
+}
+
+void CMulticlassLabels::set_multiclass_confidences_from_matrix(SGMatrix<float64_t> confidences)
+{
+	int32_t n_classes = confidences.num_cols;
+
+	SGVector<float64_t> labels(confidences.num_rows);
+	labels.zero();
+	set_labels(labels);
+
+	allocate_confidences_for(n_classes);
+
+	for (int32_t i = 0; i < confidences.num_rows; ++i)
+	{
+		auto confidences_i = confidences.get_row_vector(i);
+		auto y_pred =
+		    CMath::arg_max(confidences_i.vector, 1, confidences_i.vlen);
+
+		set_label(i, y_pred);
+		set_multiclass_confidences(i, confidences_i);
+	}
 }
 
 void CMulticlassLabels::set_multiclass_confidences(int32_t i,

--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -43,7 +43,8 @@ void CMulticlassLabels::init()
 	m_multiclass_confidences=SGMatrix<float64_t>();
 }
 
-void CMulticlassLabels::set_multiclass_confidences_from_matrix(SGMatrix<float64_t> confidences)
+void CMulticlassLabels::set_multiclass_confidences_from_matrix(
+    SGMatrix<float64_t> confidences)
 {
 	int32_t n_classes = confidences.num_cols;
 

--- a/src/shogun/labels/MulticlassLabels.h
+++ b/src/shogun/labels/MulticlassLabels.h
@@ -124,9 +124,11 @@ class CMulticlassLabels : public CDenseLabels
 
 		/** sets multiclass confidences and labels from confidence score matrix
 		 *
-		 * @param confidences matrix that contains scores for each class and sample
+		 * @param confidences matrix that contains scores for each class and
+		 * sample
 		 */
-		void set_multiclass_confidences_from_matrix(SGMatrix<float64_t> confidences);
+		void
+		set_multiclass_confidences_from_matrix(SGMatrix<float64_t> confidences);
 
 		/** allocates matrix to store confidences. should always
 		 * be called before setting confidences with

--- a/src/shogun/labels/MulticlassLabels.h
+++ b/src/shogun/labels/MulticlassLabels.h
@@ -51,12 +51,6 @@ class CMulticlassLabels : public CDenseLabels
 		 */
 		CMulticlassLabels(SGVector<float64_t> src);
 
-		/** constructor
-		 *
-		 * @param labels to set from a matrix that contains confidence scores
-		 * for each class and sample
-		 */
-		CMulticlassLabels(SGMatrix<float64_t> confidences);
 
 		/** constructor
 		 *
@@ -127,6 +121,12 @@ class CMulticlassLabels : public CDenseLabels
 		 * @param confidences confidences to be set for ith result
 		 */
 		void set_multiclass_confidences(int32_t i, SGVector<float64_t> confidences);
+
+		/** sets multiclass confidences and labels from confidence score matrix
+		 *
+		 * @param confidences matrix that contains scores for each class and sample
+		 */
+		void set_multiclass_confidences_from_matrix(SGMatrix<float64_t> confidences);
 
 		/** allocates matrix to store confidences. should always
 		 * be called before setting confidences with

--- a/tests/unit/labels/MulticlassLabels_unittest.cc
+++ b/tests/unit/labels/MulticlassLabels_unittest.cc
@@ -78,7 +78,8 @@ TEST_F(MulticlassLabelsTest, confidences)
 
 TEST_F(MulticlassLabelsTest, confidences_matrix_label_initialization)
 {
-	CMulticlassLabels* labels = new CMulticlassLabels(probabilities);
+	CMulticlassLabels* labels = new CMulticlassLabels(3);
+	labels->set_multiclass_confidences_from_matrix(probabilities);
 	int32_t n_classes = probabilities.num_cols;
 	int32_t n_labels = probabilities.num_rows;
 


### PR DESCRIPTION
- SWIG converted SGMatrix to DoubleMatrix in Java, which conflicted with the MulticlassLabels constructor that used SGVector