### PR TITLE
Add transpose flags to element_prod

### DIFF
--- a/src/shogun/mathematics/linalg/LinalgBackendBase.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendBase.h
@@ -308,20 +308,36 @@ namespace shogun
 #undef BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC
 
 /**
- * Wrapper method of in-place matrix/vector elementwise product.
+ * Wrapper method of in-place vector elementwise product.
  *
  * @see linalg::element_prod
  */
-#define BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD(Type, Container)                 \
+#define BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD(Type, Container)          \
 	virtual void element_prod(                                                 \
 	    const Container<Type>& a, const Container<Type>& b,                    \
 	    Container<Type>& result) const                                         \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
 	}
-		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGMatrix)
-		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGVector)
-#undef BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD
+		DEFINE_FOR_ALL_PTYPE(
+		    BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD, SGVector)
+#undef BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD
+
+/**
+ * Wrapper method of in-place matrix elementwise product.
+ *
+ * @see linalg::element_prod
+ */
+#define BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD(Type, Container)          \
+	virtual void element_prod(                                                 \
+	    const Container<Type>& a, const Container<Type>& b,                    \
+	    Container<Type>& result, bool transpose_A, bool transpose_B) const     \
+	{                                                                          \
+		SG_SNOTIMPLEMENTED;                                                    \
+	}
+		DEFINE_FOR_ALL_PTYPE(
+		    BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD, SGMatrix)
+#undef BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD
 
 /**
  * Wrapper method of in-place matrix block elementwise product.
@@ -331,8 +347,8 @@ namespace shogun
 #define BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD(Type, Container)           \
 	virtual void element_prod(                                                 \
 	    const linalg::Block<Container<Type>>& a,                               \
-	    const linalg::Block<Container<Type>>& b, Container<Type>& result)      \
-	    const                                                                  \
+	    const linalg::Block<Container<Type>>& b, Container<Type>& result,      \
+	    bool transpose_A, bool transpose_B) const                              \
 	{                                                                          \
 		SG_SNOTIMPLEMENTED;                                                    \
 	}

--- a/src/shogun/mathematics/linalg/LinalgBackendEigen.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendEigen.h
@@ -158,20 +158,29 @@ namespace shogun
 #undef BACKEND_GENERIC_EIGEN_SOLVER_SYMMETRIC
 
 /** Implementation of @see LinalgBackendBase::element_prod */
-#define BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD(Type, Container)                 \
+#define BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD(Type, Container)          \
 	virtual void element_prod(                                                 \
 	    const Container<Type>& a, const Container<Type>& b,                    \
 	    Container<Type>& result) const;
-		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGMatrix)
-		DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGVector)
-#undef BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD
+		DEFINE_FOR_ALL_PTYPE(
+		    BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD, SGVector)
+#undef BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD
+
+/** Implementation of @see LinalgBackendBase::element_prod */
+#define BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD(Type, Container)          \
+	virtual void element_prod(                                                 \
+	    const Container<Type>& a, const Container<Type>& b,                    \
+	    Container<Type>& result, bool transpose_A, bool transpose_B) const;
+		DEFINE_FOR_ALL_PTYPE(
+		    BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD, SGMatrix)
+#undef BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD
 
 /** Implementation of @see LinalgBackendBase::element_prod */
 #define BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD(Type, Container)           \
 	virtual void element_prod(                                                 \
 	    const linalg::Block<Container<Type>>& a,                               \
-	    const linalg::Block<Container<Type>>& b, Container<Type>& result)      \
-	    const;
+	    const linalg::Block<Container<Type>>& b, Container<Type>& result,      \
+	    bool transpose_A, bool transpose_B) const;
 		DEFINE_FOR_ALL_PTYPE(
 		    BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
 #undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
@@ -498,14 +507,15 @@ namespace shogun
 		/** Eigen3 matrix in-place elementwise product method */
 		template <typename T>
 		void element_prod_impl(
-		    const SGMatrix<T>& a, const SGMatrix<T>& b,
-		    SGMatrix<T>& result) const;
+		    const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result,
+		    bool transpose_A, bool transpose_B) const;
 
 		/** Eigen3 matrix block in-place elementwise product method */
 		template <typename T>
 		void element_prod_impl(
 		    const linalg::Block<SGMatrix<T>>& a,
-		    const linalg::Block<SGMatrix<T>>& b, SGMatrix<T>& result) const;
+		    const linalg::Block<SGMatrix<T>>& b, SGMatrix<T>& result,
+		    bool transpose_A, bool transpose_B) const;
 
 		/** Eigen3 vector in-place elementwise product method */
 		template <typename T>

