### PR TITLE
Cleanup non-const methods in dense and combined features

### DIFF
--- a/examples/undocumented/python/features_dense.py
+++ b/examples/undocumented/python/features_dense.py
@@ -24,10 +24,6 @@ def features_dense (A=matrixA,B=matrixB,C=matrixC):
 
 # print(some statistics about a)
 
-# get first feature vector and set it
-
-    a.set_feature_vector(array([1,4,0,0,0,9], dtype=float64), 0)
-
 # get matrices
     a_out = a.get_feature_matrix()
     b_out = b.get_feature_matrix()

--- a/examples/undocumented/python/features_dense_byte.py
+++ b/examples/undocumented/python/features_dense_byte.py
@@ -17,9 +17,8 @@ def features_dense_byte (A):
 	#print(a.get_num_vectors())
 	#print(a.get_num_features())
 
-	# get first feature vector and set it
+	# get first feature vector
 	#print(a.get_feature_vector(0))
-	a.set_feature_vector(numpy.array([1,4,0,0,0,9], dtype=numpy.uint8), 0)
 
 	# get matrix
 	a_out = a.get_feature_matrix()

--- a/examples/undocumented/python/features_dense_longint.py
+++ b/examples/undocumented/python/features_dense_longint.py
@@ -10,9 +10,6 @@ parameter_list = [[matrix]]
 # ... of type LongInt
 def features_dense_longint (A=matrix):
 	a=LongIntFeatures(A)
-	# get first feature vector and set it
-
-	a.set_feature_vector(array([1,4,0,0,0,9], dtype=int64), 0)
 
 	# get matrix
 	a_out = a.get_feature_matrix()

--- a/examples/undocumented/python/features_dense_real.py
+++ b/examples/undocumented/python/features_dense_real.py
@@ -17,9 +17,8 @@ def features_dense_real (A=matrix):
 #print(a.get_num_vectors())
 #print(a.get_num_features())
 
-# get first feature vector and set it
+# get first feature vector
 #print(a.get_feature_vector(0))
-    a.set_feature_vector(array([1,4,0,0,0,9], dtype=float64), 0)
 
 # get matrix
     a_out = a.get_feature_matrix()

--- a/src/shogun/classifier/NearestCentroid.cpp
+++ b/src/shogun/classifier/NearestCentroid.cpp
@@ -29,17 +29,12 @@ namespace shogun{
 
 	CNearestCentroid::~CNearestCentroid()
 	{
-		if(m_is_trained)
-			distance->remove_lhs();
-		else
-			delete m_centroids;
 	}
 
 	void CNearestCentroid::init()
 	{
 		m_shrinking=0;
 		m_is_trained=false;
-		m_centroids = new CDenseFeatures<float64_t>();
 	}
 
 
@@ -64,9 +59,6 @@ namespace shogun{
 		int32_t num_feats = ((CDenseFeatures<float64_t>*) data)->get_num_features();
 		SGMatrix<float64_t> centroids(num_feats,num_classes);
 		centroids.zero();
-
-		m_centroids->set_num_features(num_feats);
-		m_centroids->set_num_vectors(num_classes);
 
 		int64_t* num_per_class = new int64_t[num_classes];
 		for (int32_t i=0 ; i<num_classes ; i++)
@@ -100,12 +92,10 @@ namespace shogun{
 			SGVector<float64_t>::scale_vector(scale,target,num_feats);
 		}
 
-		m_centroids->free_feature_matrix();
-		m_centroids->set_feature_matrix(centroids);
-
+		auto centroids_feats = some<CDenseFeatures<float64_t>>(centroids);
 
 		m_is_trained=true;
-		distance->init(m_centroids,distance->get_rhs());
+		distance->init(centroids_feats, distance->get_rhs());
 
 		SG_FREE(num_per_class);
 

--- a/src/shogun/features/CombinedFeatures.cpp
+++ b/src/shogun/features/CombinedFeatures.cpp
@@ -41,7 +41,7 @@ CCombinedFeatures::~CCombinedFeatures()
 	SG_UNREF(feature_array);
 }
 
-CFeatures* CCombinedFeatures::get_feature_obj(int32_t idx)
+CFeatures* CCombinedFeatures::get_feature_obj(int32_t idx) const
 {
 	REQUIRE(
 	    idx < get_num_feature_obj() && idx>=0, "Feature index (%d) must be within [%d, %d]",
@@ -49,7 +49,7 @@ CFeatures* CCombinedFeatures::get_feature_obj(int32_t idx)
 	return (CFeatures*) feature_array->get_element(idx);
 }
 
-void CCombinedFeatures::list_feature_objs()
+void CCombinedFeatures::list_feature_objs() const
 {
 	SG_INFO("BEGIN COMBINED FEATURES LIST - ")
 	this->list_feature_obj();
@@ -111,12 +111,12 @@ bool CCombinedFeatures::check_feature_obj_compatibility(CCombinedFeatures* comb_
 	return result;
 }
 
-CFeatures* CCombinedFeatures::get_first_feature_obj()
+CFeatures* CCombinedFeatures::get_first_feature_obj() const
 {
 	return get_feature_obj(0);
 }
 
-CFeatures* CCombinedFeatures::get_last_feature_obj()
+CFeatures* CCombinedFeatures::get_last_feature_obj() const
 {
 	return get_feature_obj(get_num_feature_obj()-1);
 }
@@ -159,7 +159,7 @@ bool CCombinedFeatures::delete_feature_obj(int32_t idx)
 	return feature_array->delete_element(idx);
 }
 
-int32_t CCombinedFeatures::get_num_feature_obj()
+int32_t CCombinedFeatures::get_num_feature_obj() const
 {
 	return feature_array->get_num_elements();
 }
@@ -170,7 +170,7 @@ void CCombinedFeatures::init()
 	SG_ADD(&feature_array, "array", "Feature array.", MS_NOT_AVAILABLE);
 }
 
-CFeatures* CCombinedFeatures::create_merged_copy(CFeatures* other)
+CFeatures* CCombinedFeatures::create_merged_copy(CFeatures* other) const
 {
 	/* TODO, if all features are the same, only one copy should be created
 	 * in memory */
@@ -185,7 +185,7 @@ CFeatures* CCombinedFeatures::create_merged_copy(CFeatures* other)
 				get_name());
 	}
 
