### PR TITLE
Replace CMath::exp with std::exp

### DIFF
--- a/src/shogun/classifier/GaussianProcessClassification.cpp
+++ b/src/shogun/classifier/GaussianProcessClassification.cpp
@@ -239,7 +239,7 @@ SGVector<float64_t> CGaussianProcessClassification::get_probabilities(
 
 	// evaluate probabilities
 	for (index_t idx=0; idx<p.vlen; idx++)
-		p[idx]=CMath::exp(p[idx]);
+		p[idx] = std::exp(p[idx]);
 
 	return p;
 }

--- a/src/shogun/classifier/mkl/MKL.cpp
+++ b/src/shogun/classifier/mkl/MKL.cpp
@@ -775,7 +775,7 @@ float64_t CMKL::compute_elasticnet_dual_objective()
 			float64_t step=1.0;
 			do
 			{
-				del=del_old*CMath::exp(-step*gg/(hh*del+gg));
+				del = del_old * std::exp(-step * gg / (hh * del + gg));
 				elasticnet_dual(&ff, &gg, &hh, del, nm, num_kernels, ent_lambda);
 				step/=2;
 			} while(ff>ff_old+1e-4*gg_old*(del-del_old));
@@ -1053,7 +1053,8 @@ float64_t CMKL::compute_optimal_betas_newton(float64_t* beta,
 				for( p=0; p<num_kernels; ++p )
 				{
 					if( inLogSpace )
-						newtBeta[p] = beta[p] * CMath::exp( + stepSize * newtDir[p] );
+						newtBeta[p] =
+						    beta[p] * std::exp(+stepSize * newtDir[p]);
 					else
 						newtBeta[p] = beta[p] + stepSize * newtDir[p];
 					if( !( newtBeta[p] >= epsBeta ) )

--- a/src/shogun/clustering/GMM.cpp
+++ b/src/shogun/clustering/GMM.cpp
@@ -165,7 +165,7 @@ float64_t CGMM::train_em(float64_t min_cov, int32_t max_iter, float64_t min_chan
 				    m_components[j]->compute_log_PDF(v) +
 				    std::log(m_coefficients[j]);
 				logPx[i] +=
-				    CMath::exp(logPxy[index_t(i * m_components.size() + j)]);
+				    std::exp(logPxy[index_t(i * m_components.size() + j)]);
 			}
 
 			logPx[i] = std::log(logPx[i]);
@@ -174,7 +174,7 @@ float64_t CGMM::train_em(float64_t min_cov, int32_t max_iter, float64_t min_chan
 			for (int32_t j=0; j<int32_t(m_components.size()); j++)
 			{
 				//logPost[i*m_components.vlen+j]=logPxy[i*m_components.vlen+j]-logPx[i];
-				alpha.matrix[i * m_components.size() + j] = CMath::exp(
+				alpha.matrix[i * m_components.size() + j] = std::exp(
 				    logPxy[index_t(i * m_components.size() + j)] - logPx[i]);
 			}
 		}
@@ -233,7 +233,7 @@ float64_t CGMM::train_smem(int32_t max_iter, int32_t max_cand, float64_t min_cov
 				    m_components[j]->compute_log_PDF(v) +
 				    std::log(m_coefficients[j]);
 				logPx[i] +=
-				    CMath::exp(logPxy[index_t(i * m_components.size() + j)]);
+				    std::exp(logPxy[index_t(i * m_components.size() + j)]);
 			}
 
 			logPx[i] = std::log(logPx[i]);
@@ -243,9 +243,9 @@ float64_t CGMM::train_smem(int32_t max_iter, int32_t max_cand, float64_t min_cov
 				logPost[index_t(i * m_components.size() + j)] =
 				    logPxy[index_t(i * m_components.size() + j)] - logPx[i];
 				logPostSum[j] +=
-				    CMath::exp(logPost[index_t(i * m_components.size() + j)]);
-				logPostSum2[j] += CMath::exp(
-				    2 * logPost[index_t(i * m_components.size() + j)]);
+				    std::exp(logPost[index_t(i * m_components.size() + j)]);
+				logPostSum2[j] +=
+				    std::exp(2 * logPost[index_t(i * m_components.size() + j)]);
 			}
 
 			int32_t counter=0;
@@ -253,7 +253,7 @@ float64_t CGMM::train_smem(int32_t max_iter, int32_t max_cand, float64_t min_cov
 			{
 				for (int32_t k=j+1; k<int32_t(m_components.size()); k++)
 				{
-					logPostSumSum[counter] += CMath::exp(
+					logPostSumSum[counter] += std::exp(
 					    logPost[index_t(i * m_components.size() + j)] +
 					    logPost[index_t(i * m_components.size() + k)]);
 					counter++;
@@ -274,8 +274,8 @@ float64_t CGMM::train_smem(int32_t max_iter, int32_t max_cand, float64_t min_cov
 				     logPostSum[i] -
 				     logPxy[index_t(j * m_components.size() + i)] +
 				     std::log(m_coefficients[i])) *
-				    (CMath::exp(logPost[index_t(j * m_components.size() + i)]) /
-				     CMath::exp(logPostSum[i]));
+				    (std::exp(logPost[index_t(j * m_components.size() + i)]) /
+				     std::exp(logPostSum[i]));
 			}
 			for (int32_t j=i+1; j<int32_t(m_components.size()); j++)
 			{
@@ -361,23 +361,23 @@ void CGMM::partial_em(int32_t comp1, int32_t comp2, int32_t comp3, float64_t min
 			    m_components[j]->compute_log_PDF(v) +
 			    std::log(m_coefficients[j]);
 			init_logPx[i] +=
-			    CMath::exp(init_logPxy[index_t(i * m_components.size() + j)]);
+			    std::exp(init_logPxy[index_t(i * m_components.size() + j)]);
 			if (j!=comp1 && j!=comp2 && j!=comp3)
 			{
-				init_logPx_fix[i] += CMath::exp(
-				    init_logPxy[index_t(i * m_components.size() + j)]);
+				init_logPx_fix[i] +=
+				    std::exp(init_logPxy[index_t(i * m_components.size() + j)]);
 			}
 		}
 
 		init_logPx[i] = std::log(init_logPx[i]);
 		post_add[i] = std::log(
-		    CMath::exp(
+		    std::exp(
 		        init_logPxy[index_t(i * m_components.size() + comp1)] -
 		        init_logPx[i]) +
-		    CMath::exp(
+		    std::exp(
 		        init_logPxy[index_t(i * m_components.size() + comp2)] -
 		        init_logPx[i]) +
-		    CMath::exp(
+		    std::exp(
 		        init_logPxy[index_t(i * m_components.size() + comp3)] -
 		        init_logPx[i]));
 	}
@@ -444,7 +444,7 @@ void CGMM::partial_em(int32_t comp1, int32_t comp2, int32_t comp3, float64_t min
 				}
 			}
 		}
-		new_d=CMath::exp(new_d*(1./dim_n));
+		new_d = std::exp(new_d * (1. / dim_n));
 		for (int32_t i=0; i<dim_n; i++)
 		{
 			components[0]->get_d().vector[i]=new_d;
@@ -463,7 +463,7 @@ void CGMM::partial_em(int32_t comp1, int32_t comp2, int32_t comp3, float64_t min
 		{
 			new_d += std::log(components[0]->get_d().vector[i]);
 		}
-		new_d=CMath::exp(new_d*(1./dim_n));
+		new_d = std::exp(new_d * (1. / dim_n));
 		for (int32_t i=0; i<dim_n; i++)
 		{
 			components[0]->get_d().vector[i]=new_d;
@@ -502,7 +502,7 @@ void CGMM::partial_em(int32_t comp1, int32_t comp2, int32_t comp3, float64_t min
 			{
 				logPxy[i * 3 + j] = components[j]->compute_log_PDF(v) +
 				                    std::log(coefficients[j]);
-				logPx[i]+=CMath::exp(logPxy[i*3+j]);
+				logPx[i] += std::exp(logPxy[i * 3 + j]);
 			}
 
 			logPx[i] = std::log(logPx[i] + init_logPx_fix[i]);
@@ -511,7 +511,8 @@ void CGMM::partial_em(int32_t comp1, int32_t comp2, int32_t comp3, float64_t min
 			for (int32_t j=0; j<3; j++)
 			{
 				//logPost[i*m_components.vlen+j]=logPxy[i*m_components.vlen+j]-logPx[i];
-				alpha.matrix[i*3+j]=CMath::exp(logPxy[i*3+j]-logPx[i]+post_add[i]);
+				alpha.matrix[i * 3 + j] =
+				    std::exp(logPxy[i * 3 + j] - logPx[i] + post_add[i]);
 			}
 		}
 
@@ -699,7 +700,7 @@ float64_t CGMM::get_likelihood_example(int32_t num_example)
 	for (auto i: range(index_t(m_components.size())))
 	{
 		SGVector<float64_t> point= ((CDenseFeatures<float64_t>*) features)->get_feature_vector(num_example);
-		result += CMath::exp(
+		result += std::exp(
 		    m_components[i]->compute_log_PDF(point) +
 		    std::log(m_coefficients[i]));
 	}
@@ -808,7 +809,7 @@ SGVector<float64_t> CGMM::cluster(SGVector<float64_t> point)
 	{
 		answer.vector[i] = m_components[i]->compute_log_PDF(point) +
 		                   std::log(m_coefficients[i]);
-		answer.vector[m_components.size()]+=CMath::exp(answer.vector[i]);
+		answer.vector[m_components.size()] += std::exp(answer.vector[i]);
 	}
 	answer.vector[m_components.size()] =
 	    std::log(answer.vector[m_components.size()]);

--- a/src/shogun/distributions/EMMixtureModel.cpp
+++ b/src/shogun/distributions/EMMixtureModel.cpp
@@ -62,7 +62,7 @@ float64_t CEMMixtureModel::expectation_step()
 
 		// fill row of alpha
 		for (int32_t j=0;j<data.alpha.num_cols;j++)
-			data.alpha(i,j)=CMath::exp(alpha_ij[j]-normalize);
+			data.alpha(i, j) = std::exp(alpha_ij[j] - normalize);
 	}
 
 	return log_likelihood;

--- a/src/shogun/distributions/Gaussian.h
+++ b/src/shogun/distributions/Gaussian.h
@@ -111,7 +111,7 @@ class CGaussian : public CDistribution
 		 */
 		virtual float64_t compute_PDF(SGVector<float64_t> point)
 		{
-			return CMath::exp(compute_log_PDF(point));
+			return std::exp(compute_log_PDF(point));
 		}
 
 		/** compute log PDF

--- a/src/shogun/evaluation/SigmoidCalibration.cpp
+++ b/src/shogun/evaluation/SigmoidCalibration.cpp
@@ -195,8 +195,8 @@ SGVector<float64_t> CSigmoidCalibration::calibrate_values(
 	for (index_t i = 0; i < values.vlen; ++i)
 	{
 		float64_t fApB = values[i] * params.a + params.b;
-		values[i] = fApB >= 0 ? CMath::exp(-fApB) / (1.0 + CMath::exp(-fApB))
-		                      : 1.0 / (1 + CMath::exp(fApB));
+		values[i] = fApB >= 0 ? std::exp(-fApB) / (1.0 + std::exp(-fApB))
+		                      : 1.0 / (1 + std::exp(fApB));
 	}
 	return values;
 }

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -838,7 +838,7 @@ SGMatrix<float64_t> CCombinedKernel::get_parameter_gradient(
 				float64_t log_sum = std::log(tmp.array().exp().sum());
 
 				factor = subkernel_log_weights[index] - max_coeff - log_sum;
-				factor = CMath::exp(factor) - CMath::exp(factor*2.0);
+				factor = std::exp(factor) - std::exp(factor * 2.0);
 
 				Map<MatrixXd> eigen_res(result.matrix, result.num_rows, result.num_cols);
 				eigen_res = eigen_res * factor;

--- a/src/shogun/kernel/ExponentialARDKernel.cpp
+++ b/src/shogun/kernel/ExponentialARDKernel.cpp
@@ -93,7 +93,7 @@ void CExponentialARDKernel::lazy_update_weights()
 			{
 				float64_t* begin=m_weights_raw.get_column_vector(i);
 				std::copy(m_log_weights.vector+offset,m_log_weights.vector+offset+m_weights_raw.num_rows-i,begin+i);
-				begin[i]=CMath::exp(begin[i]);
+				begin[i] = std::exp(begin[i]);
 				offset+=m_weights_raw.num_rows-i;
 			}
 		}
@@ -213,7 +213,7 @@ SGMatrix<float64_t> CExponentialARDKernel::get_weighted_vector(SGVector<float64_
 		for (index_t i=0;i<m_weights_rows && i<m_weights_cols;i++)
 		{
 			SGMatrix<float64_t> weights(log_weights.vector+offset,1,m_weights_rows-i,false);
-			weights[0]=CMath::exp(weights[0]);
+			weights[0] = std::exp(weights[0]);
 			SGMatrix<float64_t> rtmp(vec.vector+i,vec.vlen-i,1,false);
 			SGMatrix<float64_t> s=linalg::matrix_prod(weights,rtmp);
 			weights[0] = std::log(weights[0]);
@@ -238,7 +238,7 @@ SGMatrix<float64_t> CExponentialARDKernel::compute_right_product(SGVector<float6
 	if (m_ARD_type==KT_SCALAR)
 	{
 		right=SGMatrix<float64_t>(vec.vector,vec.vlen,1,false);
-		scalar_weight*=CMath::exp(m_log_weights[0]);
+		scalar_weight *= std::exp(m_log_weights[0]);
 	}
 	else if (m_ARD_type==KT_DIAG || m_ARD_type==KT_FULL)
 		right=get_weighted_vector(vec);

--- a/src/shogun/kernel/ExponentialARDKernel.h
+++ b/src/shogun/kernel/ExponentialARDKernel.h
@@ -141,7 +141,7 @@ protected:
 	 */
 	virtual float64_t compute(int32_t idx_a, int32_t idx_b)
 	{
-		return CMath::exp(-distance(idx_a,idx_b));
+		return std::exp(-distance(idx_a, idx_b));
 	}
 
 public:

--- a/src/shogun/kernel/GaussianARDKernel.cpp
+++ b/src/shogun/kernel/GaussianARDKernel.cpp
@@ -40,7 +40,7 @@ float64_t CGaussianARDKernel::distance(int32_t idx_a, int32_t idx_b)
 	if (m_ARD_type==KT_SCALAR)
 	{
 		result=(m_sq_lhs[idx_a]+m_sq_rhs[idx_b]-2.0*CDotKernel::compute(idx_a,idx_b));
-		result*=CMath::exp(2.0*m_log_weights[0]);
+		result *= std::exp(2.0 * m_log_weights[0]);
 	}
 	else
 	{
@@ -118,7 +118,7 @@ float64_t CGaussianARDKernel::compute_helper(SGVector<float64_t> avec, SGVector<
 	if (m_ARD_type==KT_SCALAR)
 	{
 		left=SGMatrix<float64_t>(avec.vector,1,avec.vlen,false);
-		scalar_weight=CMath::exp(m_log_weights[0]);
+		scalar_weight = std::exp(m_log_weights[0]);
 	}
 	else if(m_ARD_type==KT_FULL || m_ARD_type==KT_DIAG)
 	{
@@ -138,7 +138,8 @@ float64_t CGaussianARDKernel::compute_gradient_helper(SGVector<float64_t> avec,
 	float64_t result=0.0;
 
 	if(m_ARD_type==KT_DIAG)
-		result=2.0*avec[index]*bvec[index]*CMath::exp(2.0*m_log_weights[index]);
+		result = 2.0 * avec[index] * bvec[index] *
+		         std::exp(2.0 * m_log_weights[index]);
 	else
 	{
 		SGMatrix<float64_t> res;
@@ -148,7 +149,7 @@ float64_t CGaussianARDKernel::compute_gradient_helper(SGVector<float64_t> avec,
 			SGMatrix<float64_t> left(avec.vector,1,avec.vlen,false);
 			SGMatrix<float64_t> right(bvec.vector,bvec.vlen,1,false);
 			res=linalg::matrix_prod(left, right);
-			result=2.0*res[0]*CMath::exp(2.0*m_log_weights[0]);
+			result = 2.0 * res[0] * std::exp(2.0 * m_log_weights[0]);
 		}
 		else if(m_ARD_type==KT_FULL)
 		{
@@ -168,7 +169,7 @@ float64_t CGaussianARDKernel::compute_gradient_helper(SGVector<float64_t> avec,
 			SGVector<float64_t> row_vec = SGVector<float64_t>(
 			    m_log_weights.vector + total_offset, m_weights_rows - row_index,
 			    false);
-			row_vec[0]=CMath::exp(row_vec[0]);
+			row_vec[0] = std::exp(row_vec[0]);
 
 			SGMatrix<float64_t> row_vec_r(row_vec.vector,row_vec.vlen,1,false);
 			SGMatrix<float64_t> left(avec.vector+row_index,1,avec.vlen-row_index,false);
@@ -224,7 +225,7 @@ SGVector<float64_t> CGaussianARDKernel::get_parameter_gradient_diagonal(
 				if (m_ARD_type==KT_SCALAR)
 				{
 					float64_t dist=distance(j,j);
-					derivative[j]=CMath::exp(-dist)*(-dist*2.0);
+					derivative[j] = std::exp(-dist) * (-dist * 2.0);
 				}
 				else
 				{
@@ -281,7 +282,7 @@ SGMatrix<float64_t> CGaussianARDKernel::get_parameter_gradient(
 				if (m_ARD_type==KT_SCALAR)
 				{
 					float64_t dist=distance(j,k);
-					derivative(j,k)=CMath::exp(-dist)*(-dist*2.0);
+					derivative(j, k) = std::exp(-dist) * (-dist * 2.0);
 				}
 				else
 				{

--- a/src/shogun/kernel/GaussianCompactKernel.cpp
+++ b/src/shogun/kernel/GaussianCompactKernel.cpp
@@ -35,5 +35,5 @@ float64_t CGaussianCompactKernel::compute(int32_t idx_a, int32_t idx_b)
     if(result_multiplier<=0)
         return 0;
 
-    return CMath::pow(result_multiplier, power)*CMath::exp(-result);
+	return CMath::pow(result_multiplier, power) * std::exp(-result);
 }

--- a/src/shogun/kernel/GaussianKernel.cpp
+++ b/src/shogun/kernel/GaussianKernel.cpp
@@ -91,7 +91,7 @@ void CGaussianKernel::set_width(float64_t w)
 
 float64_t CGaussianKernel::get_width() const
 {
-	return CMath::exp(m_log_width*2.0)*2.0;
+	return std::exp(m_log_width * 2.0) * 2.0;
 }
 
 SGMatrix<float64_t> CGaussianKernel::get_parameter_gradient(const TParameter* param, index_t index)
@@ -108,7 +108,7 @@ SGMatrix<float64_t> CGaussianKernel::get_parameter_gradient(const TParameter* pa
 			for (int j=0; j<num_lhs; j++)
 			{
 				float64_t element=distance(j, k);
-				derivative(j, k)=CMath::exp(-element)*element*2.0;
+				derivative(j, k) = std::exp(-element) * element * 2.0;
 			}
 		}
 		return derivative;
@@ -123,7 +123,7 @@ SGMatrix<float64_t> CGaussianKernel::get_parameter_gradient(const TParameter* pa
 float64_t CGaussianKernel::compute(int32_t idx_a, int32_t idx_b)
 {
     float64_t result=distance(idx_a, idx_b);
-    return CMath::exp(-result);
+	return std::exp(-result);
 }
 
 void CGaussianKernel::load_serializable_post() throw (ShogunException)

--- a/src/shogun/kernel/PeriodicKernel.cpp
+++ b/src/shogun/kernel/PeriodicKernel.cpp
@@ -78,7 +78,8 @@ float64_t CPeriodicKernel::compute(int32_t idx_a, int32_t idx_b)
 	 k({\bf x},{\bf x'})= exp(-\frac{2sin^2(|{\bf x}-{\bf x'}|/p)}{l^2})
 	*/
 	float64_t sin_term=CMath::sin(M_PI*distance(idx_a,idx_b)/m_period);
-	return CMath::exp(-2*CMath::pow(sin_term, 2)/CMath::pow(m_length_scale,2));
+	return std::exp(
+	    -2 * CMath::pow(sin_term, 2) / CMath::pow(m_length_scale, 2));
 }
 
 void CPeriodicKernel::precompute_squared()

--- a/src/shogun/kernel/PyramidChi2.cpp
+++ b/src/shogun/kernel/PyramidChi2.cpp
@@ -225,8 +225,7 @@ float64_t CPyramidChi2::compute(int32_t idx_a, int32_t idx_b)
 			}
 		}
 	}
-	result= CMath::exp(-result/width);
-
+	result = std::exp(-result / width);
 
 	((CDenseFeatures<float64_t>*) lhs)->free_feature_vector(avec, idx_a, afree);
 	((CDenseFeatures<float64_t>*) rhs)->free_feature_vector(bvec, idx_b, bfree);

--- a/src/shogun/labels/BinaryLabels.cpp
+++ b/src/shogun/labels/BinaryLabels.cpp
@@ -128,8 +128,9 @@ void CBinaryLabels::scores_to_probabilities(float64_t a, float64_t b)
 	for (index_t i = 0; i < m_current_values.vlen; ++i)
 	{
 		float64_t fApB = m_current_values[i] * a + b;
-		m_current_values[i] = fApB >= 0 ? CMath::exp(-fApB) / (1.0 + CMath::exp(-fApB)) :
-		                      1.0 / (1 + CMath::exp(fApB));
+		m_current_values[i] = fApB >= 0
+		                          ? std::exp(-fApB) / (1.0 + std::exp(-fApB))
+		                          : 1.0 / (1 + std::exp(fApB));
 	}
 
 	SG_DEBUG("leaving CBinaryLabels::scores_to_probabilities()\n")

--- a/src/shogun/loss/ExponentialLoss.cpp
+++ b/src/shogun/loss/ExponentialLoss.cpp
@@ -40,7 +40,7 @@ float64_t CExponentialLoss::loss(float64_t prediction, float64_t label)
 
 float64_t CExponentialLoss::loss(float64_t z)
 {
-	return CMath::exp(-z);
+	return std::exp(-z);
 }
 
 float64_t CExponentialLoss::first_derivative(float64_t prediction, float64_t label)

--- a/src/shogun/machine/gp/EPInferenceMethod.cpp
+++ b/src/shogun/machine/gp/EPInferenceMethod.cpp
@@ -184,7 +184,7 @@ void CEPInferenceMethod::update()
 
 	// get and scale diagonal of the kernel matrix
 	SGVector<float64_t> ktrtr_diag=m_ktrtr.get_diagonal_vector();
-	ktrtr_diag.scale(CMath::exp(m_log_scale*2.0));
+	ktrtr_diag.scale(std::exp(m_log_scale * 2.0));
 
 	// marginal likelihood for ttau = tnu = 0
 	float64_t nlZ0=-SGVector<float64_t>::sum(m_model->get_log_zeroth_moments(
@@ -207,7 +207,7 @@ void CEPInferenceMethod::update()
 		// copy data manually, since we don't have appropriate method
 		for (index_t i=0; i<m_ktrtr.num_rows; i++)
 			for (index_t j=0; j<m_ktrtr.num_cols; j++)
-				m_Sigma(i,j)=m_ktrtr(i,j)*CMath::exp(m_log_scale);
+				m_Sigma(i, j) = m_ktrtr(i, j) * std::exp(m_log_scale);
 
 		CREATE_SGVECTOR(m_mu, n, float64_t);
 		m_mu.zero();
@@ -328,8 +328,9 @@ void CEPInferenceMethod::update_alpha()
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 
 	// solve LL^T * v = tS^(1/2) * K * tnu
-	VectorXd eigen_v=eigen_L.triangularView<Upper>().adjoint().solve(
-			eigen_sttau.cwiseProduct(eigen_K*CMath::exp(m_log_scale*2.0)*eigen_tnu));
+	VectorXd eigen_v = eigen_L.triangularView<Upper>().adjoint().solve(
+	    eigen_sttau.cwiseProduct(
+	        eigen_K * std::exp(m_log_scale * 2.0) * eigen_tnu));
 	eigen_v=eigen_L.triangularView<Upper>().solve(eigen_v);
 
 	// compute alpha = (I - tS^(1/2) * B^(-1) * tS(1/2) * K) * tnu =
@@ -351,9 +352,10 @@ void CEPInferenceMethod::update_chol()
 
 	// compute upper triangular factor L^T of the Cholesky decomposion of the
 	// matrix: B = tS^(1/2) * K * tS^(1/2) + I
-	LLT<MatrixXd> eigen_chol((eigen_sttau*eigen_sttau.adjoint()).cwiseProduct(
-			eigen_K*CMath::exp(m_log_scale*2.0))+
-			MatrixXd::Identity(m_L.num_rows, m_L.num_cols));
+	LLT<MatrixXd> eigen_chol(
+	    (eigen_sttau * eigen_sttau.adjoint())
+	        .cwiseProduct(eigen_K * std::exp(m_log_scale * 2.0)) +
+	    MatrixXd::Identity(m_L.num_rows, m_L.num_cols));
 
 	eigen_L=eigen_chol.matrixU();
 }
@@ -371,14 +373,15 @@ void CEPInferenceMethod::update_approx_cov()
 	Map<MatrixXd> eigen_Sigma(m_Sigma.matrix, m_Sigma.num_rows, m_Sigma.num_cols);
 
 	// compute V = L^(-1) * tS^(1/2) * K, using upper triangular factor L^T
-	MatrixXd eigen_V=eigen_L.triangularView<Upper>().adjoint().solve(
-			eigen_sttau.asDiagonal()*eigen_K*CMath::exp(m_log_scale*2.0));
+	MatrixXd eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
+	    eigen_sttau.asDiagonal() * eigen_K * std::exp(m_log_scale * 2.0));
 
 	// compute covariance matrix of the posterior:
 	// Sigma = K - K * tS^(1/2) * (L * L^T)^(-1) * tS^(1/2) * K =
 	// K - (K * tS^(1/2)) * (L^T)^(-1) * L^(-1) * tS^(1/2) * K =
 	// K - (tS^(1/2) * K)^T * (L^(-1))^T * L^(-1) * tS^(1/2) * K = K - V^T * V
-	eigen_Sigma=eigen_K*CMath::exp(m_log_scale*2.0)-eigen_V.adjoint()*eigen_V;
+	eigen_Sigma =
+	    eigen_K * std::exp(m_log_scale * 2.0) - eigen_V.adjoint() * eigen_V;
 }
 
 void CEPInferenceMethod::update_approx_mean()
@@ -485,7 +488,7 @@ SGVector<float64_t> CEPInferenceMethod::get_derivative_wrt_inference_method(
 
 	// compute derivative wrt kernel scale: dnlZ=-sum(F.*K*scale*2)/2
 	result[0]=-(eigen_F.cwiseProduct(eigen_K)).sum();
-	result[0]*=CMath::exp(m_log_scale*2.0);
+	result[0] *= std::exp(m_log_scale * 2.0);
 
 	return result;
 }
@@ -521,7 +524,7 @@ SGVector<float64_t> CEPInferenceMethod::get_derivative_wrt_kernel(
 
 		// compute derivative wrt kernel parameter: dnlZ=-sum(F.*dK*scale^2)/2.0
 		result[i]=-(eigen_F.cwiseProduct(eigen_dK)).sum();
-		result[i]*=CMath::exp(m_log_scale*2.0)/2.0;
+		result[i] *= std::exp(m_log_scale * 2.0) / 2.0;
 	}
 
 	return result;

--- a/src/shogun/machine/gp/ExactInferenceMethod.cpp
+++ b/src/shogun/machine/gp/ExactInferenceMethod.cpp
@@ -189,8 +189,9 @@ void CExactInferenceMethod::update_chol()
 	/* creates views on kernel and cholesky matrix and perform cholesky */
 	Map<MatrixXd> K(m_ktrtr.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
 	Map<MatrixXd> L(m_L.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
-	LLT<MatrixXd> llt(K*(CMath::exp(m_log_scale*2.0)/CMath::sq(sigma))+
-		MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols));
+	LLT<MatrixXd> llt(
+	    K * (std::exp(m_log_scale * 2.0) / CMath::sq(sigma)) +
+	    MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols));
 	L=llt.matrixU();
 }
 
@@ -233,7 +234,7 @@ void CExactInferenceMethod::update_mean()
 	m_mu=SGVector<float64_t>(m.vlen);
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
 
-	eigen_mu=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_alpha;
+	eigen_mu = eigen_K * std::exp(m_log_scale * 2.0) * eigen_alpha;
 }
 
 void CExactInferenceMethod::update_cov()
@@ -248,8 +249,8 @@ void CExactInferenceMethod::update_cov()
 			m_Sigma.num_cols);
 
 	// compute V = L^(-1) * K, using upper triangular factor L^T
-	MatrixXd eigen_V=eigen_L.triangularView<Upper>().adjoint().solve(
-			eigen_K*CMath::exp(m_log_scale*2.0));
+	MatrixXd eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
+	    eigen_K * std::exp(m_log_scale * 2.0));
 
 	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
 	float64_t sigma=lik->get_sigma();
@@ -257,7 +258,8 @@ void CExactInferenceMethod::update_cov()
 	eigen_V = eigen_V/sigma;
 
 	// compute covariance matrix of the posterior: Sigma = K - V^T * V
-	eigen_Sigma=eigen_K*CMath::exp(m_log_scale*2.0)-eigen_V.adjoint()*eigen_V;
+	eigen_Sigma =
+	    eigen_K * std::exp(m_log_scale * 2.0) - eigen_V.adjoint() * eigen_V;
 }
 
 void CExactInferenceMethod::update_deriv()
@@ -300,7 +302,7 @@ SGVector<float64_t> CExactInferenceMethod::get_derivative_wrt_inference_method(
 
 	// compute derivative wrt kernel scale: dnlZ=sum(Q.*K*scale*2)/2
 	result[0]=(eigen_Q.cwiseProduct(eigen_K)).sum();
-	result[0]*=CMath::exp(m_log_scale*2.0);
+	result[0] *= std::exp(m_log_scale * 2.0);
 
 	return result;
 }
@@ -366,7 +368,7 @@ SGVector<float64_t> CExactInferenceMethod::get_derivative_wrt_kernel(
 
 		// compute derivative wrt kernel parameter: dnlZ=sum(Q.*dK*scale)/2.0
 		result[i]=(eigen_Q.cwiseProduct(eigen_dK)).sum();
-		result[i]*=CMath::exp(m_log_scale*2.0)/2.0;
+		result[i] *= std::exp(m_log_scale * 2.0) / 2.0;
 	}
 
 	return result;

--- a/src/shogun/machine/gp/FITCInferenceMethod.cpp
+++ b/src/shogun/machine/gp/FITCInferenceMethod.cpp
@@ -166,8 +166,10 @@ void CFITCInferenceMethod::update_chol()
 
 	// solve Luu' * Luu = Kuu + m_ind_noise * I
 	//Luu  = chol(Kuu+snu2*eye(nu));                         % Kuu + snu2*I = Luu'*Luu
-	LLT<MatrixXd> Luu(eigen_kuu*CMath::exp(m_log_scale*2.0)+CMath::exp(m_log_ind_noise)*MatrixXd::Identity(
-		m_kuu.num_rows, m_kuu.num_cols));
+	LLT<MatrixXd> Luu(
+	    eigen_kuu * std::exp(m_log_scale * 2.0) +
+	    std::exp(m_log_ind_noise) *
+	        MatrixXd::Identity(m_kuu.num_rows, m_kuu.num_cols));
 
 	// create shogun and eigen3 representation of cholesky of covariance of
 	// inducing features Luu (m_chol_uu and eigen_chol_uu)
@@ -181,8 +183,8 @@ void CFITCInferenceMethod::update_chol()
 
 	m_V=SGMatrix<float64_t>(m_chol_uu.num_cols, m_ktru.num_cols);
 	Map<MatrixXd> V(m_V.matrix, m_V.num_rows, m_V.num_cols);
-	V=eigen_chol_uu.triangularView<Upper>().adjoint().solve(eigen_ktru*
-			CMath::exp(m_log_scale*2.0));
+	V = eigen_chol_uu.triangularView<Upper>().adjoint().solve(
+	    eigen_ktru * std::exp(m_log_scale * 2.0));
 
 	// create shogun and eigen3 representation of
 	// dg = diag(K) + sn2 - diag(Q)
@@ -191,8 +193,9 @@ void CFITCInferenceMethod::update_chol()
 	Map<VectorXd> eigen_t(m_t.vector, m_t.vlen);
 
 	//g_sn2 = diagK + sn2 - sum(V.*V,1)';          % g + sn2 = diag(K) + sn2 - diag(Q)
-	eigen_t=eigen_ktrtr_diag*CMath::exp(m_log_scale*2.0)+CMath::sq(sigma)*
-		VectorXd::Ones(m_t.vlen)-(V.cwiseProduct(V)).colwise().sum().adjoint();
+	eigen_t = eigen_ktrtr_diag * std::exp(m_log_scale * 2.0) +
+	          CMath::sq(sigma) * VectorXd::Ones(m_t.vlen) -
+	          (V.cwiseProduct(V)).colwise().sum().adjoint();
 	eigen_t=MatrixXd::Ones(eigen_t.rows(),1).cwiseQuotient(eigen_t);
 
 	// solve Lu' * Lu = V * diag(1/dg) * V' + I
@@ -308,7 +311,7 @@ void CFITCInferenceMethod::update_deriv()
 	Map<MatrixXd> eigen_B(m_B.matrix, m_B.num_rows, m_B.num_cols);
 
 	//B = iKuu*Ku; w = B*al;
-	eigen_B=iKuu*eigen_Ktru*CMath::exp(m_log_scale*2.0);
+	eigen_B = iKuu * eigen_Ktru * std::exp(m_log_scale * 2.0);
 
 	// create shogun and eigen representation of w
 	m_w=SGVector<float64_t>(m_B.num_rows);
@@ -352,7 +355,7 @@ SGVector<float64_t> CFITCInferenceMethod::get_posterior_mean()
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 	Map<MatrixXd> eigen_Ktru(m_ktru.matrix, m_ktru.num_rows, m_ktru.num_cols);
 	//time complexity of the following operation is O(m*n)
-	eigen_mu=CMath::exp(m_log_scale*2.0)*eigen_Ktru.adjoint()*eigen_alpha;
+	eigen_mu = std::exp(m_log_scale * 2.0) * eigen_Ktru.adjoint() * eigen_alpha;
 
 	return SGVector<float64_t>(m_mu);
 }
@@ -392,8 +395,8 @@ SGMatrix<float64_t> CFITCInferenceMethod::get_posterior_covariance()
 	MatrixXd part1=eigen_V.adjoint()*(eigen_Lu.triangularView<Upper>().solve(MatrixXd::Identity(
 		m_kuu.num_rows, m_kuu.num_cols)));
 	eigen_Sigma=part1*part1.adjoint();
-	VectorXd part2=eigen_ktrtr_diag*CMath::exp(m_log_scale*2.0)-(
-		eigen_V.cwiseProduct(eigen_V)).colwise().sum().adjoint();
+	VectorXd part2 = eigen_ktrtr_diag * std::exp(m_log_scale * 2.0) -
+	                 (eigen_V.cwiseProduct(eigen_V)).colwise().sum().adjoint();
 	eigen_Sigma+=part2.asDiagonal();
 
 	return SGMatrix<float64_t>(m_Sigma);

--- a/src/shogun/machine/gp/GaussianLikelihood.cpp
+++ b/src/shogun/machine/gp/GaussianLikelihood.cpp
@@ -83,7 +83,7 @@ SGVector<float64_t> CGaussianLikelihood::get_predictive_variances(
 	SGVector<float64_t> result(s2);
 	Map<VectorXd> eigen_result(result.vector, result.vlen);
 
-	eigen_result=eigen_result.array()+CMath::exp(m_log_sigma*2.0);
+	eigen_result = eigen_result.array() + std::exp(m_log_sigma * 2.0);
 
 	return result;
 }
@@ -108,8 +108,10 @@ SGVector<float64_t> CGaussianLikelihood::get_log_probability_f(const CLabels* la
 
 	// compute log probability: lp=-(y-f).^2./sigma^2/2-log(2*pi*sigma^2)/2
 	eigen_result=eigen_y-eigen_f;
-	eigen_result=-eigen_result.cwiseProduct(eigen_result)/(2.0*CMath::exp(m_log_sigma*2.0))-
-		VectorXd::Ones(result.vlen)*log(2.0*CMath::PI*CMath::exp(m_log_sigma*2.0))/2.0;
+	eigen_result = -eigen_result.cwiseProduct(eigen_result) /
+	                   (2.0 * std::exp(m_log_sigma * 2.0)) -
+	               VectorXd::Ones(result.vlen) *
+	                   log(2.0 * CMath::PI * std::exp(m_log_sigma * 2.0)) / 2.0;
 
 	return result;
 }
@@ -138,9 +140,10 @@ SGVector<float64_t> CGaussianLikelihood::get_log_probability_derivative_f(
 
 	// compute derivatives of log probability wrt f
 	if (i == 1)
-		eigen_result/=CMath::exp(m_log_sigma*2.0);
+		eigen_result /= std::exp(m_log_sigma * 2.0);
 	else if (i == 2)
-		eigen_result=-VectorXd::Ones(result.vlen)/CMath::exp(m_log_sigma*2.0);
+		eigen_result =
+		    -VectorXd::Ones(result.vlen) / std::exp(m_log_sigma * 2.0);
 	else if (i == 3)
 		eigen_result=VectorXd::Zero(result.vlen);
 
@@ -171,7 +174,8 @@ SGVector<float64_t> CGaussianLikelihood::get_first_derivative(const CLabels* lab
 	// dlp_dlogsigma
 	// lp_dsigma=(y-f).^2/sigma^2-1
 	eigen_result=eigen_y-eigen_f;
-	eigen_result=eigen_result.cwiseProduct(eigen_result)/CMath::exp(m_log_sigma*2.0);
+	eigen_result =
+	    eigen_result.cwiseProduct(eigen_result) / std::exp(m_log_sigma * 2.0);
 	eigen_result-=VectorXd::Ones(result.vlen);
 
 	return result;
@@ -200,7 +204,7 @@ SGVector<float64_t> CGaussianLikelihood::get_second_derivative(const CLabels* la
 	// compute derivative of (the first log_sigma derivative of log probability) wrt f:
 	// d2lp_dlogsigma_df == d2lp_df_dlogsigma
 	// dlp_dsigma=2*(f-y)/sigma^2
-	eigen_result=2.0*(eigen_f-eigen_y)/CMath::exp(m_log_sigma*2.0);
+	eigen_result = 2.0 * (eigen_f - eigen_y) / std::exp(m_log_sigma * 2.0);
 
 	return result;
 }
@@ -225,7 +229,8 @@ SGVector<float64_t> CGaussianLikelihood::get_third_derivative(const CLabels* lab
 	// compute derivative of (the derivative of the first log_sigma derivative of log probability) wrt f:
 	// d3lp_dlogsigma_df_df == d3lp_df_df_dlogsigma
 	// d2lp_dsigma=2/sigma^2
-	eigen_result=2.0*VectorXd::Ones(result.vlen)/CMath::exp(m_log_sigma*2.0);
+	eigen_result =
+	    2.0 * VectorXd::Ones(result.vlen) / std::exp(m_log_sigma * 2.0);
 
 	return result;
 }
@@ -265,7 +270,7 @@ SGVector<float64_t> CGaussianLikelihood::get_log_zeroth_moments(
 	Map<VectorXd> eigen_result(result.vector, result.vlen);
 
 	// compule lZ=-(y-mu).^2./(sn2+s2)/2-log(2*pi*(sn2+s2))/2
-	eigen_s2=eigen_s2.array()+CMath::exp(m_log_sigma*2.0);
+	eigen_s2 = eigen_s2.array() + std::exp(m_log_sigma * 2.0);
 	eigen_result=-(eigen_y-eigen_mu).array().square()/(2.0*eigen_s2.array())-
 		(2.0*CMath::PI*eigen_s2.array()).log()/2.0;
 
@@ -288,7 +293,8 @@ float64_t CGaussianLikelihood::get_first_moment(SGVector<float64_t> mu,
 	SGVector<float64_t> y=((CRegressionLabels*)lab)->get_labels();
 
 	// compute 1st moment
-	float64_t Ex=mu[i]+s2[i]*(y[i]-mu[i])/(CMath::exp(m_log_sigma*2.0)+s2[i]);
+	float64_t Ex =
+	    mu[i] + s2[i] * (y[i] - mu[i]) / (std::exp(m_log_sigma * 2.0) + s2[i]);
 
 	return Ex;
 }
@@ -307,7 +313,8 @@ float64_t CGaussianLikelihood::get_second_moment(SGVector<float64_t> mu,
 			"Labels must be type of CRegressionLabels\n")
 
 	// compute 2nd moment
-	float64_t Var=s2[i]-CMath::sq(s2[i])/(CMath::exp(m_log_sigma*2.0)+s2[i]);
+	float64_t Var =
+	    s2[i] - CMath::sq(s2[i]) / (std::exp(m_log_sigma * 2.0) + s2[i]);
 
 	return Var;
 }

--- a/src/shogun/machine/gp/GaussianLikelihood.h
+++ b/src/shogun/machine/gp/GaussianLikelihood.h
@@ -75,7 +75,10 @@ public:
 	 *
 	 * @return noise standard deviation
 	 */
-	float64_t get_sigma() { return CMath::exp(m_log_sigma); }
+	float64_t get_sigma()
+	{
+		return std::exp(m_log_sigma);
+	}
 
 	/** sets the noise standard deviation
 	 *

--- a/src/shogun/machine/gp/Inference.cpp
+++ b/src/shogun/machine/gp/Inference.cpp
@@ -47,7 +47,7 @@ CInference::CInference()
 
 float64_t CInference::get_scale() const
 {
-	return CMath::exp(m_log_scale);
+	return std::exp(m_log_scale);
 }
 
 void CInference::set_scale(float64_t scale)
@@ -154,7 +154,7 @@ float64_t CInference::get_marginal_likelihood_estimate(
 	sg_memcpy(scaled_kernel.matrix, m_ktrtr.matrix,
 			sizeof(float64_t)*m_ktrtr.num_rows*m_ktrtr.num_cols);
 	for (index_t i=0; i<m_ktrtr.num_rows*m_ktrtr.num_cols; ++i)
-		scaled_kernel.matrix[i]*=CMath::exp(m_log_scale*2.0);
+		scaled_kernel.matrix[i] *= std::exp(m_log_scale * 2.0);
 
 	/* add ridge */
 	for (index_t i=0; i<m_ktrtr.num_rows; ++i)

--- a/src/shogun/machine/gp/KLCholeskyInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLCholeskyInferenceMethod.cpp
@@ -122,7 +122,7 @@ bool CKLCholeskyInferenceMethod::precompute()
 
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
 	//mu=K*alpha+m
-	eigen_mu=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+	eigen_mu = eigen_K * std::exp(m_log_scale * 2.0) * eigen_alpha + eigen_mean;
 
 	update_C();
 	Map<MatrixXd> eigen_C(m_C.matrix, m_C.num_rows, m_C.num_cols);
@@ -165,7 +165,8 @@ void CKLCholeskyInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<fl
 
 	Map<VectorXd> eigen_dnlz_alpha(gradient.vector, len);
 	//dnlZ_alpha  = -K*(df-alpha);
-	eigen_dnlz_alpha=eigen_K*CMath::exp(m_log_scale*2.0)*(-eigen_df+eigen_alpha);
+	eigen_dnlz_alpha =
+		eigen_K * std::exp(m_log_scale * 2.0) * (-eigen_df + eigen_alpha);
 
 	Map<VectorXd> eigen_dnlz_C_seq(gradient.vector+len, gradient.vlen-len);
 

--- a/src/shogun/machine/gp/KLCovarianceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLCovarianceInferenceMethod.cpp
@@ -139,7 +139,7 @@ bool CKLCovarianceInferenceMethod::precompute()
 
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
 	//mu=K*alpha+m
-	eigen_mu=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+	eigen_mu = eigen_K * std::exp(m_log_scale * 2.0) * eigen_alpha + eigen_mean;
 
 	//construct s2
 	Map<VectorXd> eigen_log_neg_lambda(m_alpha.vector+len, len);
@@ -150,16 +150,21 @@ bool CKLCovarianceInferenceMethod::precompute()
 	Map<VectorXd> eigen_sW(m_sW.vector, m_sW.vlen);
 	eigen_sW=eigen_W.array().sqrt().matrix();
 
-	m_L=CMatrixOperations::get_choleksy(m_W, m_sW, m_ktrtr, CMath::exp(m_log_scale));
+	m_L = CMatrixOperations::get_choleksy(
+		m_W, m_sW, m_ktrtr, std::exp(m_log_scale));
 	Map<MatrixXd> eigen_L(m_L.matrix, m_L.num_rows, m_L.num_cols);
 
 	//solve L'*V=diag(sW)*K
 	Map<MatrixXd> eigen_V(m_V.matrix, m_V.num_rows, m_V.num_cols);
-	eigen_V=eigen_L.triangularView<Upper>().adjoint().solve(eigen_sW.asDiagonal()*eigen_K*CMath::exp(m_log_scale*2.0));
+	eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
+		eigen_sW.asDiagonal() * eigen_K * std::exp(m_log_scale * 2.0));
 	Map<VectorXd> eigen_s2(m_s2.vector, m_s2.vlen);
 	//Sigma=inv(inv(K)-2*diag(lambda))=K-K*diag(sW)*inv(L)'*inv(L)*diag(sW)*K
 	//v=abs(diag(Sigma))
-	eigen_s2=(eigen_K.diagonal().array()*CMath::exp(m_log_scale*2.0)-(eigen_V.array().pow(2).colwise().sum().transpose())).abs().matrix();
+	eigen_s2 = (eigen_K.diagonal().array() * std::exp(m_log_scale * 2.0) -
+		        (eigen_V.array().pow(2).colwise().sum().transpose()))
+		           .abs()
+		           .matrix();
 
 	CVariationalGaussianLikelihood * lik=get_variational_likelihood();
 	bool status = lik->set_variational_distribution(m_mu, m_s2, m_labels);
@@ -199,14 +204,16 @@ void CKLCovarianceInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<
 	// A=I-K*diag(sW)*inv(L)*inv(L')*diag(sW)
 	eigen_A=MatrixXd::Identity(len, len)-eigen_V.transpose()*eigen_U;
 
-	m_Sigma=CMatrixOperations::get_inverse(m_L, m_ktrtr, m_sW, m_V, CMath::exp(m_log_scale));
+	m_Sigma = CMatrixOperations::get_inverse(
+		m_L, m_ktrtr, m_sW, m_V, std::exp(m_log_scale));
 	Map<MatrixXd> eigen_Sigma(m_Sigma.matrix, m_Sigma.num_rows, m_Sigma.num_cols);
 
 	Map<VectorXd> eigen_dnlz_alpha(gradient.vector, len);
 	Map<VectorXd> eigen_dnlz_log_neg_lambda(gradient.vector+len, len);
 
 	//dlZ_alpha  = K*(df-alpha);
-	eigen_dnlz_alpha=eigen_K*CMath::exp(m_log_scale*2.0)*(-eigen_df+eigen_alpha);
+	eigen_dnlz_alpha =
+		eigen_K * std::exp(m_log_scale * 2.0) * (-eigen_df + eigen_alpha);
 
 	//dlZ_lambda = 2*(Sigma.*Sigma)*dV +v -sum(Sigma.*A,2);   % => fast diag(V*VinvK')
 	//dlZ_log_neg_lambda = dlZ_lambda .* lambda;
@@ -281,7 +288,8 @@ void CKLCovarianceInferenceMethod::update_alpha()
 		nlml_new=get_negative_log_marginal_likelihood_helper();
 
 		float64_t trace=0;
-		LLT<MatrixXd> llt((eigen_K*CMath::exp(m_log_scale*2.0))+
+		LLT<MatrixXd> llt(
+			(eigen_K * std::exp(m_log_scale * 2.0)) +
 			MatrixXd::Identity(eigen_K.rows(), eigen_K.cols()));
 		MatrixXd LL=llt.matrixU();
 		MatrixXd tt=LL.triangularView<Upper>().adjoint().solve(MatrixXd::Identity(LL.rows(),LL.cols()));
@@ -289,10 +297,14 @@ void CKLCovarianceInferenceMethod::update_alpha()
 		for(index_t idx=0; idx<tt.rows(); idx++)
 			trace+=(tt.col(idx).array().pow(2)).sum();
 
-		MatrixXd eigen_V=LL.triangularView<Upper>().adjoint().solve(eigen_K*CMath::exp(m_log_scale*2.0));
+		MatrixXd eigen_V = LL.triangularView<Upper>().adjoint().solve(
+			eigen_K * std::exp(m_log_scale * 2.0));
 		SGVector<float64_t> s2_tmp(m_s2.vlen);
 		Map<VectorXd> eigen_s2(s2_tmp.vector, s2_tmp.vlen);
-		eigen_s2=(eigen_K.diagonal().array()*CMath::exp(m_log_scale*2.0)-(eigen_V.array().pow(2).colwise().sum().transpose())).abs().matrix();
+		eigen_s2 = (eigen_K.diagonal().array() * std::exp(m_log_scale * 2.0) -
+			        (eigen_V.array().pow(2).colwise().sum().transpose()))
+			           .abs()
+			           .matrix();
 		SGVector<float64_t> mean=m_mean->get_mean_vector(m_features);
 
 		CVariationalGaussianLikelihood * lik=get_variational_likelihood();

--- a/src/shogun/machine/gp/KLDiagonalInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDiagonalInferenceMethod.cpp
@@ -118,7 +118,7 @@ bool CKLDiagonalInferenceMethod::precompute()
 
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
 	//mu=K*alpha+m
-	eigen_mu=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+	eigen_mu = eigen_K * std::exp(m_log_scale * 2.0) * eigen_alpha + eigen_mean;
 
 	Map<VectorXd> eigen_log_v(m_alpha.vector+len, m_alpha.vlen-len);
 	Map<VectorXd> eigen_s2(m_s2.vector, m_s2.vlen);
@@ -155,7 +155,8 @@ void CKLDiagonalInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<fl
 
 	Map<VectorXd> eigen_dnlz_alpha(gradient.vector, len);
 	//dnlZ_alpha  = -K*(df-alpha);
-	eigen_dnlz_alpha=eigen_K*CMath::exp(m_log_scale*2.0)*(-eigen_df+eigen_alpha);
+	eigen_dnlz_alpha =
+		eigen_K * std::exp(m_log_scale * 2.0) * (-eigen_df + eigen_alpha);
 
 	Map<VectorXd> eigen_dnlz_log_v(gradient.vector+len, gradient.vlen-len);
 

--- a/src/shogun/machine/gp/KLDualInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDualInferenceMethod.cpp
@@ -317,23 +317,28 @@ bool CKLDualInferenceMethod::precompute()
 	Map<VectorXd> eigen_sW(m_sW.vector, m_sW.vlen);
 	eigen_sW=eigen_W.array().sqrt().matrix();
 
-	m_L=CMatrixOperations::get_choleksy(m_W, m_sW, m_ktrtr, CMath::exp(m_log_scale));
+	m_L = CMatrixOperations::get_choleksy(
+		m_W, m_sW, m_ktrtr, std::exp(m_log_scale));
 	Map<MatrixXd> eigen_L(m_L.matrix, m_L.num_rows, m_L.num_cols);
 
 	//solve L'*V=diag(sW)*K
 	Map<MatrixXd> eigen_V(m_V.matrix, m_V.num_rows, m_V.num_cols);
-	eigen_V=eigen_L.triangularView<Upper>().adjoint().solve(eigen_sW.asDiagonal()*eigen_K*CMath::exp(m_log_scale*2.0));
+	eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
+		eigen_sW.asDiagonal() * eigen_K * std::exp(m_log_scale * 2.0));
 	Map<VectorXd> eigen_s2(m_s2.vector, m_s2.vlen);
 	//Sigma=inv(inv(K)+diag(W))=K-K*diag(sW)*inv(L)'*inv(L)*diag(sW)*K
 	//v=abs(diag(Sigma))
-	eigen_s2=(eigen_K.diagonal().array()*CMath::exp(m_log_scale*2.0)-(eigen_V.array().pow(2).colwise().sum().transpose())).abs().matrix();
+	eigen_s2 = (eigen_K.diagonal().array() * std::exp(m_log_scale * 2.0) -
+		        (eigen_V.array().pow(2).colwise().sum().transpose()))
+		           .abs()
+		           .matrix();
 
 	//construct mu
 	SGVector<float64_t> mean=m_mean->get_mean_vector(m_features);
 	Map<VectorXd> eigen_mean(mean.vector, mean.vlen);
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
 	//mu=K*alpha+m
-	eigen_mu=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+	eigen_mu = eigen_K * std::exp(m_log_scale * 2.0) * eigen_alpha + eigen_mean;
 	return true;
 }
 
@@ -471,7 +476,8 @@ void CKLDualInferenceMethod::update_alpha()
 		SGVector<float64_t> sW_tmp(len);
 		Map<VectorXd> eigen_sW(sW_tmp.vector, sW_tmp.vlen);
 		eigen_sW=eigen_W.array().sqrt().matrix();
-		SGMatrix<float64_t> L_tmp=CMatrixOperations::get_choleksy(W_tmp, sW_tmp, m_ktrtr, CMath::exp(m_log_scale*2.0));
+		SGMatrix<float64_t> L_tmp = CMatrixOperations::get_choleksy(
+			W_tmp, sW_tmp, m_ktrtr, std::exp(m_log_scale * 2.0));
 		Map<MatrixXd> eigen_L(L_tmp.matrix, L_tmp.num_rows, L_tmp.num_cols);
 
 		lik->set_dual_parameters(W_tmp, m_labels);
@@ -486,12 +492,17 @@ void CKLDualInferenceMethod::update_alpha()
 		SGVector<float64_t> mu_tmp(len);
 		Map<VectorXd> eigen_mu(mu_tmp.vector, mu_tmp.vlen);
 		//mu=K*alpha+m
-		eigen_mu=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+		eigen_mu =
+			eigen_K * std::exp(m_log_scale * 2.0) * eigen_alpha + eigen_mean;
 		//construct s2
-		MatrixXd eigen_V=eigen_L.triangularView<Upper>().adjoint().solve(eigen_sW.asDiagonal()*eigen_K*CMath::exp(m_log_scale*2.0));
+		MatrixXd eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
+			eigen_sW.asDiagonal() * eigen_K * std::exp(m_log_scale * 2.0));
 		SGVector<float64_t> s2_tmp(len);
 		Map<VectorXd> eigen_s2(s2_tmp.vector, s2_tmp.vlen);
-		eigen_s2=(eigen_K.diagonal().array()*CMath::exp(m_log_scale*2.0)-(eigen_V.array().pow(2).colwise().sum().transpose())).abs().matrix();
+		eigen_s2 = (eigen_K.diagonal().array() * std::exp(m_log_scale * 2.0) -
+			        (eigen_V.array().pow(2).colwise().sum().transpose()))
+			           .abs()
+			           .matrix();
 
 		lik->set_variational_distribution(mu_tmp, s2_tmp, m_labels);
 
@@ -575,7 +586,8 @@ void CKLDualInferenceMethod::update_chol()
 
 void CKLDualInferenceMethod::update_approx_cov()
 {
-	m_Sigma=CMatrixOperations::get_inverse(m_L, m_ktrtr, m_sW, m_V, CMath::exp(m_log_scale));
+	m_Sigma = CMatrixOperations::get_inverse(
+		m_L, m_ktrtr, m_sW, m_V, std::exp(m_log_scale));
 }
 
 } /* namespace shogun */

--- a/src/shogun/machine/gp/KLInference.cpp
+++ b/src/shogun/machine/gp/KLInference.cpp
@@ -233,7 +233,7 @@ Eigen::LDLT<Eigen::MatrixXd> CKLInference::update_init_helper()
 	eigen_K=eigen_K+m_noise_factor*MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols);
 
 	Eigen::LDLT<Eigen::MatrixXd> ldlt;
-	ldlt.compute(eigen_K*CMath::exp(m_log_scale*2.0));
+	ldlt.compute(eigen_K * std::exp(m_log_scale * 2.0));
 
 	float64_t attempt_count=0;
 	MatrixXd Kernel_D=ldlt.vectorD();
@@ -250,7 +250,7 @@ Eigen::LDLT<Eigen::MatrixXd> CKLInference::update_init_helper()
 		noise_factor*=m_exp_factor;
 		//updat the noise  eigen_K=eigen_K+noise_factor*(m_exp_factor^attempt_count)*Identity()
 		eigen_K=eigen_K+(noise_factor-pre_noise_factor)*MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols);
-		ldlt.compute(eigen_K*CMath::exp(m_log_scale*2.0));
+		ldlt.compute(eigen_K * std::exp(m_log_scale * 2.0));
 		Kernel_D=ldlt.vectorD();
 	}
 
@@ -380,7 +380,7 @@ SGVector<float64_t> CKLInference::get_derivative_wrt_inference_method(const TPar
 	SGVector<float64_t> result(1);
 
 	result[0]=get_derivative_related_cov(m_ktrtr);
-	result[0]*=CMath::exp(m_log_scale*2.0)*2.0;
+	result[0] *= std::exp(m_log_scale * 2.0) * 2.0;
 
 	return result;
 }
@@ -403,7 +403,7 @@ SGVector<float64_t> CKLInference::get_derivative_wrt_kernel(const TParameter* pa
 			dK=m_kernel->get_parameter_gradient(param, i);
 
 		result[i]=get_derivative_related_cov(dK);
-		result[i]*=CMath::exp(m_log_scale*2.0);
+		result[i] *= std::exp(m_log_scale * 2.0);
 	}
 
 	return result;

--- a/src/shogun/machine/gp/LogitLikelihood.cpp
+++ b/src/shogun/machine/gp/LogitLikelihood.cpp
@@ -88,8 +88,8 @@ public:
 	 */
 	virtual float64_t operator() (float64_t x)
 	{
-		return (1.0/(CMath::sqrt(2*CMath::PI)*m_sigma))*
-			CMath::exp(-CMath::sq(x-m_mu)/(2.0*CMath::sq(m_sigma)));
+		return (1.0 / (CMath::sqrt(2 * CMath::PI) * m_sigma)) *
+			   std::exp(-CMath::sq(x - m_mu) / (2.0 * CMath::sq(m_sigma)));
 	}
 
 private:
@@ -133,7 +133,7 @@ public:
 	 */
 	virtual float64_t operator() (float64_t x)
 	{
-		return 1.0/(1.0+CMath::exp(-m_a*x));
+		return 1.0 / (1.0 + std::exp(-m_a * x));
 	}
 
 private:

--- a/src/shogun/machine/gp/LogitVGPiecewiseBoundLikelihood.cpp
+++ b/src/shogun/machine/gp/LogitVGPiecewiseBoundLikelihood.cpp
@@ -469,12 +469,14 @@ void CLogitVGPiecewiseBoundLikelihood::precompute()
 			if (CMath::abs(zl(r, c)) == CMath::INFTY)
 				m_pl(r, c) = 0;
 			else
-				m_pl(r, c) = CMath::exp(CGaussianDistribution::univariate_log_pdf(zl(r, c)));
+				m_pl(r, c) = std::exp(
+					CGaussianDistribution::univariate_log_pdf(zl(r, c)));
 
 			if (CMath::abs(zh(r, c)) == CMath::INFTY)
 				m_ph(r, c) = 0;
 			else
-				m_ph(r, c) = CMath::exp(CGaussianDistribution::univariate_log_pdf(zh(r, c)));
+				m_ph(r, c) = std::exp(
+					CGaussianDistribution::univariate_log_pdf(zh(r, c)));
 		}
 	}
 

--- a/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/MultiLaplaceInferenceMethod.cpp
@@ -84,7 +84,8 @@ public:
 		float64_t result=0;
 		for(index_t bl=0; bl<C; bl++)
 		{
-			eigen_f.block(bl*n,0,n,1)=K*alpha->block(bl*n,0,n,1)*CMath::exp(log_scale*2.0);
+			eigen_f.block(bl * n, 0, n, 1) =
+				K * alpha->block(bl * n, 0, n, 1) * std::exp(log_scale * 2.0);
 			result+=alpha->block(bl*n,0,n,1).dot(eigen_f.block(bl*n,0,n,1))/2.0;
 			eigen_f.block(bl*n,0,n,1)+=eigen_m;
 		}
@@ -200,8 +201,11 @@ void CMultiLaplaceInferenceMethod::update_approx_cov()
 	MatrixXd eigen_U(C*n,n);
 	for(index_t bl=0; bl<C; bl++)
 	{
-		eigen_U.block(bl*n,0,n,n)=eigen_K*CMath::exp(m_log_scale*2.0)*eigen_E.block(0,bl*n,n,n);
-		eigen_Sigma.block(bl*n,bl*n,n,n)=(MatrixXd::Identity(n,n)-eigen_U.block(bl*n,0,n,n))*(eigen_K*CMath::exp(m_log_scale*2.0));
+		eigen_U.block(bl * n, 0, n, n) = eigen_K * std::exp(m_log_scale * 2.0) *
+			                             eigen_E.block(0, bl * n, n, n);
+		eigen_Sigma.block(bl * n, bl * n, n, n) =
+			(MatrixXd::Identity(n, n) - eigen_U.block(bl * n, 0, n, n)) *
+			(eigen_K * std::exp(m_log_scale * 2.0));
 	}
 	MatrixXd eigen_V=eigen_M.triangularView<Upper>().adjoint().solve(eigen_U.transpose());
 	eigen_Sigma+=eigen_V.transpose()*eigen_V;
@@ -272,7 +276,9 @@ void CMultiLaplaceInferenceMethod::update_alpha()
 	{
 		Map<VectorXd> alpha(m_alpha.vector, m_alpha.vlen);
 		for(index_t bl=0; bl<C; bl++)
-			eigen_mu.block(bl*n,0,n,1)=eigen_ktrtr*CMath::exp(m_log_scale*2.0)*alpha.block(bl*n,0,n,1);
+			eigen_mu.block(bl * n, 0, n, 1) = eigen_ktrtr *
+				                              std::exp(m_log_scale * 2.0) *
+				                              alpha.block(bl * n, 0, n, 1);
 
 		//alpha'*(f-m)/2.0
 		Psi_New=alpha.dot(eigen_mu)/2.0;
@@ -317,7 +323,9 @@ void CMultiLaplaceInferenceMethod::update_alpha()
 		for(index_t bl=0; bl<C; bl++)
 		{
 			VectorXd eigen_sD=eigen_dpi.block(bl*n,0,n,1).cwiseSqrt();
-			LLT<MatrixXd> chol_tmp((eigen_sD*eigen_sD.transpose()).cwiseProduct(eigen_ktrtr*CMath::exp(m_log_scale*2.0))+
+			LLT<MatrixXd> chol_tmp(
+				(eigen_sD * eigen_sD.transpose())
+				    .cwiseProduct(eigen_ktrtr * std::exp(m_log_scale * 2.0)) +
 				MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols));
 			MatrixXd eigen_L_tmp=chol_tmp.matrixU();
 			MatrixXd eigen_E_bl=eigen_L_tmp.triangularView<Upper>().adjoint().solve(MatrixXd(eigen_sD.asDiagonal()));
@@ -345,7 +353,10 @@ void CMultiLaplaceInferenceMethod::update_alpha()
 
 		Map<VectorXd> &eigen_c=eigen_W;
 		for(index_t bl=0; bl<C; bl++)
-			eigen_c.block(bl*n,0,n,1)=eigen_E.block(0,bl*n,n,n)*(eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_b.block(bl*n,0,n,1));
+			eigen_c.block(bl * n, 0, n, 1) =
+				eigen_E.block(0, bl * n, n, n) *
+				(eigen_ktrtr * std::exp(m_log_scale * 2.0) *
+				 eigen_b.block(bl * n, 0, n, 1));
 
 		Map<MatrixXd> c_tmp(eigen_c.data(),n,C);
 
@@ -429,7 +440,7 @@ SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_inference_m
 	// compute derivative K wrt scale
 
 	result[0]=get_derivative_helper(m_ktrtr);
-	result[0]*=CMath::exp(m_log_scale*2.0)*2.0;
+	result[0] *= std::exp(m_log_scale * 2.0) * 2.0;
 
 	return result;
 }
@@ -455,7 +466,7 @@ SGVector<float64_t> CMultiLaplaceInferenceMethod::get_derivative_wrt_kernel(
 			dK=m_kernel->get_parameter_gradient(param, i);
 
 		result[i]=get_derivative_helper(dK);
-		result[i]*=CMath::exp(m_log_scale*2.0);
+		result[i] *= std::exp(m_log_scale * 2.0);
 	}
 
 	return result;

--- a/src/shogun/machine/gp/ProbitLikelihood.cpp
+++ b/src/shogun/machine/gp/ProbitLikelihood.cpp
@@ -136,8 +136,9 @@ SGVector<float64_t> CProbitLikelihood::get_log_probability_derivative_f(
 		else
 		{
 			//dlp(~id2) = exp(-z(~id2).*z(~id2)/2-lp(~id2))/sqrt(2*pi); % safe computation
-			eigen_dlp[j]=CMath::exp(-v*v/2.0-CStatistics::lnormal_cdf(v))
-				/CMath::sqrt(2.0*CMath::PI);
+			eigen_dlp[j] =
+			    std::exp(-v * v / 2.0 - CStatistics::lnormal_cdf(v)) /
+			    CMath::sqrt(2.0 * CMath::PI);
 		}
 	}
 
@@ -230,7 +231,8 @@ float64_t CProbitLikelihood::get_first_moment(SGVector<float64_t> mu,
 	float64_t ncdf=CStatistics::normal_cdf(z);
 
 	// compute npdf=normal_pdf(z)=(1/sqrt(2*pi))*exp(-z.^2/2)
-	float64_t npdf=(1.0/CMath::sqrt(2.0*CMath::PI))*CMath::exp(-0.5*CMath::sq(z));
+	float64_t npdf =
+	    (1.0 / CMath::sqrt(2.0 * CMath::PI)) * std::exp(-0.5 * CMath::sq(z));
 
 	// compute the 1st moment: E[x] = mu + (y*s2*N(z))/(Phi(z)*sqrt(1+s2))
 	float64_t Ex=mu[i]+(npdf/ncdf)*(y[i]*s2[i])/CMath::sqrt(1.0+s2[i]);
@@ -259,7 +261,8 @@ float64_t CProbitLikelihood::get_second_moment(SGVector<float64_t> mu,
 	float64_t ncdf=CStatistics::normal_cdf(z);
 
 	// compute npdf=normal_pdf(z)=(1/sqrt(2*pi))*exp(-z.^2/2)
-	float64_t npdf=(1.0/CMath::sqrt(2.0*CMath::PI))*CMath::exp(-0.5*CMath::sq(z));
+	float64_t npdf =
+	    (1.0 / CMath::sqrt(2.0 * CMath::PI)) * std::exp(-0.5 * CMath::sq(z));
 
 	SGVector<float64_t> r(y.vlen);
 	Map<VectorXd> eigen_r(r.vector, r.vlen);

--- a/src/shogun/machine/gp/SingleFITCInference.cpp
+++ b/src/shogun/machine/gp/SingleFITCInference.cpp
@@ -190,7 +190,7 @@ SGVector<float64_t> CSingleFITCInference::get_derivative_wrt_inducing_noise(
 	SGMatrix<float64_t> R(m_B.num_rows, m_B.num_cols);
 	Map<MatrixXd> eigen_R(R.matrix, R.num_rows, R.num_cols);
 	//dKuui = 2*snu2; R = -dKuui*B;
-	float64_t factor=2.0*CMath::exp(m_log_ind_noise);
+	float64_t factor = 2.0 * std::exp(m_log_ind_noise);
 	eigen_R=-eigen_B*factor;
 
 	SGVector<float64_t> v(m_B.num_cols);
@@ -229,7 +229,7 @@ SGVector<float64_t> CSingleFITCInference::get_derivative_related_inducing_featur
 	m_kernel->init(inducing_features, m_features);
 	//A = (Kpu.*BdK)*diag(e);
 	//Kpu=1 in our setting
-	MatrixXd A=CMath::exp(m_log_scale*2.0)*eigen_BdK;
+	MatrixXd A = std::exp(m_log_scale * 2.0) * eigen_BdK;
 	for(int32_t lat_idx=0; lat_idx<A.rows(); lat_idx++)
 	{
 		Map<VectorXd> deriv_lat_col_vec(deriv_lat.vector+lat_idx*dim,dim);
@@ -242,7 +242,8 @@ SGVector<float64_t> CSingleFITCInference::get_derivative_related_inducing_featur
 	m_kernel->init(inducing_features, inducing_features);
 	//C = (Kpuu.*(BdK*B'))*diag(e);
 	//Kpuu=1 in our setting
-	MatrixXd C=CMath::exp(m_log_scale*2.0)*(eigen_BdK*eigen_B.transpose());
+	MatrixXd C =
+	    std::exp(m_log_scale * 2.0) * (eigen_BdK * eigen_B.transpose());
 	for(int32_t lat_lidx=0; lat_lidx<C.rows(); lat_lidx++)
 	{
 		Map<VectorXd> deriv_lat_col_vec(deriv_lat.vector+lat_lidx*dim,dim);

--- a/src/shogun/machine/gp/SingleLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/SingleLaplaceInferenceMethod.cpp
@@ -46,7 +46,7 @@ public:
 
 		// compute alpha=alpha+x*dalpha and f=K*alpha+m
 		(*alpha)=start_alpha+x*dalpha;
-		eigen_f=K*(*alpha)*CMath::exp(log_scale*2.0)+eigen_m;
+		eigen_f = K * (*alpha) * std::exp(log_scale * 2.0) + eigen_m;
 
 		// get first and second derivatives of log likelihood
 		(*dlp)=lik->get_log_probability_derivative_f(lab, (*f), 1);
@@ -222,13 +222,22 @@ float64_t CSingleLaplaceNewtonOptimizer::minimize()
 		// compute sW = sqrt(W)
 		eigen_sW=eigen_W.cwiseSqrt();
 
-		LLT<MatrixXd> L((eigen_sW*eigen_sW.transpose()).cwiseProduct(eigen_ktrtr*CMath::exp((m_obj->m_log_scale)*2.0))+
-			MatrixXd::Identity( (m_obj->m_ktrtr).num_rows, (m_obj->m_ktrtr).num_cols));
+		LLT<MatrixXd> L(
+			(eigen_sW * eigen_sW.transpose())
+			    .cwiseProduct(
+			        eigen_ktrtr * std::exp((m_obj->m_log_scale) * 2.0)) +
+			MatrixXd::Identity(
+			    (m_obj->m_ktrtr).num_rows, (m_obj->m_ktrtr).num_cols));
 
 		VectorXd b=eigen_W.cwiseProduct(eigen_mu - eigen_mean)+eigen_dlp;
 
-		VectorXd dalpha=b-eigen_sW.cwiseProduct(
-			L.solve(eigen_sW.cwiseProduct(eigen_ktrtr*b*CMath::exp((m_obj->m_log_scale)*2.0))))-eigen_alpha;
+		VectorXd dalpha = b -
+			              eigen_sW.cwiseProduct(
+			                  L.solve(
+			                      eigen_sW.cwiseProduct(
+			                          eigen_ktrtr * b *
+			                          std::exp((m_obj->m_log_scale) * 2.0)))) -
+			              eigen_alpha;
 
 #ifdef USE_GPL_SHOGUN
 		// perform Brent's optimization
@@ -333,8 +342,9 @@ float64_t CSingleLaplaceInferenceMethod::get_negative_log_marginal_likelihood()
 		Map<VectorXd> eigen_sW(m_sW.vector, m_sW.vlen);
 		Map<MatrixXd> eigen_ktrtr(m_ktrtr.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
 
-		FullPivLU<MatrixXd> lu(MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols)+
-			eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_sW.asDiagonal());
+		FullPivLU<MatrixXd> lu(
+			MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols) +
+			eigen_ktrtr * std::exp(m_log_scale * 2.0) * eigen_sW.asDiagonal());
 
 		result=(eigen_alpha.dot(eigen_mu-eigen_mean))/2.0-
 			lp+log(lu.determinant())/2.0;
@@ -358,14 +368,15 @@ void CSingleLaplaceInferenceMethod::update_approx_cov()
 	Map<MatrixXd> eigen_Sigma(m_Sigma.matrix, m_Sigma.num_rows,	m_Sigma.num_cols);
 
 	// compute V = L^(-1) * W^(1/2) * K, using upper triangular factor L^T
-	MatrixXd eigen_V=eigen_L.triangularView<Upper>().adjoint().solve(
-			eigen_sW.asDiagonal()*eigen_K*CMath::exp(m_log_scale*2.0));
+	MatrixXd eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
+		eigen_sW.asDiagonal() * eigen_K * std::exp(m_log_scale * 2.0));
 
 	// compute covariance matrix of the posterior:
 	// Sigma = K - K * W^(1/2) * (L * L^T)^(-1) * W^(1/2) * K =
 	// K - (K * W^(1/2)) * (L^T)^(-1) * L^(-1) * W^(1/2) * K =
 	// K - (W^(1/2) * K)^T * (L^(-1))^T * L^(-1) * W^(1/2) * K = K - V^T * V
-	eigen_Sigma=eigen_K*CMath::exp(m_log_scale*2.0)-eigen_V.adjoint()*eigen_V;
+	eigen_Sigma =
+		eigen_K * std::exp(m_log_scale * 2.0) - eigen_V.adjoint() * eigen_V;
 }
 
 void CSingleLaplaceInferenceMethod::update_chol()
@@ -401,8 +412,8 @@ void CSingleLaplaceInferenceMethod::update_chol()
 	{
 		//A = eye(n)+K.*repmat(w',n,1);
 		FullPivLU<MatrixXd> lu(
-			MatrixXd::Identity(m_ktrtr.num_rows,m_ktrtr.num_cols)+
-			eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_W.asDiagonal());
+			MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols) +
+			eigen_ktrtr * std::exp(m_log_scale * 2.0) * eigen_W.asDiagonal());
 		// compute cholesky: L = -(K + 1/W)^-1
 		//-iA = -inv(A)
 		eigen_L=-lu.inverse();
@@ -413,7 +424,8 @@ void CSingleLaplaceInferenceMethod::update_chol()
 	{
 		// compute cholesky: L = chol(sW * sW' .* K + I)
 		LLT<MatrixXd> L(
-			(eigen_sW*eigen_sW.transpose()).cwiseProduct(eigen_ktrtr*CMath::exp(m_log_scale*2.0))+
+			(eigen_sW * eigen_sW.transpose())
+			    .cwiseProduct(eigen_ktrtr * std::exp(m_log_scale * 2.0)) +
 			MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols));
 
 		eigen_L = L.matrixU();
@@ -467,7 +479,8 @@ void CSingleLaplaceInferenceMethod::update_init()
 		Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 
 		// compute f = K * alpha + m
-		eigen_mu=eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+		eigen_mu = eigen_ktrtr * std::exp(m_log_scale * 2.0) * eigen_alpha +
+			       eigen_mean;
 
 		Psi_New=eigen_alpha.dot(eigen_mu-eigen_mean)/2.0-
 			SGVector<float64_t>::sum(m_model->get_log_probability_f(m_labels, m_mu));
@@ -538,7 +551,8 @@ void CSingleLaplaceInferenceMethod::update_alpha()
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
 
 	// compute f = K * alpha + m
-	eigen_mu=eigen_ktrtr*CMath::exp(m_log_scale*2.0)*eigen_alpha+eigen_mean;
+	eigen_mu =
+		eigen_ktrtr * std::exp(m_log_scale * 2.0) * eigen_alpha + eigen_mean;
 }
 
 void CSingleLaplaceInferenceMethod::update_deriv()
@@ -565,12 +579,16 @@ void CSingleLaplaceInferenceMethod::update_deriv()
 		eigen_Z=-eigen_L;
 
 		// compute iA = (I + K * diag(W))^-1
-		FullPivLU<MatrixXd> lu(MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols)+
-				eigen_K*CMath::exp(m_log_scale*2.0)*eigen_W.asDiagonal());
+		FullPivLU<MatrixXd> lu(
+			MatrixXd::Identity(m_ktrtr.num_rows, m_ktrtr.num_cols) +
+			eigen_K * std::exp(m_log_scale * 2.0) * eigen_W.asDiagonal());
 		MatrixXd iA=lu.inverse();
 
 		// compute derivative ln|L'*L| wrt W: g=sum(iA.*K,2)/2
-		eigen_g=(iA.cwiseProduct(eigen_K*CMath::exp(m_log_scale*2.0))).rowwise().sum()/2.0;
+		eigen_g = (iA.cwiseProduct(eigen_K * std::exp(m_log_scale * 2.0)))
+			          .rowwise()
+			          .sum() /
+			      2.0;
 	}
 	else
 	{
@@ -581,12 +599,13 @@ void CSingleLaplaceInferenceMethod::update_deriv()
 		eigen_Z=eigen_sW.asDiagonal()*eigen_Z;
 
 		// solve L'*C=diag(sW)*K
-		MatrixXd C=eigen_L.triangularView<Upper>().adjoint().solve(
-				eigen_sW.asDiagonal()*eigen_K*CMath::exp(m_log_scale*2.0));
+		MatrixXd C = eigen_L.triangularView<Upper>().adjoint().solve(
+			eigen_sW.asDiagonal() * eigen_K * std::exp(m_log_scale * 2.0));
 
 		// compute derivative ln|L'*L| wrt W: g=(diag(K)-sum(C.^2,1)')/2
-		eigen_g=(eigen_K.diagonal()*CMath::exp(m_log_scale*2.0)-
-				(C.cwiseProduct(C)).colwise().sum().adjoint())/2.0;
+		eigen_g = (eigen_K.diagonal() * std::exp(m_log_scale * 2.0) -
+			       (C.cwiseProduct(C)).colwise().sum().adjoint()) /
+			      2.0;
 	}
 
 	// create shogun and eigen representation of the vector dfhat
@@ -622,8 +641,10 @@ SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_inference_
 	VectorXd b=eigen_K*eigen_dlp;
 
 	// compute dnlZ=dnlZ-dfhat'*(b-K*(Z*b))
-	result[0]=result[0]-eigen_dfhat.dot(b-eigen_K*CMath::exp(m_log_scale*2.0)*(eigen_Z*b));
-	result[0]*=CMath::exp(m_log_scale*2.0)*2.0;
+	result[0] = result[0] -
+		        eigen_dfhat.dot(
+		            b - eigen_K * std::exp(m_log_scale * 2.0) * (eigen_Z * b));
+	result[0] *= std::exp(m_log_scale * 2.0) * 2.0;
 
 	return result;
 }
