### PR TITLE
Support std::string wrapping in SWIG

### DIFF
--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -1,5 +1,6 @@
 /* base includes required by any module */
 %include "stdint.i"
+%include "std_string.i"
 %include "exception.i"
 
 %feature("ref")   shogun::CSGObject "SG_REF($this);"


### PR DESCRIPTION
Makes it possible to do:

```(python)
import shogun; print shogun.GaussianKernel().has('log_width')
```