### PR TITLE
Make trained model testing support single mixins

### DIFF
--- a/src/shogun/CMakeLists.txt
+++ b/src/shogun/CMakeLists.txt
@@ -592,6 +592,13 @@ IF (CTAGS_FOUND)
         --c++-kinds=cfgp
         --fields=+im
         --exclude=*.cpp
+        --exclude=third_party
+        --exclude=GoogleMock
+        --exclude=rxcpp
+        --exclude=StanMath
+        --exclude=interfaces
+        --exclude=Eigen3
+        --exclude=external
         --languages=c++
         -R ${CMAKE_SOURCE_DIR})
 

--- a/tests/unit/base/trained_model_serialization_test.cc.py
+++ b/tests/unit/base/trained_model_serialization_test.cc.py
@@ -84,7 +84,7 @@ def get_shogun_classes(tags):
         if base is not None:
             for mix in MIXINS:
                 if mix == base:
-                    mixin = mixin
+                    mixin = mix
                     # extract template parameter of mixin and use as base class
                     declaration = attrs[-4]
                     base = declaration[(declaration.find("<")+1):declaration.find(">")]

--- a/tests/unit/base/trained_model_serialization_test.cc.py
+++ b/tests/unit/base/trained_model_serialization_test.cc.py
@@ -81,14 +81,12 @@ def get_shogun_classes(tags):
         # parse mixings from declaration, using declarations of the like of
         # /^class CNewtonSVM : public CIterativeMachine<CLinearMachine>$/;"
         mixin = None
-        if base is not None:
-            for mix in MIXINS:
-                if mix == base:
-                    mixin = mix
-                    # extract template parameter of mixin and use as base class
-                    declaration = attrs[-4]
-                    base = declaration[(declaration.find("<")+1):declaration.find(">")]
-                    break
+        if base is not None and base in MIXINS:
+            mixin = base
+            # extract template parameter of mixin and use as base class
+            declaration = attrs[-4]
+            base = declaration[(declaration.find("<")+1):declaration.find(">")]
+            break
 
         classes[symbol] = {
             'include': location,

--- a/tests/unit/base/trained_model_serialization_test.cc.py
+++ b/tests/unit/base/trained_model_serialization_test.cc.py
@@ -86,7 +86,6 @@ def get_shogun_classes(tags):
             # extract template parameter of mixin and use as base class
             declaration = attrs[-4]
             base = declaration[(declaration.find("<")+1):declaration.find(">")]
-            break
 
         classes[symbol] = {
             'include': location,

--- a/tests/unit/base/trained_model_serialization_test.cc.py
+++ b/tests/unit/base/trained_model_serialization_test.cc.py
@@ -87,8 +87,7 @@ def get_shogun_classes(tags):
                     mixin = mixin
                     # extract template parameter of mixin and use as base class
                     declaration = attrs[-4]
-                    b = declaration[(declaration.find("<")+1):declaration.find(">")]
-                    base = b
+                    base = declaration[(declaration.find("<")+1):declaration.find(">")]
                     break
 
         classes[symbol] = {


### PR DESCRIPTION
@micmn we added mixins which makes the base class checking a bit more complicated.
mixins are defined as `template <class T> CIterativeMachine : public T { ... }`, and the `class Perceptron : public CIterativeMachine<CLinearMachine> { ... }`, so ctags will generate `inherits: CIterativeMachine` and therefore the perceptron would not be included in the tests.

We cannot use your mapping function instead because I dont know what type of machine will lie inside, e.g. `'CiterativeMachine: CMachine'` would not work for example for kernel machines.

So what I did here is to extract the mixin template parameter from the declaration of the class and then substitute the base class with that, but keep the mixin in the `classes` dictionary (we might want to define tests for mixins only later on).