-	CCombinedFeatures* casted=dynamic_cast<CCombinedFeatures*>(other);
+	auto casted = dynamic_cast<const CCombinedFeatures*>(other);
 
 	if (!casted)
 	{

--- a/src/shogun/features/CombinedFeatures.h
+++ b/src/shogun/features/CombinedFeatures.h
@@ -76,7 +76,7 @@ class CCombinedFeatures : public CFeatures
 		}
 
 		/** list feature objects */
-		void list_feature_objs();
+		void list_feature_objs() const;
 
 		/** check feature object compatibility
 		 *
@@ -89,20 +89,20 @@ class CCombinedFeatures : public CFeatures
 		 *
 		 * @return first feature object
 		 */
-		CFeatures* get_first_feature_obj();
+		CFeatures* get_first_feature_obj() const;
 
 		/** get feature object at index idx
 		*
 		* @param idx index of feature object
 		* @return the feature object at index idx
 		*/
-		CFeatures* get_feature_obj(int32_t idx);
+		CFeatures* get_feature_obj(int32_t idx) const;
 
 		/** get last feature object
 		 *
 		 * @return last feature object
 		 */
-		CFeatures* get_last_feature_obj();
+		CFeatures* get_last_feature_obj() const;
 
 		/** insert feature object at index idx
 		 *  Important, idx must be < num_feature_obj
@@ -131,7 +131,7 @@ class CCombinedFeatures : public CFeatures
 		 *
 		 * @return number of feature objects
 		 */
-		int32_t get_num_feature_obj();
+		int32_t get_num_feature_obj() const;
 
 		/** Takes another feature instance and returns a new instance which is
 		 * a concatenation of a copy if this instace's data and the given
@@ -143,7 +143,7 @@ class CCombinedFeatures : public CFeatures
 		 * @return new feature object which contains copy of data of this
 		 * instance and of given one
 		 */
-		CFeatures* create_merged_copy(CFeatures* other);
+		CFeatures* create_merged_copy(CFeatures* other) const;
 
 		/** adds a subset of indices on top of the current subsets (possibly
 		 * subset o subset. Calls subset_changed_post() afterwards.

--- a/src/shogun/features/DenseFeatures.h
+++ b/src/shogun/features/DenseFeatures.h
@@ -113,12 +113,6 @@ public:
 	 */
 	void free_feature_matrix();
 
-	/** free feature matrix and cache
-	 *
-	 * Any subset is removed
-	 */
-	void free_features();
-
 	/** get feature vector
 	 * for sample num from the matrix as it is if matrix is
 	 * initialized, else return preprocessed compute_feature_vector (not
@@ -131,15 +125,6 @@ public:
 	 * @return feature vector
 	 */
 	ST* get_feature_vector(int32_t num, int32_t& len, bool& dofree);
-
-	/** set feature vector num
-	 *
-	 * possible with subset
-	 *
-	 * @param vector vector
-	 * @param num index if vector to set
-	 */
-	void set_feature_vector(SGVector<ST> vector, int32_t num);
 
 	/** get feature vector num
 	 *
@@ -206,15 +191,7 @@ public:
 	 *
 	 * @return matrix feature matrix
 	 */
-	SGMatrix<ST> get_feature_matrix();
-
-	/** steals feature matrix, i.e. returns matrix and
-	 * forget about it
-	 * subset is ignored
-	 *
-	 * @return matrix feature matrix
-	 */
-	SGMatrix<ST> steal_feature_matrix();
+	SGMatrix<ST> get_feature_matrix() const;
 
 	/** Setter for feature matrix
 	 *
@@ -238,7 +215,7 @@ public:
 	 * @param num_vec number of vectors in matrix
 	 * @return feature matrix
 	 */
