### PR TITLE
Fix issue when building without GPL.

### DIFF
--- a/cmake/FindMetaExamples.cmake
+++ b/cmake/FindMetaExamples.cmake
@@ -35,8 +35,6 @@ function(get_excluded_meta_examples)
       statistical_testing/quadratic_time_maximum_mean_discrepancy.sg
       gaussian_process/classifier.sg
       gaussian_process/regression.sg
-      binary/svmlin.sg
-      binary/svmsgd.sg
       )
 	ENDIF()
 


### PR DESCRIPTION
If -DLICENSE_GPL_SHOGUN=OFF -DUSE_SVMLIGHT=OFF are provided then the cmake procedure fails because it does not find some SVM meta examples (which are non-existing).