### PR TITLE
Set classifier_mkl_svmlight_modelselection_bug loglevel to info

### DIFF
--- a/examples/undocumented/libshogun/classifier_mkl_svmlight_modelselection_bug.cpp
+++ b/examples/undocumented/libshogun/classifier_mkl_svmlight_modelselection_bug.cpp
@@ -149,7 +149,7 @@ void test()
 int main(int argc, char **argv)
 {
 	init_shogun_with_defaults();
-	sg_io->set_loglevel(MSG_DEBUG);
+	sg_io->set_loglevel(MSG_INFO);
 
 	test();
 


### PR DESCRIPTION
Valgrind analysis build fails with: `parser error : xmlSAX2Characters: huge text node` (
http://buildbot.shogun-toolbox.org:8080/#/builders/2/builds/56/steps/9/logs/stdio).
I think that the cause is the script `classifier_mkl_svmlight_modelselection_bug.py`: the log level is set to debug and its outputs ~115MB of text.

I tried running xsltproc on the output file removing that test case (the file goes down to ~5MB) and it generates the html.