### PR TITLE
[FeaturesRefactor] Features::view()/preprocess()

### DIFF
--- a/src/shogun/classifier/Perceptron.cpp
+++ b/src/shogun/classifier/Perceptron.cpp
@@ -9,11 +9,13 @@
  */
 
 #include <shogun/classifier/Perceptron.h>
+#include <shogun/features/iterators/DotIterator.h>
 #include <shogun/labels/Labels.h>
 #include <shogun/labels/BinaryLabels.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/lib/Signal.h>
 #include <shogun/base/range.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -53,7 +55,7 @@ bool CPerceptron::train_machine(CFeatures* data)
 	int32_t num_vec=features->get_num_vectors();
 
 	ASSERT(num_vec==train_labels.vlen)
-	float64_t* output=SG_MALLOC(float64_t, num_vec);
+	SGVector<float64_t> output(num_vec);
 
 	SGVector<float64_t> w = get_w();
 	if (m_initialize_hyperplane)
@@ -61,27 +63,28 @@ bool CPerceptron::train_machine(CFeatures* data)
 		w = SGVector<float64_t>(num_feat);
 		//start with uniform w, bias=0
 		bias=0;
-		for (int32_t i=0; i<num_feat; i++)
-			w.vector[i]=1.0/num_feat;
+		linalg::add_scalar(w, 1.0/num_feat);
 	}
-
 
 	//loop till we either get everything classified right or reach max_iter
 	while (!(cancel_computation()) && (!converged && iter < max_iter))
 	{
 		converged=true;
-		for (auto example_idx : features->index_iterator())
+		auto iter_train_labels = train_labels.cbegin();
+		auto iter_output = output.begin();
+		for (const auto& v : DotIterator(features))
 		{
-			const auto predicted_label = features->dense_dot(example_idx, w.vector, w.vlen) + bias;
-			const auto true_label = train_labels[example_idx];
-			output[example_idx] = predicted_label;
+			const auto true_label = *(iter_train_labels++);
+			auto& predicted_label = *(iter_output++);
+
+			predicted_label = v.dot(w) + bias;
 
 			if (CMath::sign<float64_t>(predicted_label) != true_label)
 			{
 				converged = false;
-				const auto gradient = learn_rate * train_labels[example_idx];
+				const auto gradient = learn_rate * true_label;
 				bias += gradient;
-				features->add_to_dense_vec(gradient, example_idx, w.vector, w.vlen);
+				v.add(gradient, w);
 			}
 		}
 
@@ -92,8 +95,6 @@ bool CPerceptron::train_machine(CFeatures* data)
 		SG_INFO("Perceptron algorithm converged after %d iterations.\n", iter)
 	else
 		SG_WARNING("Perceptron algorithm did not converge after %d iterations.\n", max_iter)
-
-	SG_FREE(output);
 
 	set_w(w);
 

--- a/src/shogun/evaluation/CrossValidation.cpp
+++ b/src/shogun/evaluation/CrossValidation.cpp
@@ -270,20 +270,16 @@ float64_t CCrossValidation::evaluate_one_run()
 		for (index_t i=0; i <num_subsets; ++i)
 		{
 			CMachine* machine;
-			CFeatures* features;
-			CLabels* labels;
 			CEvaluation* evaluation_criterion;
 
 			if (get_global_parallel()->get_num_threads()==1)
 			{
 				machine=m_machine;
-				features=m_features;
 				evaluation_criterion=m_evaluation_criterion;
 			}
 			else
 			{
 				machine=(CMachine*)m_machine->clone();
-				features=(CFeatures*)m_features->clone();
 				evaluation_criterion=(CEvaluation*)m_evaluation_criterion->clone();
 			}
 
@@ -302,18 +298,12 @@ float64_t CCrossValidation::evaluate_one_run()
 			}
 			}
 
-			/* set feature subset for training */
+			/* create indices vector for training */
 			SGVector<index_t> inverse_subset_indices=
 					m_splitting_strategy->generate_subset_inverse(i);
 
-			features->add_subset(inverse_subset_indices);
-
-			/* set label subset for training */
-			if (get_global_parallel()->get_num_threads()==1)
-				labels=m_labels;
-			else
-				labels=machine->get_labels();
-			labels->add_subset(inverse_subset_indices);
+			/* set label view for training */
+			machine->set_labels(m_labels->view(inverse_subset_indices));
 
 			SG_DEBUG("training set %d:\n", i)
 			if (io->get_loglevel()==MSG_DEBUG)
@@ -324,7 +314,7 @@ float64_t CCrossValidation::evaluate_one_run()
 
 			/* train machine on training features and remove subset */
 			SG_DEBUG("starting training\n")
-			machine->train(features);
+			machine->train(m_features->view(inverse_subset_indices));
 			SG_DEBUG("finished training\n")
 
 			/* evtl. update xvalidation output class */
@@ -341,16 +331,13 @@ float64_t CCrossValidation::evaluate_one_run()
 			}
 			}
 
-			features->remove_subset();
-			labels->remove_subset();
-
-			/* set feature subset for testing (subset method that stores pointer) */
+			/* create feature view for testing */
 			SGVector<index_t> subset_indices =
 					m_splitting_strategy->generate_subset_indices(i);
-			features->add_subset(subset_indices);
+			auto test_features = m_features->view(subset_indices);
 
-			/* set label subset for testing */
-			labels->add_subset(subset_indices);
+			/* create label view for testing */
+			auto test_labels = m_labels->view(subset_indices);
 
 			SG_DEBUG("test set %d:\n", i)
 			if (io->get_loglevel()==MSG_DEBUG)
@@ -361,14 +348,13 @@ float64_t CCrossValidation::evaluate_one_run()
 
 			/* apply machine to test features and remove subset */
 			SG_DEBUG("starting evaluation\n")
-			SG_DEBUG("%p\n", features)
-			CLabels* result_labels=machine->apply(features);
+			SG_DEBUG("%p\n", test_features)
+			CLabels* result_labels=machine->apply(test_features);
 			SG_DEBUG("finished evaluation\n")
-			features->remove_subset();
 			SG_REF(result_labels);
 
 			/* evaluate */
-			results[i]=evaluation_criterion->evaluate(result_labels, labels);
+			results[i]=evaluation_criterion->evaluate(result_labels, test_labels);
 			SG_DEBUG("result on fold %d is %f\n", i, results[i])
 
 			/* evtl. update xvalidation output class */
@@ -379,7 +365,7 @@ float64_t CCrossValidation::evaluate_one_run()
 			{
 				current->update_test_indices(subset_indices, "\t");
 				current->update_test_result(result_labels, "\t");
-				current->update_test_true_result(labels, "\t");
+				current->update_test_true_result(test_labels, "\t");
 				current->post_update_results();
 				current->update_evaluation_result(results[i], "\t");
 				SG_UNREF(current);
@@ -388,13 +374,10 @@ float64_t CCrossValidation::evaluate_one_run()
 			}
 			}
 
-			/* clean up, remove subsets */
-			labels->remove_subset();
+			/* clean up */
 			if (get_global_parallel()->get_num_threads()!=1)
 			{
 				SG_UNREF(machine);
-				SG_UNREF(features);
-				SG_UNREF(labels);
 				SG_UNREF(evaluation_criterion);
 			}
 			SG_UNREF(result_labels);

--- a/src/shogun/features/DenseFeatures.h
+++ b/src/shogun/features/DenseFeatures.h
@@ -206,7 +206,7 @@ public:
 	 *
 	 * @return matrix feature matrix
 	 */
-	SGMatrix<ST> get_feature_matrix();
+	const SGMatrix<ST>& get_feature_matrix();
 
 	/** steals feature matrix, i.e. returns matrix and
 	 * forget about it
@@ -238,7 +238,7 @@ public:
 	 * @param num_vec number of vectors in matrix
 	 * @return feature matrix
 	 */
-	ST* get_feature_matrix(int32_t &num_feat, int32_t &num_vec);
+	const ST* get_feature_matrix(int32_t &num_feat, int32_t &num_vec);
 
 	/** get a transposed copy of the features
 	 *
@@ -501,6 +501,21 @@ public:
 	 */
 	CFeatures* create_merged_copy(CFeatures* other);
 
+	/** Creates a subset view of the features
+	 * @see CFeatures::view
+	 */
+	Some<CDenseFeatures<ST>> view(const SGVector<index_t>& subset);
+
+	/** Creates a subset view of the features
+	 * @see CFeatures::view
+	 */
+	Some<CDenseFeatures<ST>> view(const std::vector<index_t>& subset);
+
+	/** apply preprocessor
+	 * @see CFeatures::preprocess
+	 */
+	Some<CDenseFeatures<ST>> preprocess(CPreprocessor* p);
+
 	/** helper method used to specialize a base class instance
 	 *
 	 */
@@ -530,6 +545,9 @@ protected:
 
 private:
 	void init();
+
+	/** preprocessors and subsets evaluation implementation */
+	virtual void eval_features();
 
 protected:
 	/*

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -216,6 +216,18 @@ class CDotFeatures : public CFeatures
 		static SGVector<float64_t>
 		compute_mean(CDotFeatures* lhs, CDotFeatures* rhs);
 
+		/** get std
+		 *
+		 * @return std returned
+		 */
+		virtual SGVector<float64_t> get_std();
+
+		/** get std with precomputed mean
+		 *
+		 * @return std returned
+		 */
+		virtual SGVector<float64_t> get_std(const SGVector<float64_t >& mean);
+
 		/** get covariance
 		 *
 		 * @param copy_data_for_speed if true, the method stores explicitly

--- a/src/shogun/features/Features.h
+++ b/src/shogun/features/Features.h
@@ -25,6 +25,7 @@
 #include <shogun/lib/DynamicObjectArray.h>
 #include <shogun/lib/DynamicArray.h>
 #include <shogun/base/range.h>
+#include <shogun/base/some.h>
 
 namespace shogun
 {
@@ -125,6 +126,13 @@ class CFeatures : public CSGObject
 			return range(0, get_num_vectors());
 		}
 #endif
+
+		/** apply preprocessor
+		 *
+		 * @param p preprocessor to apply
+		 * @return new features object
+		 */
+		Some<CFeatures> preprocess(CPreprocessor* p);
 
 		/** add preprocessor
 		 *
@@ -269,6 +277,22 @@ class CFeatures : public CSGObject
 			return NULL;
 		}
 
+		/** Creates a subset view of the features containing the elements
+		 * whose indices are listed in the passed vector
+		 *
+		 * @param subset subset of indices
+		 * @return new CFeatures object wrapped by a smart pointer
+		 */
+		Some<CFeatures> view(const SGVector<index_t>& subset);
+
+		/** Creates a subset view of the features containing the elements
+		 * whose indices are listed in the passed vector
+		 *
+		 * @param subset subset of indices
+		 * @return new CFeatures object wrapped by a smart pointer
+		 */
+		Some<CFeatures> view(const std::vector<index_t>& subset);
+
 		/** Adds a subset of indices on top of the current subsets (possibly
 		 * subset of subset). Every call causes a new active index vector
 		 * to be stored. Added subsets can be removed one-by-one. If this is not
@@ -349,6 +373,9 @@ class CFeatures : public CSGObject
 		 */
 		virtual bool get_feature_class_compatibility (EFeatureClass rhs) const;
 
