### PR TITLE
Fix translation bug with static calls

### DIFF
--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -483,7 +483,7 @@ class Translator:
             method = expr[key][0]["Identifier"]
             argsList = None
             try:
-                argsList = expr[key][2]
+                argsList = expr[key][1]
             except IndexError:
                 pass
             translatedArgsList = self.translateArgumentList(argsList)


### PR DESCRIPTION
Fixes this bug:

Meta language:

```
Kernel k = kernel("GaussianKernel")
```

Translates to:

```
import numpy as np
from shogun import kernel

k = kernel()
```

i.e. the argument list is not included