### PR TITLE
factory methods in lda meta example #4247

### DIFF
--- a/examples/meta/src/binary/linear_discriminant_analysis.sg
+++ b/examples/meta/src/binary/linear_discriminant_analysis.sg
@@ -1,13 +1,13 @@
-CSVFile f_feats_train("../../data/classifier_binary_2d_linear_features_train.dat")
-CSVFile f_feats_test("../../data/classifier_binary_2d_linear_features_test.dat")
-CSVFile f_labels_train("../../data/classifier_binary_2d_linear_labels_train.dat")
-CSVFile f_labels_test("../../data/classifier_binary_2d_linear_labels_test.dat")
+File f_feats_train = csv_file("../../data/classifier_binary_2d_linear_features_train.dat")
+File f_feats_test = csv_file("../../data/classifier_binary_2d_linear_features_test.dat")
+File f_labels_train = csv_file("../../data/classifier_binary_2d_linear_labels_train.dat")
+File f_labels_test = csv_file("../../data/classifier_binary_2d_linear_labels_test.dat")
 
 #![create_features]
 Features features_train = features(f_feats_train)
 Features features_test = features(f_feats_test)
-BinaryLabels labels_train(f_labels_train)
-BinaryLabels labels_test(f_labels_test)
+Labels labels_train = labels(f_labels_train)
+Labels labels_test = labels(f_labels_test)
 #![create_features]
 
 #![create_instance]
@@ -16,17 +16,15 @@ Machine lda = machine("LDA", labels=labels_train)
 
 #![train_and_apply]
 lda.train(features_train)
-BinaryLabels labels_predict = lda.apply_binary(features_test)
+Labels labels_predict = lda.apply(features_test)
+RealVector labels = labels_predict.get_real_vector("labels")
 #![train_and_apply]
 
 #![extract_weights]
-RealVector w = lda.get_real_vector("w")
+RealVector weights = lda.get_real_vector("w")
 #![extract_weights]
 
 #![evaluate_accuracy]
-AccuracyMeasure eval()
+Evaluation eval = evaluation("AccuracyMeasure")
 real accuracy = eval.evaluate(labels_predict, labels_test)
 #![evaluate_accuracy]
-
-#additional integration testing variables
-RealVector output = labels_predict.get_labels()

--- a/src/shogun/classifier/LDA.cpp
+++ b/src/shogun/classifier/LDA.cpp
@@ -49,7 +49,7 @@ void CLDA::init()
 	SG_ADD(
 	    (machine_int_t*)&m_method, "m_method",
 	    "Method used for LDA calculation", MS_NOT_AVAILABLE);
-	SG_ADD(&m_gamma, "m_gamma", "Regularization parameter", MS_NOT_AVAILABLE);
+	SG_ADD(&m_gamma, "m_gamma", "Regularization parameter", MS_AVAILABLE);
 	SG_ADD(&m_bdc_svd, "m_bdc_svd", "Use BDC-SVD algorithm", MS_NOT_AVAILABLE);
 }
 
@@ -105,16 +105,16 @@ template <typename ST>
 bool CLDA::solver_svd()
 {
 	auto dense_feat = static_cast<CDenseFeatures<ST>*>(features);
-  auto labels = multiclass_labels(m_labels);
-  REQUIRE(labels->get_num_classes()==2, "Number of classes exceeds 2 for binary classifier: %d provided\n", labels->get_num_classes())
+	auto labels = multiclass_labels(m_labels);
+	REQUIRE(
+	    labels->get_num_classes() == 2, "Number of classes (%d) must be 2\n",
+	    labels->get_num_classes())
 
 	// keep just one dimension to do binary classification
 	const index_t projection_dim = 1;
 	auto solver = std::unique_ptr<LDACanVarSolver<ST>>(
 	    new LDACanVarSolver<ST>(
-	        dense_feat,
-	        labels,
-	        projection_dim, m_gamma, m_bdc_svd));
+	        dense_feat, labels, projection_dim, m_gamma, m_bdc_svd));
 
 	SGVector<ST> w_st(solver->get_eigenvectors());
 
@@ -140,15 +140,14 @@ template <typename ST>
 bool CLDA::solver_classic()
 {
 	auto dense_feat = static_cast<CDenseFeatures<ST>*>(features);
-  auto labels = multiclass_labels(m_labels);
-  REQUIRE(labels->get_num_classes()==2, "Number of classes exceeds 2 for binary classifier: %d provided\n", labels->get_num_classes())
-  index_t num_feat = dense_feat->get_num_features();
+	auto labels = multiclass_labels(m_labels);
+	REQUIRE(
+	    labels->get_num_classes() == 2, "Number of classes (%d) must be 2\n",
+	    labels->get_num_classes())
+	index_t num_feat = dense_feat->get_num_features();
 
 	auto solver = std::unique_ptr<LDASolver<ST>>(
-	    new LDASolver<ST>(
-	        dense_feat,
-          labels,
-	        m_gamma));
+	    new LDASolver<ST>(dense_feat, labels, m_gamma));
 
 	auto class_mean = solver->get_class_mean();
 	auto class_count = solver->get_class_count();

--- a/src/shogun/labels/MulticlassLabels.cpp
+++ b/src/shogun/labels/MulticlassLabels.cpp
@@ -235,6 +235,8 @@ namespace shogun
 				    orig->as<CMulticlassLabels>());
 			case LT_DENSE_GENERIC:
 				return to_multiclass(orig->as<CDenseLabels>());
+			case LT_BINARY:
+				return to_multiclass(orig->as<CBinaryLabels>());
 			default:
 				SG_SNOTIMPLEMENTED
 			}


### PR DESCRIPTION
```lda.get_real("m_gamma")``` did not work due to this casting of gamma(float) as int