+		/** apply subsets and preprocessors to features */
+		void eval();
+
 #ifndef SWIG // SWIG should skip this part
 		virtual CFeatures* shallow_subset_copy() 
 		{ 
@@ -359,6 +386,9 @@ class CFeatures : public CSGObject
 
 	private:
 		void init();
+
+		/** apply preprocessors and subsets implementation */
+		virtual void eval_features() { SG_NOTIMPLEMENTED; }
 
 	private:
 		/** feature properties */

--- a/src/shogun/features/iterators/DotIterator.cpp
+++ b/src/shogun/features/iterators/DotIterator.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors: 2017 Michele Mazzoni
+ */
+
+#include <shogun/features/iterators/DotIterator.h>
+
+namespace shogun
+{
+
+float64_t DotIterator::feature_vector::dot(const SGVector<float64_t>& v) const
+{
+	return m_features->dense_dot(m_idx, v.vector, v.vlen);
+}
+
+void DotIterator::feature_vector::add(float64_t alpha, SGVector<float64_t>& v) const
+{
+	m_features->add_to_dense_vec(alpha, m_idx, v.vector, v.vlen);
+}
+
+typename DotIterator::iterator::reference DotIterator::iterator::operator*()
+{
+	return m_feature_vector;
+}
+
+typename DotIterator::iterator& DotIterator::iterator::operator++()
+{
+	++(m_feature_vector.m_idx);
+	return *this;
+}
+
+typename DotIterator::iterator DotIterator::iterator::operator++(int)
+{
+	iterator tmp(*this);
+	++(*this);
+	return tmp;
+}
+
+bool DotIterator::iterator::operator==(const iterator& rhs)
+{
+	return m_feature_vector.m_idx == rhs.m_feature_vector.m_idx;
+}
+
+bool DotIterator::iterator::operator!=(const iterator& rhs)
+{
+	return !(*this == rhs);
+}
+
+DotIterator::iterator DotIterator::begin() const
+{
+	return iterator(m_features, 0);
+}
+
+DotIterator::iterator DotIterator::end() const
+{
+	return iterator(m_features, m_features->get_num_vectors());
+}
+
+}

--- a/src/shogun/features/iterators/DotIterator.h
+++ b/src/shogun/features/iterators/DotIterator.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2017, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Authors: 2017 Michele Mazzoni
+ */
+
+#ifndef _DOTITERATOR_H___
+#define _DOTITERATOR_H___
+
+#include <shogun/features/DotFeatures.h>
+
+namespace shogun
+{
+
+class DotIterator
+{
+	class iterator;
+
+	class feature_vector
+	{
+		public:
+		/** constructor
+		 *
+		 * @param features pointer to CDotFeatures
+		 * @param idx position of the iterator
+		 */
+		feature_vector(CDotFeatures* features, index_t idx) : m_features(features), m_idx(idx) { }
+
+		/** copy constructor */
+		feature_vector(const feature_vector& orig) : m_features(orig.m_features), m_idx(orig.m_idx) { }
+
+		/** dot product between the current feature vector and another vector
+		 *
+		 * @param v vector
+		 * @return dot product result
+		 */
+		float64_t dot(const SGVector<float64_t>& v) const;
+
+		/** multiply the current feature vector to a scalar and add it to a vector
+		 *
+		 * @param alpha scalar to multiply the feature vector to
+		 * @param v accumulator vector
+		 */
+		void add(float64_t alpha, SGVector<float64_t>& v) const;
+
+		protected:
+		CDotFeatures* m_features;
+		index_t m_idx;
+
+		friend class iterator;
+	};
+
+	class iterator
+	{
+		using value_type = feature_vector;
+		using difference_type = index_t;
+		using pointer = feature_vector*;
+		using reference = feature_vector&;
+		using iterator_category = std::forward_iterator_tag;
+
+		public:
+		/** default constructor */
+		iterator() : m_feature_vector(nullptr, -1) { }
+
+		/** constructor
+		 *
+		 * @param features pointer to CDotFeatures
+		 * @param idx position of the iterator
+		 */
+		iterator(CDotFeatures* features, index_t idx=0) : m_feature_vector(features, idx) { }
+
+		/** dereference operator */
+		reference operator*();
+
+		/** pre-increment operator */
+		iterator &operator++();
+
+		/** post-increment operator */
+		iterator operator++(int);
+
+		/** equality operator */
+		bool operator==(const iterator& rhs);
+
+		/** inequality operator */
+		bool operator!=(const iterator& rhs);
+
+		protected:
+		value_type m_feature_vector;
+	};
+
+	public:
+	/** constructor
+	 *
+	 * @param features pointer to CDotFeatures
+	 */
+	DotIterator(CDotFeatures* features) : m_features(features) {}
+
+	/** iterator pointing to the first feature vector
+	 *
+	 * @return iterator
+	 */
+	iterator begin() const;
+
+	/** iterator pointing to the past-the-end feature vector
+	 *
+	 * @return iterator
+	 */
+	iterator end() const;
+
+
+	protected:
+	CDotFeatures* m_features;
+};
+
+}
+
+#endif // _DOTITERATOR_H___

--- a/src/shogun/labels/BinaryLabels.cpp
+++ b/src/shogun/labels/BinaryLabels.cpp
@@ -152,3 +152,18 @@ CLabels* CBinaryLabels::shallow_subset_copy()
 
 	return shallow_copy_labels;
 }
+
+CLabels* CBinaryLabels::duplicate() const
+{
+	return new CBinaryLabels(*this);
+}
+
+Some<CBinaryLabels> CBinaryLabels::view(const SGVector<index_t>& subset)
+{
+	return wrap(static_cast<CBinaryLabels*>(CLabels::view(subset).get()));
+}
+
+Some<CBinaryLabels> CBinaryLabels::view(const std::vector<index_t>& subset)
+{
+	return wrap(static_cast<CBinaryLabels*>(CLabels::view(subset).get()));
+}

--- a/src/shogun/labels/BinaryLabels.h
+++ b/src/shogun/labels/BinaryLabels.h
@@ -91,6 +91,21 @@ public:
 	 */
 	virtual ELabelType get_label_type() const;
 
+	/** shallow-copy of the labels object
+	 * @see CLabels::duplicate
+	 */
+	virtual CLabels* duplicate() const;
+
+	/** Creates a subset view of the labels
+	 * @see CLabels::view
+	 */
+	Some<CBinaryLabels> view(const SGVector<index_t>& subset);
+
+	/** Creates a subset view of the labels
+	 * @see CLabels::view
+	 */
+	Some<CBinaryLabels> view(const std::vector<index_t>& subset);
+
 	/** Converts all scores to calibrated probabilities by fitting a
 	 * sigmoid function using the method described in
 	 * Lin, H., Lin, C., and Weng, R. (2007).

--- a/src/shogun/labels/DenseLabels.cpp
+++ b/src/shogun/labels/DenseLabels.cpp
@@ -33,8 +33,6 @@ CDenseLabels::CDenseLabels(int32_t num_lab)
 	init();
 	m_labels = SGVector<float64_t>(num_lab);
 	m_current_values=SGVector<float64_t>(num_lab);
-	linalg::zero(m_labels);
-	linalg::zero(m_current_values);
 }
 
 CDenseLabels::CDenseLabels(CFile* loader)
@@ -42,6 +40,12 @@ CDenseLabels::CDenseLabels(CFile* loader)
 {
 	init();
 	load(loader);
+}
+
+CDenseLabels::CDenseLabels(const CDenseLabels& orig) : CLabels(orig)
+{
+	init();
+	m_labels = orig.m_labels;
 }
 
 CDenseLabels::~CDenseLabels()

--- a/src/shogun/labels/DenseLabels.h
+++ b/src/shogun/labels/DenseLabels.h
@@ -50,6 +50,9 @@ class CDenseLabels : public CLabels
 		 */
 		CDenseLabels(CFile* loader);
 
+		/** copy constructor */
+		CDenseLabels(const CDenseLabels& orig);
+
 		/** destructor */
 		virtual ~CDenseLabels();
 

--- a/src/shogun/labels/Labels.cpp
+++ b/src/shogun/labels/Labels.cpp
@@ -22,6 +22,19 @@ CLabels::CLabels()
 	init();
 }
 