@@ -656,8 +677,9 @@ SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_likelihood
 	VectorXd b=eigen_K*eigen_dlp_dhyp;
 
 	// compute dnlZ=-g'*d2lp_dhyp-sum(lp_dhyp)-dfhat'*(b-K*(Z*b))
-	result[0]=-eigen_g.dot(eigen_d2lp_dhyp)-eigen_lp_dhyp.sum()-
-		eigen_dfhat.dot(b-eigen_K*CMath::exp(m_log_scale*2.0)*(eigen_Z*b));
+	result[0] = -eigen_g.dot(eigen_d2lp_dhyp) - eigen_lp_dhyp.sum() -
+		        eigen_dfhat.dot(
+		            b - eigen_K * std::exp(m_log_scale * 2.0) * (eigen_Z * b));
 
 	return result;
 }
@@ -696,9 +718,11 @@ SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_kernel(
 		VectorXd b=eigen_dK*eigen_dlp;
 
 		// compute dnlZ=dnlZ-dfhat'*(b-K*(Z*b))
-		result[i]=result[i]-eigen_dfhat.dot(b-eigen_K*CMath::exp(m_log_scale*2.0)*
-				(eigen_Z*b));
-		result[i]*=CMath::exp(m_log_scale*2.0);
+		result[i] =
+			result[i] -
+			eigen_dfhat.dot(
+			    b - eigen_K * std::exp(m_log_scale * 2.0) * (eigen_Z * b));
+		result[i] *= std::exp(m_log_scale * 2.0);
 	}
 
 	return result;
