### PR TITLE
Get/put instead of get/set

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -44,7 +44,7 @@ namespace shogun
 	class CSGObject::Self
 	{
 	public:
-		void set(const BaseTag& tag, const Any& any)
+		void put(const BaseTag& tag, const Any& any)
 		{
 			map[tag] = any;
 		}
@@ -787,9 +787,9 @@ bool CSGObject::clone_parameters(CSGObject* other)
 	return true;
 }
 
-void CSGObject::type_erased_set(const BaseTag& _tag, const Any& any)
+void CSGObject::type_erased_put(const BaseTag& _tag, const Any& any)
 {
-	self->set(_tag, any);
+	self->put(_tag, any);
 }
 
 Any CSGObject::type_erased_get(const BaseTag& _tag) const

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -339,12 +339,12 @@ public:
 	 * @param value value of the parameter
 	 */
 	template <typename T>
-	void set(const Tag<T>& _tag, const T& value)
+	void put(const Tag<T>& _tag, const T& value)
 	{
 		if(type_erased_has(_tag))
 		{
 			if(has<T>(_tag.name()))
-				type_erased_set(_tag, erase_type(value));
+				type_erased_put(_tag, erase_type(value));
 			else
 			{
 				SG_ERROR("Type for parameter with name \"%s\" is not correct.\n",
@@ -364,11 +364,11 @@ public:
 	 * @param name name of the parameter
 	 * @param value value of the parameter along with type information
 	 */
-	template <typename T, typename U=void>
-	void set(const std::string& name, const T& value)
+	template <typename T, typename U = void>
+	void put(const std::string& name, const T& value)
 	{
 		Tag<T> tag(name);
-		set(tag, value);
+		put(tag, value);
 	}
 
 	/** Getter for a class parameter, identified by a Tag.
@@ -462,7 +462,8 @@ protected:
 	virtual void save_serializable_post() throw (ShogunException);
 
 	/** Registers a class parameter which is identified by a tag.
-	 * This enables the parameter to be modified by set() and retrieved by get().
+	 * This enables the parameter to be modified by put() and retrieved by
+	 * get().
 	 * Parameters can be registered in the constructor of the class.
 	 *
 	 * @param _tag name and type information of parameter
@@ -471,11 +472,12 @@ protected:
 	template <typename T>
 	void register_param(Tag<T>& _tag, const T& value)
 	{
-		type_erased_set(_tag, erase_type(value));
+		type_erased_put(_tag, erase_type(value));
 	}
 
 	/** Registers a class parameter which is identified by a name.
-	 * This enables the parameter to be modified by set() and retrieved by get().
+	 * This enables the parameter to be modified by put() and retrieved by
+	 * get().
 	 * Parameters can be registered in the constructor of the class.
 	 *
 	 * @param name name of the parameter
@@ -485,7 +487,7 @@ protected:
 	void register_param(const std::string& name, const T& value)
 	{
 		BaseTag tag(name);
-		type_erased_set(tag, erase_type(value));
+		type_erased_put(tag, erase_type(value));
 	}
 
 public:
@@ -551,7 +553,7 @@ private:
 	 * @param _tag name information of parameter
 	 * @param any value without type information of the parameter
 	 */
-	void type_erased_set(const BaseTag& _tag, const Any& any);
+	void type_erased_put(const BaseTag& _tag, const Any& any);
 
 	/** Getter for a class parameter, identified by a BaseTag.
 	 * Throws an exception if the class does not have such a parameter.

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -320,8 +320,8 @@ TEST(SGObject, tags_set_get_string_sgvector)
 	auto vec = SGVector<float64_t>(1);
 	vec[0] = 1;
 
-	obj->set("vector", vec);
-	EXPECT_THROW(obj->set("foo", vec), ShogunException);
+	obj->put("vector", vec);
+	EXPECT_THROW(obj->put("foo", vec), ShogunException);
 
 	auto retr = obj->get<SGVector<float64_t> >("vector");
 
@@ -338,9 +338,10 @@ TEST(SGObject, tags_set_get_tag_sgvector)
 	vec[0] = 1;
 	float64_t bar = 1.0;
 
-	obj->set(Tag<SGVector<float64_t> >("vector"), vec);
-	EXPECT_THROW(obj->set(Tag<SGVector<float64_t> >("foo"), vec), ShogunException);
-	EXPECT_THROW(obj->set(Tag<float64_t>("vector"), bar), ShogunException);
+	obj->put(Tag<SGVector<float64_t>>("vector"), vec);
+	EXPECT_THROW(
+	    obj->put(Tag<SGVector<float64_t>>("foo"), vec), ShogunException);
+	EXPECT_THROW(obj->put(Tag<float64_t>("vector"), bar), ShogunException);
 
 	auto retr = obj->get<SGVector<float64_t> >("vector");
 
@@ -355,7 +356,7 @@ TEST(SGObject, tags_set_get_int)
 	auto obj = some<CMockObject>();
 
 	EXPECT_THROW(obj->get<int32_t>("foo"), ShogunException);
-	obj->set("int", 10);
+	obj->put("int", 10);
 	EXPECT_EQ(obj->get(Tag<int32_t>("int")), 10);
 	EXPECT_THROW(obj->get<float64_t>("int"), ShogunException);
 	EXPECT_THROW(obj->get(Tag<float64_t>("int")), ShogunException);
@@ -372,7 +373,7 @@ TEST(SGObject, tags_has)
 	EXPECT_EQ(obj->has<float64_t>("int"), false);
 	EXPECT_EQ(obj->has<int32_t>("int"), true);
 
-	obj->set("int", 10);
+	obj->put("int", 10);
 	EXPECT_EQ(obj->has(Tag<int32_t>("int")), true);
 	EXPECT_EQ(obj->has(Tag<float64_t>("int")), false);
 	EXPECT_EQ(obj->has("int"), true);


### PR DESCRIPTION
Motivation is basic
- No need to replace set -> sets so no need to rename get
- Consistent with Java Map API