### PR TITLE
Observe/Observer benchmarks with Perceptron

### DIFF
--- a/src/shogun/lib/parameter_observers/ObservedValue.h
+++ b/src/shogun/lib/parameter_observers/ObservedValue.h
@@ -53,6 +53,7 @@ namespace shogun
 	/* Type of the observed value */
 	enum SG_OBS_VALUE_TYPE
 	{
+		LOGGER,
 		TENSORBOARD,
 		CROSSVALIDATION
 	};

--- a/src/shogun/lib/parameter_observers/ParameterObserverLogger.cpp
+++ b/src/shogun/lib/parameter_observers/ParameterObserverLogger.cpp
@@ -17,7 +17,8 @@ CParameterObserverLogger::~CParameterObserverLogger() {}
 void CParameterObserverLogger::on_next(const TimedObservedValue &value)
 {
 	CHECK_OBSERVED_VALUE_TYPE(value.first.get_type());
-	SG_SPRINT("Value observed");
+	// Just get the value for now. It does nothing else.
+	//SG_SPRINT("Value observed");
 }
 
 void CParameterObserverLogger::on_error(std::exception_ptr ptr) {}

--- a/src/shogun/lib/parameter_observers/ParameterObserverLogger.cpp
+++ b/src/shogun/lib/parameter_observers/ParameterObserverLogger.cpp
@@ -1,0 +1,24 @@
+/*
+* Written (W) 2018 Giovanni De Toni
+*/
+
+#include <shogun/io/SGIO.h>
+#include <shogun/lib/parameter_observers/ParameterObserverLogger.h>
+
+using namespace shogun;
+
+CParameterObserverLogger::CParameterObserverLogger() : ParameterObserverInterface()
+{
+	m_type = LOGGER;
+}
+
+CParameterObserverLogger::~CParameterObserverLogger() {}
+
+void CParameterObserverLogger::on_next(const TimedObservedValue &value)
+{
+	CHECK_OBSERVED_VALUE_TYPE(value.first.get_type());
+	SG_SPRINT("Value observed");
+}
+
+void CParameterObserverLogger::on_error(std::exception_ptr ptr) {}
+void CParameterObserverLogger::on_complete() {}

--- a/src/shogun/lib/parameter_observers/ParameterObserverLogger.h
+++ b/src/shogun/lib/parameter_observers/ParameterObserverLogger.h
@@ -1,0 +1,33 @@
+/*
+* Written (W) 2018 Giovanni De Toni
+*/
+
+#include <shogun/lib/config.h>
+
+#ifndef SHOGUN_PARAMETEROBSERVERLOGGER_H
+#define SHOGUN_PARAMETEROBSERVERLOGGER_H
+
+#include <shogun/lib/parameter_observers/ParameterObserverInterface.h>
+#include <shogun/base/SGObject.h>
+
+namespace shogun {
+
+	class CParameterObserverLogger : public ParameterObserverInterface, public CSGObject {
+	public:
+
+		CParameterObserverLogger();
+		~CParameterObserverLogger();
+
+		virtual void on_next(const TimedObservedValue& value);
+		virtual void on_error(std::exception_ptr ptr);
+		virtual void on_complete();
+
+		virtual const char* get_name() const
+		{
+			return "ParameterObserverLogger";
+		}
+	};
+}
+
+
+#endif //SHOGUN_PARAMETEROBSERVERLOGGER_H

--- a/src/shogun/util/PutPerceptron_benchmark.cc
+++ b/src/shogun/util/PutPerceptron_benchmark.cc
@@ -1,3 +1,4 @@
+#include <random>
 #include <benchmark/benchmark.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/features/DotFeatures.h>
@@ -154,7 +155,8 @@ namespace shogun
 		{
 			auto perceptron = new CMockPerceptron();
 			std::function<void()> callback = [&perceptron]() {
-				auto value = make_any(perceptron->weights);
+				perceptron->w = perceptron->weights;
+				auto value = make_any(perceptron->w);
 				std::string name = "weights";
 				ObservedValue observed_value (1, name, value, LOGGER);
 				perceptron->observe_dispatcher(observed_value);
@@ -172,7 +174,8 @@ namespace shogun
 			auto perceptron = new CMockPerceptron();
 			perceptron->subscribe_to_parameters(observer);
 			std::function<void()> callback = [&perceptron]() {
-				auto value = make_any(perceptron->weights);
+				perceptron->w = perceptron->weights;
+				auto value = make_any(perceptron->w);
 				std::string name = "weights";
 				ObservedValue observed_value (1, name, value, LOGGER);
 				perceptron->observe_dispatcher(observed_value);


### PR DESCRIPTION
The benchmarks results can be found [here](https://gist.github.com/geektoni/1e01f693b0c479f1c1cf40916445dafd). However, I think that in case of observers, the real overhead is bounded by the observers used (e.g. a logger will slow down the execution of a tiny bit, but an observer which does more complex things may increase a lot the computational time).