### PR TITLE
Fix platt scaling

### DIFF
--- a/examples/undocumented/libshogun/labels_binary_fit_sigmoid.cpp
+++ b/examples/undocumented/libshogun/labels_binary_fit_sigmoid.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <shogun/base/init.h>
+#include <shogun/evaluation/SigmoidCalibration.h>
 #include <shogun/labels/BinaryLabels.h>
 
 using namespace shogun;
@@ -12,16 +13,24 @@ using namespace shogun;
 void test_sigmoid_fitting()
 {
 	CBinaryLabels* labels=new CBinaryLabels(10);
+	CBinaryLabels* predictions = new CBinaryLabels(10);
 	labels->set_values(SGVector<float64_t>(labels->get_num_labels()));
 
 	for (index_t i=0; i<labels->get_num_labels(); ++i)
-		labels->set_value(i%2==0 ? 1 : -1, i);
+	{
+		predictions->set_value(i % 2 == 0 ? 1 : -1, i);
+		labels->set_value(i % 4 == 0 ? 1 : -1, i);
+	}
+	predictions->get_values().display_vector("scores");
+	CSigmoidCalibration* sigmoid_calibration = new CSigmoidCalibration();
+	sigmoid_calibration->fit_binary(predictions, labels);
+	CBinaryLabels* calibrated_labels =
+	    sigmoid_calibration->calibrate_binary(predictions);
+	calibrated_labels->get_values().display_vector("probabilities");
 
-	labels->get_values().display_vector("scores");
-	labels->scores_to_probabilities();
-	labels->get_values().display_vector("probabilities");
-
-
+	SG_UNREF(predictions);
+	SG_UNREF(sigmoid_calibration);
+	SG_UNREF(calibrated_labels);
 	SG_UNREF(labels);
 }
 

--- a/src/shogun/evaluation/Calibration.h
+++ b/src/shogun/evaluation/Calibration.h
@@ -1,0 +1,69 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann, Dhruv Arya
+ */
+
+#ifndef _CALIBRATION_H__
+#define _CALIBRATION_H__
+
+#include <shogun/lib/config.h>
+
+#include <shogun/machine/Machine.h>
+
+namespace shogun
+{
+	/** @brief Base class for all calibration methods. Call fit_binary() or
+	fit_multiclass() to
+	fit the parameters on the predictions and the true labels. Call calibrate to
+	calibrate predictions. **/
+	class CCalibration : public CSGObject
+	{
+	public:
+		/** Constructor. */
+		CCalibration()
+		{
+		}
+		/** Destructor. */
+		virtual ~CCalibration()
+		{
+		}
+
+		virtual const char* get_name() const
+		{
+			return "Calibration";
+		}
+
+		/** Fit calibration parameters for binary labels.
+		* @param predictions The predictions outputted by the machine
+		* @param targets The true labels corresponding to the predictions
+		* @return Indicates whether the calibration was succesful
+		**/
+		virtual bool
+		fit_binary(CBinaryLabels* predictions, CBinaryLabels* targets) = 0;
+
+		/** Calibrate binary predictions based on parameters learned by calling
+		*fit.
+		* @param predictions The predictions outputted by the machine
+		* @return Calibrated binary labels
+		**/
+		virtual CBinaryLabels* calibrate_binary(CBinaryLabels* predictions) = 0;
+
+		/** Fit calibration parameters for multiclass labels.
+		* @param predictions The predictions outputted by the machine
+		* @param targets The true labels corresponding to the predictions
+		* @return Indicates whether the calibration was succesful
+		**/
+		virtual bool fit_multiclass(
+		    CMulticlassLabels* predictions, CMulticlassLabels* targets) = 0;
+
+		/** Calibrate multiclass predictions based on parameters learned by
+		*calling fit.
+		* @param predictions The predictions outputted by the machine
+		* @return Calibrated binary labels
+		**/
+		virtual CMulticlassLabels*
+		calibrate_multiclass(CMulticlassLabels* predictions) = 0;
+	};
+}
+#endif