+CLabels::CLabels(const CLabels& orig) : CSGObject(orig)
+{
+	init();
+
+	m_current_values = orig.m_current_values;
+	if (orig.m_subset_stack != NULL)
+	{
+		SG_UNREF(m_subset_stack);
+		m_subset_stack=new CSubsetStack(*orig.m_subset_stack);
+		SG_REF(m_subset_stack);
+	}
+}
+
 CLabels::~CLabels()
 {
 	SG_UNREF(m_subset_stack);
@@ -62,6 +75,24 @@ CSubsetStack* CLabels::get_subset_stack()
 {
 	SG_REF(m_subset_stack);
 	return m_subset_stack;
+}
+
+Some<CLabels> CLabels::view(const SGVector<index_t>& subset)
+{
+	auto labels_view = wrap(this->duplicate());
+	labels_view->add_subset(subset);
+	return labels_view;
+}
+
+Some<CLabels> CLabels::view(const std::vector<index_t>& subset)
+{
+	auto labels_view = wrap(this->duplicate());
+
+	auto sg_subset = SGVector<index_t>(subset.size());
+	std::copy(subset.cbegin(), subset.cend(), sg_subset.data());
+	labels_view->add_subset(sg_subset);
+
+	return labels_view;
 }
 
 float64_t CLabels::get_value(int32_t idx)

--- a/src/shogun/labels/Labels.h
+++ b/src/shogun/labels/Labels.h
@@ -16,6 +16,7 @@
 #include <shogun/lib/config.h>
 
 #include <shogun/lib/common.h>
+#include <shogun/base/some.h>
 #include <shogun/base/SGObject.h>
 #include <shogun/labels/LabelsFactory.h>
 #include <shogun/labels/LabelTypes.h>
@@ -45,6 +46,9 @@ class CLabels : public CSGObject
 public:
 	/** default constructor */
 	CLabels();
+
+	/** copy constructor */
+	CLabels(const CLabels& orig);
 
 	/** destructor */
 	virtual ~CLabels();
@@ -100,6 +104,28 @@ public:
 	 * @return subset stack
 	 */
 	virtual CSubsetStack* get_subset_stack();
+
+	/** Creates a subset view of the labels containing the elements
+	 * whose indices are listed in the passed vector
+	 *
+	 * @param subset subset of indices
+	 * @return new CLabels object wrapped by a smart pointer
+	 */
+	Some<CLabels> view(const SGVector<index_t>& subset);
+
+	/** Creates a subset view of the labels containing the elements
+	 * whose indices are listed in the passed vector
+	 *
+	 * @param subset subset of indices
+	 * @return new CLabels object wrapped by a smart pointer
+	 */
+	Some<CLabels> view(const std::vector<index_t>& subset);
+
+	/** shallow-copy of the labels object
+	 *
+	 * @return labels object
+	 */
+	virtual CLabels* duplicate() const { SG_NOTIMPLEMENTED; return nullptr; }
 
 	/** set the confidence value for a particular label
 	 *

--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -34,6 +34,13 @@ CMulticlassLabels::CMulticlassLabels(CBinaryLabels* labels)
 		m_labels[i] = (labels->get_label(i) == 1 ? 1 : 0);
 }
 
+CMulticlassLabels::CMulticlassLabels(const CMulticlassLabels& orig) : CDenseLabels(orig)
+{
+	init();
+	m_multiclass_confidences = orig.m_multiclass_confidences;
+}
+
+
 CMulticlassLabels::~CMulticlassLabels()
 {
 }
@@ -177,4 +184,19 @@ CLabels* CMulticlassLabels::shallow_subset_copy()
 		shallow_copy_labels->add_subset(m_subset_stack->get_last_subset()->get_subset_idx());
 
 	return shallow_copy_labels;
+}
+
+CLabels* CMulticlassLabels::duplicate() const
+{
+	return new CMulticlassLabels(*this);
+}
+
+Some<CMulticlassLabels> CMulticlassLabels::view(const SGVector<index_t>& subset)
+{
+	return wrap(static_cast<CMulticlassLabels*>(CLabels::view(subset).get()));
+}
+
+Some<CMulticlassLabels> CMulticlassLabels::view(const std::vector<index_t>& subset)
+{
+	return wrap(static_cast<CMulticlassLabels*>(CLabels::view(subset).get()));
 }

--- a/src/shogun/labels/MulticlassLabels.h
+++ b/src/shogun/labels/MulticlassLabels.h
@@ -66,6 +66,9 @@ class CMulticlassLabels : public CDenseLabels
 		 */
 		CMulticlassLabels(CBinaryLabels* labels);
 
+		/** copy constructor */
+		CMulticlassLabels(const CMulticlassLabels& orig);
+
 		/** destructor */
 		~CMulticlassLabels();
 
@@ -82,6 +85,21 @@ class CMulticlassLabels : public CDenseLabels
 		 * @return label type multiclass
 		 */
 		virtual ELabelType get_label_type() const;
+
+		/** shallow-copy of the labels object
+		 * @see CLabels::duplicate
+		 */
+		virtual CLabels* duplicate() const;
+
+		/** Creates a subset view of the labels
+		 * @see CLabels::view
+		 */
+		Some<CMulticlassLabels> view(const SGVector<index_t>& subset);
+
+		/** Creates a subset view of the labels
+		 * @see CLabels::view
+		 */
+		Some<CMulticlassLabels> view(const std::vector<index_t>& subset);
 
 		/** returns labels containing +1 at positions with ith class
 		 *  and -1 at other positions

--- a/src/shogun/labels/RegressionLabels.cpp
+++ b/src/shogun/labels/RegressionLabels.cpp
@@ -38,3 +38,18 @@ CLabels* CRegressionLabels::shallow_subset_copy()
 
 	return shallow_copy_labels;
 }
+
+CLabels* CRegressionLabels::duplicate() const
+{
+	return new CRegressionLabels(*this);
+}
+
+Some<CRegressionLabels> CRegressionLabels::view(const SGVector<index_t>& subset)
+{
+	return wrap(static_cast<CRegressionLabels*>(CLabels::view(subset).get()));
+}
+
+Some<CRegressionLabels> CRegressionLabels::view(const std::vector<index_t>& subset)
+{
+	return wrap(static_cast<CRegressionLabels*>(CLabels::view(subset).get()));
+}

--- a/src/shogun/labels/RegressionLabels.h
+++ b/src/shogun/labels/RegressionLabels.h
@@ -66,6 +66,21 @@ class CRegressionLabels : public CDenseLabels
 		/** @return object name */
 		virtual const char* get_name() const { return "RegressionLabels"; }
 
+		/** shallow-copy of the labels object
+		 * @see CLabels::duplicate
+		 */
+		virtual CLabels* duplicate() const;
+
+		/** Creates a subset view of the labels
+		 * @see CLabels::view
+		 */
+		Some<CRegressionLabels> view(const SGVector<index_t>& subset);
+
+		/** Creates a subset view of the labels
+		 * @see CLabels::view
+		 */
+		Some<CRegressionLabels> view(const std::vector<index_t>& subset);
+
 #ifndef SWIG // SWIG should skip this part
 		virtual CLabels* shallow_subset_copy();
 #endif

--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -1234,6 +1234,100 @@ SGVector<T> SGMatrix<T>::get_diagonal_vector() const
 	return diag;
 }
 
+#ifndef SWIG // SWIG should skip this parts
+// Iterator implementation
+template <class T>
+typename SGMatrix<T>::iterator SGMatrix<T>::begin()
+{
+	return iterator(get_column(0));
+}
+
+template <class T>
+typename SGMatrix<T>::iterator SGMatrix<T>::end()
+{
+	return iterator(get_column(num_cols));
+}
+
+template <class T>
+typename SGMatrix<T>::iterator::reference SGMatrix<T>::iterator::operator*()
+{
+	return m_vector;
+}
+
+template <class T>
+typename SGMatrix<T>::iterator& SGMatrix<T>::iterator::operator++()
+{
+	m_vector.vector += m_vector.vlen;
+	return *this;
+}
+
+template <class T>
+typename SGMatrix<T>::iterator SGMatrix<T>::iterator::operator++(int)
+{
+	iterator tmp(*this);
+	++(*this);
+	return tmp;
+}
+
+template <class T>
+bool SGMatrix<T>::iterator::operator==(const iterator& rhs) const
+{
+	return m_vector.vector == rhs.m_vector.vector;
+}
+
+template <class T>
+bool SGMatrix<T>::iterator::operator!=(const iterator& rhs) const
+{
+	return !(*this == rhs);
+}
+
+// Const-iterator implementation
+template <class T>
+typename SGMatrix<T>::const_iterator SGMatrix<T>::cbegin() const
+{
+	return const_iterator(get_column(0));
+}
+
+template <class T>
+typename SGMatrix<T>::const_iterator SGMatrix<T>::cend() const
+{
+	return const_iterator(get_column(num_cols));
+}
+
+template <class T>
+typename SGMatrix<T>::const_iterator::reference SGMatrix<T>::const_iterator::operator*()
+{
+	return m_vector;
+}
+
+template <class T>
+typename SGMatrix<T>::const_iterator& SGMatrix<T>::const_iterator::operator++()
+{
+	m_vector.vector += m_vector.vlen;
+	return *this;
+}
+
+template <class T>
+typename SGMatrix<T>::const_iterator SGMatrix<T>::const_iterator::operator++(int)
+{
+	const_iterator tmp(*this);
+	++(*this);
+	return tmp;
+}
+
+template <class T>
+bool SGMatrix<T>::const_iterator::operator==(const const_iterator& rhs) const
+{
+	return m_vector.vector == rhs.m_vector.vector;
+}
+
+template <class T>
+bool SGMatrix<T>::const_iterator::operator!=(const const_iterator& rhs) const
+{
+	return !(*this == rhs);
+}
+#endif // SWIG
+
 template class SGMatrix<bool>;
 template class SGMatrix<char>;
 template class SGMatrix<int8_t>;
@@ -1248,4 +1342,5 @@ template class SGMatrix<float32_t>;
 template class SGMatrix<float64_t>;
 template class SGMatrix<floatmax_t>;
 template class SGMatrix<complex128_t>;
+
 }

--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -114,6 +114,37 @@ SGMatrix<T>::SGMatrix(EigenMatrixXt& mat)
 	m_on_gpu.store(false, std::memory_order_release);
 }
 
+
+#ifndef SWIG
+template <class T>
+SGMatrix<T>::SGMatrix(std::initializer_list<std::initializer_list<T>> list)
+	: SGReferencedData(true)
+{
+	ASSERT(list.size() > 0)
+	num_rows = (index_t)list.size();
+	num_cols = (index_t)list.begin()->size();
+	matrix = SG_MALLOC(T, ((int64_t) num_rows)*num_cols);
+
+	index_t i = 0;
+	for (auto row : list)
+	{
+		REQUIRE(
+			(index_t)row.size() == num_cols,
+			"Each row must have the same number of entries.\n")
+
+		index_t j = 0;
+		for (auto e : row)
+		{
+			(*this)(i,j) = e;
+			++j;
+		}
+		++i;
+	}
+
+	m_on_gpu.store(false, std::memory_order_release);
+}
+#endif //SWIG
+
 template <class T>
 SGMatrix<T>::operator EigenMatrixXtMap() const
 {

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -148,6 +148,21 @@ template<class T> class SGMatrix : public SGReferencedData
 		 */
 		 SGMatrix(GPUMemoryBase<T>* matrix, index_t nrows, index_t ncols);
 
+#ifndef SWIG
+		/**
+		 * Constructor for creating an SGMatrix from an initializer list
+		 * containing the rows of the matrix, i.e.
+		 *	 SGMatrix<float64_t> matrix({
+		 * 		{1,2,3},
+		 * 		{4,5,6},
+		 * 		{7,8,9}
+		 * 	});
+		 *
+		 * 	@param list initializer list
+		 */
+		SGMatrix(std::initializer_list<std::initializer_list<T>> list);
+#endif //SWIG
+
 		/** Check whether data is stored on GPU
 		 *
 		 * @return true if matrix is on GPU

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -39,6 +39,82 @@ template<class T> class SGMatrix : public SGReferencedData
 {
 	friend class LinalgBackendEigen;
 
+#ifndef SWIG // SWIG should skip this parts
+	class iterator
+	{
+		using value_type = SGVector<T>;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type *;
+		using reference = value_type &;
+		using iterator_category = std::forward_iterator_tag;
+
+		public:
+		/** default constructor */
+		iterator() = default;
+
+		/** constructor
+		 *
+		 * @param vector column pointed by the iterator
+		 */
+		iterator(SGVector<T> vector) : m_vector(vector) {}
+
+		/** dereference operator */
+		reference operator*();
+
+		/** pre-increment operator */
+		iterator &operator++();
+
+		/** post-increment operator */
+		iterator operator++(int);
+
+		/** equality operator */
+		bool operator==(const iterator& rhs) const;
+
+		/** inequality operator */
+		bool operator!=(const iterator& rhs) const;
+
+		protected:
+		value_type m_vector;
+	};
+
+	class const_iterator
+	{
+		using value_type = SGVector<T>;
+		using difference_type = std::ptrdiff_t;
+		using pointer = const value_type *;
+		using reference = const value_type &;
+		using iterator_category = std::forward_iterator_tag;
+
+		public:
+		/** default constructor */
+		const_iterator() = default;
+
+		/** constructor
+		 *
+		 * @param vector column pointed by the iterator
+		 */
+		const_iterator(SGVector<T> vector) : m_vector(vector) {}
+
+		/** dereference operator */
+		reference operator*();
+
+		/** pre-increment operator */
+		const_iterator &operator++();
+
+		/** post-increment operator */
+		const_iterator operator++(int);
+
+		/** equality operator */
+		bool operator==(const const_iterator& rhs) const;
+
+		/** inequality operator */
+		bool operator!=(const const_iterator& rhs) const;
+
+		protected:
+		value_type m_vector;
+	};
+#endif // SWIG
+
 	public:
 		typedef Eigen::Matrix<T,-1,-1,0,-1,-1> EigenMatrixXt;
 		typedef Eigen::Map<EigenMatrixXt,0,Eigen::Stride<0,0> > EigenMatrixXtMap;
