### PR TITLE
Replace obtain_from_generic with .as

### DIFF
--- a/src/shogun/classifier/GaussianProcessClassification.cpp
+++ b/src/shogun/classifier/GaussianProcessClassification.cpp
@@ -120,10 +120,8 @@ CBinaryLabels* CGaussianProcessClassification::apply_binary(
 		if (m_method->get_inference_type()== INF_FITC_LAPLACE_SINGLE)
 		{
 #ifdef USE_GPL_SHOGUN
-			CSingleFITCLaplaceInferenceMethod* fitc_method=
-				CSingleFITCLaplaceInferenceMethod::obtain_from_generic(m_method);
+			CSingleFITCLaplaceInferenceMethod* fitc_method = m_method->as<CSingleFITCLaplaceInferenceMethod>();
 			data=fitc_method->get_inducing_features();
-			SG_UNREF(fitc_method);
 #else
 			SG_GPL_ONLY
 #endif //USE_GPL_SHOGUN
@@ -156,10 +154,8 @@ bool CGaussianProcessClassification::train_machine(CFeatures* data)
 		if (m_method->get_inference_type()==INF_FITC_LAPLACE_SINGLE)
 		{
 #ifdef USE_GPL_SHOGUN
-			CSingleFITCLaplaceInferenceMethod* fitc_method=
-				CSingleFITCLaplaceInferenceMethod::obtain_from_generic(m_method);
+			CSingleFITCLaplaceInferenceMethod* fitc_method = m_method->as<CSingleFITCLaplaceInferenceMethod>();
 			fitc_method->set_inducing_features(data);
-			SG_UNREF(fitc_method);
 #else
 			SG_ERROR("Single FITC Laplace inference only supported under GPL.\n")
 #endif //USE_GPL_SHOGUN

--- a/src/shogun/evaluation/StructuredAccuracy.cpp
+++ b/src/shogun/evaluation/StructuredAccuracy.cpp
@@ -74,8 +74,8 @@ float64_t CStructuredAccuracy::evaluate_real(CStructuredLabels * predicted,
 
 	for (int32_t i = 0 ; i < length ; ++i)
 	{
-		CRealNumber * truth = CRealNumber::obtain_from_generic(ground_truth->get_label(i));
-		CRealNumber * pred = CRealNumber::obtain_from_generic(predicted->get_label(i));
+		CRealNumber * truth = ground_truth->get_label(i)->as<CRealNumber>();
+		CRealNumber * pred = predicted->get_label(i)->as<CRealNumber>();
 
 		num_equal += truth->value == pred->value;
 
@@ -96,8 +96,8 @@ float64_t CStructuredAccuracy::evaluate_sequence(CStructuredLabels * predicted,
 
 	for (int32_t i = 0 ; i < length ; ++i)
 	{
-		CSequence * true_seq = CSequence::obtain_from_generic(ground_truth->get_label(i));
-		CSequence * pred_seq = CSequence::obtain_from_generic(predicted->get_label(i));
+		CSequence * true_seq = ground_truth->get_label(i)->as<CSequence>();
+		CSequence * pred_seq = predicted->get_label(i)->as<CSequence>();
 
 		SGVector<int32_t> true_seq_data = true_seq->get_data();
 		SGVector<int32_t> pred_seq_data = pred_seq->get_data();

--- a/src/shogun/machine/GaussianProcessMachine.cpp
+++ b/src/shogun/machine/GaussianProcessMachine.cpp
@@ -89,7 +89,7 @@ SGVector<float64_t> CGaussianProcessMachine::get_posterior_means(CFeatures* data
 
 	// get kernel and compute kernel matrix: K(feat, data)*scale^2
 	CKernel* training_kernel=m_method->get_kernel();
-	CKernel* kernel=CKernel::obtain_from_generic(training_kernel->clone());
+	CKernel* kernel = training_kernel->clone()->as<CKernel>();
 	SG_UNREF(training_kernel);
 
 	kernel->init(feat, data);
@@ -153,7 +153,7 @@ SGVector<float64_t> CGaussianProcessMachine::get_posterior_variances(
 
 	// get kernel and compute kernel matrix: K(data, data)*scale^2
 	CKernel* training_kernel=m_method->get_kernel();
-	CKernel* kernel=CKernel::obtain_from_generic(training_kernel->clone());
+	CKernel* kernel = training_kernel->clone()->as<CKernel>();
 	SG_UNREF(training_kernel);
 	kernel->init(data, data);
 

--- a/src/shogun/machine/LinearLatentMachine.cpp
+++ b/src/shogun/machine/LinearLatentMachine.cpp
@@ -40,7 +40,7 @@ CLatentLabels* CLinearLatentMachine::apply_latent(CFeatures* data)
 	if (m_model == NULL)
 		SG_ERROR("LatentModel is not set!\n")
 
-	CLatentFeatures* lf = CLatentFeatures::obtain_from_generic(data);
+	CLatentFeatures* lf = data->as<CLatentFeatures>();
 	m_model->set_features(lf);
 
 	return apply_latent();

--- a/src/shogun/machine/gp/ExactInferenceMethod.cpp
+++ b/src/shogun/machine/gp/ExactInferenceMethod.cpp
@@ -104,9 +104,8 @@ SGVector<float64_t> CExactInferenceMethod::get_diagonal_vector()
 		update();
 
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// compute diagonal vector: sW=1/sigma
 	SGVector<float64_t> result(m_features->get_num_vectors());
@@ -121,9 +120,8 @@ float64_t CExactInferenceMethod::get_negative_log_marginal_likelihood()
 		update();
 
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// create eigen representation of alpha and L
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen);
@@ -178,9 +176,8 @@ SGMatrix<float64_t> CExactInferenceMethod::get_posterior_covariance()
 void CExactInferenceMethod::update_chol()
 {
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	/* check whether to allocate cholesky memory */
 	if (!m_L.matrix || m_L.num_rows!=m_ktrtr.num_rows)
@@ -198,9 +195,8 @@ void CExactInferenceMethod::update_chol()
 void CExactInferenceMethod::update_alpha()
 {
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// get labels and mean vector and create eigen representation
 	SGVector<float64_t> y=((CRegressionLabels*) m_labels)->get_labels();
@@ -252,9 +248,8 @@ void CExactInferenceMethod::update_cov()
 	MatrixXd eigen_V = eigen_L.triangularView<Upper>().adjoint().solve(
 	    eigen_K * std::exp(m_log_scale * 2.0));
 
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 	eigen_V = eigen_V/sigma;
 
 	// compute covariance matrix of the posterior: Sigma = K - V^T * V
@@ -265,9 +260,8 @@ void CExactInferenceMethod::update_cov()
 void CExactInferenceMethod::update_deriv()
 {
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// create eigen representation of derivative matrix and cholesky
 	Map<MatrixXd> eigen_L(m_L.matrix, m_L.num_rows, m_L.num_cols);
@@ -328,9 +322,8 @@ SGVector<float64_t> CExactInferenceMethod::get_derivative_wrt_likelihood_model(
 			m_model->get_name(), param->m_name)
 
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// create eigen representation of the matrix Q
 	Map<MatrixXd> eigen_Q(m_Q.matrix, m_Q.num_rows, m_Q.num_cols);

--- a/src/shogun/machine/gp/FITCInferenceMethod.cpp
+++ b/src/shogun/machine/gp/FITCInferenceMethod.cpp
@@ -112,9 +112,8 @@ SGVector<float64_t> CFITCInferenceMethod::get_diagonal_vector()
 		update();
 
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// compute diagonal vector: sW=1/sigma
 	SGVector<float64_t> result(m_features->get_num_vectors());
@@ -153,9 +152,8 @@ void CFITCInferenceMethod::update_chol()
 	//time complexits O(m^2*n)
 
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	// eigen3 representation of covariance matrix of inducing features (m_kuu)
 	// and training features (m_ktru)
@@ -418,9 +416,8 @@ SGVector<float64_t> CFITCInferenceMethod::get_derivative_wrt_likelihood_model(
 	Map<MatrixXd> eigen_B(m_B.matrix, m_B.num_rows, m_B.num_cols);
 
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 
 	SGVector<float64_t> result(1);
 

--- a/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.cpp
@@ -245,9 +245,8 @@ float64_t CSingleFITCLaplaceNewtonOptimizer::minimize()
 
 			if (m_obj->m_model->get_model_type()==LT_STUDENTST)
 			{
-				CStudentsTLikelihood* lik=CStudentsTLikelihood::obtain_from_generic(m_obj->m_model);
+				CStudentsTLikelihood* lik = m_obj->m_model->as<CStudentsTLikelihood>();
 				df=lik->get_degrees_freedom();
-				SG_UNREF(lik);
 			}
 			else
 				df=1;

--- a/src/shogun/machine/gp/SingleLaplaceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/SingleLaplaceInferenceMethod.cpp
@@ -209,9 +209,8 @@ float64_t CSingleLaplaceNewtonOptimizer::minimize()
 
 			if (m_obj->m_model->get_model_type()==LT_STUDENTST)
 			{
-				CStudentsTLikelihood* lik=CStudentsTLikelihood::obtain_from_generic(m_obj->m_model);
+				CStudentsTLikelihood* lik = m_obj->m_model->as<CStudentsTLikelihood>();
 				df=lik->get_degrees_freedom();
-				SG_UNREF(lik);
 			}
 			else
 				df=1;

--- a/src/shogun/machine/gp/VarDTCInferenceMethod.cpp
+++ b/src/shogun/machine/gp/VarDTCInferenceMethod.cpp
@@ -168,9 +168,8 @@ float64_t CVarDTCInferenceMethod::get_negative_log_marginal_likelihood()
 void CVarDTCInferenceMethod::update_chol()
 {
 	// get the sigma variable from the Gaussian likelihood model
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 	m_sigma2=sigma*sigma;
 
 	//m-by-m matrix
@@ -266,9 +265,8 @@ void CVarDTCInferenceMethod::update_deriv()
 	Map<MatrixXd> eigen_Tmm(m_Tmm.matrix, m_Tmm.num_rows, m_Tmm.num_cols);
 	Map<MatrixXd> eigen_Tnm(m_Tnm.matrix, m_Tnm.num_rows, m_Tnm.num_cols);
 
-	CGaussianLikelihood* lik=CGaussianLikelihood::obtain_from_generic(m_model);
+	CGaussianLikelihood* lik = m_model->as<CGaussianLikelihood>();
 	float64_t sigma=lik->get_sigma();
-	SG_UNREF(lik);
 	m_sigma2=sigma*sigma;
 
 	//invLmInvLa = invLm*invLa;  

--- a/src/shogun/regression/GaussianProcessRegression.cpp
+++ b/src/shogun/regression/GaussianProcessRegression.cpp
@@ -49,10 +49,8 @@ CRegressionLabels* CGaussianProcessRegression::apply_regression(CFeatures* data)
 		// use inducing features for FITC inference method
 		if (m_method->get_inference_type()==INF_FITC_REGRESSION)
 		{
-			CFITCInferenceMethod* fitc_method=
-				CFITCInferenceMethod::obtain_from_generic(m_method);
+			CFITCInferenceMethod* fitc_method = m_method->as<CFITCInferenceMethod>();
 			feat=fitc_method->get_inducing_features();
-			SG_UNREF(fitc_method);
 		}
 		else
 			feat=m_method->get_features();
@@ -84,8 +82,7 @@ bool CGaussianProcessRegression::train_machine(CFeatures* data)
 		// set inducing features for FITC inference method
 		if (m_method->get_inference_type()==INF_FITC_REGRESSION)
 		{
-			CFITCInferenceMethod* fitc_method=
-				CFITCInferenceMethod::obtain_from_generic(m_method);
+			CFITCInferenceMethod* fitc_method = m_method->as<CFITCInferenceMethod>();
 			fitc_method->set_inducing_features(data);
 			SG_UNREF(fitc_method);
 		}

--- a/src/shogun/structure/FactorGraphDataGenerator.cpp
+++ b/src/shogun/structure/FactorGraphDataGenerator.cpp
@@ -545,8 +545,8 @@ float64_t CFactorGraphDataGenerator::test_sosvm(EMAPInferType infer_type)
 		CStructuredData* y_truth = fg_labels_train->get_label(i);
 		acc_loss_sgd += model->delta_loss(y_truth, y_pred);
 
-		CFactorGraphObservation* y_t = CFactorGraphObservation::obtain_from_generic(y_truth);
-		CFactorGraphObservation* y_p = CFactorGraphObservation::obtain_from_generic(y_pred);
+		CFactorGraphObservation* y_t = y_truth->as<CFactorGraphObservation>();
+		CFactorGraphObservation* y_p = y_pred->as<CFactorGraphObservation>();
 
 		SGVector<int32_t> s_t = y_t->get_data();
 		SGVector<int32_t> s_p = y_p->get_data();

--- a/src/shogun/structure/FactorGraphModel.cpp
+++ b/src/shogun/structure/FactorGraphModel.cpp
@@ -228,11 +228,11 @@ void CFactorGraphModel::w_to_fparams(SGVector<float64_t> w)
 SGVector< float64_t > CFactorGraphModel::get_joint_feature_vector(int32_t feat_idx, CStructuredData* y)
 {
 	// factor graph instance
-	CFactorGraphFeatures* mf = CFactorGraphFeatures::obtain_from_generic(m_features);
+	CFactorGraphFeatures* mf = m_features->as<CFactorGraphFeatures>();
 	CFactorGraph* fg = mf->get_sample(feat_idx);
 
 	// ground truth states
-	CFactorGraphObservation* fg_states = CFactorGraphObservation::obtain_from_generic(y);
+	CFactorGraphObservation* fg_states = y->as<CFactorGraphObservation>();
 	SGVector<int32_t> states = fg_states->get_data();
 
 	// initialize psi
@@ -281,7 +281,7 @@ SGVector< float64_t > CFactorGraphModel::get_joint_feature_vector(int32_t feat_i
 CResultSet* CFactorGraphModel::argmax(SGVector<float64_t> w, int32_t feat_idx, bool const training)
 {
 	// factor graph instance
-	CFactorGraphFeatures* mf = CFactorGraphFeatures::obtain_from_generic(m_features);
+	CFactorGraphFeatures* mf = m_features->as<CFactorGraphFeatures>();
 	CFactorGraph* fg = mf->get_sample(feat_idx);
 
 	// prepare factor graph
@@ -310,8 +310,7 @@ CResultSet* CFactorGraphModel::argmax(SGVector<float64_t> w, int32_t feat_idx, b
 	ret->psi_computed = true;
 
 	// y_truth
-	CFactorGraphObservation* y_truth =
-		CFactorGraphObservation::obtain_from_generic(m_labels->get_label(feat_idx));
+	CFactorGraphObservation* y_truth = m_labels->get_label(feat_idx)->as<CFactorGraphObservation>();
 
 	SGVector<int32_t> states_gt = y_truth->get_data();
 
@@ -375,8 +374,8 @@ CResultSet* CFactorGraphModel::argmax(SGVector<float64_t> w, int32_t feat_idx, b
 
 float64_t CFactorGraphModel::delta_loss(CStructuredData* y1, CStructuredData* y2)
 {
-	CFactorGraphObservation* y_truth = CFactorGraphObservation::obtain_from_generic(y1);
-	CFactorGraphObservation* y_pred = CFactorGraphObservation::obtain_from_generic(y2);
+	CFactorGraphObservation* y_truth = y1->as<CFactorGraphObservation>();
+	CFactorGraphObservation* y_pred = y2->as<CFactorGraphObservation>();
 	SGVector<int32_t> s_truth = y_truth->get_data();
 	SGVector<int32_t> s_pred = y_pred->get_data();
 

--- a/src/shogun/structure/HMSVMModel.cpp
+++ b/src/shogun/structure/HMSVMModel.cpp
@@ -68,7 +68,7 @@ SGVector< float64_t > CHMSVMModel::get_joint_feature_vector(
 	int32_t D = mf->get_num_features();
 
 	// Get the sequence of labels
-	CSequence* label_seq = CSequence::obtain_from_generic(y);
+	CSequence* label_seq = y->as<CSequence>();
 
 	// Initialize psi
 	SGVector< float64_t > psi(get_dim());
@@ -228,8 +228,7 @@ CResultSet* CHMSVMModel::argmax(
 	// If argmax used while training, add to E the loss matrix (loss-augmented inference)
 	if ( training )
 	{
-		CSequence* ytrue =
-			CSequence::obtain_from_generic(m_labels->get_label(feat_idx));
+		CSequence* ytrue = m_labels->get_label(feat_idx)->as<CSequence>();
 
 		REQUIRE(ytrue->get_data().size() == T, "T, the length of the feature "
 			"x^i (%d) and the length of its corresponding label y^i "
@@ -344,8 +343,8 @@ CResultSet* CHMSVMModel::argmax(
 
 float64_t CHMSVMModel::delta_loss(CStructuredData* y1, CStructuredData* y2)
 {
-	CSequence* seq1 = CSequence::obtain_from_generic(y1);
-	CSequence* seq2 = CSequence::obtain_from_generic(y2);
+	CSequence* seq1 = y1->as<CSequence>();
+	CSequence* seq2 = y2->as<CSequence>();
 
 	// Compute the Hamming loss, number of distinct elements in the sequences
 	return m_state_model->loss(seq1, seq2);
@@ -448,7 +447,7 @@ bool CHMSVMModel::check_training_setup() const
 	int32_t state;
 	for ( int32_t i = 0 ; i < hmsvm_labels->get_num_labels() ; ++i )
 	{
-		seq = CSequence::obtain_from_generic(hmsvm_labels->get_label(i));
+		seq = hmsvm_labels->get_label(i)->as<CSequence>();
 
 		SGVector<int32_t> seq_data = seq->get_data();
 		for ( int32_t j = 0 ; j < seq_data.size() ; ++j )

--- a/src/shogun/structure/HashedMultilabelModel.cpp
+++ b/src/shogun/structure/HashedMultilabelModel.cpp
@@ -100,7 +100,7 @@ SGSparseVector<float64_t> CHashedMultilabelModel::get_sparse_joint_feature_vecto
 	SGSparseVector<float64_t> vec = ((CSparseFeatures<float64_t> *)m_features)->
 	                                get_sparse_feature_vector(feat_idx);
 
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(y);
+	CSparseMultilabel * slabel = y->as<CSparseMultilabel>();
 	ASSERT(slabel != NULL);
 	SGVector<int32_t> slabel_data = slabel->get_data();
 
@@ -131,8 +131,8 @@ SGSparseVector<float64_t> CHashedMultilabelModel::get_sparse_joint_feature_vecto
 float64_t CHashedMultilabelModel::delta_loss(CStructuredData * y1,
                 CStructuredData * y2)
 {
-	CSparseMultilabel * y1_slabel = CSparseMultilabel::obtain_from_generic(y1);
-	CSparseMultilabel * y2_slabel = CSparseMultilabel::obtain_from_generic(y2);
+	CSparseMultilabel * y1_slabel = y1->as<CSparseMultilabel>();
+	CSparseMultilabel * y2_slabel = y2->as<CSparseMultilabel>();
 
 	ASSERT(y1_slabel != NULL);
 	ASSERT(y2_slabel != NULL);
@@ -253,8 +253,7 @@ CResultSet * CHashedMultilabelModel::argmax(SGVector<float64_t> w,
 
 	float64_t score = 0, total_score = 0;
 
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(
-	                                     multi_labs->get_label(feat_idx));
+	CSparseMultilabel * slabel = multi_labs->get_label(feat_idx)->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_data = slabel->get_data();
 	SGVector<float64_t> y_truth = CMultilabelSOLabels::to_dense(
 	                                      slabel, m_num_classes, 1, 0);

--- a/src/shogun/structure/HierarchicalMultilabelModel.cpp
+++ b/src/shogun/structure/HierarchicalMultilabelModel.cpp
@@ -134,7 +134,7 @@ SGVector<int32_t> CHierarchicalMultilabelModel::get_label_vector(
 SGVector<float64_t> CHierarchicalMultilabelModel::get_joint_feature_vector(
         int32_t feat_idx, CStructuredData * y)
 {
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(y);
+	CSparseMultilabel * slabel = y->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_data = slabel->get_data();
 	SGVector<int32_t> label_vector = get_label_vector(slabel_data);
 
@@ -166,8 +166,8 @@ SGVector<float64_t> CHierarchicalMultilabelModel::get_joint_feature_vector(
 float64_t CHierarchicalMultilabelModel::delta_loss(CStructuredData * y1,
                 CStructuredData * y2)
 {
-	CSparseMultilabel * y1_slabel = CSparseMultilabel::obtain_from_generic(y1);
-	CSparseMultilabel * y2_slabel = CSparseMultilabel::obtain_from_generic(y2);
+	CSparseMultilabel * y1_slabel = y1->as<CSparseMultilabel>();
+	CSparseMultilabel * y2_slabel = y2->as<CSparseMultilabel>();
 
 	ASSERT(y1_slabel != NULL);
 	ASSERT(y2_slabel != NULL);

--- a/src/shogun/structure/MulticlassModel.cpp
+++ b/src/shogun/structure/MulticlassModel.cpp
@@ -50,7 +50,7 @@ SGVector< float64_t > CMulticlassModel::get_joint_feature_vector(int32_t feat_id
 
 	SGVector< float64_t > x = ((CDotFeatures*) m_features)->
 		get_computed_dot_feature_vector(feat_idx);
-	CRealNumber* r = CRealNumber::obtain_from_generic(y);
+	CRealNumber* r = y->as<CRealNumber>();
 	ASSERT(r != NULL)
 	float64_t label_value = r->value;
 
@@ -123,8 +123,8 @@ CResultSet* CMulticlassModel::argmax(
 
 float64_t CMulticlassModel::delta_loss(CStructuredData* y1, CStructuredData* y2)
 {
-	CRealNumber* rn1 = CRealNumber::obtain_from_generic(y1);
-	CRealNumber* rn2 = CRealNumber::obtain_from_generic(y2);
+	CRealNumber* rn1 = y1->as<CRealNumber>();
+	CRealNumber* rn2 = y2->as<CRealNumber>();
 	ASSERT(rn1 != NULL)
 	ASSERT(rn2 != NULL)
 
@@ -136,7 +136,7 @@ float64_t CMulticlassModel::delta_loss(int32_t y1_idx, float64_t y2)
 	REQUIRE(y1_idx >= 0 || y1_idx < m_labels->get_num_labels(),
 			"The label index must be inside [0, num_labels-1]\n");
 
-	CRealNumber* rn1 = CRealNumber::obtain_from_generic(m_labels->get_label(y1_idx));
+	CRealNumber* rn1 = m_labels->get_label(y1_idx)->as<CRealNumber>();
 	float64_t ret = delta_loss(rn1->value, y2);
 	SG_UNREF(rn1);
 

--- a/src/shogun/structure/MulticlassSOLabels.cpp
+++ b/src/shogun/structure/MulticlassSOLabels.cpp
@@ -56,7 +56,7 @@ CStructuredData* CMulticlassSOLabels::get_label(int32_t idx)
 void CMulticlassSOLabels::add_label(CStructuredData* label)
 {
         SG_REF(label);
-        float64_t value = CRealNumber::obtain_from_generic(label)->value;
+        float64_t value = label->as<CRealNumber>()->value;
         SG_UNREF(label);
 
 	//ensure_valid_sdt(label);
@@ -73,7 +73,7 @@ void CMulticlassSOLabels::add_label(CStructuredData* label)
 bool CMulticlassSOLabels::set_label(int32_t idx, CStructuredData* label)
 {
         SG_REF(label);
-        float64_t value = CRealNumber::obtain_from_generic(label)->value;
+        float64_t value = label->as<CRealNumber>()->value;
         SG_UNREF(label);
 
 	// ensure_valid_sdt(label);

--- a/src/shogun/structure/MultilabelCLRModel.cpp
+++ b/src/shogun/structure/MultilabelCLRModel.cpp
@@ -58,7 +58,7 @@ SGVector<float64_t> CMultilabelCLRModel::get_joint_feature_vector(
 	psi.zero();
 
 	int32_t num_classes = ((CMultilabelSOLabels *)m_labels)->get_num_classes();
-	int32_t num_pos_labels = (CSparseMultilabel::obtain_from_generic(y))->
+	int32_t num_pos_labels = (y->as<CSparseMultilabel>())->
 	                         get_data().vlen;
 	int32_t num_neg_labels = num_classes - num_pos_labels;
 
@@ -93,8 +93,8 @@ SGVector<float64_t> CMultilabelCLRModel::get_joint_feature_vector(
 
 float64_t CMultilabelCLRModel::delta_loss(CStructuredData * y1, CStructuredData * y2)
 {
-	CSparseMultilabel * y1_slabel = CSparseMultilabel::obtain_from_generic(y1);
-	CSparseMultilabel * y2_slabel = CSparseMultilabel::obtain_from_generic(y2);
+	CSparseMultilabel * y1_slabel = y1->as<CSparseMultilabel>();
+	CSparseMultilabel * y2_slabel = y2->as<CSparseMultilabel>();
 
 	ASSERT(y1_slabel != NULL);
 	ASSERT(y2_slabel != NULL);
@@ -185,8 +185,7 @@ CResultSet * CMultilabelCLRModel::argmax(SGVector<float64_t> w, int32_t feat_idx
 	{
 		plus_minus_one.set_const(-1);
 
-		CSparseMultilabel * y_true = CSparseMultilabel::obtain_from_generic(
-		                                     multi_labs->get_label(feat_idx));
+		CSparseMultilabel * y_true = multi_labs->get_label(feat_idx)->as<CSparseMultilabel>();
 		SGVector<int32_t> y_true_data = y_true->get_data();
 
 		for (index_t i = 0; i < y_true_data.vlen; i++)

--- a/src/shogun/structure/MultilabelModel.cpp
+++ b/src/shogun/structure/MultilabelModel.cpp
@@ -69,7 +69,7 @@ SGVector<float64_t> CMultilabelModel::get_joint_feature_vector(int32_t feat_idx,
 
 	SGVector<float64_t> x = ((CDotFeatures *)m_features)->
 	                        get_computed_dot_feature_vector(feat_idx);
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(y);
+	CSparseMultilabel * slabel = y->as<CSparseMultilabel>();
 	ASSERT(slabel != NULL);
 	SGVector<int32_t> slabel_data = slabel->get_data();
 
@@ -86,8 +86,8 @@ SGVector<float64_t> CMultilabelModel::get_joint_feature_vector(int32_t feat_idx,
 
 float64_t CMultilabelModel::delta_loss(CStructuredData * y1, CStructuredData * y2)
 {
-	CSparseMultilabel * y1_slabel = CSparseMultilabel::obtain_from_generic(y1);
-	CSparseMultilabel * y2_slabel = CSparseMultilabel::obtain_from_generic(y2);
+	CSparseMultilabel * y1_slabel = y1->as<CSparseMultilabel>();
+	CSparseMultilabel * y2_slabel = y2->as<CSparseMultilabel>();
 
 	ASSERT(y1_slabel != NULL);
 	ASSERT(y2_slabel != NULL);

--- a/src/shogun/structure/MultilabelSOLabels.cpp
+++ b/src/shogun/structure/MultilabelSOLabels.cpp
@@ -106,7 +106,7 @@ bool CMultilabelSOLabels::set_label(int32_t j, CStructuredData * label)
 		m_sdt = label->get_structured_data_type();
 	}
 
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(label);
+	CSparseMultilabel * slabel = label->as<CSparseMultilabel>();
 	m_multilabel_labels->set_label(j, slabel->get_data());
 	return true;
 }
@@ -131,7 +131,7 @@ void CMultilabelSOLabels::ensure_valid(const char * context)
 SGVector<float64_t> CMultilabelSOLabels::to_dense(CStructuredData * label,
                 int32_t dense_dim, float64_t d_true, float64_t d_false)
 {
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(label);
+	CSparseMultilabel * slabel = label->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_data = slabel->get_data();
 	return CMultilabelLabels::to_dense<int32_t, float64_t>(&slabel_data,
 	                dense_dim, d_true, d_false);

--- a/tests/unit/distribution/MixtureModel_unittest.cc
+++ b/tests/unit/distribution/MixtureModel_unittest.cc
@@ -73,8 +73,8 @@ TEST(MixtureModel,gaussian_mixture_model)
 	CMixtureModel* mix=new CMixtureModel(comps,weights);
 	mix->train(feats);
 
-	CDistribution* distr=CDistribution::obtain_from_generic(comps->get_element(0));
-	CGaussian* outg=CGaussian::obtain_from_generic(distr);
+	CDistribution* distr = comps->get_element(0)->as<CDistribution>();
+	CGaussian* outg = distr->as<CGaussian>();
 	SGVector<float64_t> m=outg->get_mean();
 	SGMatrix<float64_t> cov=outg->get_cov();
 
@@ -85,8 +85,8 @@ TEST(MixtureModel,gaussian_mixture_model)
 	SG_UNREF(outg);
 	SG_UNREF(distr);
 
-	distr=CDistribution::obtain_from_generic(comps->get_element(1));
-	outg=CGaussian::obtain_from_generic(distr);
+	distr = comps->get_element(1)->as<CDistribution>();
+	outg = distr->as<CGaussian>();
 	m=outg->get_mean();
 	cov=outg->get_cov();
 
@@ -94,7 +94,6 @@ TEST(MixtureModel,gaussian_mixture_model)
 	EXPECT_NEAR(cov(0,0),1.095106568,eps);
 
 	SG_UNREF(outg);
-	SG_UNREF(distr);
 	SG_UNREF(mix)
 }
 

--- a/tests/unit/labels/StructuredLabels_unittest.cc
+++ b/tests/unit/labels/StructuredLabels_unittest.cc
@@ -29,15 +29,15 @@ TEST(StructuredLabels, add_label)
 
 	EXPECT_EQ(3, l->get_num_labels());
 
-	real_number = CRealNumber::obtain_from_generic(l->get_label(0));
+	real_number = l->get_label(0)->as<CRealNumber>();
 	EXPECT_EQ(3, real_number->value);
 	SG_UNREF(real_number);
 
-	real_number = CRealNumber::obtain_from_generic(l->get_label(1));
+	real_number = l->get_label(1)->as<CRealNumber>();
 	EXPECT_EQ(7, real_number->value);
 	SG_UNREF(real_number);
 
-	real_number = CRealNumber::obtain_from_generic(l->get_label(2));
+	real_number = l->get_label(2)->as<CRealNumber>();
 	EXPECT_EQ(13, real_number->value);
 	SG_UNREF(real_number);
 
@@ -59,15 +59,15 @@ TEST(StructuredLabels, set_label)
 
 	EXPECT_EQ(3, l->get_num_labels());
 
-	real_number = CRealNumber::obtain_from_generic(l->get_label(0));
+	real_number = l->get_label(0)->as<CRealNumber>();
 	EXPECT_EQ(3, real_number->value);
 	SG_UNREF(real_number);
 
-	real_number = CRealNumber::obtain_from_generic(l->get_label(1));
+	real_number = l->get_label(1)->as<CRealNumber>();
 	EXPECT_EQ(23, real_number->value);
 	SG_UNREF(real_number);
 
-	real_number = CRealNumber::obtain_from_generic(l->get_label(2));
+	real_number = l->get_label(2)->as<CRealNumber>();
 	EXPECT_EQ(13, real_number->value);
 	SG_UNREF(real_number);
 

--- a/tests/unit/structure/DualLibQPBMSOSVM_unittest.cc
+++ b/tests/unit/structure/DualLibQPBMSOSVM_unittest.cc
@@ -124,7 +124,7 @@ TEST_P(DualLibQPBMSOSVMTestLoopSolvers,train_small_problem_and_predict)
 
 	for (int32_t i=0; i<num_feat; ++i)
 	{
-		CRealNumber* rn = CRealNumber::obtain_from_generic( out->get_label(i) );
+		CRealNumber* rn = out->get_label(i)->as<CRealNumber>();
 		error+=(rn->value==labs.get_element(i)) ? 0.0 : 1.0;
 		SG_UNREF(rn);
 	}

--- a/tests/unit/structure/HashedMultilabelModel_unittest.cc
+++ b/tests/unit/structure/HashedMultilabelModel_unittest.cc
@@ -193,8 +193,7 @@ TEST(HashedMultilabelModel, argmax)
 
 	CResultSet * ret_1 = model->argmax(w, 0, true);
 
-	CSparseMultilabel * y_1 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_1->argmax);
+	CSparseMultilabel * y_1 = ret_1->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_1 = y_1->get_data();
 
 
@@ -229,8 +228,7 @@ TEST(HashedMultilabelModel, argmax)
 
 	CResultSet * ret_2 = model->argmax(w, 0, false);
 
-	CSparseMultilabel * y_2 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_2->argmax);
+	CSparseMultilabel * y_2 = ret_2->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_2 = y_2->get_data();
 
 	for (index_t i = 0; i < slabel_2.vlen; i++)

--- a/tests/unit/structure/HierarchicalMultilabelModel_unittest.cc
+++ b/tests/unit/structure/HierarchicalMultilabelModel_unittest.cc
@@ -246,8 +246,7 @@ TEST(HierarchicalMultilabelModel, argmax)
 
 	CResultSet * ret_1 = model->argmax(w, 0, true);
 
-	CSparseMultilabel * y_1 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_1->argmax);
+	CSparseMultilabel * y_1 = ret_1->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_1 = y_1->get_data();
 
 	for (index_t i = 0; i < slabel_1.vlen; i++)
@@ -275,8 +274,7 @@ TEST(HierarchicalMultilabelModel, argmax)
 
 	CResultSet * ret_2 = model->argmax(w, 0, false);
 
-	CSparseMultilabel * y_2 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_2->argmax);
+	CSparseMultilabel * y_2 = ret_2->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_2 = y_2->get_data();
 
 	for (index_t i = 0; i < slabel_2.vlen; i++)
@@ -357,8 +355,7 @@ TEST(HierarchicalMultilabelModel, argmax_leaf_nodes_mandatory)
 
 	CResultSet * ret_1 = model->argmax(w, 0, true);
 
-	CSparseMultilabel * y_1 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_1->argmax);
+	CSparseMultilabel * y_1 = ret_1->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_1 = y_1->get_data();
 
 	for (index_t i = 0; i < slabel_1.vlen; i++)
@@ -382,8 +379,7 @@ TEST(HierarchicalMultilabelModel, argmax_leaf_nodes_mandatory)
 
 	CResultSet * ret_2 = model->argmax(w, 0, false);
 
-	CSparseMultilabel * y_2 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_2->argmax);
+	CSparseMultilabel * y_2 = ret_2->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_2 = y_2->get_data();
 
 	for (index_t i = 0; i < slabel_2.vlen; i++)

--- a/tests/unit/structure/MultilabelCLRModel_unittest.cc
+++ b/tests/unit/structure/MultilabelCLRModel_unittest.cc
@@ -208,8 +208,7 @@ TEST(MultilabelCLRModel, argmax)
 
 	CResultSet * ret_1 = model->argmax(w, 0, true);
 
-	CSparseMultilabel * y_1 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_1->argmax);
+	CSparseMultilabel * y_1 = ret_1->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_1 = y_1->get_data();
 
 	// calibrated/virtual label is considered to be last label
@@ -237,8 +236,7 @@ TEST(MultilabelCLRModel, argmax)
 
 	CResultSet * ret_2 = model->argmax(w, 0, false);
 
-	CSparseMultilabel * y_2 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_2->argmax);
+	CSparseMultilabel * y_2 = ret_2->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_2 = y_2->get_data();
 
 	for (index_t i = 0; i < labels->get_num_classes(); i++)

--- a/tests/unit/structure/MultilabelModel_unittest.cc
+++ b/tests/unit/structure/MultilabelModel_unittest.cc
@@ -185,8 +185,7 @@ TEST(MultilabelModel, argmax)
 	y_2_expected[0] = 0;
 	y_2_expected[1] = 1;
 
-	CSparseMultilabel * y_1 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_1->argmax);
+	CSparseMultilabel * y_1 = ret_1->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_1 = y_1->get_data();
 	SGVector<float64_t> psi_truth_1 = ret_1->psi_truth;
 
@@ -210,8 +209,7 @@ TEST(MultilabelModel, argmax)
 
 	EXPECT_EQ(ret_1->delta, 1);
 
-	CSparseMultilabel * y_2 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_2->argmax);
+	CSparseMultilabel * y_2 = ret_2->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_2 = y_2->get_data();
 	SGVector<float64_t> psi_truth_2 = ret_2->psi_truth;
 
@@ -238,8 +236,7 @@ TEST(MultilabelModel, argmax)
 	CResultSet * ret_3 = model->argmax(w, 0, false);
 	CResultSet * ret_4 = model->argmax(w, 1, false);
 
-	CSparseMultilabel * y_3 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_3->argmax);
+	CSparseMultilabel * y_3 = ret_3->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_3 = y_3->get_data();
 	SGVector<float64_t> psi_pred_3 = ret_3->psi_pred;
 
@@ -261,8 +258,7 @@ TEST(MultilabelModel, argmax)
 		}
 	}
 
-	CSparseMultilabel * y_4 = CSparseMultilabel::obtain_from_generic(
-	                                  ret_4->argmax);
+	CSparseMultilabel * y_4 = ret_4->argmax->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_4 = y_4->get_data();
 	SGVector<float64_t> psi_pred_4 = ret_4->psi_pred;
 

--- a/tests/unit/structure/MultilabelSOLabels_unittest.cc
+++ b/tests/unit/structure/MultilabelSOLabels_unittest.cc
@@ -61,8 +61,7 @@ TEST(MultilabelSOLabels, set_sparse_label)
 	lab[1] = 1;
 	ml->set_sparse_label(0, lab);
 
-	CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(
-	                                     ml->get_label(0));
+	CSparseMultilabel * slabel = ml->get_label(0)->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_data = slabel->get_data();
 
 	for (int i = 0; i < slabel_data.vlen; i++)
@@ -90,8 +89,7 @@ TEST(MultilabelSOLabels, set_label)
 	SG_REF(slabel);
 	ml->set_label(0, slabel);
 
-	CSparseMultilabel * slabel_out = CSparseMultilabel::obtain_from_generic(
-	                ml->get_label(0));
+	CSparseMultilabel * slabel_out = ml->get_label(0)->as<CSparseMultilabel>();
 	SGVector<int32_t> slabel_data = slabel_out->get_data();
 
 	for (index_t i = 0; i < slabel_data.vlen; i++)
@@ -127,7 +125,7 @@ TEST(MultilabelSOLabels, set_sparse_labels)
 
 	for (int i = 0; i < ml->get_num_labels(); i++)
 	{
-		CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(ml->get_label(i));
+		CSparseMultilabel * slabel = ml->get_label(i)->as<CSparseMultilabel>();
 		SGVector<int32_t> slabel_data = slabel->get_data();
 		SGVector<int32_t> lab = labels[i];
 		EXPECT_EQ(slabel_data.vlen, lab.vlen);
@@ -167,7 +165,7 @@ TEST(MultilabelSOLabels, to_dense)
 
 	for (int i = 0; i < ml->get_num_labels(); i++)
 	{
-		CSparseMultilabel * slabel = CSparseMultilabel::obtain_from_generic(ml->get_label(0));
+		CSparseMultilabel * slabel = ml->get_label(0)->as<CSparseMultilabel>();
 		SGVector<float64_t> slabel_dense_data = CMultilabelSOLabels::to_dense(slabel, ml->get_num_classes(), 1, 0);
 		SG_UNREF(slabel);
 		EXPECT_EQ(slabel_dense_data.vlen, ml->get_num_classes());


### PR DESCRIPTION
Refer #4191 
This is partial wok. There are more cases that need to be re-factored.
 
PS The build is expected to fail terribly when interface options are set. This is because `build/src/interfaces/{language}/shogun{language}wrap.cxx` needs refactoring wherever `obtain_from_generic` is used.