--- a/src/shogun/evaluation/SigmoidCalibration.cpp
+++ b/src/shogun/evaluation/SigmoidCalibration.cpp
@@ -1,0 +1,202 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann, Dhruv Arya
+ */
+
+#include <shogun/evaluation/SigmoidCalibration.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/Statistics.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
+
+using namespace shogun;
+
+CSigmoidCalibration::CSigmoidCalibration() : CCalibration()
+{
+	init();
+}
+
+CSigmoidCalibration::~CSigmoidCalibration()
+{
+}
+
+void CSigmoidCalibration::init()
+{
+	m_maxiter = 100;
+	m_minstep = 1E-10;
+	m_sigma = 1E-12;
+	m_epsilon = 1E-5;
+
+	SG_ADD(
+	    &m_sigmoid_as, "m_sigmoid_as",
+	    "Vector of paramter A of sigmoid for each class.", MS_NOT_AVAILABLE);
+	SG_ADD(
+	    &m_sigmoid_bs, "m_sigmoid_bs",
+	    "Vector of paramter B of sigmoid for each class.", MS_NOT_AVAILABLE);
+	SG_ADD(
+	    &m_maxiter, "m_maxiter", "Maximum number of iteration for search.",
+	    MS_NOT_AVAILABLE);
+	SG_ADD(
+	    &m_minstep, "m_minstep", "Minimum step taken in line search.",
+	    MS_NOT_AVAILABLE);
+	SG_ADD(
+	    &m_sigma, "m_sigma",
+	    "Positive parameter to ensure positive semi-definite Hessian.",
+	    MS_NOT_AVAILABLE);
+	SG_ADD(&m_epsilon, "m_epsilon", "Stopping criteria.", MS_NOT_AVAILABLE);
+}
+
+void CSigmoidCalibration::set_maxiter(index_t maxiter)
+{
+	m_maxiter = maxiter;
+}
+
+index_t CSigmoidCalibration::get_maxiter()
+{
+	return m_maxiter;
+}
+
+void CSigmoidCalibration::set_minstep(float64_t minstep)
+{
+	m_minstep = minstep;
+}
+
+float64_t CSigmoidCalibration::get_minstep()
+{
+	return m_minstep;
+}
+
+void CSigmoidCalibration::set_sigma(float64_t sigma)
+{
+	m_sigma = sigma;
+}
+
+float64_t CSigmoidCalibration::get_sigma()
+{
+	return m_sigma;
+}
+
+void CSigmoidCalibration::set_epsilon(float64_t epsilon)
+{
+	m_epsilon = epsilon;
+}
+
+float64_t CSigmoidCalibration::get_epsilon()
+{
+	return m_epsilon;
+}
+
+bool CSigmoidCalibration::fit_binary(
+    CBinaryLabels* predictions, CBinaryLabels* targets)
+{
+	m_sigmoid_as.resize_vector(1);
+	m_sigmoid_bs.resize_vector(1);
+	auto sigmoid_params = CStatistics::fit_sigmoid(
+	    predictions->get_values(), targets->get_labels(), m_maxiter, m_minstep,
+	    m_sigma, m_epsilon);
+
+	m_sigmoid_as[0] = sigmoid_params.a;
+	m_sigmoid_bs[0] = sigmoid_params.b;
+
+	return true;
+}
+
+CBinaryLabels* CSigmoidCalibration::calibrate_binary(CBinaryLabels* predictions)
+{
+	REQUIRE(
+	    m_sigmoid_as.size() == 1,
+	    "Parameters not fitted, which need to be fitted before calibrating.\n");
+	CStatistics::SigmoidParamters params;
+	params.a = m_sigmoid_as[0];
+	params.b = m_sigmoid_bs[0];
+
+	auto probabilities = calibrate_values(predictions->get_values(), params);
+
+	CBinaryLabels* calibrated_predictions = new CBinaryLabels(probabilities);
+
+	return calibrated_predictions;
+}
+
+bool CSigmoidCalibration::fit_multiclass(
+    CMulticlassLabels* predictions, CMulticlassLabels* targets)
+{
+	index_t num_classes = predictions->get_num_classes();
+
+	m_sigmoid_as.resize_vector(num_classes);
+	m_sigmoid_bs.resize_vector(num_classes);
+
+	for (index_t i = 0; i < num_classes; ++i)
+	{
+		auto class_targets = targets->get_binary_for_class(i);
+		auto pred_values = predictions->get_confidences_for_class(i);
+		auto target_labels = class_targets->get_labels();
+
+		auto sigmoid_params = CStatistics::fit_sigmoid(
+		    pred_values, target_labels, m_maxiter, m_minstep, m_sigma,
+		    m_epsilon);
+		m_sigmoid_as[i] = sigmoid_params.a;
+		m_sigmoid_bs[i] = sigmoid_params.b;
+
+		SG_UNREF(class_targets);
+	}
+
+	return true;
+}
+
+CMulticlassLabels*
+CSigmoidCalibration::calibrate_multiclass(CMulticlassLabels* predictions)
+{
+	index_t num_classes = predictions->get_num_classes();
+	index_t num_samples = predictions->get_num_labels();
+	REQUIRE(
+	    m_sigmoid_as.size() == num_classes,
+	    "Parameters not fitted, which need to be fitted before calibrating.\n");
+
+	/** Temporarily stores the probabilities. */
+	SGMatrix<float64_t> confidence_values(num_samples, num_classes);
+
+	for (index_t i = 0; i < num_classes; ++i)
+	{
+		auto class_values = predictions->get_confidences_for_class(i);
+
+		CStatistics::SigmoidParamters sigmoid_params;
+		sigmoid_params.a = m_sigmoid_as[i];
+		sigmoid_params.b = m_sigmoid_bs[i];
+
+		SGVector<float64_t> calibrated_values =
+		    calibrate_values(class_values, sigmoid_params);
+
+		confidence_values.set_column(i, calibrated_values);
+	}
+
+	auto result_labels = new CMulticlassLabels(num_samples);
+	result_labels->allocate_confidences_for(num_classes);
+
+	/** Normalize the probabilities. */
+	for (index_t i = 0; i < num_samples; ++i)
+	{
+		SGVector<float64_t> values = confidence_values.get_row_vector(i);
+		float64_t sum = SGVector<float64_t>::sum(values);
+
+		/** All classes have equal probability when sum is zero */
+		if (sum == 0)
+			linalg::add_scalar(values, 1. / (float64_t)num_classes);
+		else
+			linalg::scale(values, values, 1 / sum);
+		result_labels->set_multiclass_confidences(i, values);
+	}
+	return result_labels;
+}
+
+SGVector<float64_t> CSigmoidCalibration::calibrate_values(
+    SGVector<float64_t> values, CStatistics::SigmoidParamters params)
+{
+	/** Calibrate values by passing them to a sigmoid function. */
+	for (index_t i = 0; i < values.vlen; ++i)
+	{
+		float64_t fApB = values[i] * params.a + params.b;
+		values[i] = fApB >= 0 ? CMath::exp(-fApB) / (1.0 + CMath::exp(-fApB))
+		                      : 1.0 / (1 + CMath::exp(fApB));
+	}
+	return values;
+}

