### PR TITLE
Test that old parameter names and tag parameter names match

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -23,8 +23,8 @@
 #include <shogun/lib/parameter_observers/ObservedValue.h>
 #include <shogun/lib/tag.h>
 
-#include <utility>
 #include <set>
+#include <utility>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace

--- a/src/shogun/base/class_list.cpp.templ
+++ b/src/shogun/base/class_list.cpp.templ
@@ -75,7 +75,7 @@ void shogun::delete_object(CSGObject* object)
 	delete object;
 }
 
-std::set<std::string> available_objects()
+std::set<std::string> shogun::available_objects()
 {
 	std::set<std::string> result;
 	for (class_list_entry_t* i=class_list; i->m_class_name != NULL;


### PR DESCRIPTION
Add a test that can be used to identify discrepancies between old parameter registration and new tag based registration.