@@ -133,6 +209,30 @@ template<class T> class SGMatrix : public SGReferencedData
 		virtual ~SGMatrix();
 
 #ifndef SWIG // SWIG should skip this parts
+		/** iterator pointing to the first column in the matrix
+		 *
+		 * @return iterator
+		 */
+		iterator begin();
+
+		/** iterator pointing to the past-the-end column in the matrix
+		 *
+		 * @return iterator
+		 */
+		iterator end();
+
+		/** const iterator pointing to the first column in the matrix
+		 *
+		 * @return const iterator
+		 */
+		const_iterator cbegin() const;
+
+		/** const iterator pointing to the past-the-end column in the matrix
+		 *
+		 * @return const iterator
+		 */
+		const_iterator cend() const;
+
 		/** Get a column vector
 		 * @param col column index
 		 * @return the column vector for index col

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -121,6 +121,23 @@ SGVector<T>::SGVector(const SGVector &orig) : SGReferencedData(orig)
 	copy_data(orig);
 }
 
+#ifndef SWIG
+template <class T>
+SGVector<T>::SGVector(std::initializer_list<T> list)
+	: SGReferencedData(true)
+{
+	ASSERT(list.size() > 0)
+	vlen = (index_t) list.size();
+	vector = SG_MALLOC(T, vlen);
+
+	index_t i = 0;
+	for (auto e : list)
+		vector[i++] = e;
+
+	m_on_gpu.store(false, std::memory_order_release);
+}
+#endif //SWIG
+
 template<class T>
 SGVector<T>& SGVector<T>::operator=(const SGVector<T>& other)
 {

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -93,7 +93,7 @@ template<class T>
 SGVector<T>::SGVector(index_t len, bool ref_counting)
 : SGReferencedData(ref_counting), vlen(len), gpu_ptr(NULL)
 {
-	vector=SG_MALLOC(T, len);
+	vector=SG_CALLOC(T, len);
 	m_on_gpu.store(false, std::memory_order_release);
 }
 
@@ -990,6 +990,100 @@ void SGVector<T>::convert_to_matrix(T*& matrix, index_t nrows, index_t ncols, co
 	}
 }
 
+#ifndef SWIG // SWIG should skip this parts
+// Iterator implementation
+template <class T>
+typename SGVector<T>::iterator SGVector<T>::begin()
+{
+	return iterator(vector);
+}
+
+template <class T>
+typename SGVector<T>::iterator SGVector<T>::end()
+{
+	return iterator(vector+vlen);
+}
+
+template <class T>
+typename SGVector<T>::iterator::reference SGVector<T>::iterator::operator*()
+{
+	return *m_data;
+}
+
+template <class T>
+typename SGVector<T>::iterator& SGVector<T>::iterator::operator++()
+{
+	++m_data;
+	return *this;
+}
+
+template <class T>
+typename SGVector<T>::iterator SGVector<T>::iterator::operator++(int)
+{
+	iterator tmp(*this);
+	++(*this);
+	return tmp;
+}
+
+template <class T>
+bool SGVector<T>::iterator::operator==(const iterator& rhs) const
+{
+	return m_data == rhs.m_data;
+}
+
+template <class T>
+bool SGVector<T>::iterator::operator!=(const iterator& rhs) const
+{
+	return !(*this == rhs);
+}
+
+// Const-iterator implementation
+template <class T>
+typename SGVector<T>::const_iterator SGVector<T>::cbegin() const
+{
+	return const_iterator(vector);
+}
+
+template <class T>
+typename SGVector<T>::const_iterator SGVector<T>::cend() const
+{
+	return const_iterator(vector+vlen);
+}
+
+template <class T>
+typename SGVector<T>::const_iterator::reference SGVector<T>::const_iterator::operator*()
+{
+	return *m_data;
+}
+
+template <class T>
+typename SGVector<T>::const_iterator& SGVector<T>::const_iterator::operator++()
+{
+	++m_data;
+	return *this;
+}
+
+template <class T>
+typename SGVector<T>::const_iterator SGVector<T>::const_iterator::operator++(int)
+{
+	const_iterator tmp(*this);
+	++(*this);
+	return tmp;
+}
+
+template <class T>
+bool SGVector<T>::const_iterator::operator==(const const_iterator& rhs) const
+{
+	return m_data == rhs.m_data;
+}
+
+template <class T>
+bool SGVector<T>::const_iterator::operator!=(const const_iterator& rhs) const
+{
+	return !(*this == rhs);
+}
+#endif // SWIG
+
 #define UNDEFINED(function, type)	\
 template <>	\
 SGVector<float64_t> SGVector<type>::function()	\
@@ -1042,6 +1136,7 @@ template class SGVector<float32_t>;
 template class SGVector<float64_t>;
 template class SGVector<floatmax_t>;
 template class SGVector<complex128_t>;
+
 }
 
 #undef COMPLEX128_ERROR_NOARG

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -155,6 +155,17 @@ template<class T> class SGVector : public SGReferencedData
 		/** Copy constructor */
 		SGVector(const SGVector &orig);
 
+#ifndef SWIG
+		/**
+		 * Constructor for creating an SGVector from an initializer list
+		 * containing its elements, i.e.
+		 *	 SGVector<float64_t> matrix({1,2,3,4});
+		 *
+		 *	 @param initializer list
+		 */
+		SGVector(std::initializer_list<T> list);
+#endif //SWIG
+
 		/** Check whether data is stored on GPU
 		 *
 		 * @return true if vector is on GPU

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -43,6 +43,82 @@ template<class T> class SGVector : public SGReferencedData
 {
 	friend class LinalgBackendEigen;
 
+#ifndef SWIG // SWIG should skip this part
+	class iterator
+	{
+		using value_type = T;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type*;
+		using reference = value_type&;
+		using iterator_category = std::forward_iterator_tag;
+
+		public:
+		/** default constructor */
+		iterator() = default;
+
+		/** constructor
+		 *
+		 * @param data element pointed by the iterator
+		 */
+		iterator(pointer data) : m_data(data) {}
+
+		/** dereference operator */
+		reference operator*();
+
+		/** pre-increment operator */
+		iterator &operator++();
+
+		/** post-increment operator */
+		iterator operator++(int);
+
+		/** equality operator */
+		bool operator==(const iterator& rhs) const;
+
+		/** inequality operator */
+		bool operator!=(const iterator& rhs) const;
+
+		protected:
+		pointer m_data;
+	};
+
+	class const_iterator
+	{
+		using value_type = const T;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type*;
+		using reference = value_type&;
+		using iterator_category = std::forward_iterator_tag;
+
+		public:
+		/** default constructor */
+		const_iterator() = default;
+
+		/** constructor
+		 *
+		 * @param data element pointed by the iterator
+		 */
+		const_iterator(pointer data) : m_data(data) {}
+
+		/** dereference operator */
+		reference operator*();
+
+		/** pre-increment operator */
+		const_iterator &operator++();
+
+		/** post-increment operator */
+		const_iterator operator++(int);
+
+		/** equality operator */
+		bool operator==(const const_iterator& rhs) const;
+
+		/** inequality operator */
+		bool operator!=(const const_iterator& rhs) const;
+
+		protected:
+		pointer m_data;
+	};
+#endif // SWIG
+
 	public:
 		typedef Eigen::Matrix<T,-1,1,0,-1,1> EigenVectorXt;
 		typedef Eigen::Matrix<T,1,-1,0x1,1,-1> EigenRowVectorXt;
@@ -149,6 +225,33 @@ template<class T> class SGVector : public SGReferencedData
 
 		/** Cast to pointer */
 		operator T*() { return vector; }
+
+
+#ifndef SWIG // SWIG should skip this part
+		/** iterator pointing to the first element in the vector
+		 *
+		 * @return iterator
+		 */
+		iterator begin();
+
+		/** iterator pointing to the past-the-end element in the vector
+		 *
+		 * @return iterator
+		 */
+		iterator end();
+
+		/** const iterator pointing to the first element in the vector
+		 *
+		 * @return const iterator
+		 */
+		const_iterator cbegin() const;
+
+		/** const iterator pointing to the past-the-end element in the vector
+		 *
+		 * @return const iterator
+		 */
+		const_iterator cend() const;
+#endif // SWIG
 
 		/** Fill vector with zeros */
 		void zero();

--- a/src/shogun/machine/StochasticGBMachine.h
+++ b/src/shogun/machine/StochasticGBMachine.h
@@ -34,9 +34,12 @@
 
 #include <shogun/lib/config.h>
 
+#include <shogun/base/some.h>
 #include <shogun/machine/Machine.h>
 #include <shogun/loss/LossFunction.h>
 #include <shogun/features/DenseFeatures.h>
+
+#include <tuple>
 
 namespace shogun
 {
@@ -151,9 +154,10 @@ protected:
 	 *
 	 * @param f labels from the intermediate model
 	 * @param hm labels from the newly trained base model
+	 * @param labs training labels
 	 * @return gamma - the scalar weights given to individual weak learners in the ensemble model
 	 */
-	float64_t compute_multiplier(CRegressionLabels* f, CRegressionLabels* hm);
+	float64_t compute_multiplier(CRegressionLabels* f, CRegressionLabels* hm, CLabels* labs);
 
 	/** train base model
 	 *
@@ -166,16 +170,18 @@ protected:
 	/** compute pseudo_residuals
 	 *
 	 * @param inter_f intermediate boosted model labels for training data
+	 * @param labs training labels
 	 * @return pseudo_residuals
 	 */
-	CRegressionLabels* compute_pseudo_residuals(CRegressionLabels* inter_f);
+	CRegressionLabels* compute_pseudo_residuals(CRegressionLabels* inter_f, CLabels* labs);
 
 	/** add randomized subset to relevant parameters
 	 *
 	 * @param f training data
 	 * @param interf intermediate boosted model labels for training data
 	 */
-	void apply_subset(CDenseFeatures<float64_t>* f, CLabels* interf);
+	std::tuple<Some<CDenseFeatures<float64_t>>, Some<CRegressionLabels>, Some<CLabels>>
+	get_subset(CDenseFeatures<float64_t>* f, CRegressionLabels* interf);
 
 	/** reset arrays of weak learners and gamma values */
 	void initialize_learners();

--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -97,7 +97,7 @@ namespace shogun
  */
 #define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container)                          \
 	virtual void add(                                                          \
-	    Container<Type>& a, Container<Type>& b, Type alpha, Type beta,         \
+	    const Container<Type>& a, const Container<Type>& b, Type alpha, Type beta,         \
 	    Container<Type>& result) const                                         \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
@@ -259,17 +259,18 @@ namespace shogun
 #undef BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC
 
 /**
- * Wrapper method of in-place matrix elementwise product.
+ * Wrapper method of in-place matrix/vector elementwise product.
  *
  * @see linalg::element_prod
  */
 #define BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD(Type, Container)                 \
 	virtual void element_prod(                                                 \
-	    Container<Type>& a, Container<Type>& b, Container<Type>& result) const \
+	    const Container<Type>& a, const Container<Type>& b, Container<Type>& result) const \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
 	}
 		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGMatrix)