--- a/src/shogun/evaluation/SigmoidCalibration.h
+++ b/src/shogun/evaluation/SigmoidCalibration.h
@@ -1,0 +1,144 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann, Dhruv Arya
+ */
+
+#ifndef _SIGMOID_CALIBRATION_H__
+#define _SIGMOID_CALIBRATION_H__
+
+#include <shogun/lib/config.h>
+
+#include <shogun/evaluation/Calibration.h>
+#include <shogun/mathematics/Statistics.h>
+
+namespace shogun
+{
+	/** @brief Calibrates labels based on Platt Scaling [1]. Note that first
+	* calibration parameters need to be fitted by
+	* calling fit_binary() or fit_multiclass(). Then call calibrate on
+	* calibrate_binary() or calibrate_multiclass() on
+	* labels to calibrate them.
+	* Usually this done using the training data and labels.
+	* [1] Platt J. Probabilistic outputs for support vector machines and
+	* comparisons to regularized likelihood methods.
+	* Advances in large margin classifiers. 1999
+	*/
+	class CSigmoidCalibration : public CCalibration
+	{
+	public:
+		/** Constructor. */
+		CSigmoidCalibration();
+
+		/** Destructor. */
+		virtual ~CSigmoidCalibration();
+
+		/** Get name. */
+		virtual const char* get_name() const
+		{
+			return "SigmoidCalibration";
+		}
+
+		/** Fit sigmoid parameters for binary labels.
+		* @param predictions The predictions outputted by the machine
+		* @param targets The true labels corresponding to the predictions
+		* @return Indicates whether the calibration was succesful
+		**/
+		virtual bool
+		fit_binary(CBinaryLabels* predictions, CBinaryLabels* targets);
+
+		/** Calibrate binary predictions based on parameters learned by calling
+		*fit.
+		* @param predictions The predictions outputted by the machine
+		* @return Calibrated binary labels
+		**/
+		virtual CBinaryLabels* calibrate_binary(CBinaryLabels* predictions);
+
+		/** Fit calibration parameters for multiclass labels. Fits sigmoid
+		* parameters for each class seperately.
+		* @param predictions The predictions outputted by the machine
+		* @param targets The true labels corresponding to the predictions
+		* @return Indicates whether the calibration was succesful
+		**/
+		virtual bool fit_multiclass(
+		    CMulticlassLabels* predictions, CMulticlassLabels* targets);
+
+		/** Calibrate multiclass predictions based on parameters learned by
+		*calling fit.
+		* The predictions are normalized over all classes.
+		* @param predictions The predictions outputted by the machine
+		* @return Calibrated binary labels
+		**/
+		virtual CMulticlassLabels*
+		calibrate_multiclass(CMulticlassLabels* predictions);
+
+		/** Set maximum number of iterations
+		* @param maxiter maximum number of iterations
+		*/
+		void set_maxiter(index_t maxiter);
+
+		/** Get max iterations
+		* @return maximum number of iterations
+		*/
+		index_t get_maxiter();
+
+		/** Set min step
+		* @param minstep min step taken in line search
+		*/
+		void set_minstep(float64_t minstep);
+
+		/** Get min step
+		* @return minimum steps taken in line search
+		*/
+		float64_t get_minstep();
+
+		/** Set sigma
+		* @param sigma Set to a value greater than 0 to ensure that the Hessian
+		* matrix is positive semi-definite
+		*/
+		void set_sigma(float64_t sigma);
+
+		/** Get sigma
+		* @return sigma
+		*/
+		float64_t get_sigma();
+
+		/** Get epsilon
+		* @param epsilon stopping criteria
+		*/
+		void set_epsilon(float64_t epsilon);
+
+		/** Get epsilon
+		* @return stopping critera
+		*/
+		float64_t get_epsilon();
+
+	private:
+		/** Initialize parameters */
+		void init();
+
+		/** Helper function that calibrates values of given vector using the
+		* given sigmoid parameters
+		* @param values The values to be calibrated
+		* @param params The sigmoid paramters to be used for calibration
+		*/
+		SGVector<float64_t> calibrate_values(
+		    SGVector<float64_t> values, CStatistics::SigmoidParamters params);
+
+	private:
+		/** Stores parameter A of sigmoid for each class. In case of binary
+		 * labels, only one pair of parameters are stored. */
+		SGVector<float64_t> m_sigmoid_as;
+		/** Stores parameter B of sigmoid for each class. */
+		SGVector<float64_t> m_sigmoid_bs;
+		/** Maximum number of iterations. */
+		index_t m_maxiter;
+		/** Minimum step taken in line search. */
+		float64_t m_minstep;
+		/** Positive number to ensure positive semi-definite Hessian matrix */
+		float64_t m_sigma;
+		/** Stopping criteria of search */
+		float64_t m_epsilon;
+	};
+}
+#endif

