### PR TITLE
Add an example for creating kernel by its name

### DIFF
--- a/examples/meta/src/base_api/kernel.sg
+++ b/examples/meta/src/base_api/kernel.sg
@@ -1,0 +1,3 @@
+Kernel k = kernel("GaussianKernel")
+
+k.get_name()

--- a/src/shogun/CMakeLists.txt
+++ b/src/shogun/CMakeLists.txt
@@ -458,10 +458,11 @@ IF (CTAGS_FOUND)
     SET(CTAGS_FILE ${CMAKE_CURRENT_BINARY_DIR}/tags CACHE INTERNAL "" FORCE)
     ADD_CUSTOM_COMMAND(OUTPUT ${CTAGS_FILE}
         COMMAND ${CTAGS_EXECUTABLE} -f ${CTAGS_FILE}
-        # functions, classes, macroses, enumerations, enumerators, typedefs
-        --c++-kinds=fcdgetp
+        # classes, enums, functions
+        --c++-kinds=cgp
         --fields=+im
-        -h "h.hpp"
+        --exclude=*.cpp
+        --languages=c++
         -R ${CMAKE_SOURCE_DIR})
 
     ADD_CUSTOM_TARGET(ctags DEPENDS ${CTAGS_FILE})

--- a/tests/unit/base/trained_model_serialization_unittest.cc.py
+++ b/tests/unit/base/trained_model_serialization_unittest.cc.py
@@ -16,11 +16,13 @@ IGNORE = [
     'CMultitaskL12LogisticRegression', 'CMultitaskLeastSquaresRegression',
     'CMultitaskTraceLogisticRegression', 'CMultitaskClusteredLogisticRegression',
     'CLatentSVM', 'CLatentSOSVM', 'CDomainAdaptationSVMLinear',
+    'CLinearLatentMachine',
 
     # KernelMachines
     'CDomainAdaptationSVM', 'CMKLRegression',
     'CMKLClassification', 'CMKLOneClass',
     'CSVM', # doesn't implement a solver
+    'CMKL',
 
     # LinearMulticlassMachines
     'CDomainAdaptationMulticlassLibLinear',


### PR DESCRIPTION
I had to remove functions from ctags due to multiple clash of the 'kernel' name. This way it doesn't clash.