### PR TITLE
Do not use anything but headers for tags

### DIFF
--- a/src/shogun/CMakeLists.txt
+++ b/src/shogun/CMakeLists.txt
@@ -461,6 +461,7 @@ IF (CTAGS_FOUND)
         # functions, classes, macroses, enumerations, enumerators, typedefs
         --c++-kinds=fcdgetp
         --fields=+im
+        -h "h.hpp"
         -R ${CMAKE_SOURCE_DIR})
 
     ADD_CUSTOM_TARGET(ctags DEPENDS ${CTAGS_FILE})


### PR DESCRIPTION
We use tags to add dependencies such as `#include`. Only headers are to be used here.

@sorig that was causing that segfault of C++ meta_api/calls example! 🤣 