### PR TITLE
Fix issue #4186, replace CMath::is_infinity with std::isinf

### DIFF
--- a/src/shogun/machine/gp/KLDualInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDualInferenceMethod.cpp
@@ -174,7 +174,7 @@ float64_t CKLDualInferenceMethodMinimizer::evaluate(void *obj, const float64_t *
 	REQUIRE(obj_prt, "The instance object passed to L-BFGS optimizer should not be NULL\n");
 
 	float64_t cost=obj_prt->m_fun->get_cost();
-	if (CMath::is_nan(cost) || CMath::is_infinity(cost))
+	if (CMath::is_nan(cost) || std::isinf(cost))
 			return cost;
 	//get the gradient wrt variable_new
 	SGVector<float64_t> grad=obj_prt->m_fun->get_gradient();

--- a/src/shogun/mathematics/Math.cpp
+++ b/src/shogun/mathematics/Math.cpp
@@ -216,11 +216,6 @@ int CMath::is_nan(double f)
   return std::isnan(f);
 }
 
-int CMath::is_infinity(double f)
-{
-  return std::isinf(f);
-}
-
 int CMath::is_finite(double f)
 {
   return std::isfinite(f);

--- a/src/shogun/mathematics/Math.h
+++ b/src/shogun/mathematics/Math.h
@@ -1746,9 +1746,6 @@ class CMath : public CSGObject
 		/// checks whether a float is finite
 		static int is_finite(double f);
 
-		/// checks whether a float is infinity
-		static int is_infinity(double f);
-
 		/// checks whether a float is nan
 		static int is_nan(double f);
 

--- a/src/shogun/modelselection/GradientModelSelection.cpp
+++ b/src/shogun/modelselection/GradientModelSelection.cpp
@@ -189,7 +189,7 @@ float64_t CGradientModelSelection::get_cost(SGVector<float64_t> model_vars, SGVe
 
 	float64_t cost = SGVector<float64_t>::sum(value);
 
-	if (CMath::is_nan(cost) || CMath::is_infinity(cost))
+	if (CMath::is_nan(cost) || std::isinf(cost))
 	{
 		if (m_machine_eval->get_evaluation_direction()==ED_MINIMIZE)
 			return cost;

--- a/src/shogun/optimization/lbfgs/LBFGSMinimizer.cpp
+++ b/src/shogun/optimization/lbfgs/LBFGSMinimizer.cpp
@@ -187,7 +187,7 @@ float64_t CLBFGSMinimizer::evaluate(void *obj, const float64_t *variable,
 
 	float64_t cost=obj_prt->m_fun->get_cost();
 
-	if (CMath::is_nan(cost) || CMath::is_infinity(cost))
+	if (CMath::is_nan(cost) || std::isinf(cost))
 		return cost;
 
 	//get the gradient wrt variable_new

--- a/src/shogun/optimization/lbfgs/lbfgs.cpp
+++ b/src/shogun/optimization/lbfgs/lbfgs.cpp
@@ -623,7 +623,7 @@ static int32_t line_search_backtracking(
 
         for(index_t j=0; j<n; j++)
         {
-            if (CMath::is_nan(s[j]) || CMath::is_infinity(s[j]))
+            if (CMath::is_nan(s[j]) || std::isinf(s[j]))
                 return LBFGSERR_INVALID_VALUE;
         }
 
@@ -636,7 +636,7 @@ static int32_t line_search_backtracking(
             /* Evaluate the function and gradient values. */
             *f = cd->proc_evaluate(cd->instance, x, g.vector, cd->n, *stp);
             ++count;
-            if (CMath::is_nan(*f) || CMath::is_infinity(*f))
+            if (CMath::is_nan(*f) || std::isinf(*f))
                 *stp*=decay;
             else
                 break;

--- a/tests/unit/mathematics/Math_unittest.cc
+++ b/tests/unit/mathematics/Math_unittest.cc
@@ -180,7 +180,7 @@ TEST(CMath, strtofloat)
 	EXPECT_TRUE(CMath::is_nan(float_result));
 
 	EXPECT_TRUE(CMath::strtof("inf", &float_result));
-	EXPECT_TRUE(CMath::is_infinity(float_result));
+	EXPECT_TRUE(std::isinf(float_result));
 
 	EXPECT_TRUE(CMath::strtof("-inf", &float_result));
 	EXPECT_DOUBLE_EQ(-CMath::INFTY, float_result);
@@ -196,7 +196,7 @@ TEST(CMath, strtodouble)
 	EXPECT_TRUE(CMath::is_nan(double_result));
 
 	EXPECT_TRUE(CMath::strtod("inf", &double_result));
-	EXPECT_TRUE(CMath::is_infinity(double_result));
+	EXPECT_TRUE(std::isinf(double_result));
 
 	EXPECT_TRUE(CMath::strtod("-inf", &double_result));
 	EXPECT_DOUBLE_EQ(-CMath::INFTY, double_result);
@@ -212,7 +212,7 @@ TEST(CMath, strtolongdouble)
 	EXPECT_TRUE(CMath::is_nan(long_double_result));
 
 	EXPECT_TRUE(CMath::strtold("inf", &long_double_result));
-	EXPECT_TRUE(CMath::is_infinity(long_double_result));
+	EXPECT_TRUE(std::isinf(long_double_result));
 
 	EXPECT_TRUE(CMath::strtold("-inf", &long_double_result));
 	EXPECT_DOUBLE_EQ(-CMath::INFTY, long_double_result);

--- a/tests/unit/mathematics/Statistics_unittest.cc
+++ b/tests/unit/mathematics/Statistics_unittest.cc
@@ -733,7 +733,7 @@ TEST(Statistics, vector_mean_overflow_test)
 	SGVector<float64_t> a(10);
 	a.set_const(std::numeric_limits<float64_t>::max());
 #ifdef _MSC_VER
-	EXPECT_TRUE(CMath::is_infinity(CStatistics::mean(a)));
+	EXPECT_TRUE(std::isinf(CStatistics::mean(a)));
 #else
 	EXPECT_EQ(std::numeric_limits<float64_t>::max(), CStatistics::mean(a));
 #endif


### PR DESCRIPTION
Fix issue #4186, drop CMath::is_infinity. 
Replace CMath::is_infinity with std::isinf and delete the function is_infinity in CMath.