### PR TITLE
Extend the meta-language to support keyword arguments

### DIFF
--- a/examples/meta/generator/generate.py
+++ b/examples/meta/generator/generate.py
@@ -69,8 +69,8 @@ def translateExamples(inputDir, outputDir, targetsDir, ctagsFile,
         # print("Translating {}".format(os.sep.join([dirRelative, filename])))
 
         # Parse the example file
-        filePath = os.path.join(dirRelative, filename)
-        with open(os.path.join(inputDir, dirRelative, filename), 'r') as file:
+        filePath = os.path.join(inputDir, dirRelative, filename)
+        with open(filePath, 'r') as file:
             ast = parse(file.read(), filePath, generatedFilesOutputDir)
 
         # Translate ast to each target language

--- a/examples/meta/generator/targets/cpp.json
+++ b/examples/meta/generator/targets/cpp.json
@@ -10,8 +10,14 @@
     "Statement": "$statement;\n",
     "Comment": "//$comment\n",
     "Init": {
-        "Construct": "auto $name = some<C$typeName>($arguments)",
-        "Copy": "auto $name = $expr",
+        "Construct": "auto $name = some<C$typeName>($arguments)$kwargs",
+        "Copy": "auto $name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": ";\n$elements",
+            "Element": "$name->put(\"$keyword\", $expr)",
+            "Separator": ";\n",
+            "InitialSeperatorWhenArgs>0": false
+        },
         "BoolVector": "auto $name = SGVector<bool>($arguments)",
         "CharVector": "auto $name = SGVector<char>($arguments)",
         "ByteVector": "auto $name = SGVector<uint8_t>($arguments)",

--- a/examples/meta/generator/targets/csharp.json
+++ b/examples/meta/generator/targets/csharp.json
@@ -3,8 +3,14 @@
     "Statement": "$statement;\n",
     "Comment": "//$comment\n",
     "Init": {
-        "Construct": "$typeName $name = new $typeName($arguments)",
-        "Copy": "$typeName $name = $expr",
+        "Construct": "$typeName $name = new $typeName($arguments)$kwargs",
+        "Copy": "$typeName $name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": ";\n$elements",
+            "Element": "$name.put(\"$keyword\", $expr)",
+            "Separator": ";\n",
+            "InitialSeperatorWhenArgs>0": false
+        },
         "CharVector": "var $name = new char[$arguments]",
         "ByteVector": "var $name = new byte[$arguments]",
         "WordVector": "var $name = new ushort[$arguments]",

--- a/examples/meta/generator/targets/java.json
+++ b/examples/meta/generator/targets/java.json
@@ -10,8 +10,14 @@
     "Statement": "$statement;\n",
     "Comment": "//$comment\n",
     "Init": {
-        "Construct": "$typeName $name = new $typeName($arguments)",
-        "Copy": "$typeName $name = $expr",
+        "Construct": "$typeName $name = new $typeName($arguments)$kwargs",
+        "Copy": "$typeName $name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": ";\n$elements",
+            "Element": "$name.put(\"$keyword\", $expr)",
+            "Separator": ";\n",
+            "InitialSeperatorWhenArgs>0": false
+        },
         "CharVector": "DoubleMatrix $name = new DoubleMatrix(1, $arguments)",
         "ByteVector": "DoubleMatrix $name = new DoubleMatrix(1, $arguments)",
         "WordVector": "DoubleMatrix $name = new DoubleMatrix(1, $arguments)",

--- a/examples/meta/generator/targets/lua.json
+++ b/examples/meta/generator/targets/lua.json
@@ -3,8 +3,14 @@
     "Statement": "$statement\n",
     "Comment": "--$comment\n",
     "Init": {
-        "Construct": "$name = shogun.$typeName($arguments)",
-        "Copy": "$name = $expr"
+        "Construct": "$name = shogun.$typeName($arguments)$kwargs",
+        "Copy": "$name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": "\n$elements",
+            "Element": "$name:put(\"$keyword\", $expr)",
+            "Separator": "\n",
+            "InitialSeperatorWhenArgs>0": false
+        }
     },
     "Assign": "$identifier = $expr",
     "Type": {

--- a/examples/meta/generator/targets/octave.json
+++ b/examples/meta/generator/targets/octave.json
@@ -3,8 +3,14 @@
     "Statement": "$statement;\n",
     "Comment": "%$comment\n",
     "Init": {
-        "Construct": "$name = $typeName($arguments)",
-        "Copy": "$name = $expr",
+        "Construct": "$name = $typeName($arguments)$kwargs",
+        "Copy": "$name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": ";\n$elements",
+            "Element": "$name.put(\"$keyword\", $expr)",
+            "Separator": ";\n",
+            "InitialSeperatorWhenArgs>0": false
+        },
         "CharVector": "$name = zeros(1, $arguments, 'char')",
         "ByteVector": "$name = zeros(1, $arguments, 'int8')",
         "WordVector": "$name = zeros(1, $arguments, 'int16')",

--- a/examples/meta/generator/targets/python.json
+++ b/examples/meta/generator/targets/python.json
@@ -12,8 +12,14 @@
     "Statement": "$statement\n",
     "Comment": "#$comment\n",
     "Init": {
-        "Construct": "$name = $typeName($arguments)",
-        "Copy": "$name = $expr",
+        "Construct": "$name = $typeName($arguments)$kwargs",
+        "Copy": "$name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": "\n$elements",
+            "Element": "$name.put(\"$keyword\", $expr)",
+            "Separator": "\n",
+            "InitialSeperatorWhenArgs>0": false
+        },
         "BoolVector": "$name = np.zeros( ($arguments), dtype='bool')",
         "CharVector": "$name = np.zeros( ($arguments), dtype='|S1')",
         "ByteVector": "$name = np.zeros( ($arguments), dtype='uint8')",

--- a/examples/meta/generator/targets/r.json
+++ b/examples/meta/generator/targets/r.json
@@ -3,8 +3,14 @@
     "Statement": "$statement\n",
     "Comment": "#$comment\n",
     "Init": {
-        "Construct": "$name <- $typeName($arguments)",
-        "Copy": "$name <- $expr"
+        "Construct": "$name <- $typeName($arguments)$kwargs",
+        "Copy": "$name <- $expr$kwargs",
+        "KeywordArguments": {
+            "List": "\n$elements",
+            "Element": "$name$$put('$keyword', $expr)",
+            "Separator": "\n",
+            "InitialSeperatorWhenArgs>0": false
+        }
     },
     "Assign": "$identifier <- $expr",
     "Type": {

--- a/examples/meta/generator/targets/ruby.json
+++ b/examples/meta/generator/targets/ruby.json
@@ -3,8 +3,14 @@
     "Statement": "$statement\n",
     "Comment": "#$comment\n",
     "Init": {
-        "Construct": "$name = Shogun::$typeName.new $arguments",
-        "Copy": "$name = $expr",
+        "Construct": "$name = Shogun::$typeName.new $arguments$kwargs",
+        "Copy": "$name = $expr$kwargs",
+        "KeywordArguments": {
+            "List": "\n$elements",
+            "Element": "$name.put \"$keyword\", $expr",
+            "Separator": "\n",
+            "InitialSeperatorWhenArgs>0": false
+        },
         "CharVector": "$name = NArray.byte($arguments)",
         "ByteVector": "$name = NArray.byte($arguments)",
         "WordVector": "$name = NArray.byte($arguments)",

--- a/examples/meta/src/meta_api/kwargs.sg
+++ b/examples/meta/src/meta_api/kwargs.sg
@@ -1,0 +1,38 @@
+# Keyword arguments are supported when constructing objects
+
+# Either when using factory functions:
+#Kernel k1 = kernel_factory(param=2)
+#Kernel k2 = kernel_factory("GaussianKernel", c=1.0)
+
+# Or when constructing objects from class constructors
+#SomeKernelClass k3(1, a=2, b=3)
+
+# This fails (keyword arguments appear before normal arguments)
+#Kernel k4(asd=123, "SomeParam", kw=val)
+
+# This fails (keywords not allowed outside initialisations of variables)
+#k4 = kernel_factory("GaussianKernel", b=2)
+
+# This fails (keywords not allowed outside initialisation of variables)
+#Kernel k5 = kernel_factory("GaussianKernel", a=glob_fun(kw=123))
+
+# This is fine:
+#Kernel k6 = kernel_factory("GaussianKernel", a=glob_fun(ordinary_argument))
+
+# This also fails (keywords not allowed outside initialisation variables)
+#kernel_factory("GaussianKernel", a=glob_fun(ordinary_argument))
+
+
+# Real example
+# ------------
+
+# The following lines fail in Octave because of a float literal issue
+#KernelMachine svm = kernel_machine("LibSVM", C1=2.0)
+#GaussianKernel k(log_width=2.0)
+#k.put("log_width", 4.0)
+
+# The following line fails in Python because of a bool literal issue
+#GaussianKernel k2(log_width=14.0, lhs_equals_rhs=True)
+
+# The following line currently gives a type error
+#svm.put("kernel", k)


### PR DESCRIPTION
Allows keyword arguments in class constructors and factory functions (when the factory function is called to set the value of a newly initialised variable).

The update in meta-language allows translation of statements like these (meta-language):
```
Kernel k = kernel_machine("SomeKernel", some_parameter=2)

Kernel k2(parameter=500)
```
**A)** To something like this (python)
```
k = kernel_machine("SomeKernel")
k.put("some_parameter", 2)

k2 = Kernel()
k2.put("parameter", 500)
```
**B)** Or something like this (python):
```
k = kernel_machine("SomeKernel", some_parameter=2)

k2 = Kernel(parameter=500)
```
# Changing from translation type A) to B)
To get A), the `targets/python.json` file should contain:
```
{
    ...
    "Init": {
        "Construct": "$name = $typeName($arguments)\n$kwargs",
        "Copy": "$name = $expr\n$kwargs",
        "KeywordArguments": {
            "List": "$elements",
            "Element": "$name.put(\"$keyword\",$expr)",
            "Separator": "\n",
            "InitialSeperatorWhenArgs>0": false
        },
        ...
    },
    ...
    "Expr": {
        ...
        "GlobalCall": "$method($arguments)",
        ...
    },
    ...
}
```

