### PR TITLE
Correct syntax for compatibilty with python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ def shogun_debug_information():
 
 
 def parse_shogun_version(version_header):
-    shogun_version_pattern = re.compile(ur'#define MAINVERSION \"([0-9]\.[0-9]\.[0-9])\"')
+    shogun_version_pattern = re.compile(r'#define MAINVERSION \"([0-9]\.[0-9]\.[0-9])\"')
 
     with open(version_header, 'r') as f:
         content = f.read()


### PR DESCRIPTION
The argument in line 127 for `re.compile()` doesn't need `u` flag as the argument has no Unicode letters used. Moreover, this shows as syntax error when run with python3 interpretor.
Removing `u` flag has no adverse consequences on the remaining setup process.