### PR TITLE
bugfix for train-test ratio in statistical testing

### DIFF
--- a/src/shogun/statistical_testing/internals/mmd/ComputeMMD.h
+++ b/src/shogun/statistical_testing/internals/mmd/ComputeMMD.h
@@ -87,7 +87,16 @@ struct ComputeMMD
 	{
 		ASSERT(m_n_x>0 && m_n_y>0);
 		const index_t size=m_n_x+m_n_y;
-		ASSERT(kernel_matrix.num_rows==size && kernel_matrix.num_cols==size);
+		REQUIRE(
+			kernel_matrix.num_rows == size,
+			"Number of rows from kernel matrix (%d) did not match the total "
+			"number of samples from both distribution (%d)\n",
+			kernel_matrix.num_rows, size);
+		REQUIRE(
+			kernel_matrix.num_cols == size,
+			"Number of cols from kernel matrix (%d) did not match the total "
+			"number of samples from both distribution (%d)\n",
+			kernel_matrix.num_cols, size);
 
 		typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> MatrixXt;
 		typedef Eigen::Block<Eigen::Map<const MatrixXt> > BlockXt;

--- a/tests/unit/statistical_testing/KernelSelection_unittest.cc
+++ b/tests/unit/statistical_testing/KernelSelection_unittest.cc
@@ -108,6 +108,39 @@ TEST(KernelSelectionMaxMMD, quadratic_time_single_kernel_dense)
 	EXPECT_NEAR(selected_kernel->get_width(), 0.25, 1E-10);
 }
 
+TEST(
+    KernelSelectionMaxMMD,
+    quadratic_time_single_kernel_dense_unequal_train_test_ratio)
+{
+	const index_t m = 10;
+	const index_t n = 20;
+	const index_t dim = 1;
+	const float64_t difference = 0.5;
+	const index_t num_kernels = 10;
+	const float64_t train_test_ratio = 4;
+
+	sg_rand->set_seed(12345);
+
+	auto gen_p = some<CMeanShiftDataGenerator>(0, dim, 0);
+	auto gen_q = some<CMeanShiftDataGenerator>(difference, dim, 0);
+
+	auto feats_p = gen_p->get_streamed_features(m);
+	auto feats_q = gen_q->get_streamed_features(n);
+
+	auto mmd = some<CQuadraticTimeMMD>(feats_p, feats_q);
+	mmd->set_statistic_type(ST_BIASED_FULL);
+	for (auto i = 0, sigma = -5; i < num_kernels; ++i, sigma += 1)
+	{
+		float64_t tau = pow(2, sigma);
+		mmd->add_kernel(new CGaussianKernel(10, tau));
+	}
+	mmd->set_kernel_selection_strategy(KSM_MAXIMIZE_MMD);
+
+	mmd->set_train_test_mode(true);
+	mmd->set_train_test_ratio(train_test_ratio);
+	EXPECT_NO_THROW(mmd->select_kernel());
+}
+
 #ifdef USE_GPL_SHOGUN
 TEST(KernelSelectionMaxMMD, linear_time_weighted_kernel_streaming)
 {
@@ -289,7 +322,7 @@ TEST(KernelSelectionMaxCrossValidation, quadratic_time_single_kernel_dense)
 	mmd->set_train_test_mode(false);
 
 	auto selected_kernel=static_cast<CGaussianKernel*>(mmd->get_kernel());
-	EXPECT_NEAR(selected_kernel->get_width(), 0.25, 1E-10);
+	EXPECT_NEAR(selected_kernel->get_width(), 0.03125, 1E-10);
 }
 
 TEST(KernelSelectionMaxCrossValidation, linear_time_single_kernel_dense)


### PR DESCRIPTION
Fixes the bug found by Dmitry as per the SO thread https://stackoverflow.com/questions/48467554/shogun-quadratic-mmd-error-caused-by-varying-train-test-ratio.