-	ST* get_feature_matrix(int32_t &num_feat, int32_t &num_vec);
+	ST* get_feature_matrix(int32_t& num_feat, int32_t& num_vec) const;
 
 	/** get a transposed copy of the features
 	 *
@@ -316,16 +293,6 @@ public:
 	 * @return templated feature type
 	 */
 	virtual EFeatureType get_feature_type() const;
-
-	/** reshape
-	 *
-	 * not possible with subset
-	 *
-	 * @param p_num_features new number of features
-	 * @param p_num_vectors new number of vectors
-	 * @return if reshaping was successful
-	 */
-	virtual bool reshape(int32_t p_num_features, int32_t p_num_vectors);
 
 	/** obtain the dimensionality of the feature space
 	 *
@@ -483,7 +450,7 @@ public:
 	 * @return new feature object which contains copy of data of this
 	 * instance and of given one
 	 */
-	CFeatures* create_merged_copy(CList* other);
+	CFeatures* create_merged_copy(CList* other) const;
 
 	/** Convenience method for method with same name and list as parameter.
 	 *
@@ -491,11 +458,11 @@ public:
 	 * @return new feature object which contains copy of data of this
 	 * instance and of given one
 	 */
-	CFeatures* create_merged_copy(CFeatures* other);
+	CFeatures* create_merged_copy(CFeatures* other) const;
 
-	/** helper method used to specialize a base class instance
-	 *
-	 */
+/** helper method used to specialize a base class instance
+ *
+ */
 #ifndef SWIG
 	[[deprecated("use .as template function")]]
 #endif
@@ -522,6 +489,12 @@ protected:
 	 */
 	virtual ST* compute_feature_vector(int32_t num, int32_t& len,
 			ST* target = NULL);
+
+	/** free feature matrix and cache
+	 *
+	 * Any subset is removed
+	 */
+	void free_features();
 
 private:
 	void init();

--- a/src/shogun/features/Features.h
+++ b/src/shogun/features/Features.h
@@ -245,7 +245,7 @@ class CFeatures : public CSGObject
 		 * @return new feature object which contains copy of data of this
 		 * instance and given ones
 		 */
-		virtual CFeatures* create_merged_copy(CList* others)
+		virtual CFeatures* create_merged_copy(CList* others) const
 		{
 			SG_ERROR("%s::create_merged_copy() is not yet implemented!\n")
 			return NULL;
@@ -259,7 +259,7 @@ class CFeatures : public CSGObject
 		 * @return new feature object which contains copy of data of this
 		 * instance and of given one
 		 */
-		virtual CFeatures* create_merged_copy(CFeatures* other)
+		virtual CFeatures* create_merged_copy(CFeatures* other) const
 		{
 			SG_ERROR("%s::create_merged_copy() is not yet implemented!\n")
 			return NULL;

--- a/src/shogun/preprocessor/DimensionReductionPreprocessor.cpp
+++ b/src/shogun/preprocessor/DimensionReductionPreprocessor.cpp
@@ -43,7 +43,8 @@ SGMatrix<float64_t> CDimensionReductionPreprocessor::apply_to_feature_matrix(CFe
 	{
 		m_converter->set_target_dim(m_target_dim);
 		CDenseFeatures<float64_t>* embedding = m_converter->embed(features);
-		SGMatrix<float64_t> embedding_feature_matrix = embedding->steal_feature_matrix();
+		SGMatrix<float64_t> embedding_feature_matrix =
+			embedding->get_feature_matrix();
 		((CDenseFeatures<float64_t>*)features)->set_feature_matrix(embedding_feature_matrix);
 		delete embedding;
 		return embedding_feature_matrix;

--- a/tests/unit/features/DenseFeatures_unittest.cc
+++ b/tests/unit/features/DenseFeatures_unittest.cc
@@ -106,7 +106,7 @@ TEST(DenseFeaturesTest, create_merged_copy_with_subsets)
 			expected_merged_mat.matrix+active_data_1.size());
 
 	auto merged=static_cast<CDenseFeatures<float64_t>*>(features_1->create_merged_copy(features_2));
-	SGMatrix<float64_t> merged_mat=merged->steal_feature_matrix();
+	SGMatrix<float64_t> merged_mat = merged->get_feature_matrix();
 
 	ASSERT_EQ(expected_merged_mat.num_rows, merged_mat.num_rows);
 	ASSERT_EQ(expected_merged_mat.num_cols, merged_mat.num_cols);


### PR DESCRIPTION
* methods made const: `create_merged_copy`, `get_feature_matrix`, `get_feature_obj`
* dropped public methods: `set_feature_vector`, `reshape`, `steal_feature_matrix`
* made `free_features` protected