### PR TITLE
dropped CMath::max #4186

### DIFF
--- a/src/shogun/base/DynArray.h
+++ b/src/shogun/base/DynArray.h
@@ -1,8 +1,8 @@
 /*
  * This software is distributed under BSD 3-clause license (see LICENSE file).
  *
- * Authors: Soeren Sonnenburg, Heiko Strathmann, Evgeniy Andreev, Thoralf Klein, 
- *          Evan Shelhamer, Yuyu Zhang, Weijie Lin, Fernando Iglesias, 
+ * Authors: Soeren Sonnenburg, Heiko Strathmann, Evgeniy Andreev, Thoralf Klein,
+ *          Evan Shelhamer, Yuyu Zhang, Weijie Lin, Fernando Iglesias,
  *          Björn Esser, Sergey Lisitsyn
  */
 
@@ -16,21 +16,24 @@
 
 namespace shogun
 {
-template <class T> class CDynamicArray;
+	template <class T>
+	class CDynamicArray;
 
-/** @brief Template Dynamic array class that creates an array that can
- * be used like a list or an array.
- *
- * It grows and shrinks dynamically, while elements can be accessed
- * via index.  It is performance tuned for simple types like float
- * etc. and for hi-level objects only stores pointers, which are not
- * automagically SG_REF'd/deleted.
- */
-template <class T> class DynArray
-{
-	template<class U> friend class CDynamicArray;
-	friend class CDynamicObjectArray;
-	friend class CCommUlongStringKernel;
+	/** @brief Template Dynamic array class that creates an array that can
+	 * be used like a list or an array.
+	 *
+	 * It grows and shrinks dynamically, while elements can be accessed
+	 * via index.  It is performance tuned for simple types like float
+	 * etc. and for hi-level objects only stores pointers, which are not
+	 * automagically SG_REF'd/deleted.
+	 */
+	template <class T>
+	class DynArray
+	{
+		template <class U>
+		friend class CDynamicArray;
+		friend class CDynamicObjectArray;
+		friend class CCommUlongStringKernel;
 
 	public:
 		/** constructor
@@ -38,19 +41,19 @@ template <class T> class DynArray
 		 * @param p_resize_granularity resize granularity
 		 * @param tracable
 		 */
-		DynArray(int32_t p_resize_granularity=128, bool tracable=true)
+		DynArray(int32_t p_resize_granularity = 128, bool tracable = true)
 		{
-			resize_granularity=p_resize_granularity;
-			free_array=true;
-			use_sg_mallocs=tracable;
+			resize_granularity = p_resize_granularity;
+			free_array = true;
+			use_sg_mallocs = tracable;
 
 			if (use_sg_mallocs)
-				array=SG_MALLOC(T, p_resize_granularity);
+				array = SG_MALLOC(T, p_resize_granularity);
 			else
-				array=(T*) malloc(size_t(p_resize_granularity)*sizeof(T));
+				array = (T*)malloc(size_t(p_resize_granularity) * sizeof(T));
 
-			num_elements=p_resize_granularity;
-			current_num_elements=0;
+			num_elements = p_resize_granularity;
+			current_num_elements = 0;
 		}
 
 		/** constructor
@@ -61,14 +64,18 @@ template <class T> class DynArray
 		 * @param p_copy_array if array must be copied
 		 * @param tracable
 		 */
-		DynArray(T* p_array, int32_t p_array_size, bool p_free_array, bool p_copy_array, bool tracable=true)
+		DynArray(
+		    T* p_array, int32_t p_array_size, bool p_free_array,
+		    bool p_copy_array, bool tracable = true)
 		{
-			resize_granularity=p_array_size;
-			free_array=false;
-			use_sg_mallocs=tracable;
+			resize_granularity = p_array_size;
+			free_array = false;
+			use_sg_mallocs = tracable;
 
-			array=NULL;
-			set_array(p_array, p_array_size, p_array_size, p_free_array, p_copy_array);
+			array = NULL;
+			set_array(
+			    p_array, p_array_size, p_array_size, p_free_array,
+			    p_copy_array);
 		}
 
 		/** constructor
@@ -77,20 +84,20 @@ template <class T> class DynArray
 		 * @param p_array_size array's size
 		 * @param tracable
 		 */
-		DynArray(const T* p_array, int32_t p_array_size, bool tracable=true)
+		DynArray(const T* p_array, int32_t p_array_size, bool tracable = true)
 		{
-			resize_granularity=p_array_size;
-			free_array=false;
-			use_sg_mallocs=tracable;
+			resize_granularity = p_array_size;
+			free_array = false;
+			use_sg_mallocs = tracable;
 
-			array=NULL;
+			array = NULL;
 			set_array(p_array, p_array_size, p_array_size);
 		}
 
 		/** destructor */
 		virtual ~DynArray()
 		{
-			if (array!=NULL && free_array)
+			if (array != NULL && free_array)
 			{
 				if (use_sg_mallocs)
 					SG_FREE(array);
@@ -106,7 +113,7 @@ template <class T> class DynArray
 		 */
 		inline int32_t set_granularity(int32_t g)
 		{
-			g=std::max(g,1);
+			g = std::max(g, 1);
 			this->resize_granularity = g;
 			return g;
 		}
@@ -147,7 +154,7 @@ template <class T> class DynArray
 		 */
 		inline T get_last_element() const
 		{
-			return array[current_num_elements-1];
+			return array[current_num_elements - 1];
 		}
 
 		/** get array element at index as pointer
@@ -171,10 +178,11 @@ template <class T> class DynArray
 		 */
 		inline T get_element_safe(int32_t index) const
 		{
-			if (index>=get_num_elements())
+			if (index >= get_num_elements())
 			{
-				SG_SERROR("array index out of bounds (%d >= %d)\n",
-						 index, get_num_elements());
+				SG_SERROR(
+				    "array index out of bounds (%d >= %d)\n", index,
+				    get_num_elements());
 			}
 			return array[index];
 		}
@@ -191,15 +199,15 @@ template <class T> class DynArray
 			{
 				return false;
 			}
-			else if (index <= current_num_elements-1)
+			else if (index <= current_num_elements - 1)
 			{
-				array[index]=element;
+				array[index] = element;
 				return true;
 			}
 			else if (index < num_elements)
 			{
-				array[index]=element;
-				current_num_elements=index+1;
+				array[index] = element;
+				current_num_elements = index + 1;
 				return true;
 			}
 			else
@@ -219,13 +227,13 @@ template <class T> class DynArray
 		 */
 		inline bool insert_element(T element, int32_t index)
 		{
-			if (append_element(get_element(current_num_elements-1)))
+			if (append_element(get_element(current_num_elements - 1)))
 			{
-				for (int32_t i=current_num_elements-2; i>index; i--)
+				for (int32_t i = current_num_elements - 2; i > index; i--)
 				{
-					array[i]=array[i-1];
+					array[i] = array[i - 1];
 				}
-				array[index]=element;
+				array[index] = element;
 
 				return true;
 			}
@@ -264,7 +272,7 @@ template <class T> class DynArray
 			if (get_num_elements() <= 0)
 				return;
 
-			delete_element(get_num_elements()-1);
+			delete_element(get_num_elements() - 1);
 		}
 
 		/** STD VECTOR compatible. Return array element at the end
@@ -277,7 +285,7 @@ template <class T> class DynArray
 			if (get_num_elements() <= 0)
 				return get_element(0);
 
-			return get_element(get_num_elements()-1);
+			return get_element(get_num_elements() - 1);
 		}
 
 		/** find first occurence of array element and return its index
@@ -288,14 +296,14 @@ template <class T> class DynArray
 		 */
 		int32_t find_element(T element) const
 		{
-			int32_t idx=-1;
-			int32_t num=get_num_elements();
+			int32_t idx = -1;
+			int32_t num = get_num_elements();
 
-			for (int32_t i=0; i<num; i++)
+			for (int32_t i = 0; i < num; i++)
 			{
 				if (array[i] == element)
 				{
-					idx=i;
+					idx = i;
 					break;
 				}
 			}
@@ -311,15 +319,15 @@ template <class T> class DynArray
 		 */
 		inline bool delete_element(int32_t idx)
 		{
-			if (idx>=0 && idx<=current_num_elements-1)
+			if (idx >= 0 && idx <= current_num_elements - 1)
 			{
-				for (int32_t i=idx; i<current_num_elements-1; i++)
-					array[i]=array[i+1];
+				for (int32_t i = idx; i < current_num_elements - 1; i++)
+					array[i] = array[i + 1];
 
 				current_num_elements--;
 
-				if (num_elements - current_num_elements - 1
-					> resize_granularity)
+				if (num_elements - current_num_elements - 1 >
+				    resize_granularity)
 					resize_array(current_num_elements);
 
 				return true;
@@ -334,29 +342,29 @@ template <class T> class DynArray
 		 * @param exact_resize resize exactly to size n
 		 * @return if resizing was successful
 		 */
-		bool resize_array(int32_t n, bool exact_resize=false)
+		bool resize_array(int32_t n, bool exact_resize = false)
 		{
-			int32_t new_num_elements=n;
+			int32_t new_num_elements = n;
 
 			if (!exact_resize)
 			{
-				new_num_elements=((n/resize_granularity)+1)*resize_granularity;
+				new_num_elements =
+				    ((n / resize_granularity) + 1) * resize_granularity;
 			}
-
 
 			if (use_sg_mallocs)
 				array = SG_REALLOC(T, array, num_elements, new_num_elements);
 			else
-				array = (T*) realloc(array, new_num_elements*sizeof(T));
+				array = (T*)realloc(array, new_num_elements * sizeof(T));
 
-			//in case of shrinking we must adjust last element idx
-			if (n-1<current_num_elements-1)
-				current_num_elements=n;
+			// in case of shrinking we must adjust last element idx
+			if (n - 1 < current_num_elements - 1)
+				current_num_elements = n;
 
-			num_elements=new_num_elements;
+			num_elements = new_num_elements;
 			return true;
 
-			return array || new_num_elements==0;
+			return array || new_num_elements == 0;
 		}
 
 		/** get the array
@@ -379,26 +387,27 @@ template <class T> class DynArray
 		 * @param p_free_array if array must be freed
 		 * @param p_copy_array if array must be copied
 		 */
-		inline void set_array(T* p_array, int32_t p_num_elements,
-				int32_t p_array_size, bool p_free_array, bool p_copy_array)
+		inline void set_array(
+		    T* p_array, int32_t p_num_elements, int32_t p_array_size,
+		    bool p_free_array, bool p_copy_array)
 		{
-			if (array!=NULL && free_array)
+			if (array != NULL && free_array)
 				SG_FREE(array);
 
 			if (p_copy_array)
 			{
 				if (use_sg_mallocs)
-					array=SG_MALLOC(T, p_array_size);
+					array = SG_MALLOC(T, p_array_size);
 				else
-					array=(T*) malloc(p_array_size*sizeof(T));
-				sg_memcpy(array, p_array, p_array_size*sizeof(T));
+					array = (T*)malloc(p_array_size * sizeof(T));
+				sg_memcpy(array, p_array, p_array_size * sizeof(T));
 			}
 			else
-				array=p_array;
+				array = p_array;
 
-			num_elements=p_array_size;
-			current_num_elements=p_num_elements;
-			free_array=p_free_array;
+			num_elements = p_array_size;
+			current_num_elements = p_num_elements;
+			free_array = p_free_array;
 		}
 
 		/** set the array pointer and free previously allocated memory
@@ -407,30 +416,30 @@ template <class T> class DynArray
 		 * @param p_num_elements last element index + 1
 		 * @param p_array_size number of elements in array
 		 */
-		inline void set_array(const T* p_array, int32_t p_num_elements,
-							  int32_t p_array_size)
+		inline void set_array(
+		    const T* p_array, int32_t p_num_elements, int32_t p_array_size)
 		{
-			if (array!=NULL && free_array)
+			if (array != NULL && free_array)
 				SG_FREE(array);
 
 			if (use_sg_mallocs)
-				array=SG_MALLOC(T, p_array_size);
+				array = SG_MALLOC(T, p_array_size);
 			else
-				array=(T*) malloc(p_array_size*sizeof(T));
-			sg_memcpy(array, p_array, p_array_size*sizeof(T));
+				array = (T*)malloc(p_array_size * sizeof(T));
+			sg_memcpy(array, p_array, p_array_size * sizeof(T));
 
-			num_elements=p_array_size;
-			current_num_elements=p_num_elements;
-			free_array=true;
+			num_elements = p_array_size;
+			current_num_elements = p_num_elements;
+			free_array = true;
 		}
 
 		/** clear the array (with e.g. zeros) */
 		inline void clear_array(T value)
 		{
-			if (current_num_elements-1 >= 0)
+			if (current_num_elements - 1 >= 0)
 			{
-				for (int32_t i=0; i<current_num_elements; i++)
-					array[i]=value;
+				for (int32_t i = 0; i < current_num_elements; i++)
+					array[i] = value;
 			}
 		}
 
@@ -438,28 +447,31 @@ template <class T> class DynArray
 		void reset(T value)
 		{
 			clear_array(value);
-			current_num_elements=0;
+			current_num_elements = 0;
 		}
 
 		/** randomizes the array (not thread safe!) */
 		void shuffle()
 		{
-			for (index_t i=0; i<=current_num_elements-1; ++i)
-				CMath::swap(array[i], array[CMath::random(i, current_num_elements-1)]);
+			for (index_t i = 0; i <= current_num_elements - 1; ++i)
+				CMath::swap(
+				    array[i],
+				    array[CMath::random(i, current_num_elements - 1)]);
 		}
 
 		/** randomizes the array with external random state */
-		void shuffle(CRandom * rand)
+		void shuffle(CRandom* rand)
 		{
-			for (index_t i=0; i<=current_num_elements-1; ++i)
-				CMath::swap(array[i], array[rand->random(i, current_num_elements-1)]);
+			for (index_t i = 0; i <= current_num_elements - 1; ++i)
+				CMath::swap(
+				    array[i], array[rand->random(i, current_num_elements - 1)]);
 		}
 
 		/** set array with a constant */
 		void set_const(const T& const_element)
 		{
-			for (int32_t i=0; i<num_elements; i++)
-				array[i]=const_element;
+			for (int32_t i = 0; i < num_elements; i++)
+				array[i] = const_element;
 		}
 
 		/** operator overload for array read only access
@@ -484,28 +496,31 @@ template <class T> class DynArray
 		 */
 		DynArray<T>& operator=(DynArray<T>& orig)
 		{
-			resize_granularity=orig.resize_granularity;
+			resize_granularity = orig.resize_granularity;
 
 			/* check if orig array is larger than current, create new array */
-			if (orig.num_elements>num_elements)
+			if (orig.num_elements > num_elements)
 			{
 				SG_FREE(array);
 
 				if (use_sg_mallocs)
-					array=SG_MALLOC(T, orig.num_elements);
+					array = SG_MALLOC(T, orig.num_elements);
 				else
-					array=(T*) malloc(sizeof(T)*orig.num_elements);
+					array = (T*)malloc(sizeof(T) * orig.num_elements);
 			}
 
-			sg_memcpy(array, orig.array, sizeof(T)*orig.num_elements);
-			num_elements=orig.num_elements;
-			current_num_elements=orig.current_num_elements;
+			sg_memcpy(array, orig.array, sizeof(T) * orig.num_elements);
+			num_elements = orig.num_elements;
+			current_num_elements = orig.current_num_elements;
 
 			return *this;
 		}
 
 		/** @return object name */
-		virtual const char* get_name() const { return "DynArray"; }
+		virtual const char* get_name() const
+		{
+			return "DynArray";
+		}
 
 	protected:
 		/** shrink/grow step size */
@@ -525,6 +540,6 @@ template <class T> class DynArray
 
 		/** if array must be freed */
 		bool free_array;
-};
+	};
 }
 #endif /* _DYNARRAY_H_  */

--- a/src/shogun/base/DynArray.h
+++ b/src/shogun/base/DynArray.h
@@ -106,7 +106,7 @@ template <class T> class DynArray
 		 */
 		inline int32_t set_granularity(int32_t g)
 		{
-			g=CMath::max(g,1);
+			g=std::max(g,1);
 			this->resize_granularity = g;
 			return g;
 		}


### PR DESCRIPTION
replaced `CMath::max` with `std::max` in __DynArray.h__.