### PR TITLE
Replace lapack with linalg in MahalanobisDistance

### DIFF
--- a/cmake/FindMetaExamples.cmake
+++ b/cmake/FindMetaExamples.cmake
@@ -35,7 +35,6 @@ function(get_excluded_meta_examples)
 
 	IF(NOT HAVE_LAPACK)
 		LIST(APPEND EXCLUDED_META_EXAMPLES
-			distance/mahalanobis.sg
 			)
 	ENDIF()
 

--- a/src/shogun/distance/MahalanobisDistance.cpp
+++ b/src/shogun/distance/MahalanobisDistance.cpp
@@ -7,14 +7,12 @@
 
 #include <shogun/lib/config.h>
 
-#ifdef HAVE_LAPACK
-
-#include <shogun/lib/common.h>
-#include <shogun/io/SGIO.h>
 #include <shogun/distance/MahalanobisDistance.h>
 #include <shogun/features/Features.h>
+#include <shogun/io/SGIO.h>
+#include <shogun/lib/common.h>
 #include <shogun/mathematics/Math.h>
-#include <shogun/mathematics/lapack.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -83,12 +81,8 @@ float64_t CMahalanobisDistance::compute(int32_t idx_a, int32_t idx_b)
 	for (int32_t i=0; i < diff.vlen; i++)
 		diff[i] = bvec.vector[i] - diff[i];
 
-	SGVector<float64_t> v = diff.clone();
-	cblas_dgemv(CblasColMajor, CblasNoTrans,
-		icov.num_rows, icov.num_cols, 1.0, icov.matrix,
-		diff.vlen, diff.vector, 1, 0.0, v.vector, 1);
-
-	float64_t result = cblas_ddot(v.vlen, v.vector, 1, diff.vector, 1);
+	auto v = linalg::matrix_prod(icov, diff);
+	float64_t result = linalg::dot(v, diff);
 
 	if (!use_mean)
 		((CDenseFeatures<float64_t>*) lhs)->free_feature_vector(avec, idx_a);
@@ -110,4 +104,3 @@ void CMahalanobisDistance::init()
 	m_parameters->add(&use_mean, "use_mean", "If distance shall be computed between mean vector and vector from rhs or between lhs and rhs.");
 }
 
-#endif /* HAVE_LAPACK */

--- a/src/shogun/distance/MahalanobisDistance.cpp
+++ b/src/shogun/distance/MahalanobisDistance.cpp
@@ -5,6 +5,7 @@
  *          Evan Shelhamer, Sergey Lisitsyn
  */
 
+#ifdef HAVE_LAPACK
 #include <shogun/lib/config.h>
 
 #include <shogun/distance/MahalanobisDistance.h>
@@ -104,3 +105,4 @@ void CMahalanobisDistance::init()
 	m_parameters->add(&use_mean, "use_mean", "If distance shall be computed between mean vector and vector from rhs or between lhs and rhs.");
 }
 
+#endif // HAVE_LAPACK