@@ -730,8 +754,11 @@ SGVector<float64_t> CSingleLaplaceInferenceMethod::get_derivative_wrt_mean(
 		Map<VectorXd> eigen_dmu(dmu.vector, dmu.vlen);
 
 		// compute dnlZ=-alpha'*dm-dfhat'*(dm-K*(Z*dm))
-		result[i]=-eigen_alpha.dot(eigen_dmu)-eigen_dfhat.dot(eigen_dmu-
-				eigen_K*CMath::exp(m_log_scale*2.0)*(eigen_Z*eigen_dmu));
+		result[i] =
+			-eigen_alpha.dot(eigen_dmu) -
+			eigen_dfhat.dot(
+			    eigen_dmu -
+			    eigen_K * std::exp(m_log_scale * 2.0) * (eigen_Z * eigen_dmu));
 	}
 
 	return result;
@@ -764,8 +791,8 @@ float64_t CSingleLaplaceInferenceMethod::get_psi_wrt_alpha()
 	Eigen::Map<Eigen::VectorXd> eigen_mean_f(m_mean_f.vector,
 		m_mean_f.vlen);
 	/* f = K * alpha + mean_f given alpha*/
-	eigen_f
-		= kernel * ((eigen_alpha) * CMath::exp(m_log_scale*2.0)) + eigen_mean_f;
+	eigen_f =
+		kernel * ((eigen_alpha)*std::exp(m_log_scale * 2.0)) + eigen_mean_f;
 
 	/* psi = 0.5 * alpha .* (f - m) - sum(dlp)*/
 	float64_t psi = eigen_alpha.dot(eigen_f - eigen_mean_f) * 0.5;