--- a/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
@@ -95,24 +95,33 @@ DEFINE_FOR_NUMERIC_PTYPE(BACKEND_GENERIC_ADD_SCALAR, SGMatrix)
 DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_DOT, SGVector)
 #undef BACKEND_GENERIC_DOT
 
-#define BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD(Type, Container)                 \
+#define BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD(Type, Container)          \
 	void LinalgBackendEigen::element_prod(                                     \
 	    const Container<Type>& a, const Container<Type>& b,                    \
 	    Container<Type>& result) const                                         \
 	{                                                                          \
 		element_prod_impl(a, b, result);                                       \
 	}
-DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGMatrix)
-DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD, SGVector)
-#undef BACKEND_GENERIC_IN_PLACE_ELEMENT_PROD
+DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD, SGVector)
+#undef BACKEND_GENERIC_IN_PLACE_VECTOR_ELEMENT_PROD
+
+#define BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD(Type, Container)          \
+	void LinalgBackendEigen::element_prod(                                     \
+	    const Container<Type>& a, const Container<Type>& b,                    \
+	    Container<Type>& result, bool transpose_A, bool transpose_B) const     \
+	{                                                                          \
+		element_prod_impl(a, b, result, transpose_A, transpose_B);             \
+	}
+DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD, SGMatrix)
+#undef BACKEND_GENERIC_IN_PLACE_MATRIX_ELEMENT_PROD
 
 #define BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD(Type, Container)           \
 	void LinalgBackendEigen::element_prod(                                     \
 	    const linalg::Block<Container<Type>>& a,                               \
-	    const linalg::Block<Container<Type>>& b, Container<Type>& result)      \
-	    const                                                                  \
+	    const linalg::Block<Container<Type>>& b, Container<Type>& result,      \
+	    bool transpose_A, bool transpose_B) const                              \
 	{                                                                          \
-		element_prod_impl(a, b, result);                                       \
+		element_prod_impl(a, b, result, transpose_A, transpose_B);             \
 	}
 DEFINE_FOR_ALL_PTYPE(BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD, SGMatrix)
 #undef BACKEND_GENERIC_IN_PLACE_BLOCK_ELEMENT_PROD
