### PR TITLE
Fix issue #3612

### DIFF
--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -148,7 +148,7 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			if (!k->has_features())
 				SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
 
-			//extract row & column subset indices from combined features
+			// extract row & column subset indices from combined features
 			auto lhs_subset_stack = ((CCombinedFeatures*)l)->get_subset_stack();
 			auto rhs_subset_stack = ((CCombinedFeatures*)r)->get_subset_stack();
 

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -111,8 +111,10 @@ bool CCombinedKernel::init_with_extracted_subsets(
 				SG_UNREF(lf);
 				SG_UNREF(rf);
 				SG_UNREF(k);
-				SG_ERROR("CombinedKernel: Number of features/kernels does not "
-				         "match - bailing out\n")
+				SG_ERROR(
+				    "CombinedKernel: Number of features/kernels does not "
+				    "match - bailing out\n")
+
 			}
 
 			SG_DEBUG("Initializing 0x%p - \"%s\"\n", this, k->get_name())
@@ -173,8 +175,9 @@ bool CCombinedKernel::init_with_extracted_subsets(
 	if (((CCombinedFeatures*)l)->get_num_feature_obj() <= 0 ||
 	    ((CCombinedFeatures*)l)->get_num_feature_obj() !=
 	        ((CCombinedFeatures*)r)->get_num_feature_obj())
-		SG_ERROR("CombinedKernel: Number of features/kernels does not match - "
-		         "bailing out\n")
+		SG_ERROR(
+		    "CombinedKernel: Number of features/kernels does not match - "
+		    "bailing out\n")
 
 	init_normalizer();
 	initialized = true;
@@ -234,8 +237,9 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 	    l->get_feature_type() == r->get_feature_type() &&
 	    l->get_feature_class() != C_COMBINED)
 	{
-		SG_DEBUG("Initialising combined kernel's combined features with the "
-		         "same instance from parameters\n");
+		SG_DEBUG(
+		    "Initialising combined kernel's combined features with the "
+		    "same instance from parameters\n");
 		/* construct combined features with each element being the parameter
 		 * The we must make sure that we make any custom kernels aware of any
 		 * subsets present!

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -114,7 +114,6 @@ bool CCombinedKernel::init_with_extracted_subsets(
 				SG_ERROR(
 				    "CombinedKernel: Number of features/kernels does not "
 				    "match - bailing out\n")
-
 			}
 
 			SG_DEBUG("Initializing 0x%p - \"%s\"\n", this, k->get_name())

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -149,16 +149,24 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 				SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
 
 			//extract row & column subset indices from combined features
-			auto lhs_subset = ((CCombinedFeatures*)l)->get_subset_stack()->get_last_subset()->get_subset_idx();
-			auto rhs_subset = ((CCombinedFeatures*)r)->get_subset_stack()->get_last_subset()->get_subset_idx();
+			auto lhs_subset_stack = ((CCombinedFeatures*)l)->get_subset_stack();
+			auto rhs_subset_stack = ((CCombinedFeatures*)r)->get_subset_stack();
 
-			//clear all previous subsets
-			((CCustomKernel*)k)->remove_all_row_subsets();
-			((CCustomKernel*)k)->remove_all_col_subsets();
-
-			//apply new subset
-			((CCustomKernel*)k)->add_row_subset(lhs_subset);
-			((CCustomKernel*)k)->add_col_subset(rhs_subset);
+			if (lhs_subset_stack->has_subsets()) {
+                auto lhs_subset = lhs_subset_stack->get_last_subset()->get_subset_idx();
+                //clear all previous subsets
+                ((CCustomKernel*)k)->remove_all_row_subsets();
+                //apply new subset
+                ((CCustomKernel*)k)->add_row_subset(lhs_subset);
+            }
+            
+            if (rhs_subset_stack->has_subsets()) {
+                auto rhs_subset = rhs_subset_stack->get_last_subset()->get_subset_idx();
+                //clear all previous subsets
+                ((CCustomKernel*)k)->remove_all_col_subsets();
+                //apply new subset
+                ((CCustomKernel*)k)->add_col_subset(rhs_subset);
+            }
 
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -177,8 +177,7 @@ bool CCombinedKernel::init_with_extracted_subsets(
 	}
 
 	if (l_combined->get_num_feature_obj() <= 0 ||
-	    l_combined->get_num_feature_obj() !=
-	        r_combined->get_num_feature_obj())
+	    l_combined->get_num_feature_obj() != r_combined->get_num_feature_obj())
 		SG_ERROR(
 		    "CombinedKernel: Number of features/kernels does not match - "
 		    "bailing out\n")

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -147,6 +147,19 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			SG_DEBUG("Initializing 0x%p - \"%s\" (skipping init, this is a CUSTOM kernel)\n", this, k->get_name())
 			if (!k->has_features())
 				SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
+
+			//extract row & column subset indices from combined features
+			auto lhs_subset = ((CCombinedFeatures*)l)->get_subset_stack()->get_last_subset()->get_subset_idx();
+			auto rhs_subset = ((CCombinedFeatures*)r)->get_subset_stack()->get_last_subset()->get_subset_idx();
+
+			//clear all previous subsets
+			((CCustomKernel*)k)->remove_all_row_subsets();
+			((CCustomKernel*)k)->remove_all_col_subsets();
+
+			//apply new subset
+			((CCustomKernel*)k)->add_row_subset(lhs_subset);
+			((CCustomKernel*)k)->add_col_subset(rhs_subset);
+
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())
 			if (k->get_num_vec_rhs() != num_rhs)

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -147,18 +147,22 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			SG_DEBUG("Initializing 0x%p - \"%s\" (skipping init, this is a CUSTOM kernel)\n", this, k->get_name())
 			if (!k->has_features())
 				SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
-
-			//extract row & column subset indices from combined features
-			auto lhs_subset = ((CCombinedFeatures*)l)->get_subset_stack()->get_last_subset()->get_subset_idx();
-			auto rhs_subset = ((CCombinedFeatures*)r)->get_subset_stack()->get_last_subset()->get_subset_idx();
-
-			//clear all previous subsets
-			((CCustomKernel*)k)->remove_all_row_subsets();
-			((CCustomKernel*)k)->remove_all_col_subsets();
-
-			//apply new subset
-			((CCustomKernel*)k)->add_row_subset(lhs_subset);
-			((CCustomKernel*)k)->add_col_subset(rhs_subset);
+            if (((CCombinedFeatures*)l)->get_subset_stack() != NULL){
+                //extract row subset indices from combined features
+                auto lhs_subset = ((CCombinedFeatures*)l)->get_subset_stack()->get_last_subset()->get_subset_idx();
+                //clear all previous subsets
+                ((CCustomKernel*)k)->remove_all_row_subsets();
+                //apply new subset
+                ((CCustomKernel*)k)->add_row_subset(lhs_subset);
+            }
+            if (((CCombinedFeatures*)r)->get_subset_stack() != NULL){
+                //extract col subset indices from combined features
+                auto rhs_subset = ((CCombinedFeatures*)r)->get_subset_stack()->get_last_subset()->get_subset_idx();
+                //clear all previous subsets
+                ((CCustomKernel*)k)->remove_all_col_subsets();
+                //apply new subset
+                ((CCustomKernel*)k)->add_col_subset(rhs_subset);
+            }
 
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -61,6 +61,109 @@ void CCombinedKernel::init_subkernel_weights()
 	eigen_wt = eigen_wt.array().exp();
 	set_subkernel_weights(wt);
 }
+bool CCombinedKernel::init_with_extracted_subsets(CFeatures *l, CFeatures *r, SGVector<index_t> lhs_subset,
+                                                  SGVector<index_t> rhs_subset) {
+
+
+    CKernel::init(l,r);
+    REQUIRE(l->get_feature_class()==C_COMBINED, "%s::init(): LHS features are"
+            " of class %s but need to be combined features!\n",
+            get_name(), l->get_name());
+    REQUIRE(r->get_feature_class()==C_COMBINED, "%s::init(): RHS features are"
+            " of class %s but need to be combined features!\n",
+            get_name(), r->get_name());
+    ASSERT(l->get_feature_type()==F_UNKNOWN)
+    ASSERT(r->get_feature_type()==F_UNKNOWN)
+
+    CFeatures* lf=NULL;
+    CFeatures* rf=NULL;
+    CKernel* k=NULL;
+
+    bool result=true;
+    index_t f_idx = 0;
+
+    SG_DEBUG("Starting for loop for kernels\n")
+    for (index_t k_idx=0; k_idx<get_num_kernels() && result; k_idx++)
+    {
+        k = get_kernel(k_idx);
+
+        if (!k)
+        SG_ERROR("Kernel at position %d is NULL\n", k_idx);
+
+        // skip over features - the custom kernel does not need any
+        if (k->get_kernel_type() != K_CUSTOM)
+        {
+            if (((CCombinedFeatures*)l)->get_num_feature_obj() > f_idx &&
+                ((CCombinedFeatures*)r)->get_num_feature_obj() > f_idx)
+            {
+                lf = ((CCombinedFeatures*)l)->get_feature_obj(f_idx);
+                rf = ((CCombinedFeatures*)r)->get_feature_obj(f_idx);
+            }
+
+            f_idx++;
+            if (!lf || !rf)
+            {
+                SG_UNREF(lf);
+                SG_UNREF(rf);
+                SG_UNREF(k);
+                SG_ERROR("CombinedKernel: Number of features/kernels does not match - bailing out\n")
+            }
+
+            SG_DEBUG("Initializing 0x%p - \"%s\"\n", this, k->get_name())
+            result=k->init(lf,rf);
+            SG_UNREF(lf);
+            SG_UNREF(rf);
+
+            if (!result)
+                break;
+        }
+        else
+        {
+            SG_DEBUG("Initializing 0x%p - \"%s\" (skipping init, this is a CUSTOM kernel)\n", this, k->get_name())
+            if (!k->has_features())
+            SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
+
+
+                // clear all previous subsets
+                ((CCustomKernel*)k)->remove_all_row_subsets();
+                // apply new subset
+                ((CCustomKernel*)k)->add_row_subset(lhs_subset);
+
+                ((CCustomKernel*)k)->remove_all_col_subsets();
+                // apply new subset
+                ((CCustomKernel*)k)->add_col_subset(rhs_subset);
+
+            if (k->get_num_vec_lhs() != num_lhs)
+            SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())
+            if (k->get_num_vec_rhs() != num_rhs)
+            SG_ERROR("Number of rhs-feature vectors (%d) not match with number of cols (%d) of custom kernel\n", num_rhs, k->get_num_vec_rhs())
+        }
+
+        SG_UNREF(k);
+    }
+
+    if (!result)
+    {
+        SG_INFO("CombinedKernel: Initialising the following kernel failed\n")
+        if (k)
+        {
+            k->list_kernel();
+            SG_UNREF(k);
+        }
+        else
+        SG_INFO("<NULL>\n")
+        return false;
+    }
+
+    if ( ((CCombinedFeatures*) l)->get_num_feature_obj()<=0 ||
+         ((CCombinedFeatures*) l)->get_num_feature_obj() != ((CCombinedFeatures*) r)->get_num_feature_obj() )
+    SG_ERROR("CombinedKernel: Number of features/kernels does not match - bailing out\n")
+
+    init_normalizer();
+    initialized=true;
+    return true;
+
+}
 
 bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 {
@@ -68,6 +171,40 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 	{
 		init_subkernel_weights();
 	}
+    /*
+     * The two subsets, we will be passing those to init_with_extracted_subsets
+     */
+    SGVector<index_t> lhs_subset;
+    SGVector<index_t> rhs_subset;
+
+    /*
+     * We will be passing these features to init_with_extracted_subsets
+     */
+    CCombinedFeatures* combined_l;
+    CCombinedFeatures* combined_r;
+
+    /*
+     * Extract the subsets so that we can pass them on
+     */
+    auto l_subset_stack = l->get_subset_stack();
+    auto r_subset_stack = r->get_subset_stack();
+
+    if (l_subset_stack->has_subsets()) {
+        lhs_subset = l_subset_stack->get_last_subset()->get_subset_idx();
+    } else {
+        lhs_subset = SGVector<index_t>(l->get_num_vectors());
+        lhs_subset.range_fill();
+    }
+
+    if (r_subset_stack->has_subsets()) {
+        rhs_subset = r_subset_stack->get_last_subset()->get_subset_idx();
+    } else {
+        rhs_subset = SGVector<index_t>(r->get_num_vectors());
+        rhs_subset.range_fill();
+    }
+
+    SG_UNREF(l_subset_stack);
+    SG_UNREF(r_subset_stack);
 
 	/* if the specified features are not combined features, but a single other
 	 * feature type, assume that the caller wants to use all kernels on these */
@@ -77,133 +214,26 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 	{
 		SG_DEBUG("Initialising combined kernel's combined features with the "
 				"same instance from parameters\n");
-		/* construct combined features with each element being the parameter */
-		CCombinedFeatures* combined_l=new CCombinedFeatures();
-		CCombinedFeatures* combined_r=new CCombinedFeatures();
+		/* construct combined features with each element being the parameter
+         * The we must make sure that we make any custom kernels aware of any subsets present!
+         */
+		combined_l=new CCombinedFeatures();
+        combined_r=new CCombinedFeatures();
+
 		for (index_t i=0; i<get_num_subkernels(); ++i)
 		{
 			combined_l->append_feature_obj(l);
 			combined_r->append_feature_obj(r);
 		}
+	} else {
+        /*
+         * Otherwise, we just pass l & r straight on
+         */
+        combined_l = (CCombinedFeatures*)l;
+        combined_r = (CCombinedFeatures*)r;
+    }
 
-		/* recursive call with constructed combined kernel */
-		return init(combined_l, combined_r);
-	}
-
-	CKernel::init(l,r);
-	REQUIRE(l->get_feature_class()==C_COMBINED, "%s::init(): LHS features are"
-			" of class %s but need to be combined features!\n",
-			get_name(), l->get_name());
-	REQUIRE(r->get_feature_class()==C_COMBINED, "%s::init(): RHS features are"
-			" of class %s but need to be combined features!\n",
-			get_name(), r->get_name());
-	ASSERT(l->get_feature_type()==F_UNKNOWN)
-	ASSERT(r->get_feature_type()==F_UNKNOWN)
-
-	CFeatures* lf=NULL;
-	CFeatures* rf=NULL;
-	CKernel* k=NULL;
-
-	bool result=true;
-	index_t f_idx = 0;
-
-	SG_DEBUG("Starting for loop for kernels\n")
-	for (index_t k_idx=0; k_idx<get_num_kernels() && result; k_idx++)
-	{
-		k = get_kernel(k_idx);
-
-		if (!k)
-			SG_ERROR("Kernel at position %d is NULL\n", k_idx);
-
-		// skip over features - the custom kernel does not need any
-		if (k->get_kernel_type() != K_CUSTOM)
-		{
-			if (((CCombinedFeatures*)l)->get_num_feature_obj() > f_idx &&
-			    ((CCombinedFeatures*)r)->get_num_feature_obj() > f_idx)
-			{
-				lf = ((CCombinedFeatures*)l)->get_feature_obj(f_idx);
-				rf = ((CCombinedFeatures*)r)->get_feature_obj(f_idx);
-			}
-
-			f_idx++;
-			if (!lf || !rf)
-			{
-				SG_UNREF(lf);
-				SG_UNREF(rf);
-				SG_UNREF(k);
-				SG_ERROR("CombinedKernel: Number of features/kernels does not match - bailing out\n")
-			}
-
-			SG_DEBUG("Initializing 0x%p - \"%s\"\n", this, k->get_name())
-			result=k->init(lf,rf);
-			SG_UNREF(lf);
-			SG_UNREF(rf);
-
-			if (!result)
-				break;
-		}
-		else
-		{
-			SG_DEBUG("Initializing 0x%p - \"%s\" (skipping init, this is a CUSTOM kernel)\n", this, k->get_name())
-			if (!k->has_features())
-				SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
-
-			// extract row & column subset indices from combined features
-			auto lhs_subset_stack = ((CCombinedFeatures*)l)->get_subset_stack();
-			auto rhs_subset_stack = ((CCombinedFeatures*)r)->get_subset_stack();
-
-			if (lhs_subset_stack->has_subsets())
-			{
-				auto lhs_subset =
-				    lhs_subset_stack->get_last_subset()->get_subset_idx();
-				// clear all previous subsets
-				((CCustomKernel*)k)->remove_all_row_subsets();
-				// apply new subset
-				((CCustomKernel*)k)->add_row_subset(lhs_subset);
-			}
-
-			if (rhs_subset_stack->has_subsets())
-			{
-				auto rhs_subset =
-				    rhs_subset_stack->get_last_subset()->get_subset_idx();
-				// clear all previous subsets
-				((CCustomKernel*)k)->remove_all_col_subsets();
-				// apply new subset
-				((CCustomKernel*)k)->add_col_subset(rhs_subset);
-			}
-
-            SG_UNREF(lhs_subset_stack)
-            SG_UNREF(rhs_subset_stack)
-
-			if (k->get_num_vec_lhs() != num_lhs)
-				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())
-			if (k->get_num_vec_rhs() != num_rhs)
-				SG_ERROR("Number of rhs-feature vectors (%d) not match with number of cols (%d) of custom kernel\n", num_rhs, k->get_num_vec_rhs())
-		}
-
-		SG_UNREF(k);
-	}
-
-	if (!result)
-	{
-		SG_INFO("CombinedKernel: Initialising the following kernel failed\n")
-		if (k)
-		{
-			k->list_kernel();
-			SG_UNREF(k);
-		}
-		else
-			SG_INFO("<NULL>\n")
-		return false;
-	}
-
-	if ( ((CCombinedFeatures*) l)->get_num_feature_obj()<=0 ||
-		((CCombinedFeatures*) l)->get_num_feature_obj() != ((CCombinedFeatures*) r)->get_num_feature_obj() )
-		SG_ERROR("CombinedKernel: Number of features/kernels does not match - bailing out\n")
-
-	init_normalizer();
-	initialized=true;
-	return true;
+    return init_with_extracted_subsets(combined_l, combined_r, lhs_subset, rhs_subset);
 }
 
 void CCombinedKernel::remove_lhs()

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -183,7 +183,7 @@ bool CCombinedKernel::init_with_extracted_subsets(
 
 bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 {
-	if(enable_subkernel_weight_opt && !weight_update)
+	if (enable_subkernel_weight_opt && !weight_update)
 	{
 		init_subkernel_weights();
 	}
@@ -230,12 +230,12 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 
 	/* if the specified features are not combined features, but a single other
 	 * feature type, assume that the caller wants to use all kernels on these */
-	if (l && r && l->get_feature_class()==r->get_feature_class() &&
-			l->get_feature_type()==r->get_feature_type() &&
-			l->get_feature_class()!= C_COMBINED)
+	if (l && r && l->get_feature_class() == r->get_feature_class() &&
+	    l->get_feature_type() == r->get_feature_type() &&
+	    l->get_feature_class() != C_COMBINED)
 	{
 		SG_DEBUG("Initialising combined kernel's combined features with the "
-				"same instance from parameters\n");
+		         "same instance from parameters\n");
 		/* construct combined features with each element being the parameter
 		 * The we must make sure that we make any custom kernels aware of any
 		 * subsets present!
@@ -243,7 +243,7 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 		combined_l = new CCombinedFeatures();
 		combined_r = new CCombinedFeatures();
 
-		for (index_t i=0; i<get_num_subkernels(); ++i)
+		for (index_t i = 0; i < get_num_subkernels(); ++i)
 		{
 			combined_l->append_feature_obj(l);
 			combined_r->append_feature_obj(r);

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -147,22 +147,18 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			SG_DEBUG("Initializing 0x%p - \"%s\" (skipping init, this is a CUSTOM kernel)\n", this, k->get_name())
 			if (!k->has_features())
 				SG_ERROR("No kernel matrix was assigned to this Custom kernel\n")
-            if (((CCombinedFeatures*)l)->get_subset_stack() != NULL){
-                //extract row subset indices from combined features
-                auto lhs_subset = ((CCombinedFeatures*)l)->get_subset_stack()->get_last_subset()->get_subset_idx();
-                //clear all previous subsets
-                ((CCustomKernel*)k)->remove_all_row_subsets();
-                //apply new subset
-                ((CCustomKernel*)k)->add_row_subset(lhs_subset);
-            }
-            if (((CCombinedFeatures*)r)->get_subset_stack() != NULL){
-                //extract col subset indices from combined features
-                auto rhs_subset = ((CCombinedFeatures*)r)->get_subset_stack()->get_last_subset()->get_subset_idx();
-                //clear all previous subsets
-                ((CCustomKernel*)k)->remove_all_col_subsets();
-                //apply new subset
-                ((CCustomKernel*)k)->add_col_subset(rhs_subset);
-            }
+
+			//extract row & column subset indices from combined features
+			auto lhs_subset = ((CCombinedFeatures*)l)->get_subset_stack()->get_last_subset()->get_subset_idx();
+			auto rhs_subset = ((CCombinedFeatures*)r)->get_subset_stack()->get_last_subset()->get_subset_idx();
+
+			//clear all previous subsets
+			((CCustomKernel*)k)->remove_all_row_subsets();
+			((CCustomKernel*)k)->remove_all_col_subsets();
+
+			//apply new subset
+			((CCustomKernel*)k)->add_row_subset(lhs_subset);
+			((CCustomKernel*)k)->add_col_subset(rhs_subset);
 
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -152,21 +152,25 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 			auto lhs_subset_stack = ((CCombinedFeatures*)l)->get_subset_stack();
 			auto rhs_subset_stack = ((CCombinedFeatures*)r)->get_subset_stack();
 
-			if (lhs_subset_stack->has_subsets()) {
-                auto lhs_subset = lhs_subset_stack->get_last_subset()->get_subset_idx();
-                //clear all previous subsets
-                ((CCustomKernel*)k)->remove_all_row_subsets();
-                //apply new subset
-                ((CCustomKernel*)k)->add_row_subset(lhs_subset);
-            }
+			if (lhs_subset_stack->has_subsets())
+			{
+				auto lhs_subset =
+				    lhs_subset_stack->get_last_subset()->get_subset_idx();
+				// clear all previous subsets
+				((CCustomKernel*)k)->remove_all_row_subsets();
+				// apply new subset
+				((CCustomKernel*)k)->add_row_subset(lhs_subset);
+			}
 
-            if (rhs_subset_stack->has_subsets()) {
-                auto rhs_subset = rhs_subset_stack->get_last_subset()->get_subset_idx();
-                //clear all previous subsets
-                ((CCustomKernel*)k)->remove_all_col_subsets();
-                //apply new subset
-                ((CCustomKernel*)k)->add_col_subset(rhs_subset);
-            }
+			if (rhs_subset_stack->has_subsets())
+			{
+				auto rhs_subset =
+				    rhs_subset_stack->get_last_subset()->get_subset_idx();
+				// clear all previous subsets
+				((CCustomKernel*)k)->remove_all_col_subsets();
+				// apply new subset
+				((CCustomKernel*)k)->add_col_subset(rhs_subset);
+			}
 
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -172,6 +172,9 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
 				((CCustomKernel*)k)->add_col_subset(rhs_subset);
 			}
 
+            SG_UNREF(lhs_subset_stack)
+            SG_UNREF(rhs_subset_stack)
+
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR("Number of lhs-feature vectors (%d) not match with number of rows (%d) of custom kernel\n", num_lhs, k->get_num_vec_lhs())
 			if (k->get_num_vec_rhs() != num_rhs)

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -84,6 +84,9 @@ bool CCombinedKernel::init_with_extracted_subsets(
 	CFeatures* rf = NULL;
 	CKernel* k = NULL;
 
+    auto l_combined = dynamic_cast<CCombinedFeatures*>(l);
+    auto r_combined = dynamic_cast<CCombinedFeatures*>(r);
+
 	bool result = true;
 	index_t f_idx = 0;
 
@@ -98,11 +101,11 @@ bool CCombinedKernel::init_with_extracted_subsets(
 		// skip over features - the custom kernel does not need any
 		if (k->get_kernel_type() != K_CUSTOM)
 		{
-			if (((CCombinedFeatures*)l)->get_num_feature_obj() > f_idx &&
-			    ((CCombinedFeatures*)r)->get_num_feature_obj() > f_idx)
+			if (l_combined->get_num_feature_obj() > f_idx &&
+			    r_combined->get_num_feature_obj() > f_idx)
 			{
-				lf = ((CCombinedFeatures*)l)->get_feature_obj(f_idx);
-				rf = ((CCombinedFeatures*)r)->get_feature_obj(f_idx);
+				lf = l_combined->get_feature_obj(f_idx);
+				rf = r_combined->get_feature_obj(f_idx);
 			}
 
 			f_idx++;
@@ -134,14 +137,16 @@ bool CCombinedKernel::init_with_extracted_subsets(
 				SG_ERROR(
 				    "No kernel matrix was assigned to this Custom kernel\n")
 
-			// clear all previous subsets
-			((CCustomKernel*)k)->remove_all_row_subsets();
-			// apply new subset
-			((CCustomKernel*)k)->add_row_subset(lhs_subset);
+            auto k_custom = dynamic_cast<CCustomKernel*>(k);
 
-			((CCustomKernel*)k)->remove_all_col_subsets();
+			// clear all previous subsets
+			k_custom->remove_all_row_subsets();
 			// apply new subset
-			((CCustomKernel*)k)->add_col_subset(rhs_subset);
+            k_custom->add_row_subset(lhs_subset);
+
+            k_custom->remove_all_col_subsets();
+			// apply new subset
+            k_custom->add_col_subset(rhs_subset);
 
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR(
@@ -171,9 +176,9 @@ bool CCombinedKernel::init_with_extracted_subsets(
 		return false;
 	}
 
-	if (((CCombinedFeatures*)l)->get_num_feature_obj() <= 0 ||
-	    ((CCombinedFeatures*)l)->get_num_feature_obj() !=
-	        ((CCombinedFeatures*)r)->get_num_feature_obj())
+	if (l_combined->get_num_feature_obj() <= 0 ||
+	    l_combined->get_num_feature_obj() !=
+	        r_combined->get_num_feature_obj())
 		SG_ERROR(
 		    "CombinedKernel: Number of features/kernels does not match - "
 		    "bailing out\n")

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -84,8 +84,8 @@ bool CCombinedKernel::init_with_extracted_subsets(
 	CFeatures* rf = NULL;
 	CKernel* k = NULL;
 
-    auto l_combined = dynamic_cast<CCombinedFeatures*>(l);
-    auto r_combined = dynamic_cast<CCombinedFeatures*>(r);
+	auto l_combined = dynamic_cast<CCombinedFeatures*>(l);
+	auto r_combined = dynamic_cast<CCombinedFeatures*>(r);
 
 	bool result = true;
 	index_t f_idx = 0;
@@ -137,16 +137,16 @@ bool CCombinedKernel::init_with_extracted_subsets(
 				SG_ERROR(
 				    "No kernel matrix was assigned to this Custom kernel\n")
 
-            auto k_custom = dynamic_cast<CCustomKernel*>(k);
+			auto k_custom = dynamic_cast<CCustomKernel*>(k);
 
 			// clear all previous subsets
 			k_custom->remove_all_row_subsets();
 			// apply new subset
-            k_custom->add_row_subset(lhs_subset);
+			k_custom->add_row_subset(lhs_subset);
 
-            k_custom->remove_all_col_subsets();
+			k_custom->remove_all_col_subsets();
 			// apply new subset
-            k_custom->add_col_subset(rhs_subset);
+			k_custom->add_col_subset(rhs_subset);
 
 			if (k->get_num_vec_lhs() != num_lhs)
 				SG_ERROR(

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -159,7 +159,7 @@ bool CCombinedKernel::init(CFeatures* l, CFeatures* r)
                 //apply new subset
                 ((CCustomKernel*)k)->add_row_subset(lhs_subset);
             }
-            
+
             if (rhs_subset_stack->has_subsets()) {
                 auto rhs_subset = rhs_subset_stack->get_last_subset()->get_subset_idx();
                 //clear all previous subsets

--- a/src/shogun/kernel/CombinedKernel.h
+++ b/src/shogun/kernel/CombinedKernel.h
@@ -458,6 +458,16 @@ class CCombinedKernel : public CKernel
 
 	private:
 		void init();
+		/**
+		 * The purpose of this function is to make customkernels aware of any subsets present, regardless
+		 * whether the features passed are of type CCombinedFeatures or not
+		 * @param lhs combined features
+		 * @param rhs rombined features
+		 * @param lhs_subset subset present on lhs - pass identity subset if none
+		 * @param rhs_subset subset present on rhs - pass identity subset if none
+		 * @return init succesful
+		 */
+		bool init_with_extracted_subsets(CFeatures* lhs, CFeatures* rhs, SGVector<index_t> lhs_subset, SGVector<index_t> rhs_subset);
 
 	protected:
 		/** list of kernels */

--- a/src/shogun/kernel/CombinedKernel.h
+++ b/src/shogun/kernel/CombinedKernel.h
@@ -459,15 +459,20 @@ class CCombinedKernel : public CKernel
 	private:
 		void init();
 		/**
-		 * The purpose of this function is to make customkernels aware of any subsets present, regardless
-		 * whether the features passed are of type CCombinedFeatures or not
+		 * The purpose of this function is to make customkernels aware of any
+		 * subsets present, regardless whether the features passed are of type
+		 * CCombinedFeatures or not
 		 * @param lhs combined features
 		 * @param rhs rombined features
-		 * @param lhs_subset subset present on lhs - pass identity subset if none
-		 * @param rhs_subset subset present on rhs - pass identity subset if none
+		 * @param lhs_subset subset present on lhs - pass identity subset if
+		 * none
+		 * @param rhs_subset subset present on rhs - pass identity subset if
+		 * none
 		 * @return init succesful
 		 */
-		bool init_with_extracted_subsets(CFeatures* lhs, CFeatures* rhs, SGVector<index_t> lhs_subset, SGVector<index_t> rhs_subset);
+		bool init_with_extracted_subsets(
+		    CFeatures* lhs, CFeatures* rhs, SGVector<index_t> lhs_subset,
+		    SGVector<index_t> rhs_subset);
 
 	protected:
 		/** list of kernels */

--- a/tests/unit/kernel/CombinedKernel_unittest.cc
+++ b/tests/unit/kernel/CombinedKernel_unittest.cc
@@ -1,12 +1,12 @@
-#include <shogun/kernel/CombinedKernel.h>
-#include <shogun/kernel/GaussianKernel.h>
-#include <shogun/io/SerializableAsciiFile.h>
-#include <shogun/kernel/CustomKernel.h>
-#include <shogun/features/CombinedFeatures.h>
-#include <shogun/features/streaming/generators/MeanShiftDataGenerator.h>
-#include <shogun/features/DenseFeatures.h>
-#include <shogun/mathematics/Math.h>
 #include <gtest/gtest.h>
+#include <shogun/features/CombinedFeatures.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/features/streaming/generators/MeanShiftDataGenerator.h>
+#include <shogun/io/SerializableAsciiFile.h>
+#include <shogun/kernel/CombinedKernel.h>
+#include <shogun/kernel/CustomKernel.h>
+#include <shogun/kernel/GaussianKernel.h>
+#include <shogun/mathematics/Math.h>
 
 using namespace shogun;
 
@@ -42,13 +42,13 @@ TEST(CombinedKernelTest,test_array_operations)
 	SG_UNREF(combined);
 }
 
-TEST(CombinedKernelTest,test_subset_mixed)
+TEST(CombinedKernelTest, test_subset_mixed)
 {
 
-	CMeanShiftDataGenerator* gen=new CMeanShiftDataGenerator(0, 2);
-	CFeatures* feats=gen->get_streamed_features(10);
+	CMeanShiftDataGenerator* gen = new CMeanShiftDataGenerator(0, 2);
+	CFeatures* feats = gen->get_streamed_features(10);
 
-    CCombinedFeatures* cf = new CCombinedFeatures();
+	CCombinedFeatures* cf = new CCombinedFeatures();
 
 	CCombinedKernel* combined = new CCombinedKernel();
 
@@ -59,41 +59,46 @@ TEST(CombinedKernelTest,test_subset_mixed)
 	gaus_ck->init(feats, feats);
 
 	CCustomKernel* custom_1 = new CCustomKernel(gaus_ck);
-	CCustomKernel* custom_2 = new CCustomKernel(gaus_ck);;
+	CCustomKernel* custom_2 = new CCustomKernel(gaus_ck);
+	;
 
 	combined->append_kernel(custom_1);
 	combined->append_kernel(gaus_1);
-    cf->append_feature_obj(feats);
+	cf->append_feature_obj(feats);
 
 	combined->append_kernel(custom_2);
 	combined->append_kernel(gaus_2);
-    cf->append_feature_obj(feats);
+	cf->append_feature_obj(feats);
 
 	SGVector<index_t> inds(10);
 	inds.range_fill();
 
-	for (index_t i=0; i<10; ++i)
+	for (index_t i = 0; i < 10; ++i)
 	{
 		CMath::permute(inds);
 
 		cf->add_subset(inds);
-		combined->init(cf,cf);
+		combined->init(cf, cf);
 
 		CKernel* k_g = combined->get_kernel(1);
 		CKernel* k_0 = combined->get_kernel(0);
 		CKernel* k_3 = combined->get_kernel(2);
 
-		SGMatrix<float64_t> gauss_matrix=k_g->get_kernel_matrix();
-		SGMatrix<float64_t> custom_matrix_1=k_0->get_kernel_matrix();
-		SGMatrix<float64_t> custom_matrix_2=k_3->get_kernel_matrix();
+		SGMatrix<float64_t> gauss_matrix = k_g->get_kernel_matrix();
+		SGMatrix<float64_t> custom_matrix_1 = k_0->get_kernel_matrix();
+		SGMatrix<float64_t> custom_matrix_2 = k_3->get_kernel_matrix();
 
-		for (index_t j=0; j<10; ++j)
+		for (index_t j = 0; j < 10; ++j)
 		{
-            for (index_t k=0; k<10; ++k)
-            {
-                EXPECT_LE(CMath::abs(gauss_matrix(k,j) - custom_matrix_1(k,j)),1e-6);
-                EXPECT_LE(CMath::abs(gauss_matrix(k,j) - custom_matrix_2(k,j)),1e-6);
-            }
+			for (index_t k = 0; k < 10; ++k)
+			{
+				EXPECT_LE(
+				    CMath::abs(gauss_matrix(k, j) - custom_matrix_1(k, j)),
+				    1e-6);
+				EXPECT_LE(
+				    CMath::abs(gauss_matrix(k, j) - custom_matrix_2(k, j)),
+				    1e-6);
+			}
 		}
 
 		cf->remove_subset();
@@ -102,16 +107,16 @@ TEST(CombinedKernelTest,test_subset_mixed)
 		SG_UNREF(k_3);
 	}
 
-    SG_UNREF(gen);
+	SG_UNREF(gen);
 	SG_UNREF(gaus_ck);
 	SG_UNREF(combined);
 }
 
-TEST(CombinedKernelTest,test_subset_combined_only)
+TEST(CombinedKernelTest, test_subset_combined_only)
 {
 
-	CMeanShiftDataGenerator* gen=new CMeanShiftDataGenerator(0, 2);
-	CFeatures* feats=gen->get_streamed_features(10);
+	CMeanShiftDataGenerator* gen = new CMeanShiftDataGenerator(0, 2);
+	CFeatures* feats = gen->get_streamed_features(10);
 
 	CCombinedKernel* combined = new CCombinedKernel();
 
@@ -119,7 +124,8 @@ TEST(CombinedKernelTest,test_subset_combined_only)
 	gaus_ck->init(feats, feats);
 
 	CCustomKernel* custom_1 = new CCustomKernel(gaus_ck);
-	CCustomKernel* custom_2 = new CCustomKernel(gaus_ck);;
+	CCustomKernel* custom_2 = new CCustomKernel(gaus_ck);
+	;
 
 	combined->append_kernel(custom_1);
 	combined->append_kernel(custom_2);
@@ -127,28 +133,32 @@ TEST(CombinedKernelTest,test_subset_combined_only)
 	SGVector<index_t> inds(10);
 	inds.range_fill();
 
-	for (index_t i=0; i<10; ++i)
+	for (index_t i = 0; i < 10; ++i)
 	{
 		CMath::permute(inds);
 
 		feats->add_subset(inds);
-		combined->init(feats,feats);
-        gaus_ck->init(feats,feats);
+		combined->init(feats, feats);
+		gaus_ck->init(feats, feats);
 
 		CKernel* k_0 = combined->get_kernel(0);
 		CKernel* k_1 = combined->get_kernel(1);
 
-		SGMatrix<float64_t> gauss_matrix=gaus_ck->get_kernel_matrix();
-		SGMatrix<float64_t> custom_matrix_1=k_0->get_kernel_matrix();
-		SGMatrix<float64_t> custom_matrix_2=k_1->get_kernel_matrix();
+		SGMatrix<float64_t> gauss_matrix = gaus_ck->get_kernel_matrix();
+		SGMatrix<float64_t> custom_matrix_1 = k_0->get_kernel_matrix();
+		SGMatrix<float64_t> custom_matrix_2 = k_1->get_kernel_matrix();
 
-		for (index_t j=0; j<10; ++j)
+		for (index_t j = 0; j < 10; ++j)
 		{
-            for (index_t k=0; k<10; ++k)
-            {
-                EXPECT_LE(CMath::abs(gauss_matrix(k,j) - custom_matrix_1(k,j)),1e-6);
-                EXPECT_LE(CMath::abs(gauss_matrix(k,j) - custom_matrix_2(k,j)),1e-6);
-            }
+			for (index_t k = 0; k < 10; ++k)
+			{
+				EXPECT_LE(
+				    CMath::abs(gauss_matrix(k, j) - custom_matrix_1(k, j)),
+				    1e-6);
+				EXPECT_LE(
+				    CMath::abs(gauss_matrix(k, j) - custom_matrix_2(k, j)),
+				    1e-6);
+			}
 		}
 
 		feats->remove_subset();
@@ -156,7 +166,7 @@ TEST(CombinedKernelTest,test_subset_combined_only)
 		SG_UNREF(k_1);
 	}
 
-    SG_UNREF(gen);
+	SG_UNREF(gen);
 	SG_UNREF(gaus_ck);
 	SG_UNREF(combined);
 }
@@ -341,5 +351,3 @@ TEST(CombinedKernelTest,combination)
 	SG_UNREF(combined_list);
 	SG_UNREF(kernel_list);
 }