@@ -790,7 +817,8 @@ void CSingleLaplaceInferenceMethod::get_gradient_wrt_alpha(SGVector<float64_t> g
 		m_mean_f.vlen);
 
 	/* f = K * alpha + mean_f given alpha*/
-	eigen_f = kernel * ((eigen_alpha) * CMath::exp(m_log_scale*2.0)) + eigen_mean_f;
+	eigen_f =
+		kernel * ((eigen_alpha)*std::exp(m_log_scale * 2.0)) + eigen_mean_f;
 
 	SGVector<float64_t> dlp_f =
 		m_model->get_log_probability_derivative_f(m_labels, f, 1); 
@@ -798,7 +826,8 @@ void CSingleLaplaceInferenceMethod::get_gradient_wrt_alpha(SGVector<float64_t> g
 	Eigen::Map<Eigen::VectorXd> eigen_dlp_f(dlp_f.vector, dlp_f.vlen);
 
 	/* g_alpha = K * (alpha - dlp_f)*/
-	eigen_gradient = kernel * ((eigen_alpha - eigen_dlp_f) * CMath::exp(m_log_scale*2.0));
+	eigen_gradient =
+		kernel * ((eigen_alpha - eigen_dlp_f) * std::exp(m_log_scale * 2.0));
 }
 
 

