### PR TITLE
Make SGVector(len) 'ctor zero-initialize memory

### DIFF
--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -92,7 +92,7 @@ template<class T>
 SGVector<T>::SGVector(index_t len, bool ref_counting)
 : SGReferencedData(ref_counting), vlen(len), gpu_ptr(NULL)
 {
-	vector=SG_MALLOC(T, len);
+	vector=SG_CALLOC(T, len);
 	m_on_gpu.store(false, std::memory_order_release);
 }
 


### PR DESCRIPTION
Same behavior as SGMatrix(rows, cols) [I don't know if it makes sense or this difference is ok and I should call SGVector::zero()].

Should fix DotIterator::add() failing unittest due to non initialized memory.
http://buildbot.shogun-toolbox.org:8080/#/builders/25/builds/158 