-
-


### PR DESCRIPTION
This PR addresses issue #3612, by allowing CombinedKernel init to properly subset CustomKernel subkernels. Hence CustomKernel should now work with mkl / x-validation

Test code used to verify the fix:
```
from shogun import *
from numpy import *

init_shogun_with_defaults()

feats_train=RealFeatures(random.rand(10,10))  
labels=BinaryLabels(array([1,1,1,1,1,-1,-1,-1,-1,-1]))   

kerg = GaussianKernel(2.0)

kerg.init(feats_train,feats_train)

ker1 = CustomKernel(kerg.get_kernel_matrix())
ker2 = GaussianKernel(2.0)

cker = CombinedKernel()

cker.append_kernel(ker1)
cker.append_kernel(ker2)

cft = CombinedFeatures()

cft.append_feature_obj(feats_train)
cft.append_feature_obj(feats_train)

cker.init(cft,cft)

libsvm = LibSVM()
svm = MKLClassification(libsvm)
svm.set_interleaved_optimization_enabled(False)
svm.set_kernel(cker)
svm.set_C_mkl(1000)
svm.set_mkl_norm(1)

splitting_strategy = StratifiedCrossValidationSplitting(labels, 3)
evaluation_criterium = AccuracyMeasure()
cross = CrossValidation(svm, cft, labels, splitting_strategy, evaluation_criterium)
cross.set_autolock(False)
cross.set_num_runs(2)

mkl_obs = ParameterObserverCV(True)
cross.subscribe_to_parameters(mkl_obs)

result = CrossValidationResult()
result = CrossValidationResult.obtain_from_generic(cross.evaluate())

obs = mkl_obs.get_observation(0)
fold = obs.get_fold(0)
machine = MKLClassification.obtain_from_generic(fold.get_trained_machine())

k = CombinedKernel.obtain_from_generic(machine.get_kernel())
k1 = k.get_kernel(0)
k2 = k.get_kernel(1)

print(k1.get_kernel_matrix())
print("\n")
print(k2.get_kernel_matrix())
print("\n")
print(k1.get_kernel_matrix()-k2.get_kernel_matrix())
```