@@ -246,19 +255,27 @@ T LinalgBackendEigen::dot_impl(const SGVector<T>& a, const SGVector<T>& b) const
 
 template <typename T>
 void LinalgBackendEigen::element_prod_impl(
-    const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result) const
+    const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result,
+    bool transpose_A, bool transpose_B) const
 {
 	typename SGMatrix<T>::EigenMatrixXtMap a_eig = a;
 	typename SGMatrix<T>::EigenMatrixXtMap b_eig = b;
 	typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
 
-	result_eig = a_eig.array() * b_eig.array();
+	if (transpose_A && transpose_B)
+		result_eig = a_eig.transpose().array() * b_eig.transpose().array();
+	else if (transpose_A)
+		result_eig = a_eig.transpose().array() * b_eig.array();
+	else if (transpose_B)
+		result_eig = a_eig.array() * b_eig.transpose().array();
+	else
+		result_eig = a_eig.array() * b_eig.array();
 }
 
 template <typename T>
 void LinalgBackendEigen::element_prod_impl(
     const linalg::Block<SGMatrix<T>>& a, const linalg::Block<SGMatrix<T>>& b,
-    SGMatrix<T>& result) const
+    SGMatrix<T>& result, bool transpose_A, bool transpose_B) const
 {
 	typename SGMatrix<T>::EigenMatrixXtMap a_eig = a.m_matrix;
 	typename SGMatrix<T>::EigenMatrixXtMap b_eig = b.m_matrix;
@@ -269,7 +286,14 @@ void LinalgBackendEigen::element_prod_impl(
 	Eigen::Block<typename SGMatrix<T>::EigenMatrixXtMap> b_block =
 	    b_eig.block(b.m_row_begin, b.m_col_begin, b.m_row_size, b.m_col_size);
 
-	result_eig = a_block.array() * b_block.array();
+	if (transpose_A && transpose_B)
+		result_eig = a_block.transpose().array() * b_block.transpose().array();
+	else if (transpose_A)
+		result_eig = a_block.transpose().array() * b_block.array();
+	else if (transpose_B)
+		result_eig = a_block.array() * b_block.transpose().array();
+	else
+		result_eig = a_block.array() * b_block.array();
 }
 
 template <typename T>

--- a/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
+++ b/src/shogun/mathematics/linalg/backend/eigen/BasicOps.cpp
@@ -253,6 +253,23 @@ T LinalgBackendEigen::dot_impl(const SGVector<T>& a, const SGVector<T>& b) const
 	    .dot(typename SGVector<T>::EigenVectorXtMap(b));
 }
 
+/* Helper method to compute elementwise product with Eigen */
+template <typename MatrixType>
+void element_prod_eigen(
+    const MatrixType& A, const MatrixType& B,
+    typename SGMatrix<typename MatrixType::Scalar>::EigenMatrixXtMap& result,
+    bool transpose_A, bool transpose_B)
+{
+	if (transpose_A && transpose_B)
+		result = A.transpose().array() * B.transpose().array();
+	else if (transpose_A)
+		result = A.transpose().array() * B.array();
+	else if (transpose_B)
+		result = A.array() * B.transpose().array();
+	else
+		result = A.array() * B.array();
+}
+
 template <typename T>
 void LinalgBackendEigen::element_prod_impl(
     const SGMatrix<T>& a, const SGMatrix<T>& b, SGMatrix<T>& result,
@@ -262,14 +279,7 @@ void LinalgBackendEigen::element_prod_impl(
 	typename SGMatrix<T>::EigenMatrixXtMap b_eig = b;
 	typename SGMatrix<T>::EigenMatrixXtMap result_eig = result;
 
-	if (transpose_A && transpose_B)
-		result_eig = a_eig.transpose().array() * b_eig.transpose().array();
-	else if (transpose_A)
-		result_eig = a_eig.transpose().array() * b_eig.array();
-	else if (transpose_B)
-		result_eig = a_eig.array() * b_eig.transpose().array();
-	else
-		result_eig = a_eig.array() * b_eig.array();
+	element_prod_eigen(a_eig, b_eig, result_eig, transpose_A, transpose_B);
 }
 
 template <typename T>
@@ -286,14 +296,7 @@ void LinalgBackendEigen::element_prod_impl(
 	Eigen::Block<typename SGMatrix<T>::EigenMatrixXtMap> b_block =
 	    b_eig.block(b.m_row_begin, b.m_col_begin, b.m_row_size, b.m_col_size);
 
-	if (transpose_A && transpose_B)
-		result_eig = a_block.transpose().array() * b_block.transpose().array();
-	else if (transpose_A)
-		result_eig = a_block.transpose().array() * b_block.array();
-	else if (transpose_B)
-		result_eig = a_block.array() * b_block.transpose().array();
-	else
-		result_eig = a_block.array() * b_block.array();
+	element_prod_eigen(a_block, b_block, result_eig, transpose_A, transpose_B);
 }
 
 template <typename T>


### PR DESCRIPTION
Add transpose flags to arguments of `linalg::element_prod`
```
void element_prod(const SGMatrix<T>& A, const SGMatrix<T>& B, SGMatrix<T>& result,
                                bool transpose_A = false, bool transpose_B = false)
```
This makes `element_prod` have a consistent interface as `matrix_prod`