--- a/src/shogun/machine/gp/SingleSparseInference.cpp
+++ b/src/shogun/machine/gp/SingleSparseInference.cpp
@@ -233,7 +233,7 @@ SGVector<float64_t> CSingleSparseInference::get_derivative_wrt_inference_method(
 	SGVector<float64_t> result(1);
 
 	result[0]=get_derivative_related_cov(deriv_trtr, deriv_uu, deriv_tru);
-	result[0]*=CMath::exp(m_log_scale*2.0)*2.0;
+	result[0] *= std::exp(m_log_scale * 2.0) * 2.0;
 	return result;
 }
 
@@ -273,7 +273,7 @@ SGVector<float64_t> CSingleSparseInference::get_derivative_wrt_kernel(
 				deriv_tru.num_cols);
 
 		result[i]=get_derivative_related_cov(deriv_trtr, deriv_uu, deriv_tru);
-		result[i]*=CMath::exp(m_log_scale*2.0);
+		result[i] *= std::exp(m_log_scale * 2.0);
 	}
 	SG_UNREF(inducing_features);
 	return result;

--- a/src/shogun/machine/gp/SparseInference.cpp
+++ b/src/shogun/machine/gp/SparseInference.cpp
@@ -117,7 +117,7 @@ void CSparseInference::set_inducing_noise(float64_t noise)
 
 float64_t CSparseInference::get_inducing_noise()
 {
-	return CMath::exp(m_log_ind_noise);
+	return std::exp(m_log_ind_noise);
 }
 
 CSparseInference::~CSparseInference()