--- a/src/shogun/distance/MahalanobisDistance.cpp
+++ b/src/shogun/distance/MahalanobisDistance.cpp
@@ -35,23 +35,9 @@ CMahalanobisDistance::~CMahalanobisDistance()
 
 bool CMahalanobisDistance::init(CFeatures* l, CFeatures* r)
 {
-	CRealDistance::init(l, r);
-
-	REQUIRE(
-	    lhs->get_feature_class() == C_DENSE,
-	    "Left hand side (was %s) has to be CDenseFeatures instance.\n",
-	    lhs->get_name());
-	REQUIRE(
-	    rhs->get_feature_class() == C_DENSE,
-	    "Right hand side (was %s) has to be CDenseFeatures instance.\n",
-	    rhs->get_name());
-
-	REQUIRE(
-	    lhs->get_feature_type() == F_DREAL,
-	    "Left hand side (was %s) has to be of double type.\n", lhs->get_name());
-	REQUIRE(
-	    rhs->get_feature_type() == F_DREAL,
-	    "Right hand side (was %s) has to be double type.\n", rhs->get_name());
+	// FIXME: See comments in
+	// https://github.com/shogun-toolbox/shogun/pull/4085#discussion_r166254024
+	ASSERT(CRealDistance::init(l, r));
 
 	SGMatrix<float64_t> cov;
 

--- a/src/shogun/distance/MahalanobisDistance.h
+++ b/src/shogun/distance/MahalanobisDistance.h
@@ -43,7 +43,7 @@ namespace shogun
  * i.e., instead of the mean as reference two vector \f$x_i\f$ and \f$x_i'\f$
  * are compared.
  *
- * @see <a href="en.wikipedia.org/wiki/Mahalanobis_distance">
+ * @see <a href="http://en.wikipedia.org/wiki/Mahalanobis_distance">
  * Wikipedia: Mahalanobis Distance</a>
  */
 class CMahalanobisDistance: public CRealDistance

--- a/src/shogun/distance/MahalanobisDistance.h
+++ b/src/shogun/distance/MahalanobisDistance.h
@@ -15,37 +15,40 @@
 
 namespace shogun
 {
-/** @brief class MahalanobisDistance
- *
- * The Mahalanobis distance for real valued features computes the distance
- * between a feature vector and a distribution of features characterized by its
- * mean and covariance.
- *
- * \f[\displaystyle
- *  D = \sqrt{ (x_i - \mu)^T \Sigma^{-1} (x_i - \mu)  }
- * \f]
- *
- * The Mahalanobis Squared distance does not take the square root:
- *
- * \f[\displaystyle
- *  D = (x_i - \mu)^T \Sigma^{-1} (x_i - \mu)
- * \f]
- *
- * If use_mean is set to false (which it is by default) the distance is computed
- * as
- *
- * \f[\displaystyle
- *  D = \sqrt{ (x_i - x_i')^T \Sigma^{-1} (x_i - x_i')  }
- * \f]
- *
- * i.e., instead of the mean as reference two vector \f$x_i\f$ and \f$x_i'\f$
- * are compared.
- *
- * @see <a href="http://en.wikipedia.org/wiki/Mahalanobis_distance">
- * Wikipedia: Mahalanobis Distance</a>
- */
-class CMahalanobisDistance: public CRealDistance
-{
+	/** @brief class MahalanobisDistance
+	 *
+	 * The Mahalanobis distance for real valued features computes the distance
+	 * between a feature vector and a distribution of features characterized by
+	 * its
+	 * mean and covariance.
+	 *
+	 * \f[\displaystyle
+	 *  D = \sqrt{ (x_i - \mu)^T \Sigma^{-1} (x_i - \mu)  }
+	 * \f]
+	 *
+	 * The Mahalanobis Squared distance does not take the square root:
+	 *
+	 * \f[\displaystyle
+	 *  D = (x_i - \mu)^T \Sigma^{-1} (x_i - \mu)
+	 * \f]
+	 *
+	 * If use_mean is set to false (which it is by default) the distance is
+	 * computed
+	 * as
+	 *
+	 * \f[\displaystyle
+	 *  D = \sqrt{ (x_i - x_i')^T \Sigma^{-1} (x_i - x_i')  }
+	 * \f]
+	 *
+	 * i.e., instead of the mean as reference two vector \f$x_i\f$ and
+	 * \f$x_i'\f$
+	 * are compared.
+	 *
+	 * @see <a href="http://en.wikipedia.org/wiki/Mahalanobis_distance">
+	 * Wikipedia: Mahalanobis Distance</a>
+	 */
+	class CMahalanobisDistance : public CRealDistance
+	{
 	public:
 		/** default constructor */
 		CMahalanobisDistance();

--- a/src/shogun/distance/MahalanobisDistance.h
+++ b/src/shogun/distance/MahalanobisDistance.h
@@ -142,8 +142,12 @@ namespace shogun
 
 		/** vector mean of the lhs feature vectors */
 		SGVector<float64_t> mean;
-		/** inverse of the covariance matrix of lhs feature vectors */
-		SGMatrix<float64_t> icov;
+
+		/** LDLT decomposition of the covariance matrix of lhs feature vectors
+		 */
+		SGMatrix<float64_t> chol_cov_L;
+		SGVector<float64_t> chol_cov_d;
+		SGVector<index_t> chol_cov_p;
 };
 
 } // namespace shogun

--- a/src/shogun/distance/MahalanobisDistance.h
+++ b/src/shogun/distance/MahalanobisDistance.h
@@ -10,8 +10,6 @@
 
 #include <shogun/lib/config.h>
 
-#ifdef HAVE_LAPACK
-
 #include <shogun/lib/common.h>
 #include <shogun/distance/RealDistance.h>
 
@@ -146,5 +144,4 @@ class CMahalanobisDistance: public CRealDistance
 };
 
 } // namespace shogun
-#endif /* HAVE_LAPACK */
 #endif /* _MAHALANOBISDISTANCE_H__ */

--- a/tests/unit/distance/MahalanobisDistance_unittest.cc
+++ b/tests/unit/distance/MahalanobisDistance_unittest.cc
@@ -1,32 +1,7 @@
 /*
- * Copyright (c) The Shogun Machine Learning Toolbox
- * Written (w) 2018 Wuwei Lin
- * All rights reserved.
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- * The views and conclusions contained in the software and documentation are
- * those of the authors and should not be interpreted as representing official
- * policies, either expressed or implied, of the Shogun Development Team.
+ * Authors: Wuwei Lin
  */
 
 #include <gtest/gtest.h>

--- a/tests/unit/distance/MahalanobisDistance_unittest.cc
+++ b/tests/unit/distance/MahalanobisDistance_unittest.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2018 Wuwei Lin
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <gtest/gtest.h>
+#include <shogun/base/some.h>
+#include <shogun/distance/MahalanobisDistance.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/lib/common.h>
+
+using namespace shogun;
+
+TEST(MahalanobisDistance, compute_distance)
+{
+	// create four points (0,0) (2,10) (2,8) (5,5)
+	SGMatrix<float64_t> rect(2, 4);
+	rect(0, 0) = 0;
+	rect(1, 0) = 0;
+	rect(0, 1) = 2;
+	rect(1, 1) = 10;
+	rect(0, 2) = 2;
+	rect(1, 2) = 8;
+	rect(0, 3) = 5;
+	rect(1, 3) = 5;
+
+	auto feature = some<CDenseFeatures<float64_t>>(rect);
+	auto distance = some<CMahalanobisDistance>(feature, feature);
+	EXPECT_NEAR(distance->distance(1, 1), 0.0, 1e-10);
+	EXPECT_NEAR(distance->distance(1, 3), 2.63447126986, 1e-10);
+	EXPECT_NEAR(distance->distance(2, 3), 2.22834405812, 1e-10);
+}


### PR DESCRIPTION
This PR replaces lapack usage with linalg in `MahalanobisDistance`.
A unit test of `MahalanobisDistance` is added (reference computed with Matlab)