### PR TITLE
Fix SubsetStack copy ctor and dtor memory error

### DIFF
--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -76,7 +76,6 @@ template<class ST> CDenseFeatures<ST>::~CDenseFeatures()
 
 template<class ST> void CDenseFeatures<ST>::free_features()
 {
-	m_subset_stack->remove_all_subsets();
 	free_feature_matrix();
 	SG_UNREF(feature_cache);
 }

--- a/src/shogun/features/SubsetStack.cpp
+++ b/src/shogun/features/SubsetStack.cpp
@@ -45,9 +45,12 @@ CSubsetStack::CSubsetStack(const CSubsetStack& other)
 
 	for (int32_t i=0; i < other.m_active_subsets_stack->get_num_elements(); ++i)
 	{
-		m_active_subset=(CSubset*)other.m_active_subsets_stack->get_element(i);
-		m_active_subsets_stack->append_element(m_active_subset);
+		auto subset = other.m_active_subsets_stack->get_element(i);
+		m_active_subsets_stack->append_element(subset);
+		SG_UNREF(subset)
 	}
+	m_active_subset = other.m_active_subset;
+	SG_REF(m_active_subset)
 }
 
 CSubsetStack::~CSubsetStack()
@@ -63,6 +66,7 @@ void CSubsetStack::remove_all_subsets()
 		m_active_subsets_stack->delete_element(i);
 
 	SG_UNREF(m_active_subset);
+	m_active_subset = nullptr;
 }
 
 void CSubsetStack::init()


### PR DESCRIPTION
Playing around with xval's knn unit test I got segfaults on Subset deallocation, there seems to be two issues:

- `DenseFeatures`  calls `m_subset_stack->remove_all_subsets()` two times, in `free_features()` and in `free_feature_matrix()` that is called from the former;

- SubsetStack's copy ctor doesn't ref `m_active_subset`, but I'm a bit confused about this since every subset is refd by `(CSubset*)other.m_active_subsets_stack->get_element(i);`, so on the contrary I'd expect some memleak...

To reproduce it: https://gist.github.com/micmn/59a41d97d5415b4206eaabf616d26f20


@karlnapf 