### PR TITLE
Replace CMath::ceil with std::ceil

### DIFF
--- a/src/shogun/features/DataGenerator.cpp
+++ b/src/shogun/features/DataGenerator.cpp
@@ -32,7 +32,7 @@ SGMatrix<float64_t> CDataGenerator::generate_checkboard_data(int32_t num_classes
 {
 	int32_t points_per_class = num_points / num_classes;
 
-	int32_t grid_size = (int32_t ) CMath::ceil(CMath::sqrt((float64_t ) num_classes));
+	int32_t grid_size = (int32_t)std::ceil(CMath::sqrt((float64_t)num_classes));
 	float64_t cell_size = (float64_t ) 1 / grid_size;
 	SGVector<float64_t> grid_idx(dim);
 	for (index_t i=0; i<dim; i++)

--- a/src/shogun/features/StringFeatures.cpp
+++ b/src/shogun/features/StringFeatures.cpp
@@ -1143,7 +1143,7 @@ template<class ST> bool CStringFeatures<ST>::load_compressed(char* src, bool dec
 		}
 		else
 		{
-			int32_t offs=CMath::ceil(2.0*sizeof(int32_t)/sizeof(ST));
+			int32_t offs = std::ceil(2.0 * sizeof(int32_t) / sizeof(ST));
 			features[i].string=SG_MALLOC(ST, len_compressed+offs);
 			features[i].slen=len_compressed+offs;
 			int32_t* feat32ptr=((int32_t*) (features[i].string));

--- a/src/shogun/lib/JLCoverTree.h
+++ b/src/shogun/lib/JLCoverTree.h
@@ -98,7 +98,7 @@ inline float dist_of_scale (int s)
 
 inline int get_scale(float d)
 {
-  return (int) CMath::ceil(il2 * log(d));
+	return (int)std::ceil(il2 * log(d));
 }
 
 template<class P>

--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -374,15 +374,6 @@ class CMath : public CSGObject
 			return std::floor(d);
 		}
 
-		/** The value of x rounded upward (as a floating-point value)
-		 * @param d input decimal value
-		 * @return rounded off value
-		 */
-		static inline float64_t ceil(float64_t d)
-		{
-			return std::ceil(d);
-		}
-
 		/** Signum of input value
 		 * @param a input value
 		 * @return 1 if a>0, -1 if a<0

--- a/src/shogun/mathematics/ajd/FFDiag.cpp
+++ b/src/shogun/mathematics/ajd/FFDiag.cpp
@@ -45,7 +45,7 @@ SGMatrix<float64_t> CFFDiag::diagonalize(SGNDArray<float64_t> C0, SGMatrix<float
 			 W.data());
 
 		W.transposeInPlace();
-		int e = CMath::ceil(log2(W.array().abs().rowwise().sum().maxCoeff()));
+		int e = std::ceil(log2(W.array().abs().rowwise().sum().maxCoeff()));
 		int s = std::max(0,e-1);
 		W /= pow(2,s);
 

--- a/src/shogun/preprocessor/DecompressString.cpp
+++ b/src/shogun/preprocessor/DecompressString.cpp
@@ -82,7 +82,7 @@ ST* CDecompressString<ST>::apply_to_string(ST* f, int32_t &len)
 	uint64_t compressed_size=((int32_t*) f)[0];
 	uint64_t uncompressed_size=((int32_t*) f)[1];
 
-	int32_t offs=CMath::ceil(2.0*sizeof(int32_t)/sizeof(ST));
+	int32_t offs = std::ceil(2.0 * sizeof(int32_t) / sizeof(ST));
 	ASSERT(uint64_t(len)==uint64_t(offs)+compressed_size)
 
 	len=uncompressed_size;

--- a/src/shogun/regression/KRRNystrom.cpp
+++ b/src/shogun/regression/KRRNystrom.cpp
@@ -81,7 +81,7 @@ bool CKRRNystrom::solve_krr_system()
 
 	if (m_num_rkhs_basis == 0)
 	{
-		set_num_rkhs_basis((int32_t)CMath::ceil(n/2.0));
+		set_num_rkhs_basis((int32_t)std::ceil(n / 2.0));
 		SG_SWARNING("Number of sampled rows not set, default is half (%d) "
 					"of the number of data points (%d)\n", m_num_rkhs_basis, n);
 	}

--- a/src/shogun/structure/DynProg.cpp
+++ b/src/shogun/structure/DynProg.cpp
@@ -1176,18 +1176,24 @@ void CDynProg::compute_nbest_paths(int32_t max_num_signals, bool use_orf,
 					/* if the transition is an ORF or we do computation with loss, we have to disable long transitions */
 					if ((m_orf_info.element(ii,0)!=-1) || (m_orf_info.element(j,1)!=-1) || (!long_transitions))
 					{
-						look_back.set_element(CMath::ceil(penij->get_max_value()), j, ii) ;
-						//look_back_orig.set_element(CMath::ceil(penij->get_max_value()), j, ii) ;
-						if (CMath::ceil(penij->get_max_value()) > max_look_back)
-						{
+					    look_back.set_element(
+					        std::ceil(penij->get_max_value()), j, ii);
+					    //look_back_orig.set_element(CMath::ceil(penij->get_max_value()), j, ii) ;
+					    if (std::ceil(penij->get_max_value()) > max_look_back)
+					    {
 							SG_DEBUG("%d %d -> value: %f\n", ii,j,penij->get_max_value())
-							max_look_back = (int32_t) (CMath::ceil(penij->get_max_value()));
-						}
+						    max_look_back =
+						        (int32_t)(std::ceil(penij->get_max_value()));
+					    }
 					}
 					else
 					{
-						look_back.set_element(CMath::min( (int32_t)CMath::ceil(penij->get_max_value()), m_long_transition_threshold ), j, ii) ;
-						//look_back_orig.set_element( (int32_t)CMath::ceil(penij->get_max_value()), j, ii) ;
+					    look_back.set_element(
+					        CMath::min(
+					            (int32_t)std::ceil(penij->get_max_value()),
+					            m_long_transition_threshold),
+					        j, ii);
+					    //look_back_orig.set_element( (int32_t)CMath::ceil(penij->get_max_value()), j, ii) ;
 					}
 
 					if (penij->uses_svm_values())

--- a/src/shogun/structure/TwoStateModel.cpp
+++ b/src/shogun/structure/TwoStateModel.cpp
@@ -270,14 +270,18 @@ CHMSVMModel* CTwoStateModel::simulate_data(int32_t num_exm, int32_t exm_len,
 	{
 		SGVector< int32_t > lab(exm_len);
 		lab.zero();
-		rnb = num_blocks[0] + CMath::ceil((num_blocks[1]-num_blocks[0])*
-			CMath::random(0.0, 1.0)) - 1;
+		rnb = num_blocks[0] +
+		      std::ceil(
+		          (num_blocks[1] - num_blocks[0]) * CMath::random(0.0, 1.0)) -
+		      1;
 
 		for ( int32_t j = 0 ; j < rnb ; ++j )
 		{
-			rl = block_len[0] + CMath::ceil((block_len[1]-block_len[0])*
-				CMath::random(0.0, 1.0)) - 1;
-			rp = CMath::ceil((exm_len-rl)*CMath::random(0.0, 1.0));
+			rl = block_len[0] +
+			     std::ceil(
+			         (block_len[1] - block_len[0]) * CMath::random(0.0, 1.0)) -
+			     1;
+			rp = std::ceil((exm_len - rl) * CMath::random(0.0, 1.0));
 
 			for ( int32_t idx = rp-1 ; idx < rp+rl ; ++idx )
 			{

--- a/tests/unit/mathematics/Math_unittest.cc
+++ b/tests/unit/mathematics/Math_unittest.cc
@@ -84,7 +84,7 @@ TEST(CMath, float64_tests)
 	EXPECT_NEAR(CMath::round(7.5), 8.0, 1E-15);
 	EXPECT_NEAR(CMath::round(7.5-1E-15), 7.0, 1E-15);
 	EXPECT_NEAR(CMath::floor(8-1E-15), 7.0, 1E-15);
-	EXPECT_NEAR(CMath::ceil(7+1E-15), 8.0, 1E-15);
+	EXPECT_NEAR(std::ceil(7 + 1E-15), 8.0, 1E-15);
 
 	float64_t a=5.78123516567856743364;
 	// x^2, x^(1/2)


### PR DESCRIPTION
Refer #4186 .
- Replaced `CMtah::ceil` with `std::ceil` in all files.