+		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGVector)
 #undef BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD
 
 /**
@@ -279,13 +280,12 @@ namespace shogun
  */
 #define BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD(Type, Container)           \
 	virtual void element_prod(                                                 \
-	    linalg::Block<Container<Type>>& a, linalg::Block<Container<Type>>& b,  \
+	    const linalg::Block<Container<Type>>& a, const linalg::Block<Container<Type>>& b,  \
 	    Container<Type>& result) const                                         \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
 	}
-		DEFINE_FOR_ALL_PTYPE(
-		    BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
+		DEFINE_FOR_ALL_PTYPE(	   BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
 #undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
 
 /**

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -50,7 +50,7 @@ namespace shogun
 /** Implementation of @see LinalgBackendBase::add */
 #define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container)                          \
 	virtual void add(                                                          \
-	    Container<Type>& a, Container<Type>& b, Type alpha, Type beta,         \
+	    const Container<Type>& a, const Container<Type>& b, Type alpha, Type beta,         \
 	    Container<Type>& result) const;
 		DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_IN_PLACE_ADD, SGVector)
 		DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_IN_PLACE_ADD, SGMatrix)
@@ -135,15 +135,16 @@ namespace shogun
 /** Implementation of @see LinalgBackendBase::element_prod */
 #define BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD(Type, Container)                 \
 	virtual void element_prod(                                                 \
-	    Container<Type>& a, Container<Type>& b, Container<Type>& result)       \
+	    const Container<Type>& a, const Container<Type>& b, Container<Type>& result)       \
 	    const;
 		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGMatrix)
+		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGVector)
 #undef BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD
 
 /** Implementation of @see LinalgBackendBase::element_prod */
 #define BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD(Type, Container)           \
 	virtual void element_prod(                                                 \
-	    linalg::Block<Container<Type>>& a, linalg::Block<Container<Type>>& b,  \
+	    const linalg::Block<Container<Type>>& a, const linalg::Block<Container<Type>>& b,  \
 	    Container<Type>& result) const;
 		DEFINE_FOR_ALL_PTYPE(
 		    BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
@@ -368,13 +369,13 @@ namespace shogun
 		/** Eigen3 vector result = alpha*A + beta*B method */
 		template <typename T>
 		void add_impl(
-		    SGVector<T>& a, SGVector<T>& b, T alpha, T beta,
+		    const SGVector<T>& a, const SGVector<T>& b, T alpha, T beta,
 		    SGVector<T>& result) const;
 
 		/** Eigen3 matrix result = alpha*A + beta*B method */
 		template <typename T>
 		void add_impl(
-		    SGMatrix<T>& a, SGMatrix<T>& b, T alpha, T beta,
+		    const SGMatrix<T>& a, const SGMatrix<T>& b, T alpha, T beta,
 		    SGMatrix<T>& result) const;
 
 		/** Eigen3 add column vector method */
@@ -452,13 +453,18 @@ namespace shogun
 		/** Eigen3 matrix in-place elementwise product method */
 		template <typename T>
 		void element_prod_impl(
-		    SGMatrix<T>& a, SGMatrix<T>& b, SGMatrix<T>& result) const;
+		    const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result) const;
 
 		/** Eigen3 matrix block in-place elementwise product method */
 		template <typename T>
 		void element_prod_impl(
-		    linalg::Block<SGMatrix<T>>& a, linalg::Block<SGMatrix<T>>& b,
+			const linalg::Block<SGMatrix<T>>& a, const linalg::Block<SGMatrix<T>>& b,
 		    SGMatrix<T>& result) const;
+
+		/** Eigen3 vector in-place elementwise product method */
+		template <typename T>
+		void element_prod_impl(
+			const SGVector<T>& a, const SGVector<T>& b, SGVector<T>& result) const;
 
 		/** Eigen3 vector exponent method */
 		template <typename T>

--- a/src/shogun/mathematics/linalg/LinalgBackendViennaCL.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendViennaCL.h
@@ -77,7 +77,7 @@ namespace shogun
 
 	/** Implementation of @see LinalgBackendBase::add */
 	#define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container) \
