### PR TITLE
Replace old clone tests with systematic new one

### DIFF
--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -351,6 +351,7 @@ T* SGMatrix<T>::clone_matrix(const T* matrix, int32_t nrows, int32_t ncols)
 	if (!matrix || !nrows || !ncols)
 		return nullptr;
 
+	REQUIRE(nrows > 0, "Number of rows (%d) has to be positive!\n", nrows);
 	REQUIRE(ncols > 0, "Number of cols (%d) has to be positive!\n", ncols);
 
 	auto size=int64_t(nrows)*ncols;

--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -351,7 +351,6 @@ T* SGMatrix<T>::clone_matrix(const T* matrix, int32_t nrows, int32_t ncols)
 	if (!matrix || !nrows || !ncols)
 		return nullptr;
 
-	REQUIRE(nrows > 0, "Number of rows (%d) has to be positive!\n", nrows);
 	REQUIRE(ncols > 0, "Number of cols (%d) has to be positive!\n", ncols);
 
 	auto size=int64_t(nrows)*ncols;

--- a/tests/unit/base/MockObject.h
+++ b/tests/unit/base/MockObject.h
@@ -23,6 +23,7 @@ namespace shogun
 			m_some_value = 1;
 
 			watch_param("some_value", &m_some_value);
+			m_parameters->add(&m_some_value, "some_value", "Some value");
 		}
 		const char* get_name() const override
 		{
@@ -38,9 +39,8 @@ namespace shogun
 
 		virtual CSGObject* clone() override
 		{
-			auto* clone = new CCloneEqualsMockParameter<T>();
-			clone->m_was_cloned = true;
-			SG_REF(clone);
+			auto* clone = CSGObject::clone();
+			((CCloneEqualsMockParameter*)clone)->m_was_cloned = true;
 			return clone;
 		}
 
@@ -75,11 +75,10 @@ namespace shogun
 		{
 			m_basic = 1;
 			watch_param("basic", &m_basic);
+			m_parameters->add(&m_basic, "basic", "The basic guy");
 
 			m_object = new CCloneEqualsMockParameter<T>();
 			watch_param("object", &m_object);
-
-			// TODO: delete once clone is based on tags
 			m_parameters->add(
 			    (CSGObject**)&m_object, "object", "The object (tm)");
 		}
@@ -94,10 +93,12 @@ namespace shogun
 			m_sg_vector = SGVector<T>(2);
 			m_sg_vector.set_const(m_basic);
 			watch_param("sg_vector", &m_sg_vector);
+			m_parameters->add(&m_sg_vector, "sg_vector", "The SGVector");
 
 			m_sg_matrix = SGMatrix<T>(3, 4);
 			m_sg_matrix.set_const(m_basic);
 			watch_param("sg_matrix", &m_sg_matrix);
+			m_parameters->add(&m_sg_matrix, "sg_matrix", "The SGMatrix");
 		}
 
 		void init_sg_sparse_vector_matrix()
@@ -111,6 +112,8 @@ namespace shogun
 				m_sg_sparse_vector.features[i] = entry;
 			}
 			watch_param("sg_sparse_vector", &m_sg_sparse_vector);
+			m_parameters->add(
+			    &m_sg_sparse_vector, "sg_sparse_vector", "The SGSparseVector");
 
 			m_sg_sparse_matrix =
 			    SGSparseMatrix<T>(m_sg_sparse_vector.num_feat_entries, 6);
@@ -127,6 +130,8 @@ namespace shogun
 				m_sg_sparse_matrix.sparse_matrix[i] = vec;
 			}
 			watch_param("sg_sparse_matrix", &m_sg_sparse_matrix);
+			m_parameters->add(
+			    &m_sg_sparse_matrix, "sg_sparse_matrix", "The SGSparseMatrix");
 		}
 
 		void init_raw_vector()
@@ -138,6 +143,9 @@ namespace shogun
 			watch_param(
 			    "raw_vector_basic", &m_raw_vector_basic,
 			    &m_raw_vector_basic_len);
+			m_parameters->add_vector(
+			    &m_raw_vector_basic, &m_raw_vector_basic_len,
+			    "raw_vector_basic", "The raw vector basic");
 
 			m_raw_vector_sg_string_len = 7;
 			m_raw_vector_sg_string =
@@ -151,6 +159,9 @@ namespace shogun
 			watch_param(
 			    "raw_vector_sg_string", &m_raw_vector_sg_string,
 			    &m_raw_vector_sg_string_len);
+			m_parameters->add_vector(
+			    &m_raw_vector_sg_string, &m_raw_vector_sg_string_len,
+			    "raw_vector_sg_string", "The raw vector sg_string");
 
 			m_raw_vector_object_len = 6;
 			m_raw_vector_object =
@@ -160,6 +171,9 @@ namespace shogun
 			watch_param(
 			    "raw_vector_object", &m_raw_vector_object,
 			    &m_raw_vector_object_len);
+			m_parameters->add_vector(
+			    (CSGObject***)&m_raw_vector_object, &m_raw_vector_object_len,
+			    "raw_vector_object", "The raw vector object");
 		}
 
 		void free_raw_vector()
@@ -187,6 +201,9 @@ namespace shogun
 			watch_param(
 			    "raw_matrix_basic", &m_raw_matrix_basic,
 			    &m_raw_matrix_basic_rows, &m_raw_matrix_basic_cols);
