### PR TITLE
Drop CMath::max in DynArray.h

### DIFF
--- a/src/shogun/base/DynArray.h
+++ b/src/shogun/base/DynArray.h
@@ -106,7 +106,7 @@ template <class T> class DynArray
 		 */
 		inline int32_t set_granularity(int32_t g)
 		{
-			g=CMath::max(g,1);
+			g = std::max(g, 1);
 			this->resize_granularity = g;
 			return g;
 		}


### PR DESCRIPTION
Dropped `CMath::max` and added `std::max` in _DynArray.h_

Created this new PR with just the lines in which actual changes were made.