Sample output for the test  to verify subsetting works properly:
`print(k1.get_kernel_matrix())`
```
[[ 1.          0.50979882  0.49804497  0.28813449  0.27958548  0.30324122]
 [ 0.50979882  1.          0.38971996  0.27236992  0.29889661  0.40002599]
 [ 0.49804497  0.38971996  1.          0.25557584  0.49059519  0.41748011]
 [ 0.28813449  0.27236992  0.25557584  1.          0.48876277  0.16951311]
 [ 0.27958548  0.29889661  0.49059519  0.48876277  1.          0.53417933]
 [ 0.30324122  0.40002599  0.41748011  0.16951311  0.53417933  1.        ]]
```
`print(k2.get_kernel_matrix())`
```
[[ 1.          0.50979884  0.49804496  0.28813448  0.27958548  0.30324122]
 [ 0.50979884  1.          0.38971996  0.27236991  0.29889661  0.400026  ]
 [ 0.49804496  0.38971996  1.          0.25557583  0.49059518  0.41748012]
 [ 0.28813448  0.27236991  0.25557583  1.          0.48876277  0.1695131 ]
 [ 0.27958548  0.29889661  0.49059518  0.48876277  1.          0.53417934]
 [ 0.30324122  0.400026    0.41748012  0.1695131   0.53417934  1.        ]]
```
`print(k1.get_kernel_matrix()-k2.get_kernel_matrix())`
```
[[  0.00000000e+00  -1.68008413e-08   6.80469564e-09   9.58425667e-09
   -2.85334684e-09   6.21391272e-11]
 [ -1.68008413e-08   0.00000000e+00   5.66272729e-09   1.40209140e-08
    3.09241743e-09  -3.52935375e-09]
 [  6.80469564e-09   5.66272729e-09   0.00000000e+00   3.50433216e-09
    1.25876629e-08  -1.27479330e-08]
 [  9.58425667e-09   1.40209140e-08   3.50433216e-09   0.00000000e+00
   -6.48492471e-09   6.75771872e-09]
 [ -2.85334684e-09   3.09241743e-09   1.25876629e-08  -6.48492471e-09
    0.00000000e+00  -9.37992795e-09]
 [  6.21391272e-11  -3.52935375e-09  -1.27479330e-08   6.75771872e-09
   -9.37992795e-09   0.00000000e+00]]
```