And to get B), the `targets/python.json` should contain:
```
{
    ...
    "Init": {
        "Construct": "$name = $typeName($arguments$kwargs)",
        "Copy": "$name = $expr",
        "KeywordArguments": {
            "List": "$elements",
            "Element": "$keyword=$expr",
            "Separator": ", ",
            "InitialSeperatorWhenArgs>0": true
        },
        ...
    },
    ...
    "Expr": {
        ...
        "GlobalCall": "$method($arguments$kwargs)",
        ...
    },
    ...
}
```

# Where do keyword arguments not work?

Keywords arguments cannot be used anywhere else than in class constructors to initiliase variables and global functions to initialise variables. See the following examples:
```
# Keyword arguments are supported when constructing objects

# Either when using factory functions:
Kernel k = kernel_machine(a=2)
Kernel k2 = kernel_machine("GaussianKernel", c=1.0)

# Or when constructing objects from class constructors
GaussianKernel k3(1, a=2, b=3)

# This fails (keyword arguments appear before normal arguments)
#Kernel k4(asd=123,"SomeParam",kw=val)

# This fails (keywords not allowed outside initialisations of variables. This is a re-assignment of a previously initialised variable)
#k4 = kernel_machine("GaussianKernel", b=2)

# This fails (keywords not allowed outside initialisation of variables. This is a nested kwarg, but it doesn't appear in the call that initialises `k6` directlry)
#Kernel k6 = kernel_machine("GaussianKernel", a=glob_fun(kw=123))

# This is fine:
Kernel k6 = kernel_machine("GaussianKernel", a=glob_fun(ordinary_argument))

# This also fails (both kwargs appear outside of variable initialisation)
#kernel_machine("GaussianKernel", a=glob_fun(kw=123))
```