--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -71,6 +71,20 @@ void CMulticlassLabels::allocate_confidences_for(int32_t n_classes)
 	m_multiclass_confidences = SGMatrix<float64_t>(n_classes,n_labels);
 }
 
+SGVector<float64_t> CMulticlassLabels::get_confidences_for_class(int32_t i)
+{
+	REQUIRE(
+	    (m_multiclass_confidences.num_rows != 0) &&
+	        (m_multiclass_confidences.num_cols != 0),
+	    "Empty confidences, which need to be allocated before fetching.\n");
+
+	SGVector<float64_t> confs(m_multiclass_confidences.num_cols);
+	for (index_t j = 0; j < confs.size(); j++)
+		confs[j] = m_multiclass_confidences(i, j);
+
+	return confs;
+}
+
 void CMulticlassLabels::ensure_valid(const char* context)
 {
     CDenseLabels::ensure_valid(context);

--- a/src/shogun/labels/MulticlassLabels.h
+++ b/src/shogun/labels/MulticlassLabels.h
@@ -127,6 +127,12 @@ class CMulticlassLabels : public CDenseLabels
 		 */
 		void allocate_confidences_for(int32_t n_classes);
 
+		/** Returns confidence scores for given class
+		* @param i Class index
+		* @return Confidences of class i
+		*/
+		SGVector<float64_t> get_confidences_for_class(int32_t i);
+
 		/** @return object name */
 		virtual const char* get_name() const { return "MulticlassLabels"; }
 #ifndef SWIG // SWIG should skip this part

--- a/src/shogun/mathematics/Statistics.h
+++ b/src/shogun/mathematics/Statistics.h
@@ -295,7 +295,33 @@ public:
 		float64_t b;
 	};
 
