### PR TITLE
Add command to change repository before update submodule

### DIFF
--- a/doc/readme/INSTALL.md
+++ b/doc/readme/INSTALL.md
@@ -148,11 +148,10 @@ Download the latest [stable release source code](https://github.com/shogun-toolb
 Potentially update submodules
 
     git clone https://github.com/shogun-toolbox/shogun.git
-    git submodule update --init
+    cd shogun; git submodule update --init
 
 Create the build directory in the source tree root
 
-    cd shogun
     mkdir build
 
 Configure cmake, from the build directory, passing the Shogun source root as argument.


### PR DESCRIPTION
The command to change repository was misplaced. 
`git submodule update --init` has to be run on the tree root. So after cloning, the directory must be changed to shogun using `cd shogun/`, followed by the rest of the code shown as it is.