--- a/src/shogun/machine/gp/StudentsTLikelihood.cpp
+++ b/src/shogun/machine/gp/StudentsTLikelihood.cpp
@@ -93,8 +93,8 @@ public:
 	 */
 	virtual float64_t operator() (float64_t x)
 	{
-		return (1.0/(CMath::sqrt(2*CMath::PI)*m_sigma))*
-			CMath::exp(-CMath::sq(x-m_mu)/(2.0*CMath::sq(m_sigma)));
+		return (1.0 / (CMath::sqrt(2 * CMath::PI) * m_sigma)) *
+			   std::exp(-CMath::sq(x - m_mu) / (2.0 * CMath::sq(m_sigma)));
 	}
 
 private:
@@ -162,7 +162,7 @@ public:
 		float64_t lZ = CStatistics::lgamma((m_nu + 1.0) / 2.0) -
 			           CStatistics::lgamma(m_nu / 2.0) -
 			           std::log(m_nu * CMath::PI * CMath::sq(m_sigma)) / 2.0;
-		return CMath::exp(
+		return std::exp(
 			lZ -
 			((m_nu + 1.0) / 2.0) *
 			    std::log(
@@ -318,8 +318,8 @@ SGVector<float64_t> CStudentsTLikelihood::get_predictive_variances(
 		eigen_result=CMath::INFTY*VectorXd::Ones(result.vlen);
 	else
 	{
-		eigen_result+=CMath::exp(m_log_sigma*2.0)*df/(df-2.0)*
-			VectorXd::Ones(result.vlen);
+		eigen_result += std::exp(m_log_sigma * 2.0) * df / (df - 2.0) *
+			            VectorXd::Ones(result.vlen);
 	}
 
 	return result;
@@ -345,13 +345,15 @@ SGVector<float64_t> CStudentsTLikelihood::get_log_probability_f(const CLabels* l
 
 	float64_t df=get_degrees_freedom();
 	// compute lZ=log(gamma(df/2+1/2))-log(gamma(df/2))-log(df*pi*sigma^2)/2
-	VectorXd eigen_lZ=(CStatistics::lgamma(df/2.0+0.5)-
-		CStatistics::lgamma(df/2.0)-log(df*CMath::PI*CMath::exp(m_log_sigma*2.0))/2.0)*
+	VectorXd eigen_lZ =
+		(CStatistics::lgamma(df / 2.0 + 0.5) - CStatistics::lgamma(df / 2.0) -
+		 log(df * CMath::PI * std::exp(m_log_sigma * 2.0)) / 2.0) *
 		VectorXd::Ones(r.vlen);
 
 	// compute log probability: lp=lZ-(df+1)*log(1+(y-f).^2./(df*sigma^2))/2
 	eigen_r=eigen_y-eigen_f;
-	eigen_r=eigen_r.cwiseProduct(eigen_r)/(df*CMath::exp(m_log_sigma*2.0));
+	eigen_r =
+		eigen_r.cwiseProduct(eigen_r) / (df * std::exp(m_log_sigma * 2.0));
 	eigen_r=eigen_lZ-(df+1)*
 		(eigen_r+VectorXd::Ones(r.vlen)).array().log().matrix()/2.0;
 
@@ -383,7 +385,8 @@ SGVector<float64_t> CStudentsTLikelihood::get_log_probability_derivative_f(
 	float64_t df=get_degrees_freedom();
 
 	// compute a=(y-f).^2+df*sigma^2
-	VectorXd a=eigen_r2+VectorXd::Ones(r.vlen)*df*CMath::exp(m_log_sigma*2.0);
+	VectorXd a =
+		eigen_r2 + VectorXd::Ones(r.vlen) * df * std::exp(m_log_sigma * 2.0);
 
 	if (i==1)
 	{
@@ -395,7 +398,8 @@ SGVector<float64_t> CStudentsTLikelihood::get_log_probability_derivative_f(
 	{
 		// compute second derivative of log probability wrt f:
 		// d2lp=(df+1)*((y-f)^2-df*sigma^2)./a.^2
-		VectorXd b=eigen_r2-VectorXd::Ones(r.vlen)*df*CMath::exp(m_log_sigma*2.0);
+		VectorXd b = eigen_r2 -
+			         VectorXd::Ones(r.vlen) * df * std::exp(m_log_sigma * 2.0);
 
 		eigen_r=(df+1)*b.cwiseQuotient(a.cwiseProduct(a));
 	}
@@ -403,7 +407,9 @@ SGVector<float64_t> CStudentsTLikelihood::get_log_probability_derivative_f(
 	{
 		// compute third derivative of log probability wrt f:
 		// d3lp=(f+1)*2*(y-f).*((y-f)^2-3*f*sigma^2)./a.^3
-		VectorXd c=eigen_r2-VectorXd::Ones(r.vlen)*3*df*CMath::exp(m_log_sigma*2.0);
+		VectorXd c =
+			eigen_r2 -
+			VectorXd::Ones(r.vlen) * 3 * df * std::exp(m_log_sigma * 2.0);
 		VectorXd a2=a.cwiseProduct(a);
 
 		eigen_r=(df+1)*2*eigen_r.cwiseProduct(c).cwiseQuotient(
@@ -444,11 +450,19 @@ SGVector<float64_t> CStudentsTLikelihood::get_first_derivative(const CLabels* la
 		eigen_r=(df*(CStatistics::dlgamma(df*0.5+0.5)-
 			CStatistics::dlgamma(df*0.5))*0.5-0.5)*VectorXd::Ones(r.vlen);
 
-		eigen_r-=df*(VectorXd::Ones(r.vlen)+
-			eigen_r2/(df*CMath::exp(m_log_sigma*2.0))).array().log().matrix()/2.0;
+		eigen_r -= df *
+			       (VectorXd::Ones(r.vlen) +
+			        eigen_r2 / (df * std::exp(m_log_sigma * 2.0)))
+			           .array()
+			           .log()
+			           .matrix() /
+			       2.0;
 
-		eigen_r+=(df/2.0+0.5)*eigen_r2.cwiseQuotient(
-			eigen_r2+VectorXd::Ones(r.vlen)*(df*CMath::exp(m_log_sigma*2.0)));
+		eigen_r +=
+			(df / 2.0 + 0.5) *
+			eigen_r2.cwiseQuotient(
+			    eigen_r2 +
+			    VectorXd::Ones(r.vlen) * (df * std::exp(m_log_sigma * 2.0)));
 
 		eigen_r*=(1.0-1.0/df);
 
@@ -458,8 +472,11 @@ SGVector<float64_t> CStudentsTLikelihood::get_first_derivative(const CLabels* la
 	{
 		// compute derivative of log probability wrt sigma:
 		// lp_dsigma=(df+1)*r2./a-1
-		eigen_r=(df+1)*eigen_r2.cwiseQuotient(eigen_r2+
-			VectorXd::Ones(r.vlen)*(df*CMath::exp(m_log_sigma*2.0)));
+		eigen_r =
+			(df + 1) *
+			eigen_r2.cwiseQuotient(
+			    eigen_r2 +
+			    VectorXd::Ones(r.vlen) * (df * std::exp(m_log_sigma * 2.0)));
 		eigen_r-=VectorXd::Ones(r.vlen);
 
 		return r;
@@ -492,15 +509,21 @@ SGVector<float64_t> CStudentsTLikelihood::get_second_derivative(const CLabels* l
 	float64_t df=get_degrees_freedom();
 
 	// compute a=r+sigma^2*df and a2=a.^2
-	VectorXd a=eigen_r2+CMath::exp(m_log_sigma*2.0)*df*VectorXd::Ones(r.vlen);
+	VectorXd a =
+		eigen_r2 + std::exp(m_log_sigma * 2.0) * df * VectorXd::Ones(r.vlen);
 	VectorXd a2=a.cwiseProduct(a);
 
 	if (!strcmp(param->m_name, "log_df"))
 	{
 		// compute derivative of first derivative of log probability wrt df:
 		// dlp_ddf=df*r.*(a-sigma^2*(df+1))./a2
-		eigen_r=df*eigen_r.cwiseProduct(a-CMath::exp(m_log_sigma*2.0)*(df+1.0)*
-			VectorXd::Ones(r.vlen)).cwiseQuotient(a2);
+		eigen_r = df *
+			      eigen_r
+			          .cwiseProduct(
+			              a -
+			              std::exp(m_log_sigma * 2.0) * (df + 1.0) *
+			                  VectorXd::Ones(r.vlen))
+			          .cwiseQuotient(a2);
 		eigen_r*=(1.0-1.0/df);
 
 		return r;
@@ -509,8 +532,8 @@ SGVector<float64_t> CStudentsTLikelihood::get_second_derivative(const CLabels* l
 	{
 		// compute derivative of first derivative of log probability wrt sigma:
 		// dlp_dsigma=-(df+1)*2*df*sigma^2*r./a2
-		eigen_r=-(df+1.0)*2*df*CMath::exp(m_log_sigma*2.0)*
-			eigen_r.cwiseQuotient(a2);
+		eigen_r = -(df + 1.0) * 2 * df * std::exp(m_log_sigma * 2.0) *
+			      eigen_r.cwiseQuotient(a2);
 
 		return r;
 	}
@@ -542,14 +565,15 @@ SGVector<float64_t> CStudentsTLikelihood::get_third_derivative(const CLabels* la
 	float64_t df=get_degrees_freedom();
 
 	// compute a=r+sigma^2*df and a3=a.^3
-	VectorXd a=eigen_r2+CMath::exp(m_log_sigma*2.0)*df*VectorXd::Ones(r.vlen);
+	VectorXd a =
+		eigen_r2 + std::exp(m_log_sigma * 2.0) * df * VectorXd::Ones(r.vlen);
 	VectorXd a3=(a.cwiseProduct(a)).cwiseProduct(a);
 
 	if (!strcmp(param->m_name, "log_df"))
 	{
 		// compute derivative of second derivative of log probability wrt df:
 		// d2lp_ddf=df*(r2.*(r2-3*sigma^2*(1+df))+df*sigma^4)./a3
-		float64_t sigma2=CMath::exp(m_log_sigma*2.0);
+		float64_t sigma2 = std::exp(m_log_sigma * 2.0);
 
 		eigen_r=df*(eigen_r2.cwiseProduct(eigen_r2-3*sigma2*(1.0+df)*
 			VectorXd::Ones(r.vlen))+(df*CMath::sq(sigma2))*VectorXd::Ones(r.vlen));
@@ -563,8 +587,8 @@ SGVector<float64_t> CStudentsTLikelihood::get_third_derivative(const CLabels* la
 	{
 		// compute derivative of second derivative of log probability wrt sigma:
 		// d2lp_dsigma=(df+1)*2*df*sigma^2*(a-4*r2)./a3
-		eigen_r=(df+1.0)*2*df*CMath::exp(m_log_sigma*2.0)*
-			(a-4.0*eigen_r2).cwiseQuotient(a3);
+		eigen_r = (df + 1.0) * 2 * df * std::exp(m_log_sigma * 2.0) *
+			      (a - 4.0 * eigen_r2).cwiseQuotient(a3);
 
 		return r;
 	}
@@ -605,7 +629,7 @@ SGVector<float64_t> CStudentsTLikelihood::get_log_zeroth_moments(
 	CStudentsTPDF* g=new CStudentsTPDF();
 
 	g->set_nu(get_degrees_freedom());
-	g->set_sigma(CMath::exp(m_log_sigma));
+	g->set_sigma(std::exp(m_log_sigma));
 
 	// create an object of product of Student's-t pdf and normal pdf
 	CProductFunction* h=new CProductFunction(f, g);
@@ -659,7 +683,8 @@ float64_t CStudentsTLikelihood::get_first_moment(SGVector<float64_t> mu,
 	CNormalPDF* f=new CNormalPDF(mu[i], CMath::sqrt(s2[i]));
 
 	// create an object of Student's t pdf
-	CStudentsTPDF* g=new CStudentsTPDF(CMath::exp(m_log_sigma), get_degrees_freedom(), y[i]);
+	CStudentsTPDF* g =
+		new CStudentsTPDF(std::exp(m_log_sigma), get_degrees_freedom(), y[i]);
 
 	// create an object of h(x)=N(x|mu,sigma)*t(x|mu,sigma,nu)
 	CProductFunction* h=new CProductFunction(f, g);
@@ -705,7 +730,8 @@ float64_t CStudentsTLikelihood::get_second_moment(SGVector<float64_t> mu,
 	CNormalPDF* f=new CNormalPDF(mu[i], CMath::sqrt(s2[i]));
 
 	// create an object of Student's t pdf
-	CStudentsTPDF* g=new CStudentsTPDF(CMath::exp(m_log_sigma), get_degrees_freedom(), y[i]);
+	CStudentsTPDF* g =
+		new CStudentsTPDF(std::exp(m_log_sigma), get_degrees_freedom(), y[i]);
 
 	// create an object of h(x)=N(x|mu,sigma)*t(x|mu,sigma,nu)
 	CProductFunction* h=new CProductFunction(f, g);

--- a/src/shogun/machine/gp/StudentsTLikelihood.h
+++ b/src/shogun/machine/gp/StudentsTLikelihood.h
@@ -79,7 +79,10 @@ public:
 	 *
 	 * @return scale parameter
 	 */
-	float64_t get_sigma() const { return CMath::exp(m_log_sigma); }
+	float64_t get_sigma() const
+	{
+		return std::exp(m_log_sigma);
+	}
 
 	/** sets the scale parameter
 	 *
@@ -95,7 +98,10 @@ public:
 	 *
 	 * @return degrees of freedom
 	 */
-	float64_t get_degrees_freedom() const { return CMath::exp(m_log_df)+1; }
+	float64_t get_degrees_freedom() const
+	{
+		return std::exp(m_log_df) + 1;
+	}
 
 	/** set degrees of freedom
 	 *

--- a/src/shogun/machine/gp/StudentsTVGLikelihood.cpp
+++ b/src/shogun/machine/gp/StudentsTVGLikelihood.cpp
@@ -71,7 +71,9 @@ CStudentsTVGLikelihood::~CStudentsTVGLikelihood()
 
 void CStudentsTVGLikelihood::init_likelihood()
 {
-	set_likelihood(new CStudentsTLikelihood(CMath::exp(m_log_sigma), CMath::exp(m_log_df)+1.0));
+	set_likelihood(
+		new CStudentsTLikelihood(
+		    std::exp(m_log_sigma), std::exp(m_log_df) + 1.0));
 }
 
 void CStudentsTVGLikelihood::init()

--- a/src/shogun/mathematics/Math.cpp
+++ b/src/shogun/mathematics/Math.cpp
@@ -63,7 +63,7 @@ CMath::CMath()
     init_log_table();
 #else
 	int32_t i=0;
-	while ((float64_t)std::log(1 + ((float64_t)exp(-float64_t(i)))))
+	while ((float64_t)std::log(1 + ((float64_t)std::exp(-float64_t(i)))))
 		i++;
 
 	LOGRANGE=i;
@@ -85,27 +85,34 @@ int32_t CMath::determine_logrange()
     float64_t acc=0;
     for (i=0; i<50; i++)
 	{
-		acc=((float64_t)log(1+((float64_t)exp(-float64_t(i)))));
+		acc = ((float64_t)log(1 + ((float64_t)std::exp(-float64_t(i)))));
 		if (acc<=(float64_t)LOG_TABLE_PRECISION)
 			break;
 	}
 
-    SG_SINFO("determined range for x in table log(1+exp(-x)) is:%d (error:%G)\n",i,acc)
-    return i;
+	SG_SINFO(
+	    "determined range for x in table log(1+std::exp(-x)) is:%d "
+	    "(error:%G)\n",
+	    i, acc)
+	return i;
 }
 
 int32_t CMath::determine_logaccuracy(int32_t range)
 {
     range=MAX_LOG_TABLE_SIZE/range/((int)sizeof(float64_t));
-    SG_SINFO("determined accuracy for x in table log(1+exp(-x)) is:%d (error:%G)\n",range,1.0/(double) range)
-    return range;
+	SG_SINFO(
+	    "determined accuracy for x in table log(1+std::exp(-x)) is:%d "
+	    "(error:%G)\n",
+	    range, 1.0 / (double)range)
+	return range;
 }
 
 //init log table of form log(1+exp(x))
 void CMath::init_log_table()
 {
   for (int32_t i=0; i< LOGACCURACY*LOGRANGE; i++)
-	  logtable[i] = std::log(1 + exp(float64_t(-i) / float64_t(LOGACCURACY)));
+	  logtable[i] =
+		  std::log(1 + std::exp(float64_t(-i) / float64_t(LOGACCURACY)));
 }
 #endif
 

--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -542,17 +542,6 @@ class CMath : public CSGObject
 		}
 		//@}
 
-		/** Computes e^x where e=2.71828 approx.
-		 * @param x exponent
-		 */
-		static inline float64_t exp(float64_t x)
-		{
-			return std::exp(x);
-		}
-
-		/// exp(x), x being a complex128_t
-		COMPLEX128_STDMATH(exp)
-
 		/**
 		 * @name Trignometric and Hyperbolic Functions
 		 */
@@ -1074,7 +1063,7 @@ class CMath : public CSGObject
 			{
 				if (from_idx!=min_index)
 				{
-					values_without_X0[to_idx]=exp(values[from_idx]-X0);
+					values_without_X0[to_idx] = std::exp(values[from_idx] - X0);
 					to_idx++;
 				}
 			}
@@ -1811,8 +1800,8 @@ class CMath : public CSGObject
 				return p;
 			diff = p - q;
 			if (diff > 0)
-				return diff > LOGRANGE ? p : p + std::log(1 + exp(-diff));
-			return -diff > LOGRANGE ? q : q + std::log(1 + exp(diff));
+				return diff > LOGRANGE ? p : p + std::log(1 + std::exp(-diff));
+			return -diff > LOGRANGE ? q : q + std::log(1 + std::exp(diff));
 		}
 #endif
 #ifdef USE_LOGSUMARRAY

--- a/src/shogun/mathematics/Random.cpp
+++ b/src/shogun/mathematics/Random.cpp
@@ -317,7 +317,7 @@ float64_t CRandom::sample_tail() const
 
 float64_t CRandom::GaussianPdfDenorm(float64_t x) const
 {
-	return CMath::exp(-(x*x * 0.5));
+	return std::exp(-(x * x * 0.5));
 }
 
 float64_t CRandom::GaussianPdfDenormInv(float64_t y) const

--- a/src/shogun/mathematics/Statistics.cpp
+++ b/src/shogun/mathematics/Statistics.cpp
@@ -275,9 +275,9 @@ float64_t CStatistics::fishers_exact_test_for_2x3_table(
 
 #ifdef DEBUG_FISHER_TABLE
 	SG_SPRINT("nonrand_p=%.18g\n", nonrand_p)
-	SG_SPRINT("exp_nonrand_p=%.18g\n", CMath::exp(nonrand_p))
+	SG_SPRINT("exp_nonrand_p=%.18g\n", std::exp(nonrand_p))
 #endif // DEBUG_FISHER_TABLE
-	nonrand_p=CMath::exp(nonrand_p);
+	nonrand_p = std::exp(nonrand_p);
 
 	SG_FREE(log_denom_vec);
 	SG_FREE(x);
@@ -856,9 +856,9 @@ CStatistics::SigmoidParamters CStatistics::fit_sigmoid(
 	{
 		float64_t fApB = scores[i] * a + b;
 		if (fApB >= 0)
-			fval += t[i] * fApB + std::log(1 + CMath::exp(-fApB));
+			fval += t[i] * fApB + std::log(1 + std::exp(-fApB));
 		else
-			fval += (t[i] - 1) * fApB + std::log(1 + CMath::exp(fApB));
+			fval += (t[i] - 1) * fApB + std::log(1 + std::exp(fApB));
 	}
 
 	index_t it;
@@ -882,13 +882,13 @@ CStatistics::SigmoidParamters CStatistics::fit_sigmoid(
 			float64_t q;
 			if (fApB >= 0)
 			{
-				p = CMath::exp(-fApB) / (1.0 + CMath::exp(-fApB));
-				q = 1.0 / (1.0 + CMath::exp(-fApB));
+				p = std::exp(-fApB) / (1.0 + std::exp(-fApB));
+				q = 1.0 / (1.0 + std::exp(-fApB));
 			}
 			else
 			{
-				p = 1.0 / (1.0 + CMath::exp(fApB));
-				q = CMath::exp(fApB) / (1.0 + CMath::exp(fApB));
+				p = 1.0 / (1.0 + std::exp(fApB));
+				q = std::exp(fApB) / (1.0 + std::exp(fApB));
 			}
 
 			float64_t d2 = p * q;
@@ -924,9 +924,9 @@ CStatistics::SigmoidParamters CStatistics::fit_sigmoid(
 			{
 				float64_t fApB = scores[i] * newA + newB;
 				if (fApB >= 0)
-					newf += t[i] * fApB + std::log(1 + CMath::exp(-fApB));
+					newf += t[i] * fApB + std::log(1 + std::exp(-fApB));
 				else
-					newf += (t[i] - 1) * fApB + std::log(1 + CMath::exp(fApB));
+					newf += (t[i] - 1) * fApB + std::log(1 + std::exp(fApB));
 			}
 
 			/* Check sufficient decrease */
@@ -1024,9 +1024,9 @@ CStatistics::SigmoidParamters CStatistics::fit_sigmoid(SGVector<float64_t> score
 	{
 		float64_t fApB=scores[i]*a+b;
 		if (fApB>=0)
-			fval += t[i] * fApB + std::log(1 + CMath::exp(-fApB));
+			fval += t[i] * fApB + std::log(1 + std::exp(-fApB));
 		else
-			fval += (t[i] - 1) * fApB + std::log(1 + CMath::exp(fApB));
+			fval += (t[i] - 1) * fApB + std::log(1 + std::exp(fApB));
 	}
 
 	index_t it;
@@ -1050,13 +1050,13 @@ CStatistics::SigmoidParamters CStatistics::fit_sigmoid(SGVector<float64_t> score
 			float64_t q;
 			if (fApB>=0)
 			{
-				p=CMath::exp(-fApB)/(1.0+CMath::exp(-fApB));
-				q=1.0/(1.0+CMath::exp(-fApB));
+				p = std::exp(-fApB) / (1.0 + std::exp(-fApB));
+				q = 1.0 / (1.0 + std::exp(-fApB));
 			}
 			else
 			{
-				p=1.0/(1.0+CMath::exp(fApB));
-				q=CMath::exp(fApB)/(1.0+CMath::exp(fApB));
+				p = 1.0 / (1.0 + std::exp(fApB));
+				q = std::exp(fApB) / (1.0 + std::exp(fApB));
 			}
 
 			float64_t d2=p*q;
@@ -1092,9 +1092,9 @@ CStatistics::SigmoidParamters CStatistics::fit_sigmoid(SGVector<float64_t> score
 			{
 				float64_t fApB=scores[i]*newA+newB;
 				if (fApB>=0)
-					newf += t[i] * fApB + std::log(1 + CMath::exp(-fApB));
+					newf += t[i] * fApB + std::log(1 + std::exp(-fApB));
 				else
-					newf += (t[i] - 1) * fApB + std::log(1 + CMath::exp(fApB));
+					newf += (t[i] - 1) * fApB + std::log(1 + std::exp(fApB));
 			}
 
 			/* Check sufficient decrease */

--- a/src/shogun/multiclass/MulticlassOneVsRestStrategy.cpp
+++ b/src/shogun/multiclass/MulticlassOneVsRestStrategy.cpp
@@ -115,7 +115,7 @@ void CMulticlassOneVsRestStrategy::rescale_heuris_softmax(SGVector<float64_t> ou
 	}
 
 	for (int32_t i=0; i<outputs.vlen; i++)
-		outputs[i] = CMath::exp(-As[i]*outputs[i]-Bs[i]);
+		outputs[i] = std::exp(-As[i] * outputs[i] - Bs[i]);
 
 	float64_t norm = SGVector<float64_t>::sum(outputs);
 	norm += 1E-10;

--- a/src/shogun/multiclass/ShareBoost.cpp
+++ b/src/shogun/multiclass/ShareBoost.cpp
@@ -143,7 +143,8 @@ void CShareBoost::compute_rho()
 		{ // j loop samples
 			int32_t label = lab->get_int_label(j);
 
-			m_rho(i,j) = CMath::exp((label == i) - m_pred(j, label) + m_pred(j, i));
+			m_rho(i, j) =
+			    std::exp((label == i) - m_pred(j, label) + m_pred(j, i));
 		}
 	}
 

--- a/src/shogun/multiclass/tree/CHAIDTree.cpp
+++ b/src/shogun/multiclass/tree/CHAIDTree.cpp
@@ -826,9 +826,9 @@ float64_t CCHAIDTree::adjusted_p_value(float64_t up_value, int32_t inum_cat, int
 				    lterm -= std::log(j);
 
 			    if (v % 2 == 0)
-				    sum += CMath::exp(lterm);
+				    sum += std::exp(lterm);
 			    else
-				    sum -= CMath::exp(lterm);
+				    sum -= std::exp(lterm);
 		    }
 
 		    return sum * up_value;

--- a/src/shogun/multiclass/tree/ConditionalProbabilityTree.cpp
+++ b/src/shogun/multiclass/tree/ConditionalProbabilityTree.cpp
@@ -239,7 +239,7 @@ float64_t CConditionalProbabilityTree::predict_node(SGVector<float32_t> ex, bnod
 	float64_t pred = mch->apply_one(ex.vector, ex.vlen);
 	SG_UNREF(mch);
 	// use sigmoid function to turn the decision value into valid probability
-	return 1.0/(1+CMath::exp(-pred));
+	return 1.0 / (1 + std::exp(-pred));
 }
 
 int32_t CConditionalProbabilityTree::create_machine(CStreamingDenseFeatures<float32_t>* ex)

--- a/src/shogun/multiclass/tree/NbodyTree.h
+++ b/src/shogun/multiclass/tree/NbodyTree.h
@@ -289,7 +289,7 @@ private:
 		if (a==-CMath::INFTY)
 			return -CMath::INFTY;
 
-		return a + std::log(CMath::exp(x - a) + CMath::exp(y - a));
+		return a + std::log(std::exp(x - a) + std::exp(y - a));
 	}
 
 	/** log-diff-exp trick for 2 numbers
@@ -303,7 +303,7 @@ private:
 		if (x<=y)
 			return -CMath::INFTY;
 
-		return x + std::log(1 - CMath::exp(y - x));
+		return x + std::log(1 - std::exp(y - x));
 	}
 
 	/** initialize parameters */

--- a/src/shogun/neuralnets/ConvolutionalFeatureMap.cpp
+++ b/src/shogun/neuralnets/ConvolutionalFeatureMap.cpp
@@ -116,8 +116,9 @@ void CConvolutionalFeatureMap::compute_activations(
 	{
 		for (int32_t i=0; i<m_output_num_neurons; i++)
 			for (int32_t j=0; j<batch_size; j++)
-				activations(i+m_row_offset,j) =
-					1.0/(1.0+CMath::exp(-1.0*activations(i+m_row_offset,j)));
+				activations(i + m_row_offset, j) =
+				    1.0 /
+				    (1.0 + std::exp(-1.0 * activations(i + m_row_offset, j)));
 	}
 	else if (m_activation_function==CMAF_RECTIFIED_LINEAR)
 	{

--- a/src/shogun/neuralnets/DeepBeliefNetwork.cpp
+++ b/src/shogun/neuralnets/DeepBeliefNetwork.cpp
@@ -412,7 +412,7 @@ void CDeepBeliefNetwork::down_step(int32_t index, SGVector< float64_t > params,
 	{
 		int32_t len = m_layer_sizes->element(index)*m_batch_size;
 		for (int32_t i=0; i<len; i++)
-				result[i] = 1.0/(1.0+CMath::exp(-1.0*result[i]));
+			result[i] = 1.0 / (1.0 + std::exp(-1.0 * result[i]));
 	}
 
 	if (index == 0 && m_visible_units_type==RBMVUT_SOFTMAX)
@@ -423,11 +423,11 @@ void CDeepBeliefNetwork::down_step(int32_t index, SGVector< float64_t > params,
 		{
 			float64_t sum = 0;
 			for (int32_t i=0; i<m_layer_sizes->element(0); i++)
-				sum += CMath::exp(Out(i,j)-max);
+				sum += std::exp(Out(i, j) - max);
 
 			float64_t normalizer = std::log(sum);
 			for (int32_t k=0; k<m_layer_sizes->element(0); k++)
-				Out(k,j) = CMath::exp(Out(k,j)-max-normalizer);
+				Out(k, j) = std::exp(Out(k, j) - max - normalizer);
 		}
 	}
 
@@ -460,7 +460,7 @@ void CDeepBeliefNetwork::up_step(int32_t index, SGVector< float64_t > params,
 
 	int32_t len = result.num_rows*result.num_cols;
 	for (int32_t i=0; i<len; i++)
-		result[i] = 1.0/(1.0+CMath::exp(-1.0*result[i]));
+		result[i] = 1.0 / (1.0 + std::exp(-1.0 * result[i]));
 
 	if (sample_states && index>0)
 	{

--- a/src/shogun/neuralnets/NeuralLogisticLayer.cpp
+++ b/src/shogun/neuralnets/NeuralLogisticLayer.cpp
@@ -54,7 +54,7 @@ void CNeuralLogisticLayer::compute_activations(SGVector<float64_t> parameters,
 	// apply logistic activation function
 	int32_t length = m_num_neurons*m_batch_size;
 	for (int32_t i=0; i<length; i++)
-		m_activations[i] = 1.0/(1.0+CMath::exp(-1.0*m_activations[i]));
+		m_activations[i] = 1.0 / (1.0 + std::exp(-1.0 * m_activations[i]));
 }
 
 float64_t CNeuralLogisticLayer::compute_contraction_term(

--- a/src/shogun/neuralnets/NeuralSoftmaxLayer.cpp
+++ b/src/shogun/neuralnets/NeuralSoftmaxLayer.cpp
@@ -62,13 +62,13 @@ void CNeuralSoftmaxLayer::compute_activations(SGVector<float64_t> parameters,
 		float64_t sum = 0;
 		for (int32_t i=0; i<m_num_neurons; i++)
 		{
-			sum += CMath::exp(m_activations[i+j*m_num_neurons]-max);
+			sum += std::exp(m_activations[i + j * m_num_neurons] - max);
 		}
 		float64_t normalizer = std::log(sum);
 		for (int32_t k=0; k<m_num_neurons; k++)
 		{
-			m_activations[k+j*m_num_neurons] =
-				CMath::exp(m_activations[k+j*m_num_neurons]-max-normalizer);
+			m_activations[k + j * m_num_neurons] = std::exp(
+			    m_activations[k + j * m_num_neurons] - max - normalizer);
 		}
 	}
 }

--- a/src/shogun/neuralnets/RBM.cpp
+++ b/src/shogun/neuralnets/RBM.cpp
@@ -296,7 +296,7 @@ float64_t CRBM::free_energy(SGMatrix< float64_t > visible, SGMatrix< float64_t >
 	float64_t wv_term = 0;
 	for (int32_t i=0; i<m_num_hidden; i++)
 		for (int32_t j=0; j<m_batch_size; j++)
-			wv_term += std::log(1.0 + CMath::exp(wv_buffer(i, j)));
+			wv_term += std::log(1.0 + std::exp(wv_buffer(i, j)));
 
 	float64_t F = -1.0*(bv_term+wv_term)/m_batch_size;
 
@@ -444,7 +444,7 @@ float64_t CRBM::pseudo_likelihood(SGMatrix< float64_t > visible,
 	for (int32_t j=0; j<m_batch_size; j++)
 		visible(indices[j],j) = 1.0-visible(indices[j],j);
 
-	return m_num_visible * std::log(1.0 / (1 + CMath::exp(f1 - f2)));
+	return m_num_visible * std::log(1.0 / (1 + std::exp(f1 - f2)));
 }
 
 void CRBM::mean_hidden(SGMatrix< float64_t > visible, SGMatrix< float64_t > result)
@@ -462,7 +462,7 @@ void CRBM::mean_hidden(SGMatrix< float64_t > visible, SGMatrix< float64_t > resu
 
 	int32_t len = result.num_rows*result.num_cols;
 	for (int32_t i=0; i<len; i++)
-		result[i] = 1.0/(1.0+CMath::exp(-1.0*result[i]));
+		result[i] = 1.0 / (1.0 + std::exp(-1.0 * result[i]));
 }
 
 void CRBM::mean_visible(SGMatrix< float64_t > hidden, SGMatrix< float64_t > result)
@@ -486,7 +486,8 @@ void CRBM::mean_visible(SGMatrix< float64_t > hidden, SGMatrix< float64_t > resu
 		{
 			for (int32_t i=0; i<m_visible_group_sizes->element(k); i++)
 				for (int32_t j=0; j<m_batch_size; j++)
-					result(i+offset,j) = 1.0/(1.0+CMath::exp(-1.0*result(i+offset,j)));
+					result(i + offset, j) =
+					    1.0 / (1.0 + std::exp(-1.0 * result(i + offset, j)));
 		}
 		if (m_visible_group_types->element(k)==RBMVUT_SOFTMAX)
 		{
@@ -504,13 +505,13 @@ void CRBM::mean_visible(SGMatrix< float64_t > hidden, SGMatrix< float64_t > resu
 			{
 				float64_t sum = 0;
 				for (int32_t i=0; i<m_visible_group_sizes->element(k); i++)
-					sum += CMath::exp(result(i+offset,j)-max);
+					sum += std::exp(result(i + offset, j) - max);
 
 				float64_t normalizer = std::log(sum);
 
 				for (int32_t i=0; i<m_visible_group_sizes->element(k); i++)
-					result(i+offset,j) =
-						CMath::exp(result(i+offset,j)-max-normalizer);
+					result(i + offset, j) =
+					    std::exp(result(i + offset, j) - max - normalizer);
 			}
 		}
 	}

--- a/src/shogun/optimization/AdamUpdater.cpp
+++ b/src/shogun/optimization/AdamUpdater.cpp
@@ -129,7 +129,8 @@ float64_t AdamUpdater::get_negative_descend_direction(float64_t variable,
 		(1.0-m_decay_factor_second_moment)*gradient*gradient;
 	m_gradient_second_moment[idx]=scale_second_moment;
 
-	float64_t res=CMath::exp(m_log_scale_pre_iteration)*scale_first_moment/(CMath::sqrt(scale_second_moment)+m_epsilon);
+	float64_t res = std::exp(m_log_scale_pre_iteration) * scale_first_moment /
+	                (CMath::sqrt(scale_second_moment) + m_epsilon);
 	return res;
 }
 

--- a/src/shogun/preprocessor/HomogeneousKernelMap.cpp
+++ b/src/shogun/preprocessor/HomogeneousKernelMap.cpp
@@ -245,11 +245,12 @@ CHomogeneousKernelMap::get_spectrum(float64_t omega) const
 		case HomogeneousKernelIntersection:
 			return (2.0 / CMath::PI) / (1 + 4 * omega*omega);
 		case HomogeneousKernelChi2:
-			return 2.0 / (CMath::exp (CMath::PI * omega) + CMath::exp (-CMath::PI * omega)) ;
-		case HomogeneousKernelJS:
+		    return 2.0 /
+		           (std::exp(CMath::PI * omega) + std::exp(-CMath::PI * omega));
+	    case HomogeneousKernelJS:
 		    return (2.0 / std::log(4.0)) * 2.0 /
-		           (CMath::exp(CMath::PI * omega) +
-		            CMath::exp(-CMath::PI * omega)) /
+		           (std::exp(CMath::PI * omega) +
+		            std::exp(-CMath::PI * omega)) /
 		           (1 + 4 * omega * omega);
 	    default:
 		    /* throw exception */

--- a/tests/unit/mathematics/Complex_unittest.cc
+++ b/tests/unit/mathematics/Complex_unittest.cc
@@ -25,7 +25,7 @@ TEST(CMath, complex_test)
 	result=CMath::log10(a);
 	EXPECT_NEAR(result.real(), 0.89266491750538345951, 1E-14);
 	EXPECT_NEAR(result.imag(), 0.38046717720171513433, 1E-14);
-	result=CMath::exp(a);
+	result = std::exp(a);
 	EXPECT_NEAR(result.real(), 142.50190551820736573063, 1E-13);
 	EXPECT_NEAR(result.imag(), -41.46893678992289267171, 1E-13);
 

--- a/tests/unit/mathematics/Integration_unittest.cc
+++ b/tests/unit/mathematics/Integration_unittest.cc
@@ -96,8 +96,8 @@ public:
 	 */
 	virtual float64_t operator() (float64_t x)
 	{
-		return (1.0/(CMath::sqrt(2*CMath::PI)*m_sigma))*
-			CMath::exp(-CMath::sq(x-m_mu)/(2.0*CMath::sq(m_sigma)));
+		return (1.0 / (CMath::sqrt(2 * CMath::PI) * m_sigma)) *
+		       std::exp(-CMath::sq(x - m_mu) / (2.0 * CMath::sq(m_sigma)));
 	}
 
 private:
@@ -157,7 +157,7 @@ public:
 		float64_t lZ = CStatistics::lgamma(m_nu / 2.0 + 0.5) -
 		               CStatistics::lgamma(m_nu / 2.0) -
 		               std::log(m_nu * CMath::PI * CMath::sq(m_sigma)) / 2.0;
-		return CMath::exp(
+		return std::exp(
 		    lZ -
 		    (m_nu / 2.0 + 0.5) *
 		        std::log(
@@ -188,7 +188,7 @@ public:
 	 */
 	virtual float64_t operator() (float64_t x)
 	{
-		return 1.0/(1.0+CMath::exp(-x));
+		return 1.0 / (1.0 + std::exp(-x));
 	}
 };
 

--- a/tests/unit/mathematics/Math_unittest.cc
+++ b/tests/unit/mathematics/Math_unittest.cc
@@ -94,13 +94,13 @@ TEST(CMath, float64_tests)
 	EXPECT_NEAR(CMath::pow(33.42268004087848964900, 0.5), a, 1E-15);
 
 	// e^x, log_{b}(x)
-	EXPECT_NEAR(CMath::exp(a), 324.15933372813628920994, 1E-15);
+	EXPECT_NEAR(std::exp(a), 324.15933372813628920994, 1E-15);
 	EXPECT_NEAR(CMath::log2(a), 2.53137775864743908016, 1E-15);
 	EXPECT_NEAR(CMath::log10(a), 0.76202063570953693095, 1E-15);
 
 	// exp and log identities
-	EXPECT_NEAR(std::log(CMath::exp(a)), a, 1E-15);
-	EXPECT_NEAR(CMath::exp(std::log(a)), a, 1E-15);
+	EXPECT_NEAR(std::log(std::exp(a)), a, 1E-15);
+	EXPECT_NEAR(std::exp(std::log(a)), a, 1E-15);
 
 	// trigonometric functions
 	EXPECT_NEAR(CMath::sin(a), -0.48113603605414501097, 1E-15);

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -767,7 +767,7 @@ TEST(LinalgBackendEigen, logistic)
 	linalg::logistic(A, B);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(1.0/(1+CMath::exp(-1*A[i])), B[i], 1e-15);
+		EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], 1e-15);
 }
 
 TEST(LinalgBackendEigen, SGMatrix_SGVector_matrix_prod)
@@ -1302,7 +1302,7 @@ TEST(LinalgBackendEigen, SGMatrix_softmax)
 		A[i] = i / 12;
 
 	for (index_t i = 0; i < 12; ++i)
-		ref[i] = CMath::exp(A[i]);
+		ref[i] = std::exp(A[i]);
 
 	for (index_t j = 0; j < ref.num_cols; ++j)
 	{

--- a/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Viennacl_operations_unittest.cc
@@ -268,7 +268,7 @@ TEST(LinalgBackendViennaCL, SGMatrix_logistic)
 	from_gpu(B_gpu, B);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(1.0/(1+CMath::exp(-1*A[i])), B[i], 1e-15);
+		EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], 1e-15);
 }
 
 TEST(LinalgBackendViennaCL, SGMatrix_SGVector_matrix_prod)
@@ -693,7 +693,7 @@ TEST(LinalgBackendViennaCL, SGMatrix_softmax)
 		A[i] = i / 12;
 
 	for (index_t i = 0; i < 12; ++i)
-		ref[i] = CMath::exp(A[i]);
+		ref[i] = std::exp(A[i]);
 
 	for (index_t j = 0; j < ref.num_cols; ++j)
 	{

--- a/tests/unit/neuralnets/NeuralLogisticLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralLogisticLayer_unittest.cc
@@ -89,7 +89,7 @@ TEST(NeuralLogisticLayer, compute_activations)
 			for (int32_t k=0; k<x.num_rows; k++)
 				A_ref(i,j) += weights[i+k*A_ref.num_rows]*x(k,j);
 
-			A_ref(i,j) = 1/(1+CMath::exp(-1*A_ref(i,j)));
+			A_ref(i, j) = 1 / (1 + std::exp(-1 * A_ref(i, j)));
 		}
 	}
 

--- a/tests/unit/neuralnets/NeuralSoftmaxLayer_unittest.cc
+++ b/tests/unit/neuralnets/NeuralSoftmaxLayer_unittest.cc
@@ -89,7 +89,7 @@ TEST(NeuralSoftmaxLayer, compute_activations)
 			for (int32_t k=0; k<x.num_rows; k++)
 				A_ref(i,j) += weights[i+k*A_ref.num_rows]*x(k,j);
 
-			A_ref(i,j) = CMath::exp(A_ref(i,j));
+			A_ref(i, j) = std::exp(A_ref(i, j));
 		}
 	}
 


### PR DESCRIPTION
Refers #4186 
- Replaced all `CMath::exp` in all files including `Math.h` and `Math.cpp`.

- Made sure `cmake ..` and `make` do not fail.