-	/** Converts a given vector of scores to calibrated probabilities by fitting a
+	/** Converts a given vector of scores to calibrated probabilities by fitting
+	 * a
+	 * sigmoid function using the method described in
+	 * Lin, H., Lin, C., and Weng, R. (2007).
+	 * A note on Platt's probabilistic outputs for support vector machines.
+	 *
+	 * This can be used to transform scores to probabilities as setting
+	 * \f$pf=x*a+b\f$ for a given score \f$x\f$ and computing
+	 * \f$\frac{\exp(-f)}{1+}exp(-f)}\f$ if \f$f\geq 0\f$ and
+	 * \f$\frac{1}{(1+\exp(f)}\f$ otherwise
+	 *
+	 * @param scores uncalibrated scores
+	 * @param labels ground truth labels
+	 * @param maxiter maximum number of iterations
+	 * @param minstep minimum step taken in line search
+	 * @param sigma set to a value greater than zero to ensure that Hessian
+	 * matrix is positive semi-definite
+	 * @param eps stopping criteria
+	 * @return struct containing the sigmoid's shape parameters a and b
+	 */
+	static SigmoidParamters fit_sigmoid(
+		SGVector<float64_t> scores, SGVector<float64_t> labels,
+		index_t maxiter = 100, float64_t minstep = 1E-10,
+		float64_t sigma = 1E-12, float64_t eps = 1E-5);
+
+	/** Converts a given vector of scores to calibrated probabilities by fitting
+	 * a
 	 * sigmoid function using the method described in
 	 * Lin, H., Lin, C., and Weng, R. (2007).
 	 * A note on Platt's probabilistic outputs for support vector machines.

--- a/tests/unit/evaluation/SigmoidCalibration_unittest.cc
+++ b/tests/unit/evaluation/SigmoidCalibration_unittest.cc
@@ -1,0 +1,123 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann, Dhruv Arya
+ */
+#include <gtest/gtest.h>
+#include <shogun/evaluation/SigmoidCalibration.h>
+
+using namespace shogun;
+
+TEST(SigmoidCalibrationTest, binary_calibration)
+{
+	CMath::init_random(8);
+	SGVector<float64_t> preds(10), labs(10);
+
+	preds.vector[0] = 0.6;
+	preds.vector[1] = -0.2;
+	preds.vector[2] = 0.7;
+	preds.vector[3] = 0.9;
+	preds.vector[4] = -0.1;
+	preds.vector[5] = -0.3;
+	preds.vector[6] = 0.9;
+	preds.vector[7] = 0.6;
+	preds.vector[8] = -0.3;
+	preds.vector[9] = 0.7;
+
+	labs.vector[0] = 1;
+	labs.vector[1] = -1;
+	labs.vector[2] = 1;
+	labs.vector[3] = 1;
+	labs.vector[4] = -1;
+	labs.vector[5] = -1;
+	labs.vector[6] = 1;
+	labs.vector[7] = 1;
+	labs.vector[8] = -1;
+	labs.vector[9] = -1;
+
+	CBinaryLabels* predictions = new CBinaryLabels(preds);
+	CBinaryLabels* labels = new CBinaryLabels(labs);
+	SG_REF(predictions)
+	CSigmoidCalibration* sigmoid_calibration = new CSigmoidCalibration();
+	auto calibrated = sigmoid_calibration->fit_binary(predictions, labels);
+	EXPECT_EQ(calibrated, true);
+	auto calibrated_labels = sigmoid_calibration->calibrate_binary(predictions);
+	auto values = calibrated_labels->get_values();
+
+	EXPECT_EQ(values[0], 0.656628663983293337);
+	EXPECT_EQ(values[1], 0.159375349583615822);
+	EXPECT_EQ(values[2], 0.718534704684106407);
+	EXPECT_EQ(values[3], 0.819801347075004516);
+	EXPECT_EQ(values[4], 0.201976857736835741);
+	EXPECT_EQ(values[5], 0.124359200656053326);
+	EXPECT_EQ(values[6], 0.819801347075004516);
+	EXPECT_EQ(values[7], 0.656628663983293337);
+	EXPECT_EQ(values[8], 0.124359200656053326);
+	EXPECT_EQ(values[9], 0.718534704684106407);
+
+	SG_UNREF(sigmoid_calibration)
+	SG_UNREF(predictions)
+	SG_UNREF(labels)
+	SG_UNREF(calibrated_labels)
+}
+
+TEST(SigmoidCalibrationTest, multiclass_calibration)
+{
+	index_t num_vec = 10;
+	index_t num_class = 3;
+
+	double preds[] = {
+	    3.58412386,  -1.85426031, -3.01727279, 3.26476717,  -4.29277837,
+	    -0.97842984, 3.71045102,  -2.87473617, -2.39465561, 0.50210539,
+	    -0.90306753, -0.96823852, -0.23000778, 0.8901302,   -1.60981499,
+	    -0.82280503, -6.85573966, 4.49250544,  2.51249731,  -1.9841395,
+	    -1.97320905, -2.51812929, 2.75936145,  -0.9259119,  -0.92123693,
+	    1.95678501,  -1.76459559, -1.30939982, 1.79817245,  -1.30609521};
+
+	SGVector<float64_t> tgt({0, 0, 0, 0, 1, 2, 0, 1, 1, 1});
+
+	CMulticlassLabels* predictions = new CMulticlassLabels(tgt);
+	CMulticlassLabels* targets = new CMulticlassLabels(tgt);
+	predictions->allocate_confidences_for(num_class);
+
+	for (index_t i = 0; i < num_vec; i++)
+	{
+		SGVector<float64_t> confs(num_class);
+
+		for (index_t j = 0; j < num_class; j++)
+		{
+			confs[j] = preds[i * num_class + j];
+		}
+
+		predictions->set_multiclass_confidences(i, confs);
+	}
+	auto calibration_method = new CSigmoidCalibration();
+
+	auto calibrated = calibration_method->fit_multiclass(predictions, targets);
+
+	EXPECT_EQ(calibrated, true);
+
+	auto calib_result = calibration_method->calibrate_multiclass(predictions);
+
+	float64_t expected_probs[] = {
+	    0.75674645, 0.20144443, 0.04180912, 0.82689269, 0.05965391, 0.11345341,
+	    0.81409222, 0.12715657, 0.05875121, 0.48765218, 0.38500051, 0.12734731,
+	    0.31003506, 0.60319518, 0.08676976, 0.26630134, 0.01476002, 0.71893864,
+	    0.72470815, 0.20387599, 0.07141586, 0.074445,   0.80897488, 0.11658012,
+	    0.20620103, 0.71452701, 0.07927195, 0.16983872, 0.72947987, 0.10068142};
+
+	for (index_t i = 0; i < num_vec; i++)
+	{
+		auto vals = calib_result->get_multiclass_confidences(i);
+
+		for (index_t j = 0; j < vals.size(); j++)
+		{
+			EXPECT_NEAR(vals[j], expected_probs[i * num_class + j], 1E-5);
+		}
+	}
+
+	SG_UNREF(predictions);
+	SG_UNREF(targets);
+	SG_UNREF(calibration_method);
+	SG_UNREF(calib_result);
+}