+			m_parameters->add_matrix(
+			    &m_raw_matrix_basic, &m_raw_matrix_basic_rows,
+			    &m_raw_matrix_basic_cols, "raw_matrix_basic", "The raw matrix");
 		}
 
 		void free_raw_matrix()

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -193,14 +193,7 @@ TYPED_TEST(SGObjectClone, basic)
 {
 	auto obj = some<CCloneEqualsMock<TypeParam>>();
 
-	CSGObject* clone = nullptr;
-	try
-	{
-		clone = obj->clone();
-	}
-	catch (...)
-	{
-	}
+	CSGObject* clone = obj->clone();
 
 	EXPECT_NE(clone, obj);
 	ASSERT_NE(clone, nullptr);

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -189,7 +189,7 @@ TEST(SGObjectEquals, different_type)
 	EXPECT_FALSE(obj2->equals(obj1));
 }
 
-TYPED_TEST(SGObjectClone, basic)
+TYPED_TEST(SGObjectClone, basic_checks)
 {
 	auto obj = some<CCloneEqualsMock<TypeParam>>();
 
@@ -201,7 +201,8 @@ TYPED_TEST(SGObjectClone, basic)
 
 	auto clone_casted = dynamic_cast<CCloneEqualsMock<TypeParam>*>(clone);
 	ASSERT_NE(clone_casted, nullptr);
-	ASSERT_NE(clone_casted->m_object, obj->m_object);
+
+	EXPECT_NE(clone_casted->m_object, obj->m_object);
 	EXPECT_EQ(clone_casted->m_object->m_was_cloned, true);
 
 	EXPECT_EQ(std::string(clone->get_name()), std::string(obj->get_name()));
@@ -209,64 +210,34 @@ TYPED_TEST(SGObjectClone, basic)
 	SG_UNREF(clone);
 }
 
-TEST(SGObject, clone_basic_parameter)
+TYPED_TEST(SGObjectClone, equals_empty)
 {
-	auto object = some<CGaussianKernel>();
-	object->put("log_width", 2.0);
-	ASSERT_EQ(object->get<float64_t>("log_width"), 2);
+	auto obj = some<CCloneEqualsMock<TypeParam>>();
 
-	auto clone = object->clone();
-	EXPECT_EQ(
-	    object->get<float64_t>("log_width"),
-	    clone->get<float64_t>("log_width"));
+	CSGObject* clone = obj->clone();
+	EXPECT_TRUE(clone->equals(obj));
+
+	SG_UNREF(clone);
 }
 
-TEST(SGObject, clone_sgmatrix_parameter)
+TYPED_TEST(SGObjectClone, equals_non_empty)
 {
-	SGMatrix<float64_t> data(10, 10);
-	for (auto i : range(data.num_rows * data.num_cols))
-		data.matrix[i] = CMath::randn_double();
+	auto obj = some<CCloneEqualsMock<TypeParam>>();
+	obj->m_basic -= 1;
+	obj->m_object->m_some_value -= 1;
+	obj->m_sg_vector[0] -= 1;
+	obj->m_sg_matrix(0, 0) = 0;
+	obj->m_sg_sparse_vector.features[0].entry -= 1;
+	obj->m_sg_sparse_matrix.sparse_matrix[0].features[0].entry -= 1;
+	obj->m_raw_vector_basic[0] -= 1;
+	obj->m_raw_matrix_basic[0] -= 1;
+	obj->m_raw_vector_sg_string[0].string[0] -= 1;
+	obj->m_raw_vector_object[0]->m_some_value -= 1;
 
-	auto object = some<CDenseFeatures<float64_t>>(data);
-	ASSERT_TRUE(data.equals(object->get_feature_matrix()));
+	CSGObject* clone = obj->clone();
+	EXPECT_TRUE(clone->equals(obj));
 
-	auto clone = object->clone();
-	EXPECT_NE(
-	    data.data(), clone->get<SGMatrix<float64_t>>("feature_matrix").data());
-	ASSERT_TRUE(data.equals(clone->get<SGMatrix<float64_t>>("feature_matrix")));
-}
-
-TEST(SGObject, clone_sgvector_parameter)
-{
-	SGVector<float64_t> data(10);
-	for (auto i : range(data.vlen))
-		data.vector[i] = CMath::randn_double();
-
-	auto object = some<CRegressionLabels>(data);
-	ASSERT_TRUE(data.equals(object->get_labels()));
-
-	auto clone = object->clone();
-	EXPECT_NE(data.data(), clone->get<SGVector<float64_t>>("labels").data());
-	EXPECT_TRUE(data.equals(clone->get<SGVector<float64_t>>("labels")));
-}
-
-TEST(SGObject, clone_sgobject_parameter)
-{
-	SGMatrix<float64_t> data(10, 10);
-	for (auto i : range(data.num_rows * data.num_cols))
-		data.matrix[i] = CMath::randn_double();
-
-	auto object_parameter = some<CDenseFeatures<float64_t>>(data);
-	auto object = some<CGaussianKernel>();
-	object->init(object_parameter, object_parameter);
-	ASSERT_TRUE(object_parameter->equals(object->get<CSGObject*>("lhs")));
-	ASSERT_TRUE(object_parameter->equals(object->get<CSGObject*>("rhs")));
-
-	auto clone = object->clone();
-	EXPECT_NE(object_parameter, clone->get<CSGObject*>("lhs"));
-	EXPECT_NE(object_parameter, clone->get<CSGObject*>("rhs"));
-	EXPECT_TRUE(object_parameter->equals(clone->get<CSGObject*>("lhs")));
-	EXPECT_TRUE(object_parameter->equals(clone->get<CSGObject*>("rhs")));
+	SG_UNREF(clone);
 }
 
 TEST(SGObject,DISABLED_ref_copy_constructor)


### PR DESCRIPTION
CSGObject::clone should be fully covered now i.e.

* all parameter combinations that are used in Shogun are cloned in the test
* after clone, object.equals(...) is true
* non-empty objects to make meaningful test