-	virtual void add(Container<Type>& a, Container<Type>& b, Type alpha, \
+	virtual void add(const Container<Type>& a, const Container<Type>& b, Type alpha, \
 		Type beta, Container<Type>& result) const \
 	{  \
 		add_impl(a, b, alpha, beta, result); \
@@ -293,7 +293,7 @@ namespace shogun
 		/** ViennaCL vector result = alpha * A + beta * B method */
 		template <typename T>
 		void add_impl(
-		    SGVector<T>& a, SGVector<T>& b, T alpha, T beta,
+		    const SGVector<T>& a, const SGVector<T>& b, T alpha, T beta,
 		    SGVector<T>& result) const
 		{
 			GPUMemoryViennaCL<T>* a_gpu = cast_to_viennacl(a);
@@ -308,7 +308,7 @@ namespace shogun
 		/** ViennaCL matrix result = alpha * A + beta * B method */
 		template <typename T>
 		void add_impl(
-		    SGMatrix<T>& a, SGMatrix<T>& b, T alpha, T beta,
+		    const SGMatrix<T>& a, const SGMatrix<T>& b, T alpha, T beta,
 		    SGMatrix<T>& result) const
 		{
 			GPUMemoryViennaCL<T>* a_gpu = cast_to_viennacl(a);

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -295,7 +295,7 @@ namespace shogun
 		 */
 		template <typename T>
 		void
-		add(SGVector<T>& a, SGVector<T>& b, SGVector<T>& result, T alpha = 1,
+		add(const SGVector<T>& a, const SGVector<T>& b, SGVector<T>& result, T alpha = 1,
 		    T beta = 1)
 		{
 			REQUIRE(
@@ -335,7 +335,7 @@ namespace shogun
 		 */
 		template <typename T>
 		void
-		add(SGMatrix<T>& a, SGMatrix<T>& b, SGMatrix<T>& result, T alpha = 1,
+		add(const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result, T alpha = 1,
 		    T beta = 1)
 		{
 			REQUIRE(
@@ -373,7 +373,7 @@ namespace shogun
 		 */
 		template <typename T, template <typename> class Container>
 		Container<T>
-		add(Container<T>& a, Container<T>& b, T alpha = 1, T beta = 1)
+		add(const Container<T>& a, const Container<T>& b, T alpha = 1, T beta = 1)
 		{
 			auto result = a.clone();
 			add(a, b, result, alpha, beta);
@@ -791,6 +791,50 @@ namespace shogun
 			SGMatrix<T> result;
 			result = a.clone();
 
+			element_prod(a, b, result);
+
+			return result;
+		}
+
+		/** Performs the operation C = A .* B where ".*" denotes elementwise
+		 * multiplication.
+		 *
+		 * This version returns the result in a newly created vector.
+		 *
+		 * @param a First vector
+		 * @param b Second vector
+		 * @return The result of the operation
+		 */
+		template <typename T>
+		void element_prod(const SGVector<T>& a, const SGVector<T>& b, SGVector<T>& result)
+		{
+			REQUIRE(
+				a.vlen == b.vlen,
+				"Dimension mismatch! A(%d) vs B(%d)\n", a.vlen, b.vlen);
+			REQUIRE(
+				a.vlen == result.vlen,
+				"Dimension mismatch! A(%d) vs result(%d)\n", a.vlen, result.vlen);
+
+			infer_backend(a, b)->element_prod(a, b, result);
+		}
+
+		/** Performs the operation C = A .* B where ".*" denotes elementwise
+		 * multiplication.
+		 *
+		 * This version returns the result in a newly created vector.
+		 *
+		 * @param a First vector
+		 * @param b Second vector
+		 * @return The result of the operation
+		 */
+		template <typename T>
+		SGVector<T> element_prod(const SGVector<T>& a, const SGVector<T>& b)
+		{
+			REQUIRE(
+				a.vlen == b.vlen,
+				"Dimension mismatch! A(%d) vs B(%d)\n", a.vlen, b.vlen);
+
+			SGVector<T> result = a.clone();
 			element_prod(a, b, result);
 
 			return result;

--- a/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
@@ -37,7 +37,7 @@ using namespace shogun;
 
 #define BACKEND_GENERIC_IN_PLACE_ADD(Type, Container)                          \
 	void LinalgBackendEigen::add(                                              \
-	    Container<Type>& a, Container<Type>& b, Type alpha, Type beta,         \
+	    const Container<Type>& a, const Container<Type>& b, Type alpha, Type beta,         \
 	    Container<Type>& result) const                                         \
 	{                                                                          \
 		add_impl(a, b, alpha, beta, result);                                   \
@@ -87,16 +87,17 @@ DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_DOT, SGVector)
 
 #define BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD(Type, Container)                 \
 	void LinalgBackendEigen::element_prod(                                     \
-	    Container<Type>& a, Container<Type>& b, Container<Type>& result) const \
+	    const Container<Type>& a, const Container<Type>& b, Container<Type>& result) const \
 	{                                                                          \
 		element_prod_impl(a, b, result);                                       \
 	}
 DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGMatrix)
+DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGVector)
 #undef BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD
 
 #define BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD(Type, Container)           \
 	void LinalgBackendEigen::element_prod(                                     \
-	    linalg::Block<Container<Type>>& a, linalg::Block<Container<Type>>& b,  \
+	    const linalg::Block<Container<Type>>& a, const linalg::Block<Container<Type>>& b,  \
 	    Container<Type>& result) const                                         \
 	{                                                                          \
 		element_prod_impl(a, b, result);                                       \
@@ -142,7 +143,7 @@ DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_SCALE, SGMatrix)
 
 template <typename T>
 void LinalgBackendEigen::add_impl(
-    SGVector<T>& a, SGVector<T>& b, T alpha, T beta, SGVector<T>& result) const
+    const SGVector<T>& a, const SGVector<T>& b, T alpha, T beta, SGVector<T>& result) const
 {
 	typename SGVector<T>::EigenVectorXtMap a_eig = a;
 	typename SGVector<T>::EigenVectorXtMap b_eig = b;
@@ -153,7 +154,7 @@ void LinalgBackendEigen::add_impl(
 
 template <typename T>
 void LinalgBackendEigen::add_impl(
-    SGMatrix<T>& a, SGMatrix<T>& b, T alpha, T beta, SGMatrix<T>& result) const
+    const SGMatrix<T>& a, const SGMatrix<T>& b, T alpha, T beta, SGMatrix<T>& result) const
 {
 	typename SGMatrix<T>::EigenMatrixXtMap a_eig = a;
 	typename SGMatrix<T>::EigenMatrixXtMap b_eig = b;
@@ -221,7 +222,7 @@ T LinalgBackendEigen::dot_impl(const SGVector<T>& a, const SGVector<T>& b) const
 
 template <typename T>
 void LinalgBackendEigen::element_prod_impl(
-    SGMatrix<T>& a, SGMatrix<T>& b, SGMatrix<T>& result) const
+	const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result) const
 {
 	typename SGMatrix<T>::EigenMatrixXtMap a_eig = a;
 	typename SGMatrix<T>::EigenMatrixXtMap b_eig = b;
@@ -232,7 +233,7 @@ void LinalgBackendEigen::element_prod_impl(
 
 template <typename T>
 void LinalgBackendEigen::element_prod_impl(
-    linalg::Block<SGMatrix<T>>& a, linalg::Block<SGMatrix<T>>& b,
+	const linalg::Block<SGMatrix<T>>& a, const linalg::Block<SGMatrix<T>>& b,
     SGMatrix<T>& result) const
 {
 	typename SGMatrix<T>::EigenMatrixXtMap a_eig = a.m_matrix;
@@ -246,6 +247,18 @@ void LinalgBackendEigen::element_prod_impl(
 
 	result_eig = a_block.array() * b_block.array();
 }
+
+template <typename T>
+void LinalgBackendEigen::element_prod_impl(
+	const SGVector<T>& a, const SGVector<T>& b, SGVector<T>& result) const
+{
+	typename SGVector<T>::EigenVectorXtMap a_eig = a;
+	typename SGVector<T>::EigenVectorXtMap b_eig = b;
+	typename SGVector<T>::EigenVectorXtMap result_eig = result;
+
+	result_eig = a_eig.array() * b_eig.array();
+}
+
 
 template <typename T>
 void LinalgBackendEigen::exponent_impl(

--- a/src/shogun/multiclass/tree/CARTree.h
+++ b/src/shogun/multiclass/tree/CARTree.h
@@ -283,7 +283,7 @@ protected:
 	 * @param attr best attribute chosen for split
 	 * @return vector denoting whether a data point goes to left child for all data points including ones with missing attributes
 	 */
-	SGVector<bool> surrogate_split(SGMatrix<float64_t> data, SGVector<float64_t> weights, SGVector<bool> nm_left, int32_t attr);
+	SGVector<bool> surrogate_split(const SGMatrix<float64_t>& data, SGVector<float64_t> weights, SGVector<bool> nm_left, int32_t attr);
 
 
 	/** handles missing values for a chosen continuous surrogate attribute

--- a/src/shogun/preprocessor/NormOne.cpp
+++ b/src/shogun/preprocessor/NormOne.cpp
@@ -12,6 +12,7 @@
 #include <shogun/preprocessor/DensePreprocessor.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/features/Features.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -74,11 +75,5 @@ SGMatrix<float64_t> CNormOne::apply_to_feature_matrix(CFeatures* features)
 /// result in feature matrix
 SGVector<float64_t> CNormOne::apply_to_feature_vector(SGVector<float64_t> vector)
 {
-	float64_t* normed_vec = SG_MALLOC(float64_t, vector.vlen);
-	float64_t norm=CMath::sqrt(CMath::dot(vector.vector, vector.vector, vector.vlen));
-
-	for (int32_t i=0; i<vector.vlen; i++)
-		normed_vec[i]=vector.vector[i]/norm;
-
-	return SGVector<float64_t>(normed_vec,vector.vlen);
+	return linalg::scale(vector, 1.0/linalg::norm(vector));
 }

--- a/src/shogun/preprocessor/PruneVarSubMean.cpp
+++ b/src/shogun/preprocessor/PruneVarSubMean.cpp
@@ -14,6 +14,7 @@
 #include <shogun/features/Features.h>
 #include <shogun/io/SGIO.h>
 #include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -39,70 +40,35 @@ bool CPruneVarSubMean::init(CFeatures* features)
 		ASSERT(features->get_feature_type()==F_DREAL)
 
 		CDenseFeatures<float64_t>* simple_features=(CDenseFeatures<float64_t>*) features;
-		int32_t num_examples = simple_features->get_num_vectors();
 		int32_t num_features = simple_features->get_num_features();
 
-		m_mean = SGVector<float64_t>();
-		m_idx = SGVector<int32_t>();
-		m_std = SGVector<float64_t>();;
+		auto mean = simple_features->get_mean();
+		auto std = simple_features->get_std();
+		std::vector<index_t> idx;
+		index_t num_ok = 0;
 
-		m_mean.resize_vector(num_features);
-		float64_t* var=SG_MALLOC(float64_t, num_features);
-		int32_t i,j;
-
-		memset(var, 0, num_features*sizeof(float64_t));
-		m_mean.zero();
-
-		SGMatrix<float64_t> feature_matrix = simple_features->get_feature_matrix();
-
-		// compute mean
-		for (i=0; i<num_examples; i++)
+		for (index_t j=0; j<num_features; ++j)
 		{
-			for (j=0; j<num_features; j++)
-				m_mean[j]+=feature_matrix.matrix[i*num_features+j];
-		}
-
-		for (j=0; j<num_features; j++)
-			m_mean[j]/=num_examples;
-
-		// compute var
-		for (i=0; i<num_examples; i++)
-		{
-			for (j=0; j<num_features; j++)
-				var[j]+=CMath::sq(m_mean[j]-feature_matrix.matrix[i*num_features+j]);
-		}
-
-		int32_t num_ok=0;
-		int32_t* idx_ok=SG_MALLOC(int32_t, num_features);
-
-		for (j=0; j<num_features; j++)
-		{
-			var[j]/=num_examples;
-
-			if (var[j]>=1e-14)
+			if (std[j]>=1e-7)
 			{
-				idx_ok[num_ok]=j;
-				num_ok++ ;
+				idx.push_back(j);
+				++num_ok;
 			}
 		}
 
 		SG_INFO("Reducing number of features from %i to %i\n", num_features, num_ok)
 
-		m_idx.resize_vector(num_ok);
-		SGVector<float64_t> new_mean(num_ok);
-		m_std.resize_vector(num_ok);
+		m_idx = SGVector<int32_t>(num_ok);
+		m_mean = SGVector<float64_t>(num_ok);
+		m_std = SGVector<float64_t>(num_ok);
 
-		for (j=0; j<num_ok; j++)
+		for (index_t j=0; j<num_ok; ++j)
 		{
-			m_idx[j]=idx_ok[j] ;
-			new_mean[j]=m_mean[idx_ok[j]];
-			m_std[j]=CMath::sqrt(var[idx_ok[j]]);
+			m_idx[j]=idx[j];
+			m_mean[j]=mean[idx[j]];
+			m_std[j]=std[idx[j]];
 		}
 		m_num_idx = num_ok;
-		SG_FREE(idx_ok);
-		SG_FREE(var);
-		m_mean = new_mean;
-
 		m_initialized = true;
 		return true;
 	}
@@ -126,32 +92,27 @@ SGMatrix<float64_t> CPruneVarSubMean::apply_to_feature_matrix(CFeatures* feature
 {
 	ASSERT(m_initialized)
 
-	int32_t num_vectors=0;
-	int32_t num_features=0;
-	float64_t* m=((CDenseFeatures<float64_t>*) features)->get_feature_matrix(num_features, num_vectors);
+	auto src=((CDenseFeatures<float64_t>*) features)->get_feature_matrix();
+	auto num_vectors = src.num_cols;
+	SGMatrix<float64_t> dst(m_num_idx, num_vectors);
 
-	SG_INFO("get Feature matrix: %ix%i\n", num_vectors, num_features)
 	SG_INFO("Preprocessing feature matrix\n")
-	for (int32_t vec=0; vec<num_vectors; vec++)
+	for (index_t vec=0; vec<num_vectors; ++vec)
 	{
-		float64_t* v_src=&m[num_features*vec];
-		float64_t* v_dst=&m[m_num_idx*vec];
-
 		if (m_divide_by_std)
 		{
 			for (int32_t feat=0; feat<m_num_idx; feat++)
-				v_dst[feat]=(v_src[m_idx[feat]]-m_mean[feat])/m_std[feat];
+				dst[feat]=(src[m_idx[feat]]-m_mean[feat])/m_std[feat];
 		}
 		else
 		{
 			for (int32_t feat=0; feat<m_num_idx; feat++)
-				v_dst[feat]=(v_src[m_idx[feat]]-m_mean[feat]);
+				dst[feat]=(src[m_idx[feat]]-m_mean[feat]);
 		}
 	}
 
-	((CDenseFeatures<float64_t>*) features)->set_num_features(m_num_idx);
-	((CDenseFeatures<float64_t>*) features)->get_feature_matrix(num_features, num_vectors);
-	SG_INFO("new Feature matrix: %ix%i\n", num_vectors, num_features)
+	((CDenseFeatures<float64_t>*) features)->set_feature_matrix(dst);
+	SG_INFO("new Feature matrix: %ix%i\n", dst.num_rows, dst.num_cols)
 
 	return ((CDenseFeatures<float64_t>*) features)->get_feature_matrix();
 }
@@ -160,31 +121,18 @@ SGMatrix<float64_t> CPruneVarSubMean::apply_to_feature_matrix(CFeatures* feature
 /// result in feature matrix
 SGVector<float64_t> CPruneVarSubMean::apply_to_feature_vector(SGVector<float64_t> vector)
 {
-	float64_t* ret=NULL;
+	ASSERT(m_initialized)
 
-	if (m_initialized)
+	SGVector<float64_t> out(m_num_idx);
+
+	for (index_t i = 0; i < m_num_idx; ++i)
 	{
-		ret=SG_MALLOC(float64_t, m_num_idx);
-
+		out[i] = (vector[m_idx[i]]-m_mean[i]);
 		if (m_divide_by_std)
-		{
-			for (int32_t i=0; i<m_num_idx; i++)
-				ret[i]=(vector.vector[m_idx[i]]-m_mean[i])/m_std[i];
-		}
-		else
-		{
-			for (int32_t i=0; i<m_num_idx; i++)
-				ret[i]=(vector.vector[m_idx[i]]-m_mean[i]);
-		}
-	}
-	else
-	{
-		ret=SG_MALLOC(float64_t, vector.vlen);
-		for (int32_t i=0; i<vector.vlen; i++)
-			ret[i]=vector.vector[i];
+			out[i] /= m_std[i];
 	}
 
-	return SGVector<float64_t>(ret,m_num_idx);
+	return out;
 }
 
 void CPruneVarSubMean::init()
@@ -199,7 +147,7 @@ void CPruneVarSubMean::init()
 
 void CPruneVarSubMean::register_parameters()
 {
-	SG_ADD(&m_initialized, "initialized", "The prerpocessor is initialized",  MS_NOT_AVAILABLE);
+	SG_ADD(&m_initialized, "initialized", "The preprocessor is initialized",  MS_NOT_AVAILABLE);
 	SG_ADD(&m_divide_by_std, "divide_by_std", "Divide by standard deviation", MS_AVAILABLE);
 	SG_ADD(&m_num_idx, "num_idx", "Number of elements in idx_vec", MS_NOT_AVAILABLE);
 	SG_ADD(&m_std, "std_vec", "Standard dev vector", MS_NOT_AVAILABLE);

--- a/src/shogun/preprocessor/RandomFourierGaussPreproc.cpp
+++ b/src/shogun/preprocessor/RandomFourierGaussPreproc.cpp
@@ -376,7 +376,7 @@ SGMatrix<float64_t> CRandomFourierGaussPreproc::apply_to_feature_matrix(CFeature
 
 	int32_t num_vectors = 0;
 	int32_t num_features = 0;
-	float64_t* m = ((CDenseFeatures<float64_t>*) features)->get_feature_matrix(
+	const float64_t* m = ((CDenseFeatures<float64_t>*) features)->get_feature_matrix(
 			num_features, num_vectors);
 	SG_INFO("get Feature matrix: %ix%i\n", num_vectors, num_features)
 

--- a/src/shogun/regression/LeastAngleRegression.cpp
+++ b/src/shogun/regression/LeastAngleRegression.cpp
@@ -358,7 +358,7 @@ bool CLeastAngleRegression::train_machine_templated(CDenseFeatures<ST> * data)
 	// assign default estimator
 	set_w(SGVector<float64_t>(n_fea));
 	switch_w(get_path_size()-1);
-	
+
 	return true;
 }
 

--- a/tests/unit/classifier/Perceptron_unittest.cc
+++ b/tests/unit/classifier/Perceptron_unittest.cc
@@ -1,0 +1,57 @@
+/*
+* Copyright (c) The Shogun Machine Learning Toolbox
+* Written (w) 2017 Michele Mazzoni
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those
+* of the authors and should not be interpreted as representing official policies,
+* either expressed or implied, of the Shogun Development Team.
+*/
+
+#include <gtest/gtest.h>
+#include <shogun/base/some.h>
+#include <shogun/classifier/Perceptron.h>
+#include <shogun/evaluation/ContingencyTableEvaluation.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/labels/BinaryLabels.h>
+#include "environments/LinearTestEnvironment.h"
+
+using namespace shogun;
+
+extern LinearTestEnvironment* linear_test_env;
+
+TEST(Perceptron, train)
+{
+	auto env = linear_test_env->getBinaryLabelData();
+	auto features = wrap(env->get_features_train());
+	auto labels = wrap(env->get_labels_train());
+	auto test_features = wrap(env->get_features_test());
+	auto test_labels = wrap(env->get_labels_test());
+
+	auto perceptron = some<CPerceptron>(features, labels);
+	EXPECT_TRUE(perceptron->train());
+
+	auto results = wrap(perceptron->apply(test_features));
+	auto acc = some<CAccuracyMeasure>();
+	EXPECT_EQ(acc->evaluate(results, test_labels), 1.0);
+}

--- a/tests/unit/features/iterators/DotIterator_unittest.cc
+++ b/tests/unit/features/iterators/DotIterator_unittest.cc
@@ -1,0 +1,95 @@
+/*
+* Copyright (c) The Shogun Machine Learning Toolbox
+* Written (w) 2017 Michele Mazzoni
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those
+* of the authors and should not be interpreted as representing official policies,
+* either expressed or implied, of the Shogun Development Team.
+*/
+
+#include <gtest/gtest.h>
+#include <shogun/base/some.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/features/iterators/DotIterator.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
+
+using namespace shogun;
+
+std::pair<SGMatrix<float64_t>, SGVector<float64_t>> get_data()
+{
+	const index_t n_rows = 6, n_cols = 8;
+
+	SGMatrix<float64_t> mat(n_rows, n_cols);
+	for (index_t i = 0; i < n_rows * n_cols; ++i)
+		mat[i] = CMath::randn_double();
+
+	SGVector<float64_t> vec(n_rows);
+	for (index_t i = 0; i < n_rows; ++i)
+		vec[i] = CMath::randn_double();
+
+	return std::make_pair(mat, vec);
+}
+
+TEST(DotIterator, dot)
+{
+	auto data = get_data();
+	auto mat = data.first;
+	auto vec = data.second;
+
+	auto feats = some<CDenseFeatures<float64_t>>(mat);
+
+	index_t i = 0;
+	for (const auto& v : DotIterator(feats))
+	{
+		EXPECT_EQ(
+			v.dot(vec),
+			linalg::sum(linalg::element_prod(mat.get_column(i), vec))
+		);
+		++i;
+	}
+}
+
+TEST(DotIterator, add)
+{
+	auto data = get_data();
+	auto mat = data.first;
+	auto alphas = data.second;
+
+	auto vec = SGVector<float64_t>(mat.num_rows);
+	auto res = SGVector<float64_t>(mat.num_rows);
+
+	auto feats = some<CDenseFeatures<float64_t>>(mat);
+
+	index_t i = 0;
+	for (const auto& v : DotIterator(feats))
+	{
+		v.add(alphas[i], vec);
+		linalg::add(res, mat.get_column(i), res, 1.0, alphas[i]);
+		++i;
+	}
+
+	for (i = 0; i < vec.vlen; ++i)
+		EXPECT_EQ(vec[i], res[i]);
+}

--- a/tests/unit/lib/SGMatrix_unittest.cc
+++ b/tests/unit/lib/SGMatrix_unittest.cc
@@ -665,3 +665,38 @@ TEST(SGMatrixTest, set_column)
 	for (index_t i = 0; i < n_rows; ++i)
 		EXPECT_EQ(mat(i, col), vec[i]);
 }
+
+TEST(SGMatrixTest, iterator)
+{
+	const index_t n_rows = 6, n_cols = 8;
+
+	SGMatrix<float64_t> mat(n_rows, n_cols);
+	for (index_t i = 0; i < n_rows * n_cols; ++i)
+		mat[i] = CMath::randn_double();
+
+	index_t j = 0;
+	for (const auto& col : mat)
+	{
+		EXPECT_EQ(col.vector, mat.get_column_vector(j));
+		EXPECT_EQ(col.vlen, n_rows);
+		++j;
+	}
+}
+
+TEST(SGMatrixTest, const_iterator)
+{
+	const index_t n_rows = 6, n_cols = 8;
+
+	SGMatrix<float64_t> mat(n_rows, n_cols);
+	for (index_t i = 0; i < n_rows * n_cols; ++i)
+		mat[i] = CMath::randn_double();
+
+	index_t j = 0;
+	for (auto iter = mat.cbegin(); iter != mat.cend(); ++iter)
+	{
+		const auto& col = *iter;
+		EXPECT_EQ(col.vector, mat.get_column_vector(j));
+		EXPECT_EQ(col.vlen, n_rows);
+		++j;
+	}
+}

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -365,3 +365,36 @@ TEST(SGVectorTest, resize_vector_larger)
 	for (index_t i=len; i<new_len; i++)
 		EXPECT_EQ(m[i], 0);
 }
+
+TEST(SGVectorTest, iterator)
+{
+	const index_t len = 6;
+
+	SGVector<float64_t> vec(len);
+	for (index_t i = 0; i < len; ++i)
+		vec[i] = CMath::randn_double();
+
+	index_t i = 0;
+	for (const auto& v : vec)
+	{
+		EXPECT_EQ(&v, vec.vector+i);
+		++i;
+	}
+}
+
+TEST(SGVectorTest, const_iterator)
+{
+	const index_t len = 6;
+
+	SGVector<float64_t> vec(len);
+	for (index_t i = 0; i < len; ++i)
+		vec[i] = CMath::randn_double();
+
+	index_t i = 0;
+	for (auto iter=vec.cbegin(); iter!=vec.cend(); ++iter)
+	{
+		const auto& v = *iter;
+		EXPECT_EQ(&v, vec.vector+i);
+		++i;
+	}
+}

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -502,6 +502,44 @@ TEST(LinalgBackendEigen, SGMatrix_block_elementwise_product)
 			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
 }
 
+TEST(LinalgBackendEigen, SGVector_elementwise_product)
+{
+	const index_t len = 4;
+	SGVector<float64_t> a(len);
+	SGVector<float64_t> b(len);
+	SGVector<float64_t> c(len);
+
+	for (index_t i = 0; i < len; ++i)
+	{
+		a[i] = i;
+		b[i] = 0.5*i;
+	}
+
+	c = element_prod(a, b);
+
+	for (index_t i = 0; i < len; ++i)
+		EXPECT_NEAR(a[i]*b[i], c[i], 1e-15);
+}
+
+TEST(LinalgBackendEigen, SGVector_elementwise_product_in_place)
+{
+	const index_t len = 4;
+	SGVector<float64_t> a(len);
+	SGVector<float64_t> b(len);
+	SGVector<float64_t> c(len);
+
+	for (index_t i = 0; i < len; ++i)
+	{
+		a[i] = i;
+		b[i] = 0.5*i;
+		c[i] = i;
+	}
+
+	element_prod(a, b, a);
+	for (index_t i = 0; i < len; ++i)
+		EXPECT_NEAR(c[i]*b[i], a[i], 1e-15);
+}
+
 TEST(LinalgBackendEigen, SGVector_exponent)
 {
 	const index_t len = 4;

--- a/tests/unit/multiclass/tree/CARTree_unittest.cc
+++ b/tests/unit/multiclass/tree/CARTree_unittest.cc
@@ -32,6 +32,7 @@
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/multiclass/tree/CARTree.h>
 #include <gtest/gtest.h>
+#include <shogun/base/some.h>
 
 using namespace shogun;
 
@@ -124,7 +125,7 @@ TEST(CARTree, classify_nominal)
 	data(2,13)=high;
 	data(3,13)=strong;
 
-	CDenseFeatures<float64_t>* feats=new CDenseFeatures<float64_t>(data);
+	auto feats = some<CDenseFeatures<float64_t> >(data);
 
 	// yes 1. no 0.
 	SGVector<float64_t> lab(14);
@@ -194,7 +195,6 @@ TEST(CARTree, classify_nominal)
 	SG_UNREF(test_feats);
 	SG_UNREF(result);
 	SG_UNREF(c);
-	SG_UNREF(feats);
 }
 
 TEST(CARTree, classify_non_nominal)
@@ -272,7 +272,7 @@ TEST(CARTree, classify_non_nominal)
 	data(2,13)=high;
 	data(3,13)=strong;
 
-	CDenseFeatures<float64_t>* feats=new CDenseFeatures<float64_t>(data);
+	auto feats = some<CDenseFeatures<float64_t> >(data);
 
 	// yes 1. no 0.
 	SGVector<float64_t> lab(14);
@@ -342,7 +342,6 @@ TEST(CARTree, classify_non_nominal)
 	SG_UNREF(test_feats);
 	SG_UNREF(result);
 	SG_UNREF(c);
-	SG_UNREF(feats);
 }
 
 TEST(CARTree, handle_missing_nominal)
@@ -400,7 +399,7 @@ TEST(CARTree, handle_missing_nominal)
 	ft[1]=true;
 	ft[2]=true;
 
-	CDenseFeatures<float64_t>* feats=new CDenseFeatures<float64_t>(data);
+	auto feats = some<CDenseFeatures<float64_t> >(data);
 	CMulticlassLabels* labels=new CMulticlassLabels(lab);
 
 	CCARTree* c=new CCARTree();
@@ -421,7 +420,6 @@ TEST(CARTree, handle_missing_nominal)
 	SG_UNREF(left);
 	SG_UNREF(right);
 	SG_UNREF(c);
-	SG_UNREF(feats);
 }
 
 TEST(CARTree, handle_missing_continuous)
@@ -479,7 +477,7 @@ TEST(CARTree, handle_missing_continuous)
 	ft[1]=false;
 	ft[2]=false;
 
-	CDenseFeatures<float64_t>* feats=new CDenseFeatures<float64_t>(data);
+	auto feats = some<CDenseFeatures<float64_t> >(data);
 	CMulticlassLabels* labels=new CMulticlassLabels(lab);
 
 	CCARTree* c=new CCARTree();
@@ -500,7 +498,6 @@ TEST(CARTree, handle_missing_continuous)
 	SG_UNREF(left);
 	SG_UNREF(right);
 	SG_UNREF(c);
-	SG_UNREF(feats);
 }
 
 TEST(CARTree, form_t1_test)
@@ -519,7 +516,7 @@ TEST(CARTree, form_t1_test)
 	lab[3]=1;
 	lab[4]=0;
 
-	CDenseFeatures<float64_t>* feats=new CDenseFeatures<float64_t>(data);
+	auto feats = some<CDenseFeatures<float64_t> >(data);
 
 	SGVector<bool> ft=SGVector<bool>(1);
 	ft[0]=true;
@@ -540,7 +537,6 @@ TEST(CARTree, form_t1_test)
 	EXPECT_EQ(1,root->data.num_leaves);
 
 	SG_UNREF(c);
-	SG_UNREF(feats);
 	SG_UNREF(root);
 }
 
@@ -611,7 +607,7 @@ TEST(CARTree,cv_prune_simple)
 	lab[18]=1.0;
 	lab[19]=1.0;
 
-	CDenseFeatures<float64_t>* feats=new CDenseFeatures<float64_t>(data);
+	auto feats = some<CDenseFeatures<float64_t> >(data);
 
 	SGVector<bool> ft=SGVector<bool>(2);
 	ft[0]=true;
@@ -639,6 +635,5 @@ TEST(CARTree,cv_prune_simple)
 	EXPECT_EQ(2.0,root->data.weight_minus_branch);
 
 	SG_UNREF(c);
-	SG_UNREF(feats);
 	SG_UNREF(root);
 }

--- a/tests/unit/preprocessor/DensePreprocessor_unittest.cc
+++ b/tests/unit/preprocessor/DensePreprocessor_unittest.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2017 Michele Mazzoni
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/mathematics/Math.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/preprocessor/PruneVarSubMean.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/base/some.h>
+#include <gtest/gtest.h>
+
+using namespace shogun;
+
+const float64_t eps = 1e-15;
+
+TEST(DensePreprocessor, PruneVarSubMean)
+{
+	SGMatrix<float64_t> data({
+		{1, 2, 0},
+		{5, 3, 7},
+		{10, 10.5, 9.5},
+		{0, -1.0, -0.5}
+	});
+
+	auto features = some<CDenseFeatures<float64_t> >(data);
+	auto prune = some<CPruneVarSubMean>();
+	prune->init(features);
+
+	auto out = features->preprocess(prune);
+
+	for (const auto& v : out->get_mean())
+		EXPECT_NEAR(v, 0.0, eps);
+
+	for (const auto& v : out->get_std())
+		EXPECT_NEAR(v, 1.0, eps);
+}

--- a/tests/unit/preprocessor/MultipleProcessors_unittest.cc
+++ b/tests/unit/preprocessor/MultipleProcessors_unittest.cc
@@ -8,43 +8,48 @@
  */
 
 #include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 #include <shogun/preprocessor/LogPlusOne.h>
 #include <shogun/preprocessor/SumOne.h>
-#include <shogun/lib/SGVector.h>
+#include <shogun/preprocessor/PruneVarSubMean.h>
+#include <shogun/preprocessor/NormOne.h>
+#include <shogun/base/some.h>
 #include <gtest/gtest.h>
 
 using namespace shogun;
 
-TEST(MultipleProcessors, apply_to_feature_matrix)
-{
-	float64_t data[6] = {1,2,3,4,5,6};
-	int32_t num_vectors = 2;
-	int32_t num_features = 3;
-	SGMatrix<float64_t> orig(data, num_features, num_vectors, false);
+const float64_t eps = 1e-15;
+
+class MultipleProcessors : public ::testing::TestWithParam<bool> {};
+
+TEST_P(MultipleProcessors, preprocess) {
+	const index_t num_vectors = 2;
+	const index_t num_features = 3;
+	SGMatrix<float64_t> orig({{1,2},{3,4},{5,6}});
 	SGMatrix<float64_t> m = orig.clone();
 
-	CDenseFeatures<float64_t>* feats = new CDenseFeatures<float64_t>(m);
-	CSumOne* sum1 = new CSumOne();
-	CLogPlusOne* logp1 = new CLogPlusOne();
+	auto feats = some<CDenseFeatures<float64_t> >(m);
+	auto sum1 = some<CSumOne>();
+	auto logp1 = some<CLogPlusOne>();
+
 	sum1->init(feats);
-	feats->add_preprocessor(sum1);
-
 	logp1->init(feats);
-	feats->add_preprocessor(logp1);
-	feats->apply_preprocessor();
+	auto pre_feats = feats->preprocess(sum1)->preprocess(logp1);
 
-	EXPECT_EQ(2, feats->get_num_preprocessors());
+	if (GetParam())
+		pre_feats->eval();
 
 	for (index_t i = 0; i < num_vectors; i++)
 	{
-		SGVector<float64_t> v = feats->get_feature_vector(i);
-		float64_t* v_orig = orig.get_column_vector(i);
-		float64_t sum = SGVector<float64_t>::sum(v_orig, num_features);
+		auto v = pre_feats->get_feature_vector(i);
+		auto v_orig = orig.get_column(i);
+		auto sum = linalg::sum(v_orig);
+
 		for (index_t j = 0; j < num_features; j++) {
-			float64_t e = CMath::log(v_orig[j]/sum+1.0);
+			auto e = CMath::log(v_orig[j]/sum+1.0);
 			EXPECT_DOUBLE_EQ(e, v[j]);
 		}
 	}
-
-	SG_UNREF(feats);
 }
+
+INSTANTIATE_TEST_CASE_P(Eval, MultipleProcessors, ::testing::Values(false, true));


### PR DESCRIPTION
[Work in progress]

Continues #3968, only the last commit is relevant.

The design is outlined in [this](https://gist.github.com/micmn/52c82a6f47ebb8b49d35a5a3452becb8) gist.

I might split this into a few PRs that builds on the fundamental changes [1-2-3],
[4] cross validation, [5] `add/remove_subset()` replacement, [6] preprocessors.

Anyway, what's in here:

1. Base methods to construct new features `Features::preprocess()/view()`.

2. Base method to construct new labels `Labels::view()`, this requires a shallow copy 'ctor
like in `Features` classes (`duplicate()` + copy 'ctors),
implemented for (Dense/Binary/Multiclass/Regression)Labels.

3. `DenseFeatures`:
  - on-the-fly evaluation through `get_feature_vector()` method;
  - eager evaluation through `eval()` method;
  - `get_feature_matrix()` constness.

4. `CrossValidation`: use `view()` instead of `add/remove_subset()`.

5. Replace `add/remove_subset()` with `view()` + unit tests failing due to `DenseFeatures` changes [see below]:
  - `StochasticGBMachine`: refactor `get_subset()` and related functions
  to use a new labels object instead of adding the subset to `m_labels`,
  refactor unit tests and add case that covers `subset_frac < 1` branch;
  - `LMNNImpl`: refactor to use `preprocess()` instead of `apply_to_feature_matrix()`;
  - `CARTree`: fix feature matrix constness, minor changes to unit test (`some`);

6. Preprocessors:
  - `NormOne::apply_to_feature_vector()` uses linalg;
  - rewrite `PruneVarSubMean::init()` to use `DotFeatures::get_mean()/get_std()`
  (the latter was added to `DotFeatures`), add unit test;
  - `RandomFourierGaussPreproc`: fix feature matrix constness;
  - rewrite `MultipleProcessors` unit test with eval case;
  - rewrite `LeastAngleRegression.ols_equivalence` unit test to use `preprocess()`

[Misc] Initializer list constructor for `SGMatrix/Vector`
(not a big breakthrough but anyway useful for unit tests with fixed data...)

---
**Unit tests**:
  - 27 - unit-StochasticGBMachine (Fixed)
  - 32 - unit-LeastAngleRegression (Fixed)
  - 46 - unit-LMNNImpl (Fixed)
  - 47 - unit-LMNN (Fixed)
  - 167 - unit-CARTree (Fixed)
---
  - 58 - unit-Block (Failed)
  - 74 - unit-StreamingDenseFeaturesTest (Failed)
  - 80 - unit-StreamingHashedDenseFeaturesTest (Failed)
  - 122 - unit-LogPlusOne (Failed)
  - 123 - unit-RescaleFeatures (Failed)
  - 163 - unit-RandomCARTree (OTHER_FAULT)
  - 165 - unit-C45ClassifierTree (Failed)
  - 166 - unit-ID3ClassifierTree (Failed)
  - 168 - unit-RandomForest (Failed)
  - 170 - unit-CHAIDTree (SEGFAULT)
  - 178 - unit-BaggingMachine (Failed)
  - 185 - unit-GaussianProcessClassification (SEGFAULT)
  - 227 - unit-KMeans (Failed)