--- a/tests/unit/labels/BinaryLabels_unittest.cc
+++ b/tests/unit/labels/BinaryLabels_unittest.cc
@@ -35,27 +35,6 @@ public:
 	}
 };
 
-TEST_F(BinaryLabels, scores_to_probabilities)
-{
-	CBinaryLabels* labels=new CBinaryLabels(10);
-	labels->set_values(SGVector<float64_t>(labels->get_num_labels()));
-
-	for (index_t i=0; i<labels->get_num_labels(); ++i)
-		labels->set_value(i%2==0 ? 1 : -1, i);
-
-	//labels->get_values().display_vector("scores");
-	// call with 0,0 to make the method compute sigmoid parameters itself
-	// g-test somehow does not allow std parameters
-	labels->scores_to_probabilities(0,0);
-
-	/* only two probabilities will be the result. Results from implementation that
-	 * comes with the original paper, see BinaryLabels documentation */
-	EXPECT_NEAR(labels->get_value(0), 0.8571428439385661, 10E-15);
-	EXPECT_NEAR(labels->get_value(1), 0.14285715606143384, 10E-15);
-
-	SG_UNREF(labels);
-}
-
 TEST_F(BinaryLabels, serialization)
 {
 	CBinaryLabels* labels = new CBinaryLabels(10);

--- a/tests/unit/mathematics/Statistics_unittest.cc
+++ b/tests/unit/mathematics/Statistics_unittest.cc
@@ -17,18 +17,34 @@ using namespace Eigen;
 
 TEST(Statistics, fit_sigmoid)
 {
-	SGVector<float64_t> scores(10);
+	SGVector<float64_t> predictions(10), targets(10);
 
-	for (index_t i=0; i<scores.vlen; ++i)
-		scores[i]=i%2==0 ? 1 : -1;
+	predictions.vector[0] = 0.6;
+	predictions.vector[1] = -0.2;
+	predictions.vector[2] = 0.7;
+	predictions.vector[3] = 0.9;
+	predictions.vector[4] = -0.1;
+	predictions.vector[5] = -0.3;
+	predictions.vector[6] = 0.9;
+	predictions.vector[7] = 0.6;
+	predictions.vector[8] = -0.3;
+	predictions.vector[9] = 0.7;
 
-	CStatistics::SigmoidParamters params=CStatistics::fit_sigmoid(scores);
+	targets.vector[0] = 1;
+	targets.vector[1] = -1;
+	targets.vector[2] = 1;
+	targets.vector[3] = 1;
+	targets.vector[4] = -1;
+	targets.vector[5] = -1;
+	targets.vector[6] = 1;
+	targets.vector[7] = 1;
+	targets.vector[8] = -1;
+	targets.vector[9] = -1;
 
-	// compare against python implementation of john plat's algoorithm
-	//	SG_SPRINT("a=%f, b=%f\n", params.a, params.b);
+	auto params = CStatistics::fit_sigmoid(predictions, targets);
 
-	EXPECT_NEAR(params.a, -1.791759, 1E-5);
-	EXPECT_NEAR(params.b, 0.000000, 10E-5);
+	EXPECT_NEAR(params.a, -2.88898665372199437, 1E-5);
+	EXPECT_NEAR(params.b, 1.0850855568530737, 1E-5);
 }
 
 // TEST 1


### PR DESCRIPTION
This PR fixes platt scaling and adds new classes SigmoidCalibration and Calibration. Previously, `fit_sigmoid` was only using the predictions to fit parameters which is incorrect. SigmoidCalibration has been added so that `score_to_probabilites` from `CBinaryLabels` can be removed. This will make the x-validated calibration API cleaner (#4009 ). The old `fit_sigmoid` and `scores_to_probabilities` have still not be removed since they are still needed in multiclass calibration. It would probably be safe to remove them after fixing #4164 