### PR TITLE
Drop usage of set_feature_matrix

### DIFF
--- a/examples/undocumented/python/modelselection_grid_search_kernel.py
+++ b/examples/undocumented/python/modelselection_grid_search_kernel.py
@@ -85,8 +85,7 @@ def modelselection_grid_search_kernel (num_subsets, num_vectors, dim_vectors):
 	matrix=random.rand(dim_vectors, num_vectors)
 
 	# create num_feautres 2-dimensional vectors
-	features=RealFeatures()
-	features.set_feature_matrix(matrix)
+	features=RealFeatures(matrix)
 
 	# create labels, two classes
 	labels=BinaryLabels(num_vectors)

--- a/src/interfaces/python/DenseFeatures_protocols.i
+++ b/src/interfaces/python/DenseFeatures_protocols.i
@@ -658,11 +658,11 @@ int frombuffer(PyObject* exporter, bool copy)
 
 	if (copy)
 	{
-		$self->put("feature_matrix", new_feat_matrix.clone());
+		$self->put(Tag<SGMatrix< type_name >>("feature_matrix"), new_feat_matrix.clone());
 	}
 	else
 	{
-		$self->put("feature_matrix", new_feat_matrix);
+		$self->put(Tag<SGMatrix< type_name >>("feature_matrix"), new_feat_matrix);
 	}
 
 	info=(buffer_matrix_ ## type_name ## _info*) malloc(sizeof(buffer_matrix_ ## type_name ## _info));

--- a/src/interfaces/python/DenseFeatures_protocols.i
+++ b/src/interfaces/python/DenseFeatures_protocols.i
@@ -658,11 +658,11 @@ int frombuffer(PyObject* exporter, bool copy)
 
 	if (copy)
 	{
-		$self->set_feature_matrix(new_feat_matrix.clone());
+		$self->put("feature_matrix", new_feat_matrix.clone());
 	}
 	else
 	{
-		$self->set_feature_matrix(new_feat_matrix);
+		$self->put("feature_matrix", new_feat_matrix);
 	}
 
 	info=(buffer_matrix_ ## type_name ## _info*) malloc(sizeof(buffer_matrix_ ## type_name ## _info));

--- a/src/shogun/features/DenseFeatures.h
+++ b/src/shogun/features/DenseFeatures.h
@@ -193,19 +193,6 @@ public:
 	 */
 	SGMatrix<ST> get_feature_matrix() const;
 
-	/** Setter for feature matrix
-	 *
-	 * any subset is removed
-	 *
-	 * num_cols is number of feature vectors
-	 * num_rows is number of dims of vectors
-	 * see below for definition of feature_matrix
-	 *
-	 * @param matrix feature matrix to set
-	 *
-	 */
-	void set_feature_matrix(SGMatrix<ST> matrix);
-
 	/** get the pointer to the feature matrix
 	 * num_feat,num_vectors are returned by reference
 	 *
@@ -483,6 +470,19 @@ protected:
 	 * Any subset is removed
 	 */
 	void free_features();
+
+	/** Setter for feature matrix
+	 *
+	 * any subset is removed
+	 *
+	 * num_cols is number of feature vectors
+	 * num_rows is number of dims of vectors
+	 * see below for definition of feature_matrix
+	 *
+	 * @param matrix feature matrix to set
+	 *
+	 */
+	void set_feature_matrix(SGMatrix<ST> matrix);
 
 private:
 	void init();

--- a/src/shogun/kernel/AUCKernel.cpp
+++ b/src/shogun/kernel/AUCKernel.cpp
@@ -105,8 +105,7 @@ CLabels* CAUCKernel::setup_auc_maximization(CLabels* labels)
 	SG_REF(lab_auc);
 
 	// create feature object
-	CDenseFeatures<uint16_t>* f = new CDenseFeatures<uint16_t>(0);
-	f->set_feature_matrix(features_auc);
+	CDenseFeatures<uint16_t>* f = new CDenseFeatures<uint16_t>(features_auc);
 
 	// create AUC kernel and attach the features
 	init(f,f);

--- a/src/shogun/preprocessor/KernelPCA.cpp
+++ b/src/shogun/preprocessor/KernelPCA.cpp
@@ -130,15 +130,10 @@ CFeatures* CKernelPCA::transform(CFeatures* features, bool inplace)
 {
 	assert_fitted();
 
-	if (!inplace)
-		features = dynamic_cast<CFeatures*>(features->clone());
-
 	if (dynamic_cast<CDenseFeatures<float64_t>*>(features))
 	{
 		auto feature_matrix = apply_to_feature_matrix(features);
-		features->as<CDenseFeatures<float64_t>>()->set_feature_matrix(
-		    feature_matrix);
-		return features;
+		return new CDenseFeatures<float64_t>(feature_matrix);
 	}
 
 	if (features->get_feature_class() == C_STRING)

--- a/src/shogun/preprocessor/KernelPCA.h
+++ b/src/shogun/preprocessor/KernelPCA.h
@@ -44,6 +44,11 @@ public:
 
 		virtual void fit(CFeatures* features);
 
+		/** Apply transformation to features. In-place mode is not supported.
+		 *	@param features features to transform
+		 *	@param inplace whether transform in place
+		 *	@return the result feature object after applying the transformer
+		 */
 		virtual CFeatures* transform(CFeatures* features, bool inplace = true);
 
 		/// cleanup

--- a/tests/unit/kernel/PeriodicKernel_unittest.cc
+++ b/tests/unit/kernel/PeriodicKernel_unittest.cc
@@ -22,8 +22,7 @@ TEST(PeriodicKernelTest,test_kernel_matrix)
 	}
 
 	// Load them into DenseFeatures
-	CDenseFeatures<float64_t>* features= new CDenseFeatures<float64_t>();
-	features->set_feature_matrix(matrix);
+	CDenseFeatures<float64_t>* features = new CDenseFeatures<float64_t>(matrix);
 
 	// Construct kernel and compute kernel matrix
 	CPeriodicKernel* kernel = new CPeriodicKernel(features, features, 1.0, 5.0);
@@ -56,8 +55,7 @@ TEST(PeriodicKernelTest,test_derivative_width)
 	}
 
 	// Load them into DenseFeatures
-	CDenseFeatures<float64_t>* features= new CDenseFeatures<float64_t>();
-	features->set_feature_matrix(matrix);
+	CDenseFeatures<float64_t>* features = new CDenseFeatures<float64_t>(matrix);
 
 	// Construct kernel
 	CPeriodicKernel* kernel = new CPeriodicKernel(features, features, 1.0, 5.0);
@@ -94,8 +92,7 @@ TEST(PeriodicKernelTest,test_derivative_period)
 	}
 
 	// Load them into DenseFeatures
-	CDenseFeatures<float64_t>* features= new CDenseFeatures<float64_t>();
-	features->set_feature_matrix(matrix);
+	CDenseFeatures<float64_t>* features= new CDenseFeatures<float64_t>(matrix);
 
 	// Construct kernel
 	CPeriodicKernel* kernel = new CPeriodicKernel(features, features, 1.0, 5.0);


### PR DESCRIPTION
now the only usage of `set_feature_matrix` is swig https://github.com/shogun-toolbox/shogun/blob/770f748f4fd3b6db66ac08e699924f7152a8557d/src/interfaces/python/DenseFeatures_protocols.i#L661
after that we can drop it from public api