### PR TITLE
Meta examples: add functionality for special translations of certain method calls

### DIFF
--- a/examples/meta/generator/targets/cpp.json
+++ b/examples/meta/generator/targets/cpp.json
@@ -90,7 +90,10 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "${number}f",
-        "MethodCall": "$object->$method($arguments)",
+        "MethodCall": {
+            "Default": "$object->$method($arguments)",
+            "get_real": "$object->get<float64_t>($arguments)"
+        },
         "StaticCall": "C$typeName::$method($arguments)",
         "GlobalCall": "$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/csharp.json
+++ b/examples/meta/generator/targets/csharp.json
@@ -74,7 +74,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "${number}f",
-        "MethodCall": "$object.$method($arguments)",
+        "MethodCall": {
+            "Default": "$object.$method($arguments)"
+        },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "shogun.$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/doc.md
+++ b/examples/meta/generator/targets/doc.md
@@ -1,3 +1,4 @@
+```javascript
 /** Target files specify rules for translation from meta-language to a target
  *  programming language. Each rule specifies the syntax of a specific language
  *  construct in the target programming language. The rules are given in 
@@ -81,6 +82,7 @@
          * $name: The name of the variable
          * $typeName: The name of the variable's type
          * $arguments: Arguments passed to the class constructor
+         * $kwargs: translated keyword arguments according to "KeywordArguments"
          */
         "Construct": "auto $name = some<C$typeName>($arguments)",
 
@@ -88,8 +90,32 @@
          * $name: The name of the variable
          * $typeName: The name of the variable's type
          * $expr: translated expression to assign
+         * $kwargs: translated keyword arguments according to "KeywordArguments"
          */
         "Copy": "auto $name = $expr",
+
+        "KeywordArguments": {
+            /** Keywords:
+             * $elements: the list of elements according to the rules below
+             */
+            "List": "\n$elements",
+
+            /** Keywords:
+             * $name: The name of the variable
+             * $keyword: The keyword identifier
+             * $expr: The translated expression associated with the keyword
+             */
+            "Element": "$name.put(\"$keyword\", $expr)",
+
+            /** What string should go between the elements? 
+             */
+            "Separator": "\n",
+
+            /* Should there be an initial separator string when there are any
+             * normal arguments preceding the keyword arguments?
+             */
+            "InitialSeperatorWhenArgs>0": false
+        },
 
         /** SGVector and SGMatrix construction rule. Allows to use native types
          *  in the target languages.
@@ -203,12 +229,15 @@
          */
         "FloatLiteral": "${number}f",
 
-        /** Keywords:
+        /** Keywords for all rules in "MethodCall":
          * $object: name of the object
          * $method: name of the method
          * $arguments: argument list passed to the method
          */
-        "MethodCall": "$object->$method($arguments)",
+        "MethodCall": {
+            "Default": "$object->$method($arguments)",
+            "get_real": "$object->prefix_$method_postfix($arguments)"
+        },
 
         /** Keywords:
          * $typeName: name of class to call the static method on
@@ -216,6 +245,15 @@
          * $arguments: argument list passed to the method
          */
         "StaticCall": "C$typeName::$method($arguments)",
+
+        /** Keywords:
+         * $method: method name
+         * $arguments: argument list passed to the method
+         * $kwargs: translated keyword arguments (this only happens if the
+                    global function is a factory function that constructs
+                    objects)
+         */
+        "GlobalCall": "$method($arguments)$kwargs",
 
         // Keywords: $identifier
         "Identifier": "$identifier",
@@ -266,3 +304,4 @@
     "OutputDirectoryName": "cpp",
     "FileExtension": ".cpp"
 }
+```

--- a/examples/meta/generator/targets/java.json
+++ b/examples/meta/generator/targets/java.json
@@ -80,7 +80,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "${number}f",
-        "MethodCall": "$object.$method($arguments)",
+        "MethodCall": {
+            "Default": "$object.$method($arguments)"
+        },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "shogun.$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/lua.json
+++ b/examples/meta/generator/targets/lua.json
@@ -26,7 +26,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "$number",
-        "MethodCall": "$object:$method($arguments)",
+        "MethodCall": {
+            "Default": "$object:$method($arguments)"
+        },
         "StaticCall": "$typeName:$method($arguments)",
         "GlobalCall": "$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/octave.json
+++ b/examples/meta/generator/targets/octave.json
@@ -44,7 +44,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "$number",
-        "MethodCall": "$object.$method($arguments)",
+        "MethodCall": {
+            "Default": "$object.$method($arguments)"
+        },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/python.json
+++ b/examples/meta/generator/targets/python.json
@@ -55,7 +55,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "$number",
-        "MethodCall": "$object.$method($arguments)",
+        "MethodCall": {
+            "Default": "$object.$method($arguments)"
+        },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/r.json
+++ b/examples/meta/generator/targets/r.json
@@ -26,7 +26,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "$number",
-        "MethodCall": "$object$$$method($arguments)",
+        "MethodCall": {
+            "Default": "$object$$$method($arguments)"
+        },
         "StaticCall": "$typeName$$$method($arguments)",
         "GlobalCall": "$method($arguments)",
         "Identifier": "$identifier",

--- a/examples/meta/generator/targets/ruby.json
+++ b/examples/meta/generator/targets/ruby.json
@@ -46,7 +46,9 @@
         "IntLiteral": "$number",
         "RealLiteral": "$number",
         "FloatLiteral": "$number",
-        "MethodCall": "$object.$method($arguments)",
+        "MethodCall": {
+            "Default": "$object.$method($arguments)"
+        },
         "StaticCall": "Shogun::$typeName.$method($arguments)",
         "GlobalCall": "Shogun::$method($arguments)",
         "Identifier": "$identifier",


### PR DESCRIPTION
This allows typed getters like `get_real` to be translated to `get<float64_t>` in C++ and `get_real` in the SWIG interfaces.

Note that typed setters (`put`) would be more tricky as we'd have to type the keyword arguments