### PR TITLE
Add ammended correct path to versionstring_h

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup_py_location = os.path.abspath(os.path.dirname(__file__))
 
 shogun_build_directory = os.path.join(setup_py_location, 'build')
 shogun_generated_install = os.path.join(shogun_build_directory, 'install')
-shogun_versionstring_h = os.path.abspath('src/shogun/lib/versionstring.h')
+shogun_versionstring_h = os.path.join(shogun_generated_install, 'include/shogun/lib/versionstring.h')
 shogun_python_packages_location = None
 
 shogun_completed_cmake = False


### PR DESCRIPTION
On running setup.py, the following error is thrown:

`Traceback (most recent call last):
  File "setup.py", line 300, in <module>
    version = get_shogun_version(),
  File "setup.py", line 207, in get_shogun_version
    shogun_version = parse_shogun_version(shogun_versionstring_h)
  File "setup.py", line 130, in parse_shogun_version
    with open(version_header, 'r') as f:
IOError: [Errno 2] No such file or directory: 'src/shogun/lib/versionstring.h'`

Currently setup.py:iline 48, `shogun_versionstring_h` stores location to `src/shogun/lib/versionstring.h` that doesn't exists, either CMake fails to convert versionstring.h.in  to versionstring.h or it does convert, but it is stored in /build/install/include/shogun/lib/. I think the latter should be the case.  