### PR TITLE
Refactored linalg operations tests ( addresses #4383)

### DIFF
--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -11,6 +11,17 @@ using namespace shogun;
 using namespace linalg;
 using namespace Eigen;
 
+// Tolerance values for tests
+template<typename T>
+// default tolerance
+T get_epsilon() {return 0;}
+template<>
+float32_t get_epsilon() {return 1e-5;}
+template<>
+float64_t get_epsilon() {return 1e-9;}
+template<>
+floatmax_t get_epsilon() {return 1e-12;}
+
 template <typename T>
 class LinalgBackendEigenAllTypesTest: public ::testing::Test { };
 template <typename T>

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -1633,29 +1633,29 @@ void check_SGMatrix_softmax()
         EXPECT_NEAR(ref[i], A[i], 1e-7);
 }
 
-template <typename ST>
-void check_SGMatrix_squared_error()
-{
-    SGMatrix<ST> A(4, 3);
-    SGMatrix<ST> B(4, 3);
-
-    ST size = A.num_rows * A.num_cols;
-    for (ST i = 0; i < size; i+=2)
-    {
-        A[i] = i / size;
-        B[i] = (i / size) * 2;
-    }
-
-    ST ref = 0;
-    for (index_t i = 0; i < size; i++)
-        ref += CMath::pow(A[i] - B[i], 2);
-    ref *= 0.5;
-
-    printf("%d", ref);
-
-    auto result = linalg::squared_error(A, B);
-        EXPECT_NEAR(ref, result, 1e-15);
-}
+//template <typename ST>
+//void check_SGMatrix_squared_error()
+//{
+//    SGMatrix<ST> A(4, 3);
+//    SGMatrix<ST> B(4, 3);
+//
+//    ST size = A.num_rows * A.num_cols;
+//    for (ST i = 0; i < size; i+=2)
+//    {
+//        A[i] = i / size;
+//        B[i] = (i / size) * 2;
+//    }
+//
+//    ST ref = 0;
+//    for (index_t i = 0; i < size; i++)
+//        ref += CMath::pow(A[i] - B[i], 2);
+//    ref *= 0.5;
+//
+//    printf("%d", ref);
+//
+//    auto result = linalg::squared_error(A, B);
+//        EXPECT_NEAR(ref, result, 1e-15);
+//}
 
 
 template <typename ST>
@@ -2747,4 +2747,26 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_zero)
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_rank_update)
 {
     check_SGMatrix_rank_update<TypeParam>();
+}
+
+// TODO: implement typed testing for SE
+TEST(LinalgBackendEigen, SGMatrix_squared_error)
+{
+    SGMatrix<float64_t> A(4, 3);
+    SGMatrix<float64_t> B(4, 3);
+
+    int32_t size = A.num_rows * A.num_cols;
+    for (float64_t i = 0; i < size; ++i)
+    {
+        A[i] = i / size;
+        B[i] = (i / size) * 0.5;
+    }
+
+    float64_t ref = 0;
+    for (index_t i = 0; i < size; i++)
+        ref += CMath::pow(A[i] - B[i], 2);
+            ref *= 0.5;
+
+    auto result = linalg::squared_error(A, B);
+    EXPECT_NEAR(ref, result, 1e-15);
 }

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -11,148 +11,178 @@ using namespace shogun;
 using namespace linalg;
 using namespace Eigen;
 
-TEST(LinalgBackendEigen, SGVector_add)
-{
-	const float64_t alpha = 0.3;
-	const float64_t beta = -1.5;
+template <typename T>
+class LinalgBackendEigenAllTypesTest: public ::testing::Test { };
+template <typename T>
+class LinalgBackendEigenNonComplexTypesTest: public ::testing::Test { };
+template <typename T>
+class LinalgBackendEigenRealTypesTest: public ::testing::Test { };
+template <typename T>
+class LinalgBackendEigenNonIntegerTypesTest: public ::testing::Test { };
 
-	SGVector<float64_t> A(9);
-	SGVector<float64_t> B(9);
+// TODO: make global definitions
+// Definition of the 4 groups of Shogun types (shogun/mathematics/linalg/LinalgBackendBase.h)
+// TODO: add bool, chars and complex128_t types
+typedef ::testing::Types<int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t, float64_t, floatmax_t> AllTypes;
+typedef ::testing::Types<int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t, float64_t, floatmax_t> NonComplexTypes;
+typedef ::testing::Types<float32_t, float64_t, floatmax_t> RealTypes;
+// TODO: add complex128_t type
+typedef ::testing::Types<float32_t, float64_t, floatmax_t> NonIntegerTypes;
 
-	for (index_t i = 0; i < 9; ++i)
-	{
-		A[i] = i;
-		B[i] = 0.5*i;
-	}
+TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, AllTypes);
+TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, NonComplexTypes);
+TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, RealTypes);
+TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, NonIntegerTypes);
 
-	auto result = add(A, B, alpha, beta);
 
-	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
+template <typename ST>
+void check_SGVector_add() {
+
+    const ST alpha = 1;
+    const ST beta = 2;
+
+    SGVector<ST> A(9);
+    SGVector<ST> B(9);
+
+    for (index_t i = 0; i < 9; ++i)
+    {
+        A[i] = i;
+        B[i] = 2*i;
+    }
+
+    auto result = add(A, B, alpha, beta);
+
+    for (index_t i = 0; i < 9; ++i)
+        EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_add)
-{
-	const float64_t alpha = 0.3;
-	const float64_t beta = -1.5;
-	const index_t nrows = 2, ncols = 3;
+template <typename ST>
+void check_SGMatrix_add() {
 
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGMatrix<float64_t> B(nrows, ncols);
+    const ST alpha = 1;
+    const ST beta = 2;
+    const index_t nrows = 2, ncols = 3;
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-	{
-		A[i] = i;
-		B[i] = 0.5*i;
-	}
+    SGMatrix<ST> A(nrows, ncols);
+    SGMatrix<ST> B(nrows, ncols);
 
-	auto result = add(A, B, alpha, beta);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+    {
+        A[i] = i;
+        B[i] = 2*i;
+    }
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
+    auto result = add(A, B, alpha, beta);
+
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_add_in_place)
-{
-	const float64_t alpha = 0.3;
-	const float64_t beta = -1.5;
+template <typename ST>
+void check_SGVector_add_in_place() {
+    const ST alpha = 1;
+    const ST beta = 2;
 
-	SGVector<float64_t> A(9), B(9), C(9);
+    SGVector<ST> A(9), B(9), C(9);
 
-	for (index_t i = 0; i < 9; ++i)
-	{
-		A[i] = i;
-		B[i] = 0.5*i;
-		C[i] = i;
-	}
+    for (index_t i = 0; i < 9; ++i)
+    {
+    A[i] = i;
+    B[i] = 2*i;
+    C[i] = i;
+    }
 
-	add(A, B, A, alpha, beta);
+    add(A, B, A, alpha, beta);
 
-	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
+    for (index_t i = 0; i < 9; ++i)
+    EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_add_in_place)
-{
-	const float64_t alpha = 0.3;
-	const float64_t beta = -1.5;
-	const index_t nrows = 2, ncols = 3;
+template <typename ST>
+void check_SGMatrix_add_in_place() {
 
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGMatrix<float64_t> B(nrows, ncols);
-	SGMatrix<float64_t> C(nrows, ncols);
+    const ST alpha = 1;
+    const ST beta = 2;
+    const index_t nrows = 2, ncols = 3;
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-	{
-		A[i] = i;
-		B[i] = 0.5*i;
-		C[i] = i;
-	}
+    SGMatrix<ST> A(nrows, ncols);
+    SGMatrix<ST> B(nrows, ncols);
+    SGMatrix<ST> C(nrows, ncols);
 
-	add(A, B, A, alpha, beta);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+    {
+        A[i] = i;
+        B[i] = 3*i;
+        C[i] = i;
+    }
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
+    add(A, B, A, alpha, beta);
+
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_add_col_vec_allocated)
+template <typename ST>
+void check_SGVector_add_col_vec_allocated() {
+
+    const ST alpha = 1;
+    const ST beta = 2;
+    const index_t nrows = 2, ncols = 3;
+    const index_t col = 1;
+
+    SGMatrix<ST> A(nrows, ncols);
+    SGVector<ST> b(nrows);
+    SGVector<ST> result(nrows);
+
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < nrows; ++i)
+        b[i] = 3 * i;
+
+    add_col_vec(A, col, b, result, alpha, beta);
+
+    for (index_t i = 0; i < nrows; ++i)
+        EXPECT_NEAR(result[i], alpha * A.get_element(i, col) + beta * b[i], 1e-15);
+}
+
+template <typename ST>
+void check_SGVector_add_col_vec_in_place()
 {
-	const float64_t alpha = 0.7;
-	const float64_t beta = -1.2;
+    const ST alpha = 0;
+    const ST beta = 3;
+    const index_t nrows = 2, ncols = 3;
+    const index_t col = 1;
+
+    SGMatrix<ST> A(nrows, ncols);
+    SGVector<ST> b(nrows);
+
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < nrows; ++i)
+        b[i] = 2*i;
+
+    add_col_vec(A, col, b, b, alpha, beta);
+
+    for (index_t i = 0; i < nrows; ++i)
+        EXPECT_NEAR(b[i], alpha*A.get_element(i, col)+beta*2*i, 1e-15);
+}
+
+template <typename ST>
+void check_SGMatrix_add_col_vec_allocated()
+{
+	const ST alpha = 0;
+	const ST beta = 2;
 	const index_t nrows = 2, ncols = 3;
 	const index_t col = 1;
 
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGVector<float64_t> b(nrows);
-	SGVector<float64_t> result(nrows);
+	SGMatrix<ST> A(nrows, ncols);
+	SGVector<ST> b(nrows);
+	SGMatrix<ST> result(nrows, ncols);
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 0.5*i;
-
-	add_col_vec(A, col, b, result, alpha, beta);
-
-	for (index_t i = 0; i < nrows; ++i)
-		EXPECT_NEAR(result[i], alpha*A.get_element(i, col)+beta*b[i], 1e-15);
-}
-
-TEST(LinalgBackendEigen, SGVector_add_col_vec_in_place)
-{
-	const float64_t alpha = 0.6;
-	const float64_t beta = -1.3;
-	const index_t nrows = 2, ncols = 3;
-	const index_t col = 1;
-
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGVector<float64_t> b(nrows);
-
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 0.5*i;
-
-	add_col_vec(A, col, b, b, alpha, beta);
-
-	for (index_t i = 0; i < nrows; ++i)
-		EXPECT_NEAR(b[i], alpha*A.get_element(i, col)+beta*0.5*i, 1e-15);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_add_col_vec_allocated)
-{
-	const float64_t alpha = 0.8;
-	const float64_t beta = -1.4;
-	const index_t nrows = 2, ncols = 3;
-	const index_t col = 1;
-
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGVector<float64_t> b(nrows);
-	SGMatrix<float64_t> result(nrows, ncols);
-
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 0.5*i;
+		b[i] = 3*i;
 
 	add_col_vec(A, col, b, result, alpha, beta);
 
@@ -162,27 +192,28 @@ TEST(LinalgBackendEigen, SGMatrix_add_col_vec_allocated)
 		    alpha * A.get_element(i, col) + beta * b[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_add_col_vec_in_place)
+template <typename ST>
+void check_SGMatrix_add_col_vec_in_place()
 {
-	const float64_t alpha = 0.9;
-	const float64_t beta = -1.7;
+	const ST alpha = 1;
+	const ST beta = 2;
 	const index_t nrows = 2, ncols = 3;
 	const index_t col = 1;
 
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGVector<float64_t> b(nrows);
+	SGMatrix<ST> A(nrows, ncols);
+	SGVector<ST> b(nrows);
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 0.5*i;
+		b[i] = 3*i;
 
 	add_col_vec(A, col, b, A, alpha, beta);
 
 	for (index_t i = 0; i < nrows; ++i)
 		for (index_t j = 0; j < ncols; ++j)
 		{
-			float64_t a = i+j*nrows;
+			ST a = i+j*nrows;
 			if (j == col)
 				EXPECT_NEAR(A.get_element(i, j), alpha*a+beta*b[i], 1e-15);
 			else
@@ -190,10 +221,11 @@ TEST(LinalgBackendEigen, SGMatrix_add_col_vec_in_place)
 		}
 }
 
-TEST(LinalgBackendEigen, add_diag)
+template <typename ST>
+void check_add_diag()
 {
-	SGMatrix<float64_t> A1(2, 3);
-	SGVector<float64_t> b1(2);
+	SGMatrix<ST> A1(2, 3);
+	SGVector<ST> b1(2);
 
 	A1(0, 0) = 1;
 	A1(0, 1) = 2;
@@ -205,29 +237,33 @@ TEST(LinalgBackendEigen, add_diag)
 	b1[0] = 1;
 	b1[1] = 2;
 
-	add_diag(A1, b1, 0.5, 2.0);
+	const ST alpha = 1.0;
+	const ST beta = 2.0;
 
-	EXPECT_NEAR(A1(0, 0), 2.5, 1e-15);
+	add_diag(A1, b1, alpha, beta);
+
+	EXPECT_NEAR(A1(0, 0), 3, 1e-15);
 	EXPECT_NEAR(A1(0, 1), 2, 1e-15);
 	EXPECT_NEAR(A1(0, 2), 3, 1e-15);
 	EXPECT_NEAR(A1(1, 0), 4, 1e-15);
-	EXPECT_NEAR(A1(1, 1), 6.5, 1e-15);
+	EXPECT_NEAR(A1(1, 1), 9, 1e-15);
 	EXPECT_NEAR(A1(1, 2), 6, 1e-15);
 
 	// test error cases
-	SGMatrix<float64_t> A2(2, 2);
-	SGVector<float64_t> b2(3);
-	SGMatrix<float64_t> A3;
-	SGVector<float64_t> b3;
+	SGMatrix<ST> A2(2, 2);
+	SGVector<ST> b2(3);
+	SGMatrix<ST> A3;
+	SGVector<ST> b3;
 	EXPECT_THROW(add_diag(A2, b2), ShogunException);
 	EXPECT_THROW(add_diag(A2, b3), ShogunException);
 	EXPECT_THROW(add_diag(A3, b2), ShogunException);
 	EXPECT_THROW(add_diag(A3, b3), ShogunException);
 }
 
-TEST(LinalgBackendEigen, add_ridge)
+template <typename ST>
+void check_add_ridge()
 {
-	SGMatrix<float64_t> A1(2, 3);
+	SGMatrix<ST> A1(2, 3);
 
 	A1(0, 0) = 1;
 	A1(0, 1) = 2;
@@ -236,7 +272,9 @@ TEST(LinalgBackendEigen, add_ridge)
 	A1(1, 1) = 5;
 	A1(1, 2) = 6;
 
-	add_ridge(A1, 1.0);
+	const ST alpha = 1.0;
+
+	add_ridge(A1, alpha);
 
 	EXPECT_NEAR(A1(0, 0), 2, 1e-15);
 	EXPECT_NEAR(A1(0, 1), 2, 1e-15);
@@ -246,22 +284,23 @@ TEST(LinalgBackendEigen, add_ridge)
 	EXPECT_NEAR(A1(1, 2), 6, 1e-15);
 
 	// test error cases
-	SGMatrix<float64_t> A2;
-	EXPECT_THROW(add_ridge(A2, 1.0), ShogunException);
+	SGMatrix<ST> A2;
+	EXPECT_THROW(add_ridge(A2, alpha), ShogunException);
 }
 
-TEST(LinalgBackendEigen, add_vector)
+template <typename ST>
+void check_add_vector()
 {
-	const float64_t alpha = 0.7;
-	const float64_t beta = -1.2;
+	const ST alpha = 1;
+	const ST beta = 2;
 	const index_t nrows = 2, ncols = 3;
 
-	SGMatrix<float64_t> A(nrows, ncols);
-	SGMatrix<float64_t> result(nrows, ncols);
-	SGVector<float64_t> b(nrows);
+	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<ST> result(nrows, ncols);
+	SGVector<ST> b(nrows);
 
 	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 0.5 * i;
+		b[i] = 3 * i;
 	for (index_t j = 0; j < ncols; ++j)
 		for (index_t i = 0; i < nrows; ++i)
 		{
@@ -275,15 +314,16 @@ TEST(LinalgBackendEigen, add_vector)
 		EXPECT_NEAR(A[i], result[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_add_scalar)
+template <typename ST>
+void check_SGVector_add_scalar()
 {
 	const index_t n = 4;
-	float64_t s = -0.3;
+	ST s = -0.3;
 
-	SGVector<float64_t> a(n);
+	SGVector<ST> a(n);
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
 		a[i] = i;
-	SGVector<float64_t> orig = a.clone();
+	SGVector<ST> orig = a.clone();
 
 	add_scalar(a, s);
 
@@ -291,15 +331,16 @@ TEST(LinalgBackendEigen, SGVector_add_scalar)
 		EXPECT_NEAR(a[i], orig[i] + s, 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_add_scalar)
+template <typename ST>
+void check_SGMatrix_add_scalar()
 {
 	const index_t r = 4, c = 3;
-	float64_t s = 0.4;
+	ST s = 0.4;
 
-	SGMatrix<float64_t> a(r, c);
+	SGMatrix<ST> a(r, c);
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
 		a[i] = i;
-	SGMatrix<float64_t> orig = a.clone();
+	SGMatrix<ST> orig = a.clone();
 
 	add_scalar(a, s);
 
@@ -307,28 +348,31 @@ TEST(LinalgBackendEigen, SGMatrix_add_scalar)
 		EXPECT_NEAR(a[i], orig[i] + s, 1e-15);
 }
 
-TEST(LinalgBackendEigen, center_matrix)
+template <typename ST>
+void check_SGMatrix_center_matrix()
 {
 	const index_t n = 3;
-	float64_t data[] = {0.8192343,  0.13191962, 0.50888604,
-	                    0.16857468, 0.24107738, 0.89455301,
-	                    0.40657379, 0.07902286, 0.24319651};
-	float64_t result[] = {0.25587541,  -0.1173183, -0.13855711,
-	                      -0.34283925, 0.04378442, 0.29905482,
-	                      0.08696383,  0.07353387, -0.16049771};
+	ST data[] = {0.5, 0.3, 0.4,
+	             0.4, 0.5, 0.3,
+	             0.3, 0.4, 0.5};
+	ST result[] = {0.1, -0.1, 0.0,
+	               0.0, 0.1, -0.1,
+	               -0.1, 0.0, 0.1};
 
-	SGMatrix<float64_t> m(data, n, n, false);
+	SGMatrix<ST> m(data, n, n, false);
 
 	center_matrix(m);
 
 	for (index_t i = 0; i < (index_t)m.size(); ++i)
-		EXPECT_NEAR(m[i], result[i], 1e-8);
+		EXPECT_NEAR(m[i], result[i], 1e-7);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_cholesky_llt_lower)
+template <typename ST>
+void check_SGMatrix_cholesky_llt_lower()
 {
 	const index_t size=2;
-	SGMatrix<float64_t> m(size, size);
+	SGMatrix<ST> m(size, size);
+	typedef Matrix<ST, Dynamic, Dynamic> Mxx; // need to adapt the Eigen::Matrix to ST type
 
 	m(0,0)=2.0;
 	m(0,1)=1.0;
@@ -336,1756 +380,2371 @@ TEST(LinalgBackendEigen, SGMatrix_cholesky_llt_lower)
 	m(1,1)=2.5;
 
 	//lower triangular cholesky decomposition
-	SGMatrix<float64_t> L = cholesky_factor(m);
+	SGMatrix<ST> L = cholesky_factor(m);
 
-	Map<MatrixXd> map_A(m.matrix,m.num_rows,m.num_cols);
-	Map<MatrixXd> map_L(L.matrix,L.num_rows,L.num_cols);
+
+	Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
+	Map<Mxx> map_L(L.matrix,L.num_rows,L.num_cols);
 	EXPECT_NEAR((map_A-map_L*map_L.transpose()).norm(),
-		0.0, 1E-15);
+		0.0, 1E-6); // need to change the treshold to work with floats
 	EXPECT_EQ(m.num_rows, L.num_rows);
 	EXPECT_EQ(m.num_cols, L.num_cols);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_cholesky_llt_upper)
-{
-	const index_t size=2;
-	SGMatrix<float64_t> m(size, size);
-
-	m(0,0)=2.0;
-	m(0,1)=1.0;
-	m(1,0)=1.0;
-	m(1,1)=2.5;
-
-	//upper triangular cholesky decomposition
-	SGMatrix<float64_t> U = cholesky_factor(m,false);
-
-	Map<MatrixXd> map_A(m.matrix,m.num_rows,m.num_cols);
-	Map<MatrixXd> map_U(U.matrix,U.num_rows,U.num_cols);
-	EXPECT_NEAR((map_A-map_U.transpose()*map_U).norm(),
-		0.0, 1E-15);
-	EXPECT_EQ(m.num_rows, U.num_rows);
-	EXPECT_EQ(m.num_cols, U.num_cols);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_cholesky_rank_update_upper)
-{
-	const index_t size = 2;
-	SGMatrix<float64_t> A(size, size);
-	SGMatrix<float64_t> U(size, size);
-	SGVector<float64_t> b(size);
-	Map<MatrixXd> A_eig(A.matrix, size, size);
-	Map<MatrixXd> U_eig(U.matrix, size, size);
-	Map<VectorXd> b_eig(b.vector, size);
-
-	U(0, 0) = 2.0;
-	U(0, 1) = 1.0;
-	U(1, 1) = 2.5;
-	b[0] = 2;
-	b[1] = 3;
-	A_eig = U_eig.transpose() * U_eig;
-
-	auto A2 = A.clone();
-	Map<MatrixXd> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
-	A2(0, 0) += b[0] * b[0];
-	A2(0, 1) += b[0] * b[1];
-	A2(1, 0) += b[1] * b[0];
-	A2(1, 1) += b[1] * b[1];
-
-	cholesky_rank_update(U, b, 1.0, false);
-	EXPECT_NEAR((A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, 1e-14);
-
-	cholesky_rank_update(U, b, -1., false);
-	EXPECT_NEAR((A_eig - U_eig.transpose() * U_eig).norm(), 0.0, 1e-14);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_cholesky_rank_update_lower)
-{
-	const index_t size = 2;
-	SGMatrix<float64_t> A(size, size);
-	SGMatrix<float64_t> L(size, size);
-	SGVector<float64_t> b(size);
-	Map<MatrixXd> A_eig(A.matrix, size, size);
-	Map<MatrixXd> L_eig(L.matrix, size, size);
-	Map<VectorXd> b_eig(b.vector, size);
-
-	L(0, 0) = 2.0;
-	L(1, 0) = 1.0;
-	L(1, 1) = 2.5;
-	b[0] = 2;
-	b[1] = 3;
-	A_eig = L_eig * L_eig.transpose();
-
-	auto A2 = A.clone();
-	Map<MatrixXd> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
-	A2(0, 0) += b[0] * b[0];
-	A2(0, 1) += b[0] * b[1];
-	A2(1, 0) += b[1] * b[0];
-	A2(1, 1) += b[1] * b[1];
-
-	cholesky_rank_update(L, b);
-	EXPECT_NEAR((A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, 1e-14);
-
-	cholesky_rank_update(L, b, -1.);
-	EXPECT_NEAR((A_eig - L_eig * L_eig.transpose()).norm(), 0.0, 1e-14);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_cholesky_ldlt_lower)
-{
-	const index_t size = 3;
-	SGMatrix<float64_t> m(size, size);
-	m(0, 0) = 0.0;
-	m(0, 1) = 0.0;
-	m(0, 2) = 0.0;
-	m(1, 0) = 0.0;
-	m(1, 1) = 1.0;
-	m(1, 2) = 2.0;
-	m(2, 0) = 0.0;
-	m(2, 1) = 2.0;
-	m(2, 2) = 3.0;
-
-	SGMatrix<float64_t> L(size, size);
-	SGVector<float64_t> d(size);
-	SGVector<index_t> p(size);
-
-	linalg::ldlt_factor(m, L, d, p);
-
-	EXPECT_NEAR(d[0], 3.0, 1e-15);
-	EXPECT_NEAR(d[1], -0.333333333333333, 1e-15);
-	EXPECT_NEAR(d[2], 0.0, 1e-15);
-
-	EXPECT_NEAR(L(0, 0), 1.0, 1e-15);
-	EXPECT_NEAR(L(0, 1), 0.0, 1e-15);
-	EXPECT_NEAR(L(0, 2), 0.0, 1e-15);
-	EXPECT_NEAR(L(1, 0), 0.666666666666666, 1e-15);
-	EXPECT_NEAR(L(1, 1), 1.0, 1e-15);
-	EXPECT_NEAR(L(1, 2), 0.0, 1e-15);
-	EXPECT_NEAR(L(2, 0), 0.0, 1e-15);
-	EXPECT_NEAR(L(2, 1), 0.0, 1e-15);
-	EXPECT_NEAR(L(2, 2), 1.0, 1e-15);
+template <typename ST>
+void check_SGMatrix_cholesky_llt_upper()
+{
+    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+
+    const index_t size=2;
+    SGMatrix<ST> m(size, size);
+
+    m(0,0)=2.0;
+    m(0,1)=1.0;
+    m(1,0)=1.0;
+    m(1,1)=2.5;
+
+    //upper triangular cholesky decomposition
+    SGMatrix<ST> U = cholesky_factor(m,false);
+
+    Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
+    Map<Mxx> map_U(U.matrix,U.num_rows,U.num_cols);
+    EXPECT_NEAR((map_A-map_U.transpose()*map_U).norm(),
+    0.0, 1E-6); // need to change the treshold to work with floats
+    EXPECT_EQ(m.num_rows, U.num_rows);
+    EXPECT_EQ(m.num_cols, U.num_cols);
+}
+
+template <typename ST>
+void check_SGMatrix_cholesky_rank_update_upper()
+{
+    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+    typedef Matrix<ST, Dynamic, 1> Vx;
+
+    const index_t size = 2;
+    ST alpha = 1;
+    SGMatrix<ST> A(size, size);
+    SGMatrix<ST> U(size, size);
+    SGVector<ST> b(size);
+    Map<Mxx> A_eig(A.matrix, size, size);
+    Map<Mxx> U_eig(U.matrix, size, size);
+    Map<Vx> b_eig(b.vector, size);
+
+    U(0, 0) = 2.0;
+    U(0, 1) = 1.0;
+    U(1, 1) = 2.5;
+    b[0] = 2;
+    b[1] = 3;
+    A_eig = U_eig.transpose() * U_eig;
+
+    auto A2 = A.clone();
+    Map<Mxx> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
+    A2(0, 0) += b[0] * b[0];
+    A2(0, 1) += b[0] * b[1];
+    A2(1, 0) += b[1] * b[0];
+    A2(1, 1) += b[1] * b[1];
+
+    cholesky_rank_update(U, b, alpha, false);
+    EXPECT_NEAR((A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, 1e-5);  // need to change the treshold to work with floats
+
+    cholesky_rank_update(U, b, -alpha, false);
+    EXPECT_NEAR((A_eig - U_eig.transpose() * U_eig).norm(), 0.0, 1e-5);  // need to change the treshold to work with floats
+}
+
+template <typename ST>
+void check_SGMatrix_cholesky_rank_update_lower()
+{
+    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+    typedef Matrix<ST, Dynamic, 1> Vx;
+
+    const index_t size = 2;
+    ST alpha = 1;
+    SGMatrix<ST> A(size, size);
+    SGMatrix<ST> L(size, size);
+    SGVector<ST> b(size);
+    Map<Mxx> A_eig(A.matrix, size, size);
+    Map<Mxx> L_eig(L.matrix, size, size);
+    Map<Vx> b_eig(b.vector, size);
+
+    L(0, 0) = 2.0;
+    L(1, 0) = 1.0;
+    L(1, 1) = 2.5;
+    b[0] = 2;
+    b[1] = 3;
+    A_eig = L_eig * L_eig.transpose();
+
+    auto A2 = A.clone();
+    Map<Mxx> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
+    A2(0, 0) += b[0] * b[0];
+    A2(0, 1) += b[0] * b[1];
+    A2(1, 0) += b[1] * b[0];
+    A2(1, 1) += b[1] * b[1];
+
+    cholesky_rank_update(L, b, alpha);
+    EXPECT_NEAR((A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, 1e-5);
+
+    cholesky_rank_update(L, b, -alpha);
+    EXPECT_NEAR((A_eig - L_eig * L_eig.transpose()).norm(), 0.0, 1e-5);
+}
+
+template <typename ST>
+void check_SGMatrix_cholesky_ldlt_lower()
+{
+    const index_t size = 3;
+    SGMatrix<ST> m(size, size);
+    m(0, 0) = 0.0;
+    m(0, 1) = 0.0;
+    m(0, 2) = 0.0;
+    m(1, 0) = 0.0;
+    m(1, 1) = 1.0;
+    m(1, 2) = 2.0;
+    m(2, 0) = 0.0;
+    m(2, 1) = 2.0;
+    m(2, 2) = 3.0;
+
+    SGMatrix<ST> L(size, size);
+    SGVector<ST> d(size);
+    SGVector<index_t> p(size);
+
+    linalg::ldlt_factor(m, L, d, p);
+
+    EXPECT_NEAR(d[0], 3.0, 1e-15);
+    EXPECT_NEAR(d[1], -0.333333333333333, 1e-7);
+    EXPECT_NEAR(d[2], 0.0, 1e-15);
+
+    EXPECT_NEAR(L(0, 0), 1.0, 1e-15);
+    EXPECT_NEAR(L(0, 1), 0.0, 1e-15);
+    EXPECT_NEAR(L(0, 2), 0.0, 1e-15);
+    EXPECT_NEAR(L(1, 0), 0.666666666666666, 1e-7);
+    EXPECT_NEAR(L(1, 1), 1.0, 1e-15);
+    EXPECT_NEAR(L(1, 2), 0.0, 1e-15);
+    EXPECT_NEAR(L(2, 0), 0.0, 1e-15);
+    EXPECT_NEAR(L(2, 1), 0.0, 1e-15);
+    EXPECT_NEAR(L(2, 2), 1.0, 1e-15);
+
+    EXPECT_EQ(p[0], 2);
+    EXPECT_EQ(p[1], 1);
+    EXPECT_EQ(p[2], 2);
+}
+
+template <typename ST>
+void check_SGMatrix_cholesky_solver()
+{
+    const index_t size=2;
+    SGMatrix<ST> A(size, size);
+    A(0,0)=2.0;
+    A(0,1)=1.0;
+    A(1,0)=1.0;
+    A(1,1)=2.5;
+
+    SGVector<ST> b(size);
+    b[0] = 10;
+    b[1] = 13;
+
+    SGVector<ST> x_ref(size);
+    x_ref[0] = 3;
+    x_ref[1] = 4;
+
+    SGMatrix<ST> L = cholesky_factor(A);
+    SGVector<ST> x_cal = cholesky_solver(L, b);
+
+    EXPECT_NEAR(x_ref[0], x_cal[0], 1E-15);
+    EXPECT_NEAR(x_ref[1], x_cal[1], 1E-15);
+    EXPECT_EQ(x_ref.size(), x_cal.size());
+}
+
+template <typename ST>
+void check_SGMatrix_ldlt_solver()
+{
+    const index_t size = 3;
+    SGMatrix<ST> A(size, size);
+    A(0, 0) = 0.0;
+    A(0, 1) = 0.0;
+    A(0, 2) = 0.0;
+    A(1, 0) = 0.0;
+    A(1, 1) = 1.0;
+    A(1, 2) = 2.0;
+    A(2, 0) = 0.0;
+    A(2, 1) = 2.0;
+    A(2, 2) = 3.0;
+
+    SGVector<ST> b(size);
+    b[0] = 0.0;
+    b[1] = 5.0;
+    b[2] = 11.0;
+
+    SGVector<ST> x_ref(size), x(size);
+    x_ref[0] = 0.0;
+    x_ref[1] = 7.0;
+    x_ref[2] = -1.0;
+
+    SGMatrix<ST> L(size, size);
+    SGVector<ST> d(size);
+    SGVector<index_t> p(size);
+
+    linalg::ldlt_factor(A, L, d, p, true);
+    x = linalg::ldlt_solver(L, d, p, b, true);
+    for (auto i : range(size))
+        EXPECT_NEAR(x[i], x_ref[i], 1e-6);
+
+    linalg::ldlt_factor(A, L, d, p, false);
+    x = linalg::ldlt_solver(L, d, p, b, false);
+    for (auto i : range(size))
+        EXPECT_NEAR(x[i], x_ref[i], 1e-6);
+}
+
+template <typename ST>
+void check_SGMatrix_cross_entropy()
+{
+    SGMatrix<ST> A(4, 3);
+    SGMatrix<ST> B(4, 3);
+
+    uint32_t size = A.num_rows * A.num_cols;
+    for (ST i = 0; i < size; ++i)
+    {
+        A[i] = i / size;
+        B[i] = (i / size) * 0.5;
+    }
+
+    float64_t ref = 0;
+    for (uint32_t i = 0; i < size; i++)
+        ref += A[i] * std::log(B[i] + 1e-30);
+    ref *= -1;
+
+    auto result = linalg::cross_entropy(A, B);
+    EXPECT_NEAR(ref, result, 1e-6);
+}
+
+template <typename ST>
+void check_SGMatrix_pinv_psd()
+{
+    ST A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
+    // inverse generated by scipy pinv
+    ST scipy_result_data[] = {0.75, 0.5,  0.25, 0.5, 1.0,
+                                     0.5,  0.25, 0.5,  0.75};
+
+    SGMatrix<ST> A(A_data, 3, 3, false);
+    SGMatrix<ST> result(scipy_result_data, 3, 3, false);
+
+    SGMatrix<ST> identity_matrix(3, 3);
+    linalg::identity(identity_matrix);
+    // using symmetric eigen solver
+    SGMatrix<ST> A_pinvh(3, 3);
+    linalg::pinvh(A, A_pinvh);
+    // using singular value decomposition
+    SGMatrix<ST> A_pinv(3, 3);
+    linalg::pinv(A, A_pinv);
+    SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinvh);
+    for (auto i : range(3))
+    {
+        for (auto j : range(3))
+        {
+            EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-6);
+            EXPECT_NEAR(result(i, j), A_pinvh(i, j), 1e-6);
+            EXPECT_NEAR(result(i, j), A_pinv(i, j), 1e-6);
+        }
+    }
+    // no memory errors
+    EXPECT_NO_THROW(linalg::pinvh(A, A));
+}
+
+template <typename ST>
+void check_SGMatrix_pinv_2x4()
+{
+    SGMatrix<ST> A(2, 4);
+    A(0, 0) = 1;
+    A(0, 1) = 1;
+    A(0, 2) = 1;
+    A(0, 3) = 1;
+    A(1, 0) = 5;
+    A(1, 1) = 7;
+    A(1, 2) = 7;
+    A(1, 3) = 9;
+
+    SGMatrix<ST> identity_matrix(2, 2);
+    linalg::identity(identity_matrix);
+    SGMatrix<ST> A_pinverse(4, 2);
+    linalg::pinv(A, A_pinverse);
+    SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinverse);
+    for (auto i : range(2))
+    {
+        for (auto j : range(2))
+        {
+            EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-6);
+        }
+    }
+
+    // compare result with scipy pinv
+    EXPECT_NEAR(A_pinverse(0, 0), 2.0, 1e-6);
+    EXPECT_NEAR(A_pinverse(0, 1), -0.25, 1e-6);
+
+    EXPECT_NEAR(A_pinverse(1, 0), 0.25, 1e-6);
+    EXPECT_NEAR(A_pinverse(1, 1), 0.0, 1e-6);
+
+    EXPECT_NEAR(A_pinverse(2, 0), 0.25, 1e-6);
+    EXPECT_NEAR(A_pinverse(2, 1), 0.0, 1e-6);
+
+    EXPECT_NEAR(A_pinverse(3, 0), -1.5, 1e-6);
+    EXPECT_NEAR(A_pinverse(3, 1), 0.25, 1e-6);
+
+    // incorrect dimension
+    EXPECT_THROW(linalg::pinv(A, A), ShogunException);
+}
+
+template <typename ST>
+void check_SGMatrix_pinv_4x2()
+{
+    SGMatrix<ST> A(4, 2);
+    A(0, 0) = 2.0;
+    A(0, 1) = -0.25;
+    A(1, 0) = 0.25;
+    A(1, 1) = 0.0;
+    A(2, 0) = 0.25;
+    A(2, 1) = 0.0;
+    A(3, 0) = -1.5;
+    A(3, 1) = 0.25;
+
+    SGMatrix<ST> identity_matrix(2, 2);
+    linalg::identity(identity_matrix);
+    SGMatrix<ST> A_pinverse(2, 4);
+    linalg::pinv(A, A_pinverse);
+    SGMatrix<ST> I_check = linalg::matrix_prod(A_pinverse, A);
+    for (auto i : range(2))
+    {
+        for (auto j : range(2))
+        {
+        EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-05);
+        }
+    }
+    // compare with results from scipy
+    EXPECT_NEAR(A_pinverse(0, 0), 1.0, 1e-05);
+    EXPECT_NEAR(A_pinverse(0, 1), 1.0, 1e-05);
+    EXPECT_NEAR(A_pinverse(0, 2), 1.0, 1e-05);
+    EXPECT_NEAR(A_pinverse(0, 3), 1.0, 1e-05);
+
+    EXPECT_NEAR(A_pinverse(1, 0), 5.0, 1e-05);
+    EXPECT_NEAR(A_pinverse(1, 1), 7.0, 1e-05);
+    EXPECT_NEAR(A_pinverse(1, 2), 7.0, 1e-05);
+    EXPECT_NEAR(A_pinverse(1, 3), 9.0, 1e-05);
+}
+
+template <typename ST>
+void check_SGVector_dot()
+{
+    const index_t size = 3;
+    SGVector<ST> a(size), b(size);
+    a.range_fill(0);
+    b.range_fill(0);
+
+    auto result = dot(a, b);
+
+    EXPECT_NEAR(result, 5, 1E-15);
+}
+
+template <typename ST>
+void check_eigensolver()
+{
+    const index_t n = 4;
+    ST data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
+                        0.62323516, 0.16837367, 0.85027625, 0.60165948,
+                        0.04898732, 0.96701123, 0.51683275, 0.51116495,
+                        0.18277926, 0.6179262,  0.43745891, 0.63685464};
+    ST result_eigenvectors[] = {
+            -0.63494074, 0.75831593,  -0.14014031, 0.04656076,
+            0.82257205,  -0.28671857, -0.44196422, -0.21409185,
+            -0.005932,   -0.20233724, -0.52285555, 0.82803776,
+            -0.23930111, -0.56199714, -0.57298901, -0.54642272};
+    ST result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101,
+                                      2.0981937};
+
+    SGMatrix<ST> m(data, n, n, false);
+    SGMatrix<ST> eigenvectors(n, n);
+    SGVector<ST> eigenvalues(n);
+
+    eigen_solver(m, eigenvalues, eigenvectors);
+
+    auto args = CMath::argsort(eigenvalues);
+    for (index_t i = 0; i < n; ++i)
+    {
+    index_t idx = args[i];
+    EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
+
+    auto s =
+            CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
+    for (index_t j = 0; j < n; ++j)
+        EXPECT_NEAR(
+                eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
+        1e-6);
+    }
+}
+
+template <typename ST>
+void check_eigensolver_symmetric()
+{
+    const index_t n = 4;
+    ST data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
+                        0.80575314, 0.16837367, 0.96701123, 0.6179262,
+                        0.04898732, 0.96701123, 0.51683275, 0.43745891,
+                        0.69989667, 0.6179262,  0.43745891, 0.63685464};
+    ST result_eigenvectors[] = {
+            -0.54618542, 0.69935447,  -0.45219663, 0.09001671,
+            -0.56171388, -0.41397154, 0.17642953,  0.69424612,
+            -0.46818396, 0.16780603,  0.73247599,  -0.46489119,
+            0.40861077,  0.55800718,  0.47735703,  0.542029037};
+    ST result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
+                                      2.18587989};
+
+    SGMatrix<ST> m(data, n, n, false);
+    SGMatrix<ST> eigenvectors(n, n);
+    SGVector<ST> eigenvalues(n);
+
+    eigen_solver(m, eigenvalues, eigenvectors);
+
+    auto args = CMath::argsort(eigenvalues);
+    for (index_t i = 0; i < n; ++i)
+    {
+        index_t idx = args[i];
+        EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-5);
+
+        auto s =
+                CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
+        for (index_t j = 0; j < n; ++j)
+            EXPECT_NEAR(
+                    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
+            1e-5);
+    }
+}
+
+template <typename ST>
+void check_SGMatrix_elementwise_product()
+{
+    const auto m = 2;
+    SGMatrix<ST> A(m, m);
+    SGMatrix<ST> B(m, m);
+
+    for (auto i : range(m * m))
+    {
+        A[i] = i;
+        B[i] = 2*i;
+    }
+
+    auto result = element_prod(A, B);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+
+    result = element_prod(A, B, true, false);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+
+    result = element_prod(A, B, false, true);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+
+    result = element_prod(A, B, true, true);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
+}
+
+template <typename ST>
+void check_SGMatrix_elementwise_product_in_place()
+{
+    const auto m = 2;
+    SGMatrix<ST> A(m, m);
+    SGMatrix<ST> B(m, m);
+    SGMatrix<ST> result(m, m);
+
+    for (auto i : range(m * m))
+    {
+        A[i] = i;
+        B[i] = 2*i;
+    }
+
+    element_prod(A, B, result);
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+
+    element_prod(A, B, result, true, false);
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+
+    element_prod(A, B, result, false, true);
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+
+    element_prod(A, B, result, true, true);
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
+}
+
+template <typename ST>
+void check_SGMatrix_block_elementwise_product()
+{
+    const index_t nrows = 2;
+    const index_t ncols = 3;
+
+    SGMatrix<ST> A(nrows,ncols);
+    SGMatrix<ST> B(ncols,nrows);
+
+    for (auto i : range(nrows))
+        for (auto j : range(ncols))
+        {
+            A(i, j) = i * 10 + j + 1;
+            B(j, i) = i + j;
+        }
+
+    const auto m = 2;
+    auto A_block = linalg::block(A, 0, 0, m, m);
+    auto B_block = linalg::block(B, 0, 0, m, m);
+    auto result = element_prod(A_block, B_block);
+
+    ASSERT_EQ(result.num_rows, m);
+    ASSERT_EQ(result.num_cols, m);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+
+    result = element_prod(A_block, B_block, true, false);
+
+    ASSERT_EQ(result.num_rows, m);
+    ASSERT_EQ(result.num_cols, m);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+
+    result = element_prod(A_block, B_block, false, true);
+
+    ASSERT_EQ(result.num_rows, m);
+    ASSERT_EQ(result.num_cols, m);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(i, j) * B(j, i), 1E-15);
+
+    result = element_prod(A_block, B_block, true, true);
+
+    ASSERT_EQ(result.num_rows, m);
+    ASSERT_EQ(result.num_cols, m);
+
+    for (auto i : range(m))
+        for (auto j : range(m))
+            EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
+}
+
+template <typename ST>
+void check_SGVector_elementwise_product()
+{
+    const index_t len = 4;
+    SGVector<ST> a(len);
+    SGVector<ST> b(len);
+    SGVector<ST> c(len);
+
+    for (index_t i = 0; i < len; ++i)
+    {
+        a[i] = i;
+        b[i] = 2 * i;
+    }
+
+    c = element_prod(a, b);
+
+    for (index_t i = 0; i < len; ++i)
+        EXPECT_NEAR(a[i] * b[i], c[i], 1e-15);
+}
+
+template <typename ST>
+void check_SGVector_elementwise_product_in_place()
+{
+    const index_t len = 4;
+    SGVector<ST> a(len);
+    SGVector<ST> b(len);
+    SGVector<ST> c(len);
+
+    for (index_t i = 0; i < len; ++i)
+    {
+        a[i] = i;
+        b[i] = 2 * i;
+        c[i] = i;
+    }
+
+    element_prod(a, b, a);
+    for (index_t i = 0; i < len; ++i)
+        EXPECT_NEAR(c[i] * b[i], a[i], 1e-15);
+}
+
+template <typename ST>
+void check_SGVector_exponent()
+{
+    const index_t len = 4;
+    SGVector<ST> a(len);
+    a[0] = 0;
+    a[1] = 1;
+    a[2] = 2;
+    a[3] = 3;
+    auto result = exponent(a);
+
+    EXPECT_NEAR(result[0], 1.0, 1E-15);
+    EXPECT_NEAR(result[1], 2.718281828459045, 1E-6);
+    EXPECT_NEAR(result[2], 7.3890560989306495, 1E-6);
+    EXPECT_NEAR(result[3], 20.085536923187664, 1E-6);
+}
+
+template <typename ST>
+void check_SGMatrix_exponent()
+{
+    const index_t n = 2;
+    SGMatrix<ST> a(n, n);
+    a[0] = 0;
+    a[1] = 1;
+    a[2] = 2;
+    a[3] = 3;
+    auto result = exponent(a);
+
+    EXPECT_NEAR(result[0], 1.0, 1E-15);
+    EXPECT_NEAR(result[1], 2.718281828459045, 1E-6);
+    EXPECT_NEAR(result[2], 7.3890560989306495, 1E-6);
+    EXPECT_NEAR(result[3], 20.085536923187664, 1E-6);
+}
+
+template <typename ST>
+void check_SGMatrix_identity()
+{
+    const index_t n = 4;
+    SGMatrix<ST> A(n, n);
+    identity(A);
+
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = 0; j < n; ++j)
+            EXPECT_EQ(A.get_element(i, j), (i==j));
+}
+
+template <typename ST>
+void check_logistic()
+{
+    SGMatrix<ST> A(3,3);
+    SGMatrix<ST> B(3,3);
+
+    for (index_t i = 0; i < 9; ++i)
+        A[i] = i;
+    B.zero();
+
+    linalg::logistic(A, B);
+
+    for (index_t i = 0; i < 9; ++i)
+        EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], 1e-7);
+}
+
+template <typename ST>
+void check_SGMatrix_SGVector_matrix_prod()
+{
+    const index_t rows=4;
+    const index_t cols=3;
 
-	EXPECT_EQ(p[0], 2);
-	EXPECT_EQ(p[1], 1);
-	EXPECT_EQ(p[2], 2);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_cholesky_solver)
-{
-	const index_t size=2;
-	SGMatrix<float64_t> A(size, size);
-	A(0,0)=2.0;
-	A(0,1)=1.0;
-	A(1,0)=1.0;
-	A(1,1)=2.5;
-
-	SGVector<float64_t> b(size);
-	b[0] = 10;
-	b[1] = 13;
-
-	SGVector<float64_t> x_ref(size);
-	x_ref[0] = 3;
-	x_ref[1] = 4;
-
-	SGMatrix<float64_t> L = cholesky_factor(A);
-	SGVector<float64_t> x_cal = cholesky_solver(L, b);
-
-	EXPECT_NEAR(x_ref[0], x_cal[0], 1E-15);
-	EXPECT_NEAR(x_ref[1], x_cal[1], 1E-15);
-	EXPECT_EQ(x_ref.size(), x_cal.size());
-}
-
-TEST(LinalgBackendEigen, SGMatrix_ldlt_solver)
-{
-	const index_t size = 3;
-	SGMatrix<float64_t> A(size, size);
-	A(0, 0) = 0.0;
-	A(0, 1) = 0.0;
-	A(0, 2) = 0.0;
-	A(1, 0) = 0.0;
-	A(1, 1) = 1.0;
-	A(1, 2) = 2.0;
-	A(2, 0) = 0.0;
-	A(2, 1) = 2.0;
-	A(2, 2) = 3.0;
-
-	SGVector<float64_t> b(size);
-	b[0] = 0.0;
-	b[1] = 5.0;
-	b[2] = 11.0;
-
-	SGVector<float64_t> x_ref(size), x(size);
-	x_ref[0] = 0.0;
-	x_ref[1] = 7.0;
-	x_ref[2] = -1.0;
-
-	SGMatrix<float64_t> L(size, size);
-	SGVector<float64_t> d(size);
-	SGVector<index_t> p(size);
-
-	linalg::ldlt_factor(A, L, d, p, true);
-	x = linalg::ldlt_solver(L, d, p, b, true);
-	for (auto i : range(size))
-		EXPECT_NEAR(x[i], x_ref[i], 1e-15);
-
-	linalg::ldlt_factor(A, L, d, p, false);
-	x = linalg::ldlt_solver(L, d, p, b, false);
-	for (auto i : range(size))
-		EXPECT_NEAR(x[i], x_ref[i], 1e-15);
-}
-TEST(LinalgBackendEigen, SGMatrix_cross_entropy)
-{
-	SGMatrix<float64_t> A(4, 3);
-	SGMatrix<float64_t> B(4, 3);
-
-	int32_t size = A.num_rows * A.num_cols;
-	for (float64_t i = 0; i < size; ++i)
-	{
-		A[i] = i / size;
-		B[i] = (i / size) * 0.5;
-	}
-
-	float64_t ref = 0;
-	for (int32_t i = 0; i < size; i++)
-		ref += A[i] * std::log(B[i] + 1e-30);
-	ref *= -1;
-
-	auto result = linalg::cross_entropy(A, B);
-	EXPECT_NEAR(ref, result, 1e-15);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_pinv_psd)
-{
-	float64_t A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
-	// inverse generated by scipy pinv
-	float64_t scipy_result_data[] = {0.75, 0.5,  0.25, 0.5, 1.0,
-	                                 0.5,  0.25, 0.5,  0.75};
-
-	SGMatrix<float64_t> A(A_data, 3, 3, false);
-	SGMatrix<float64_t> result(scipy_result_data, 3, 3, false);
-
-	SGMatrix<float64_t> identity_matrix(3, 3);
-	linalg::identity(identity_matrix);
-	// using symmetric eigen solver
-	SGMatrix<float64_t> A_pinvh(3, 3);
-	linalg::pinvh(A, A_pinvh);
-	// using singular value decomposition
-	SGMatrix<float64_t> A_pinv(3, 3);
-	linalg::pinv(A, A_pinv);
-	SGMatrix<float64_t> I_check = linalg::matrix_prod(A, A_pinvh);
-	for (auto i : range(3))
-	{
-		for (auto j : range(3))
-		{
-			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-14);
-			EXPECT_NEAR(result(i, j), A_pinvh(i, j), 1e-14);
-			EXPECT_NEAR(result(i, j), A_pinv(i, j), 1e-14);
-		}
-	}
-	// no memory errors 
-	EXPECT_NO_THROW(linalg::pinvh(A, A));
-}
-
-TEST(LinalgBackendEigen, SGMatrix_pinv_2x4)
-{
-	SGMatrix<float64_t> A(2, 4);
-	A(0, 0) = 1;
-	A(0, 1) = 1;
-	A(0, 2) = 1;
-	A(0, 3) = 1;
-	A(1, 0) = 5;
-	A(1, 1) = 7;
-	A(1, 2) = 7;
-	A(1, 3) = 9;
-
-	SGMatrix<float64_t> identity_matrix(2, 2);
-	linalg::identity(identity_matrix);
-	SGMatrix<float64_t> A_pinverse(4, 2);
-	linalg::pinv(A, A_pinverse);
-	SGMatrix<float64_t> I_check = linalg::matrix_prod(A, A_pinverse);
-	for (auto i : range(2))
-	{
-		for (auto j : range(2))
-		{
-			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-14);
-		}
-	}
-
-	// compare result with scipy pinv
-	EXPECT_NEAR(A_pinverse(0, 0), 2.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(0, 1), -0.25, 1e-14);
-
-	EXPECT_NEAR(A_pinverse(1, 0), 0.25, 1e-14);
-	EXPECT_NEAR(A_pinverse(1, 1), 0.0, 1e-14);
-
-	EXPECT_NEAR(A_pinverse(2, 0), 0.25, 1e-14);
-	EXPECT_NEAR(A_pinverse(2, 1), 0.0, 1e-14);
-
-	EXPECT_NEAR(A_pinverse(3, 0), -1.5, 1e-14);
-	EXPECT_NEAR(A_pinverse(3, 1), 0.25, 1e-14);
-
-	// incorrect dimension
-	EXPECT_THROW(linalg::pinv(A, A), ShogunException);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_pinv_4x2)
-{
-	SGMatrix<float64_t> A(4, 2);
-	A(0, 0) = 2.0;
-	A(0, 1) = -0.25;
-	A(1, 0) = 0.25;
-	A(1, 1) = 0.0;
-	A(2, 0) = 0.25;
-	A(2, 1) = 0.0;
-	A(3, 0) = -1.5;
-	A(3, 1) = 0.25;
-
-	SGMatrix<float64_t> identity_matrix(2, 2);
-	linalg::identity(identity_matrix);
-	SGMatrix<float64_t> A_pinverse(2, 4);
-	linalg::pinv(A, A_pinverse);
-	SGMatrix<float64_t> I_check = linalg::matrix_prod(A_pinverse, A);
-	for (auto i : range(2))
-	{
-		for (auto j : range(2))
-		{
-			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-14);
-		}
-	}
-	// compare with results from scipy
-	EXPECT_NEAR(A_pinverse(0, 0), 1.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(0, 1), 1.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(0, 2), 1.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(0, 3), 1.0, 1e-14);
-
-	EXPECT_NEAR(A_pinverse(1, 0), 5.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(1, 1), 7.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(1, 2), 7.0, 1e-14);
-	EXPECT_NEAR(A_pinverse(1, 3), 9.0, 1e-14);
-}
-
-TEST(LinalgBackendEigen, SGVector_dot)
-{
-	const index_t size = 3;
-	SGVector<int32_t> a(size), b(size);
-	a.range_fill(0);
-	b.range_fill(0);
-
-	auto result = dot(a, b);
-
-	EXPECT_NEAR(result, 5, 1E-15);
-}
-
-TEST(LinalgBackendEigen, eigensolver)
-{
-	const index_t n = 4;
-	float64_t data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
-	                    0.62323516, 0.16837367, 0.85027625, 0.60165948,
-	                    0.04898732, 0.96701123, 0.51683275, 0.51116495,
-	                    0.18277926, 0.6179262,  0.43745891, 0.63685464};
-	float64_t result_eigenvectors[] = {
-	    -0.63494074, 0.75831593,  -0.14014031, 0.04656076,
-	    0.82257205,  -0.28671857, -0.44196422, -0.21409185,
-	    -0.005932,   -0.20233724, -0.52285555, 0.82803776,
-	    -0.23930111, -0.56199714, -0.57298901, -0.54642272};
-	float64_t result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101,
-	                                  2.0981937};
-
-	SGMatrix<float64_t> m(data, n, n, false);
-	SGMatrix<float64_t> eigenvectors(n, n);
-	SGVector<float64_t> eigenvalues(n);
-
-	eigen_solver(m, eigenvalues, eigenvectors);
-
-	auto args = CMath::argsort(eigenvalues);
-	for (index_t i = 0; i < n; ++i)
-	{
-		index_t idx = args[i];
-		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-7);
-
-		auto s =
-		    CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
-		for (index_t j = 0; j < n; ++j)
-			EXPECT_NEAR(
-			    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-			    1e-7);
-	}
-}
-
-TEST(LinalgBackendEigen, eigensolver_symmetric)
-{
-	const index_t n = 4;
-	float64_t data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
-	                    0.80575314, 0.16837367, 0.96701123, 0.6179262,
-	                    0.04898732, 0.96701123, 0.51683275, 0.43745891,
-	                    0.69989667, 0.6179262,  0.43745891, 0.63685464};
-	float64_t result_eigenvectors[] = {
-	    -0.54618542, 0.69935447,  -0.45219663, 0.09001671,
-	    -0.56171388, -0.41397154, 0.17642953,  0.69424612,
-	    -0.46818396, 0.16780603,  0.73247599,  -0.46489119,
-	    0.40861077,  0.55800718,  0.47735703,  0.542029037};
-	float64_t result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
-	                                  2.18587989};
-
-	SGMatrix<float64_t> m(data, n, n, false);
-	SGMatrix<float64_t> eigenvectors(n, n);
-	SGVector<float64_t> eigenvalues(n);
-
-	eigen_solver(m, eigenvalues, eigenvectors);
-
-	auto args = CMath::argsort(eigenvalues);
-	for (index_t i = 0; i < n; ++i)
-	{
-		index_t idx = args[i];
-		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-7);
-
-		auto s =
-		    CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
-		for (index_t j = 0; j < n; ++j)
-			EXPECT_NEAR(
-			    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-			    1e-7);
-	}
-}
-
-TEST(LinalgBackendEigen, SGMatrix_elementwise_product)
-{
-	const auto m = 3;
-	SGMatrix<float64_t> A(m, m);
-	SGMatrix<float64_t> B(m, m);
-
-	for (auto i : range(m * m))
-	{
-		A[i] = i;
-		B[i] = 0.5*i;
-	}
-
-	auto result = element_prod(A, B);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
-
-	result = element_prod(A, B, true, false);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
-
-	result = element_prod(A, B, false, true);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
-
-	result = element_prod(A, B, true, true);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_elementwise_product_in_place)
-{
-	const auto m = 3;
-	SGMatrix<float64_t> A(m, m);
-	SGMatrix<float64_t> B(m, m);
-	SGMatrix<float64_t> result(m, m);
-
-	for (auto i : range(m * m))
-	{
-		A[i] = i;
-		B[i] = 0.5*i;
-	}
-
-	element_prod(A, B, result);
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
-
-	element_prod(A, B, result, true, false);
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
-
-	element_prod(A, B, result, false, true);
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
-
-	element_prod(A, B, result, true, true);
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_block_elementwise_product)
-{
-	const index_t nrows = 2;
-	const index_t ncols = 3;
-
-	SGMatrix<float64_t> A(nrows,ncols);
-	SGMatrix<float64_t> B(ncols,nrows);
-
-	for (auto i : range(nrows))
-		for (auto j : range(ncols))
-		{
-			A(i, j) = i * 10 + j + 1;
-			B(j, i) = i + j;
-		}
-
-	const auto m = 2;
-	auto A_block = linalg::block(A, 0, 0, m, m);
-	auto B_block = linalg::block(B, 0, 0, m, m);
-	auto result = element_prod(A_block, B_block);
-
-	ASSERT_EQ(result.num_rows, m);
-	ASSERT_EQ(result.num_cols, m);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
-
-	result = element_prod(A_block, B_block, true, false);
-
-	ASSERT_EQ(result.num_rows, m);
-	ASSERT_EQ(result.num_cols, m);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
-
-	result = element_prod(A_block, B_block, false, true);
-
-	ASSERT_EQ(result.num_rows, m);
-	ASSERT_EQ(result.num_cols, m);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(j, i), 1E-15);
-
-	result = element_prod(A_block, B_block, true, true);
-
-	ASSERT_EQ(result.num_rows, m);
-	ASSERT_EQ(result.num_cols, m);
-
-	for (auto i : range(m))
-		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
-}
-
-TEST(LinalgBackendEigen, SGVector_elementwise_product)
-{
-	const index_t len = 4;
-	SGVector<float64_t> a(len);
-	SGVector<float64_t> b(len);
-	SGVector<float64_t> c(len);
-
-	for (index_t i = 0; i < len; ++i)
-	{
-		a[i] = i;
-		b[i] = 0.5 * i;
-	}
-
-	c = element_prod(a, b);
-
-	for (index_t i = 0; i < len; ++i)
-		EXPECT_NEAR(a[i] * b[i], c[i], 1e-15);
-}
-
-TEST(LinalgBackendEigen, SGVector_elementwise_product_in_place)
-{
-	const index_t len = 4;
-	SGVector<float64_t> a(len);
-	SGVector<float64_t> b(len);
-	SGVector<float64_t> c(len);
-
-	for (index_t i = 0; i < len; ++i)
-	{
-		a[i] = i;
-		b[i] = 0.5 * i;
-		c[i] = i;
-	}
+    SGMatrix<ST> A(rows, cols);
+    SGVector<ST> b(cols);
 
-	element_prod(a, b, a);
-	for (index_t i = 0; i < len; ++i)
-		EXPECT_NEAR(c[i] * b[i], a[i], 1e-15);
-}
-
-TEST(LinalgBackendEigen, SGVector_exponent)
-{
-	const index_t len = 4;
-	SGVector<float64_t> a(len);
-	a[0] = -2.4;
-	a[1] = 0;
-	a[2] = 0.5;
-	a[3] = 3.9;
-	auto result = exponent(a);
+    for (index_t i = 0; i < cols; ++i)
+    {
+        for (index_t j = 0; j < rows; ++j)
+            A(j, i) = i * rows + j;
+        b[i]= 2 * i;
+    }
 
-	EXPECT_NEAR(result[0], 0.090717953289413, 1E-15);
-	EXPECT_NEAR(result[1], 1.0, 1E-15);
-	EXPECT_NEAR(result[2], 1.648721270700128, 1E-15);
-	EXPECT_NEAR(result[3], 49.40244910553017, 1E-15);
-}
+    auto x = matrix_prod(A, b);
 
-TEST(LinalgBackendEigen, SGMatrix_exponent)
-{
-	const index_t n = 2;
-	SGMatrix<float64_t> a(n, n);
-	a[0] = -2.4;
-	a[1] = 0;
-	a[2] = 0.5;
-	a[3] = 3.9;
-	auto result = exponent(a);
+    ST ref[] = {40, 46, 52, 58};
 
-	EXPECT_NEAR(result[0], 0.090717953289413, 1E-15);
-	EXPECT_NEAR(result[1], 1.0, 1E-15);
-	EXPECT_NEAR(result[2], 1.648721270700128, 1E-15);
-	EXPECT_NEAR(result[3], 49.40244910553017, 1E-15);
+    EXPECT_EQ(x.vlen, A.num_rows);
+    for (index_t i = 0; i < rows; ++i)
+        EXPECT_NEAR(x[i], ref[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_identity)
+template <typename ST>
+void check_SGVector_matrix_prod_transpose()
 {
-	const index_t n = 4;
-	SGMatrix<float64_t> A(n, n);
-	identity(A);
+    const index_t rows=4;
+    const index_t cols=3;
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = 0; j < n; ++j)
-			EXPECT_EQ(A.get_element(i, j), (i==j));
-}
+    SGMatrix<ST> A(cols, rows);
+    SGVector<ST> b(cols);
 
-TEST(LinalgBackendEigen, logistic)
-{
-	SGMatrix<float64_t> A(3,3);
-	SGMatrix<float64_t> B(3,3);
+    for (index_t i = 0; i < cols; ++i)
+    {
+        for (index_t j = 0; j < rows; ++j)
+            A(i, j) = i * cols + j;
+        b[i] = 2 * i;
+    }
 
-	range_fill(A, 0.0);
-	B.zero();
+    auto x = matrix_prod(A, b, true);
 
-	linalg::logistic(A, B);
+    ST ref[] = {30, 36, 42};
 
-	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], 1e-15);
+    EXPECT_EQ(x.vlen, A.num_cols);
+    for (index_t i = 0; i < cols; ++i)
+        EXPECT_NEAR(x[i], ref[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_SGVector_matrix_prod)
+template <typename ST>
+void check_SGMatrix_SGVector_matrix_prod_in_place()
 {
-	const index_t rows=4;
-	const index_t cols=3;
+    const index_t rows=4;
+    const index_t cols=3;
 
-	SGMatrix<float64_t> A(rows, cols);
-	SGVector<float64_t> b(cols);
+    SGMatrix<ST> A(rows, cols);
+    SGVector<ST> b(cols);
+    SGVector<ST> x(rows);
 
-	for (index_t i = 0; i < cols; ++i)
-	{
-		for (index_t j = 0; j < rows; ++j)
-			A(j, i) = i * rows + j;
-		b[i]=0.5 * i;
-	}
+    for (index_t i = 0; i<cols; ++i)
+    {
+        for (index_t j = 0; j < rows; ++j)
+            A(j, i) = i * rows + j;
+        b[i] = 2 * i;
+    }
 
-	auto x = matrix_prod(A, b);
+    matrix_prod(A, b, x);
 
-	float64_t ref[] = {10, 11.5, 13, 14.5};
+    ST ref[] = {40, 46, 52, 58};
 
-	EXPECT_EQ(x.vlen, A.num_rows);
-	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], 1e-15);
+    for (index_t i = 0; i < cols; ++i)
+        EXPECT_NEAR(x[i], ref[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_SGVector_matrix_prod_transpose)
+template <typename ST>
+void check_SGMatrix_SGVector_matrix_prod_in_place_transpose()
 {
-	const index_t rows=4;
-	const index_t cols=3;
+    const index_t rows=4;
+    const index_t cols=3;
 
-	SGMatrix<float64_t> A(cols, rows);
-	SGVector<float64_t> b(cols);
+    SGMatrix<ST> A(cols, rows);
+    SGVector<ST> b(cols);
+    SGVector<ST> x(rows);
 
-	for (index_t i = 0; i < cols; ++i)
-	{
-		for (index_t j = 0; j < rows; ++j)
-			A(i, j) = i * cols + j;
-		b[i] = 0.5 * i;
-	}
+    for (index_t i = 0; i < cols; ++i)
+    {
+        for (index_t j = 0; j < rows; ++j)
+            A(i, j) = i * cols + j;
+        b[i] = 2 * i;
+    }
 
-	auto x = matrix_prod(A, b, true);
+    matrix_prod(A, b, x, true);
 
-	float64_t ref[] = {7.5, 9, 10.5, 14.5};
+    ST ref[] = {30, 36, 42};
 
-	EXPECT_EQ(x.vlen, A.num_cols);
-	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], 1e-15);
+    for (index_t i = 0; i < cols; ++i)
+        EXPECT_NEAR(x[i], ref[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_SGVector_matrix_prod_in_place)
+template <typename ST>
+void check_SGMatrix_matrix_product()
 {
-	const index_t rows=4;
-	const index_t cols=3;
+    const index_t dim1 = 2, dim2 = 4, dim3 = 2;
+    SGMatrix<ST> A(dim1, dim2);
+    SGMatrix<ST> B(dim2, dim3);
 
-	SGMatrix<float64_t> A(rows, cols);
-	SGVector<float64_t> b(cols);
-	SGVector<float64_t> x(rows);
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
 
-	for (index_t i = 0; i<cols; ++i)
-	{
-		for (index_t j = 0; j < rows; ++j)
-			A(j, i) = i * rows + j;
-		b[i] = 0.5 * i;
-	}
+    auto cal = linalg::matrix_prod(A, B);
 
-	matrix_prod(A, b, x);
+    ST ref[] = {28, 34, 76, 98};
 
-	float64_t ref[] = {10, 11.5, 13, 14.5};
-
-	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], 1e-15);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_SGVector_matrix_prod_in_place_transpose)
+template <typename ST>
+void check_SGMatrix_matrix_product_transpose_A()
 {
-	const index_t rows=4;
-	const index_t cols=3;
-
-	SGMatrix<float64_t> A(cols, rows);
-	SGVector<float64_t> b(cols);
-	SGVector<float64_t> x(rows);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim2, dim1);
+    SGMatrix<ST> B(dim2, dim3);
 
-	for (index_t i = 0; i < cols; ++i)
-	{
-		for (index_t j = 0; j < rows; ++j)
-			A(i, j) = i * cols + j;
-		b[i] = 0.5 * i;
-	}
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
 
-	matrix_prod(A, b, x, true);
+    auto cal = linalg::matrix_prod(A, B, true);
 
-	float64_t ref[] = {7.5, 9, 10.5, 14.5};
+    ST ref[] = {5, 14, 14, 50, 23, 86};
 
-	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], 1e-15);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_matrix_product)
+template <typename ST>
+void check_SGMatrix_matrix_product_transpose_B()
 {
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim1, dim2);
-	SGMatrix<float64_t> B(dim2, dim3);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim1, dim2);
+    SGMatrix<ST> B(dim3, dim2);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
 
-	auto cal = linalg::matrix_prod(A, B);
+    auto cal = linalg::matrix_prod(A, B, false, true);
 
-	float64_t ref[] = {14, 17, 38, 49, 62, 81};
+    ST ref[] = {30, 39, 36, 48, 42, 57};
 
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_transpose_A)
+template <typename ST>
+void check_SGMatrix_matrix_product_transpose_A_B()
 {
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim2, dim1);
-	SGMatrix<float64_t> B(dim2, dim3);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim2, dim1);
+    SGMatrix<ST> B(dim3, dim2);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
 
-	auto cal = linalg::matrix_prod(A, B, true);
+    auto cal = linalg::matrix_prod(A, B, true, true);
 
-	float64_t ref[] = {7, 19, 19, 63, 31, 107};
+    ST ref[] = {15, 42, 18, 54, 21, 66};
 
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_transpose_B)
+template <typename ST>
+void check_SGMatrix_matrix_product_in_place()
 {
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim1, dim2);
-	SGMatrix<float64_t> B(dim3, dim2);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim1, dim2);
+    SGMatrix<ST> B(dim2, dim3);
+    SGMatrix<ST> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
+    cal.zero();
 
-	auto cal = linalg::matrix_prod(A, B, false, true);
+    linalg::matrix_prod(A, B, cal);
 
-	float64_t ref[] = {42, 51, 48, 59, 54, 67};
+    ST ref[] = {10, 13, 28, 40, 46, 67};
 
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_transpose_A_B)
+template <typename ST>
+void check_SGMatrix_matrix_product_in_place_transpose_A()
 {
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim2, dim1);
-	SGMatrix<float64_t> B(dim3, dim2);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim2, dim1);
+    SGMatrix<ST> B(dim2, dim3);
+    SGMatrix<ST> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
+    cal.zero();
 
-	auto cal = linalg::matrix_prod(A, B, true, true);
+    linalg::matrix_prod(A, B, cal, true);
 
-	float64_t ref[] = {21, 57, 24, 68, 27, 79};
+    ST ref[] = {5, 14, 14, 50, 23, 86};
 
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_in_place)
-{
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim1, dim2);
-	SGMatrix<float64_t> B(dim2, dim3);
-	SGMatrix<float64_t> cal(dim1, dim3);
-
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5 * i;
-	cal.zero();
 
-	linalg::matrix_prod(A, B, cal);
-
-	float64_t ref[] = {14, 17, 38, 49, 62, 81};
-
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
-
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_in_place_transpose_A)
-{
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim2, dim1);
-	SGMatrix<float64_t> B(dim2, dim3);
-	SGMatrix<float64_t> cal(dim1, dim3);
-
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
-	cal.zero();
 
-	linalg::matrix_prod(A, B, cal, true);
 
-	float64_t ref[] = {7, 19, 19, 63, 31, 107};
-
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
-}
-
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_in_place_transpose_B)
+template <typename ST>
+void check_SGMatrix_matrix_product_in_place_transpose_B()
 {
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim1, dim2);
-	SGMatrix<float64_t> B(dim3, dim2);
-	SGMatrix<float64_t> cal(dim1, dim3);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim1, dim2);
+    SGMatrix<ST> B(dim3, dim2);
+    SGMatrix<ST> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
-	cal.zero();
+    for (index_t i = 0; i < dim1*dim2; ++i)
+        A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+        B[i] = i;
+    cal.zero();
 
-	linalg::matrix_prod(A, B, cal, false, true);
+    linalg::matrix_prod(A, B, cal, false, true);
 
-	float64_t ref[] = {42, 51, 48, 59, 54, 67};
+    ST ref[] = {30, 39, 36, 48, 42, 57};
 
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+        EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_matrix_product_in_place_transpose_A_B)
+template <typename ST>
+void check_SGMatrix_matrix_product_in_place_transpose_A_B()
 {
-	const index_t dim1 = 2, dim2 = 4, dim3 = 3;
-	SGMatrix<float64_t> A(dim2, dim1);
-	SGMatrix<float64_t> B(dim3, dim2);
-	SGMatrix<float64_t> cal(dim1, dim3);
+    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+    SGMatrix<ST> A(dim2, dim1);
+    SGMatrix<ST> B(dim3, dim2);
+    SGMatrix<ST> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
-		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
-		B[i] = 0.5*i;
-	cal.zero();
+    for (index_t i = 0; i < dim1*dim2; ++i)
+    A[i] = i;
+    for (index_t i = 0; i < dim2*dim3; ++i)
+    B[i] = i;
+    cal.zero();
 
-	linalg::matrix_prod(A, B, cal, true, true);
+    linalg::matrix_prod(A, B, cal, true, true);
 
-	float64_t ref[] = {21, 57, 24, 68, 27, 79};
+    ST ref[] = {15, 42, 18, 54, 21, 66};
 
-	EXPECT_EQ(dim1, cal.num_rows);
-	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
-		EXPECT_EQ(ref[i], cal[i]);
+    EXPECT_EQ(dim1, cal.num_rows);
+    EXPECT_EQ(dim3, cal.num_cols);
+    for (index_t i = 0; i < dim1*dim3; ++i)
+    EXPECT_EQ(ref[i], cal[i]);
 }
 
-TEST(LinalgBackendEigen, SGVector_max)
+template <typename ST>
+void check_SGVector_max()
 {
-	SGVector<float64_t> A(9);
+    SGVector<ST> A(9);
 
-	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 4};
+    ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 4};
 
-	for (index_t i = 0; i < A.size(); ++i)
-		A[i] = a[i];
+    for (index_t i = 0; i < A.size(); ++i)
+        A[i] = a[i];
 
-	EXPECT_NEAR(8, max(A), 1e-15);
+    EXPECT_NEAR(8, max(A), 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_max)
+template <typename ST>
+void check_SGMatrix_max()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<float64_t> A(nrows, ncols);
+    const index_t nrows = 3, ncols = 3;
+    SGMatrix<ST> A(nrows, ncols);
 
-	float64_t a[] = {1, 2, 5, 8, 3, 1, 0, -1, 12};
+    ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 12};
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		A[i] = a[i];
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        A[i] = a[i];
 
-	EXPECT_NEAR(8, max(A), 1e-15);
+    EXPECT_NEAR(12, max(A), 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_mean)
+template <typename ST>
+void check_SGVector_mean()
 {
-	const index_t size = 6;
-	SGVector<int32_t> vec(size);
-	vec.range_fill(0);
+    const index_t size = 9;
+    SGVector<ST> vec(size);
+    vec.range_fill(0);
 
-	auto result = mean(vec);
+    auto result = mean(vec);
 
-	EXPECT_NEAR(result, 2.5, 1E-15);
+    EXPECT_NEAR(result, 4, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_mean)
+template <typename ST>
+void check_SGMatrix_mean()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    const index_t nrows = 3, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	auto result = mean(mat);
+    auto result = mean(mat);
 
-	EXPECT_NEAR(result, 2.5, 1E-15);
+    EXPECT_NEAR(result, 4, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_multiply_by_logistic_derivative)
+template <typename ST>
+void check_SGMatrix_multiply_by_logistic_derivative()
 {
-	SGMatrix<float64_t> A(3, 3);
-	SGMatrix<float64_t> B(3, 3);
+    SGMatrix<ST> A(3, 3);
+    SGMatrix<ST> B(3, 3);
 
-	for (float64_t i = 0; i < 9; ++i)
-	{
-		A[i] = i / 9;
-		B[i] = i;
-	}
+    for (ST i = 9; i < 9; i+=9)
+    {
+        A[i] = i / 9;
+        B[i] = i;
+    }
 
-	linalg::multiply_by_logistic_derivative(A, B);
+    linalg::multiply_by_logistic_derivative(A, B);
 
-	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(i * A[i] * (1.0 - A[i]), B[i], 1e-15);
+    for (index_t i = 0; i < 9; ++i)
+        EXPECT_NEAR(i * A[i] * (1.0 - A[i]), B[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_multiply_by_rectified_linear_derivative)
+template <typename ST>
+void check_SGMatrix_multiply_by_rectified_linear_derivative()
 {
-	SGMatrix<float64_t> A(3, 3);
-	SGMatrix<float64_t> B(3, 3);
+    SGMatrix<ST> A(3, 3);
+    SGMatrix<ST> B(3, 3);
 
-	for (float64_t i = 0; i < 9; ++i)
-	{
-		A[i] = i * 0.5 - 0.5;
-		B[i] = i;
-	}
+    for (ST i = 0; i < 9; ++i)
+    {
+        A[i] = i * 0.5 - 0.5;
+        B[i] = i;
+    }
 
-	multiply_by_rectified_linear_derivative(A, B);
+    multiply_by_rectified_linear_derivative(A, B);
 
-	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(i * (A[i] != 0), B[i], 1e-15);
+    for (index_t i = 0; i < 9; ++i)
+        EXPECT_NEAR(i * (A[i] != 0), B[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_norm)
+template <typename ST>
+void check_SGVector_norm()
 {
-	const index_t n = 5;
-	SGVector<float64_t> v(n);
-	float64_t gt = 0;
-	for (index_t i = 0; i < n; ++i)
-	{
-		v[i] = i;
-		gt += i * i;
-	}
-	gt = std::sqrt(gt);
+    const index_t n = 24; // evaluates to norm=70
+    SGVector<ST> v(n);
+    ST gt = 0;
+    for (index_t i = 0; i < n; ++i)
+    {
+        v[i] = i;
+        gt += i * i;
+    }
 
-	auto result = norm(v);
+    gt = std::sqrt(gt);
 
-	EXPECT_NEAR(result, gt, 1E-15);
+    auto result = norm(v);
+
+    EXPECT_NEAR(result, gt, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_qr_solver)
+template <typename ST>
+void check_SGVector_qr_solver()
 {
-	const index_t n = 3;
-	float64_t data_A[] = {0.02800922, 0.99326012, 0.15204902,
-	                      0.30492837, 0.39708534, 0.40466969,
-	                      0.36415317, 0.04407589, 0.9095746};
-	float64_t data_b[] = {0.39461571, 0.6816856, 0.43323709};
-	float64_t result[] = {0.07135206, 1.56393127, -0.23141312};
+    const index_t n = 3;
+    ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
+                   0.30492837, 0.39708534, 0.40466969,
+                   0.36415317, 0.04407589, 0.9095746};
+    ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
+    ST result[] = {0.07135206, 1.56393127, -0.23141312};
 
-	SGMatrix<float64_t> A(data_A, n, n, false);
-	SGVector<float64_t> b(data_b, n, false);
+    SGMatrix<ST> A(data_A, n, n, false);
+    SGVector<ST> b(data_b, n, false);
 
-	auto x = qr_solver(A, b);
+    auto x = qr_solver(A, b);
 
-	for (index_t i = 0; i < x.size(); ++i)
-		EXPECT_NEAR(x[i], result[i], 1E-7);
+    for (index_t i = 0; i < x.size(); ++i)
+        EXPECT_NEAR(x[i], result[i], 1E-6);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_qr_solver)
+template <typename ST>
+void check_SGMatrix_qr_solver()
 {
-	const index_t n = 3, m = 2;
-	float64_t data_A[] = {0.02800922, 0.99326012, 0.15204902,
-	                      0.30492837, 0.39708534, 0.40466969,
-	                      0.36415317, 0.04407589, 0.9095746};
-	float64_t data_B[] = {0.76775073, 0.88471312, 0.34795225,
-	                      0.94311546, 0.59630347, 0.65820143};
-	float64_t result[] = {-0.73834587, 4.22750496, -1.37484721,
-	                      -1.14718091, 4.49142548, -1.08282992};
+    const index_t n = 3, m = 2;
+    ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
+                   0.30492837, 0.39708534, 0.40466969,
+                   0.36415317, 0.04407589, 0.9095746};
+    ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
+                   0.94311546, 0.59630347, 0.65820143};
+    ST result[] = {-0.73834587, 4.22750496, -1.37484721,
+                   -1.14718091, 4.49142548, -1.08282992};
 
-	SGMatrix<float64_t> A(data_A, n, n, false);
-	SGMatrix<float64_t> B(data_B, n, m, false);
+    SGMatrix<ST> A(data_A, n, n, false);
+    SGMatrix<ST> B(data_B, n, m, false);
 
-	auto X = qr_solver(A, B);
+    auto X = qr_solver(A, B);
 
-	for (index_t i = 0; i < (index_t)X.size(); ++i)
-		EXPECT_NEAR(X[i], result[i], 1E-7);
+    for (index_t i = 0; i < (index_t)X.size(); ++i)
+        EXPECT_NEAR(X[i], result[i], 1E-5);
 }
 
-TEST(LinalgBackendEigen, SGVector_range_fill)
+template <typename ST>
+void check_SGVector_range_fill()
 {
-	const index_t size = 5;
-	SGVector<int32_t> vec(size);
-	range_fill(vec, 1);
+    const index_t size = 5;
+    SGVector<ST> vec(size);
+    ST start = 1;  // FIXME: this is a bit awkward
+    range_fill(vec, start);
 
-	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(vec[i], i + 1, 1E-15);
+    for (index_t i = 0; i < size; ++i)
+        EXPECT_NEAR(vec[i], i + 1, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_range_fill)
+template <typename ST>
+void check_SGMatrix_range_fill()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
-	range_fill(mat, 1);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
+    ST start = 1;
+    range_fill(mat, start);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(mat[i], i + 1, 1E-15);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_NEAR(mat[i], i + 1, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_rectified_linear)
+template <typename ST>
+void check_SGMatrix_rectified_linear()
 {
-	SGMatrix<float64_t> A(3, 3);
-	SGMatrix<float64_t> B(3, 3);
-
-	range_fill(A, -5.0);
+    SGMatrix<ST> A(3, 3);
+    SGMatrix<ST> B(3, 3);
+    ST start = 1;
+    range_fill(A, start);
 
-	linalg::rectified_linear(A, B);
+    linalg::rectified_linear(A, B);
 
-	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(CMath::max(0.0, A[i]), B[i], 1e-15);
+    for (index_t i = 0; i < 9; ++i)
+        EXPECT_NEAR(CMath::max(static_cast<ST>(0.0), A[i]), B[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_scale)
+template <typename ST>
+void check_SGVector_scale()
 {
-	const index_t size = 5;
-	const float64_t alpha = 0.3;
-	SGVector<float64_t> a(size);
-	a.range_fill(0);
+    const index_t size = 5;
+    const ST alpha = 2;
+    SGVector<ST> a(size);
+    a.range_fill(0);
 
-	auto result = scale(a, alpha);
+    auto result = scale(a, alpha);
 
-	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(alpha * a[i], result[i], 1e-15);
+    for (index_t i = 0; i < size; ++i)
+        EXPECT_NEAR(alpha * a[i], result[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_scale)
+template <typename ST>
+void check_SGMatrix_scale()
 {
-	const float64_t alpha = 0.3;
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<float64_t> A(nrows, ncols);
+    const ST alpha = 2;
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> A(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		A[i] = i;
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        A[i] = i;
 
-	auto result = scale(A, alpha);
+    auto result = scale(A, alpha);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*A[i], result[i], 1e-15);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_NEAR(alpha*A[i], result[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_scale_in_place)
+template <typename ST>
+void check_SGVector_scale_in_place()
 {
-	const index_t size = 5;
-	const float64_t alpha = 0.3;
-	SGVector<float64_t> a(size);
-	a.range_fill(0);
+    const index_t size = 5;
+    const ST alpha = 2;
+    SGVector<ST> a(size);
+    a.range_fill(0);
 
-	scale(a, a, alpha);
+    scale(a, a, alpha);
 
-	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(alpha * i, a[i], 1e-15);
+    for (index_t i = 0; i < size; ++i)
+        EXPECT_NEAR(alpha * i, a[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_scale_in_place)
+template <typename ST>
+void check_SGMatrix_scale_in_place()
 {
-	const float64_t alpha = 0.3;
-	const index_t nrows = 2, ncols = 3;
+    const ST alpha = 2;
+    const index_t nrows = 2, ncols = 3;
 
-	SGMatrix<float64_t> A(nrows, ncols);
+    SGMatrix<ST> A(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		A[i] = i;
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        A[i] = i;
 
-	scale(A, A, alpha);
+    scale(A, A, alpha);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*i, A[i], 1e-15);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_NEAR(alpha*i, A[i], 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_set_const)
+template <typename ST>
+void check_SGVector_set_const()
 {
-	const index_t size = 5;
-	const float64_t value = 2;
-	SGVector<float64_t> a(size);
+    const index_t size = 5;
+    const ST value = 2;
+    SGVector<ST> a(size);
 
-	set_const(a, value);
+    set_const(a, value);
 
-	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(a[i], value, 1E-15);
+    for (index_t i = 0; i < size; ++i)
+        EXPECT_NEAR(a[i], value, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_set_const)
+template <typename ST>
+void check_SGMatrix_set_const()
 {
-	const index_t nrows = 2, ncols = 3;
-	const float64_t value = 2;
-	SGMatrix<float64_t> a(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    const ST value = 2;
+    SGMatrix<ST> a(nrows, ncols);
 
-	set_const(a, value);
+    set_const(a, value);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(a[i], value, 1E-15);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_NEAR(a[i], value, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_softmax)
+
+template <typename ST>
+void check_SGMatrix_softmax()
 {
-	SGMatrix<float64_t> A(4, 3);
-	SGMatrix<float64_t> ref(4, 3);
+    SGMatrix<ST> A(4, 3);
+    SGMatrix<ST> ref(4, 3);
 
-	for (float64_t i = 0; i < 12; ++i)
-		A[i] = i / 12;
+    for (ST i = 0; i < 12; ++i)
+        A[i] = i / 12;
 
-	for (index_t i = 0; i < 12; ++i)
-		ref[i] = std::exp(A[i]);
+    for (index_t i = 0; i < 12; ++i)
+        ref[i] = std::exp(A[i]);
 
-	for (index_t j = 0; j < ref.num_cols; ++j)
-	{
-		float64_t sum = 0;
-		for (index_t i = 0; i < ref.num_rows; ++i)
-			sum += ref(i, j);
+    for (index_t j = 0; j < ref.num_cols; ++j)
+    {
+        ST sum = 0;
+        for (index_t i = 0; i < ref.num_rows; ++i)
+            sum += ref(i, j);
 
-		for (index_t i = 0; i < ref.num_rows; ++i)
-			ref(i, j) /= sum;
-	}
+        for (index_t i = 0; i < ref.num_rows; ++i)
+            ref(i, j) /= sum;
+    }
 
-	linalg::softmax(A);
+    linalg::softmax(A);
 
-	for (index_t i = 0; i < 12; ++i)
-		EXPECT_NEAR(ref[i], A[i], 1e-15);
+    for (index_t i = 0; i < 12; ++i)
+        EXPECT_NEAR(ref[i], A[i], 1e-7);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_squared_error)
+template <typename ST>
+void check_SGMatrix_squared_error()
 {
-	SGMatrix<float64_t> A(4, 3);
-	SGMatrix<float64_t> B(4, 3);
+    SGMatrix<ST> A(4, 3);
+    SGMatrix<ST> B(4, 3);
+
+    ST size = A.num_rows * A.num_cols;
+    for (ST i = 0; i < size; i+=2)
+    {
+        A[i] = i / size;
+        B[i] = (i / size) * 2;
+    }
 
-	int32_t size = A.num_rows * A.num_cols;
-	for (float64_t i = 0; i < size; ++i)
-	{
-		A[i] = i / size;
-		B[i] = (i / size) * 0.5;
-	}
+    ST ref = 0;
+    for (index_t i = 0; i < size; i++)
+        ref += CMath::pow(A[i] - B[i], 2);
+    ref *= 0.5;
 
-	float64_t ref = 0;
-	for (index_t i = 0; i < size; i++)
-		ref += CMath::pow(A[i] - B[i], 2);
-	ref *= 0.5;
+    printf("%d", ref);
 
-	auto result = linalg::squared_error(A, B);
-	EXPECT_NEAR(ref, result, 1e-15);
+    auto result = linalg::squared_error(A, B);
+        EXPECT_NEAR(ref, result, 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_sum)
+
+template <typename ST>
+void check_SGVector_sum()
 {
-	const index_t size = 10;
-	SGVector<int32_t> vec(size);
-	vec.range_fill(0);
+    const index_t size = 10;
+    SGVector<ST> vec(size);
+    vec.range_fill(0);
 
-	auto result = sum(vec);
+    auto result = sum(vec);
 
-	EXPECT_NEAR(result, 45, 1E-15);
+    EXPECT_NEAR(result, 45, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_sum)
+template <typename ST>
+void check_SGMatrix_sum()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	auto result = sum(mat);
+    auto result = sum(mat);
 
-	EXPECT_NEAR(result, 15, 1E-15);
+    EXPECT_NEAR(result, 15, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_sum_no_diag)
+template <typename ST>
+void check_SGMatrix_sum_no_diag()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	auto result = sum(mat, true);
+    auto result = sum(mat, true);
 
-	EXPECT_NEAR(result, 12, 1E-15);
+    EXPECT_NEAR(result, 12, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_symmetric_with_diag)
+template <typename ST>
+void check_SGMatrix_symmetric_with_diag()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n);
-	mat.set_const(1.0);
+    const index_t n = 3;
+    SGMatrix<ST> mat(n, n);
+    mat.set_const(1);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = i + 1; j < n; ++j)
-		{
-			mat(i, j) = i * 10 + j + 1;
-			mat(j, i) = mat(i, j);
-		}
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = i + 1; j < n; ++j)
+        {
+            mat(i, j) = i * 10 + j + 1;
+            mat(j, i) = mat(i, j);
+        }
 
-	EXPECT_NEAR(sum_symmetric(mat), 39.0, 1E-15);
+    EXPECT_NEAR(sum_symmetric(mat), 39, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_symmetric_no_diag)
+template <typename ST>
+void check_SGMatrix_symmetric_no_diag()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n);
-	mat.set_const(1.0);
+    const index_t n = 3;
+    SGMatrix<ST> mat(n, n);
+    mat.set_const(1);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = i + 1; j < n; ++j)
-		{
-			mat(i, j) = i * 10 + j + 1;
-			mat(j, i) = mat(i, j);
-		}
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = i + 1; j < n; ++j)
+        {
+            mat(i, j) = i * 10 + j + 1;
+            mat(j, i) = mat(i, j);
+        }
 
-	EXPECT_NEAR(sum_symmetric(mat, true), 36.0, 1E-15);
+    EXPECT_NEAR(sum_symmetric(mat, true), 36, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_symmetric_exception)
+template <typename ST>
+void check_SGMatrix_symmetric_exception()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n + 1);
-	mat.set_const(1.0);
+    const index_t n = 3;
+    SGMatrix<ST> mat(n, n + 1);
+    mat.set_const(1.0);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = i + 1; j < n; ++j)
-		{
-			mat(i, j) = i * 10 + j + 1;
-			mat(j, i) = mat(i, j);
-		}
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = i + 1; j < n; ++j)
+        {
+            mat(i, j) = i * 10 + j + 1;
+            mat(j, i) = mat(i, j);
+        }
 
-	EXPECT_THROW(sum_symmetric(mat), ShogunException);
+    EXPECT_THROW(sum_symmetric(mat), ShogunException);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_block_sum)
+template <typename ST>
+void check_SGMatrix_block_sum()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n);
+    const index_t n = 3;
+    SGMatrix<ST> mat(n, n);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = 0; j < n; ++j)
-			mat(i, j)=i * 10 + j + 1;
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = 0; j < n; ++j)
+            mat(i, j)=i * 10 + j + 1;
 
-	auto result = sum(linalg::block(mat, 0, 0, 2, 3));
-	EXPECT_NEAR(result, 42.0, 1E-15);
+    auto result = sum(linalg::block(mat, 0, 0, 2, 3));
+    EXPECT_NEAR(result, 42.0, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_symmetric_block_with_diag)
+template <typename ST>
+void check_SGMatrix_symmetric_block_with_diag()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n);
-	mat.set_const(1.0);
+    const index_t n = 3;
+    SGMatrix<ST> mat(n, n);
+    mat.set_const(1);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = i + 1; j < n; ++j)
-		{
-			mat(i, j) = i * 10 + j + 1;
-			mat(j, i) = mat(i, j);
-		}
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = i + 1; j < n; ++j)
+        {
+            mat(i, j) = i * 10 + j + 1;
+            mat(j, i) = mat(i, j);
+        }
 
-	float64_t sum = sum_symmetric(linalg::block(mat,1,1,2,2));
-	EXPECT_NEAR(sum, 28.0, 1E-15);
+    ST sum = sum_symmetric(linalg::block(mat,1,1,2,2));
+    EXPECT_NEAR(sum, 28, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_symmetric_block_no_diag)
+template <typename ST>
+void check_SGMatrix_symmetric_block_no_diag()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n);
-	mat.set_const(1.0);
+    const index_t n = 3;
+    SGMatrix<ST> mat(n, n);
+    mat.set_const(1);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = i + 1; j < n; ++j)
-		{
-			mat(i, j) = i * 10 + j + 1;
-			mat(j, i) = mat(i, j);
-		}
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = i + 1; j < n; ++j)
+        {
+            mat(i, j) = i * 10 + j + 1;
+            mat(j, i) = mat(i, j);
+        }
 
-	float64_t sum = sum_symmetric(linalg::block(mat,1,1,2,2), true);
-	EXPECT_NEAR(sum, 26.0, 1E-15);
+    ST sum = sum_symmetric(linalg::block(mat,1,1,2,2), true);
+    EXPECT_NEAR(sum, 26, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_symmetric_block_exception)
+template <typename ST>
+void check_SGMatrix_symmetric_block_exception()
 {
-	const index_t n = 3;
-	SGMatrix<float64_t> mat(n, n);
-	mat.set_const(1.0);
+    const index_t n = 3;
+    SGMatrix<float64_t> mat(n, n);
+    mat.set_const(1.0);
 
-	for (index_t i = 0; i < n; ++i)
-		for (index_t j = i + 1; j < n; ++j)
-		{
-			mat(i, j) = i * 10 + j + 1;
-			mat(j, i) = mat(i, j);
-		}
+    for (index_t i = 0; i < n; ++i)
+        for (index_t j = i + 1; j < n; ++j)
+        {
+            mat(i, j) = i * 10 + j + 1;
+            mat(j, i) = mat(i, j);
+        }
 
-	EXPECT_THROW(sum_symmetric(linalg::block(mat,1,1,2,3)), ShogunException);
+    EXPECT_THROW(sum_symmetric(linalg::block(mat,1,1,2,3)), ShogunException);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_colwise_sum)
+template <typename ST>
+void check_SGMatrix_colwise_sum()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	SGVector<int32_t> result = colwise_sum(mat);
+    SGVector<ST> result = colwise_sum(mat);
 
-	for (index_t j = 0; j < ncols; ++j)
-	{
-		int32_t sum = 0;
-		for (index_t i = 0; i < nrows; ++i)
-			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[j], 1E-15);
-	}
+    for (index_t j = 0; j < ncols; ++j)
+    {
+        ST sum = 0;
+        for (index_t i = 0; i < nrows; ++i)
+            sum += mat(i, j);
+        EXPECT_NEAR(sum, result[j], 1E-15);
+    }
 }
 
-TEST(LinalgBackendEigen, SGMatrix_colwise_sum_no_diag)
+template <typename ST>
+void check_SGMatrix_colwise_sum_no_diag()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	SGVector<int32_t> result = colwise_sum(mat, true);
+    SGVector<ST> result = colwise_sum(mat, true);
 
-	EXPECT_NEAR(result[0], 1, 1E-15);
-	EXPECT_NEAR(result[1], 2, 1E-15);
-	EXPECT_NEAR(result[2], 9, 1E-15);
+    EXPECT_NEAR(result[0], 1, 1E-15);
+    EXPECT_NEAR(result[1], 2, 1E-15);
+    EXPECT_NEAR(result[2], 9, 1E-15);
 }
 
-
-TEST(LinalgBackendEigen, SGMatrix_block_colwise_sum)
+template <typename ST>
+void check_SGMatrix_block_colwise_sum()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<float64_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<float64_t> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows; ++i)
-		for (index_t j = 0; j < ncols; ++j)
-			mat(i, j) = i * 10 + j + 1;
+    for (index_t i = 0; i < nrows; ++i)
+        for (index_t j = 0; j < ncols; ++j)
+            mat(i, j) = i * 10 + j + 1;
 
-	auto result = colwise_sum(linalg::block(mat, 0, 0, 2, 3));
+    auto result = colwise_sum(linalg::block(mat, 0, 0, 2, 3));
 
-	for (index_t j = 0; j < ncols; ++j)
-	{
-		float64_t sum = 0;
-		for (index_t i = 0; i < nrows; ++i)
-			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[j], 1E-15);
-	}
+    for (index_t j = 0; j < ncols; ++j)
+    {
+        ST sum = 0;
+        for (index_t i = 0; i < nrows; ++i)
+            sum += mat(i, j);
+        EXPECT_NEAR(sum, result[j], 1E-15);
+    }
 }
+
 
-TEST(LinalgBackendEigen, SGMatrix_rowwise_sum)
+template <typename ST>
+void check_SGMatrix_rowwise_sum()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	SGVector<int32_t> result = rowwise_sum(mat);
+    SGVector<ST> result = rowwise_sum(mat);
 
-	for (index_t i = 0; i < nrows; ++i)
-	{
-		int32_t sum = 0;
-		for (index_t j = 0; j < ncols; ++j)
-			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[i], 1E-15);
-	}
+    for (index_t i = 0; i < nrows; ++i)
+    {
+        ST sum = 0;
+        for (index_t j = 0; j < ncols; ++j)
+            sum += mat(i, j);
+        EXPECT_NEAR(sum, result[i], 1E-15);
+    }
 }
 
-TEST(LinalgBackendEigen, SGMatrix_rowwise_sum_no_diag)
+template <typename ST>
+void check_SGMatrix_rowwise_sum_no_diag()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<int32_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows * ncols; ++i)
-		mat[i] = i;
+    for (index_t i = 0; i < nrows * ncols; ++i)
+        mat[i] = i;
 
-	SGVector<int32_t> result = rowwise_sum(mat, true);
+    SGVector<ST> result = rowwise_sum(mat, true);
 
-	EXPECT_NEAR(result[0], 6, 1E-15);
-	EXPECT_NEAR(result[1], 6, 1E-15);
+    EXPECT_NEAR(result[0], 6, 1E-15);
+    EXPECT_NEAR(result[1], 6, 1E-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_block_rowwise_sum)
+template <typename ST>
+void check_SGMatrix_block_rowwise_sum()
 {
-	const index_t nrows = 2, ncols = 3;
-	SGMatrix<float64_t> mat(nrows, ncols);
+    const index_t nrows = 2, ncols = 3;
+    SGMatrix<ST> mat(nrows, ncols);
 
-	for (index_t i = 0; i < nrows; ++i)
-		for (index_t j = 0; j < ncols; ++j)
-			mat(i, j) = i * 10 + j + 1;
+    for (index_t i = 0; i < nrows; ++i)
+        for (index_t j = 0; j < ncols; ++j)
+            mat(i, j) = i * 10 + j + 1;
 
-	auto result = rowwise_sum(linalg::block(mat, 0, 0, 2, 3));
+    auto result = rowwise_sum(linalg::block(mat, 0, 0, 2, 3));
 
-	for (index_t i = 0; i < nrows; ++i)
-	{
-		float64_t sum = 0;
-		for (index_t j = 0; j < ncols; ++j)
-			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[i], 1E-15);
-	}
+    for (index_t i = 0; i < nrows; ++i)
+    {
+        ST sum = 0;
+        for (index_t j = 0; j < ncols; ++j)
+            sum += mat(i, j);
+        EXPECT_NEAR(sum, result[i], 1E-15);
+    }
 }
 
-TEST(LinalgBackendEigen, SGMatrix_svd_jacobi_thinU)
+template <typename ST>
+void check_SGMatrix_svd_jacobi_thinU()
 {
-	const index_t m = 5, n = 3;
-	float64_t data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
-	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
-	                    0.28540373, 0.06264684, 0.56204061};
-	float64_t result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	float64_t result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-	                        -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-	                        0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-	                        -0.12681555, -0.53830325, 0.69323293};
+    const index_t m = 5, n = 3;
+    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+                 0.28540373, 0.06264684, 0.56204061};
+    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+    ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
+                     -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+                     0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+                     -0.12681555, -0.53830325, 0.69323293};
 
-	SGMatrix<float64_t> A(data, m, n, false);
-	SGMatrix<float64_t> U(m, n);
-	SGVector<float64_t> s(n);
+    SGMatrix<ST> A(data, m, n, false);
+    SGMatrix<ST> U(m, n);
+    SGVector<ST> s(n);
 
-	svd(A, s, U, true, SVDAlgorithm::Jacobi);
+    svd(A, s, U, true, SVDAlgorithm::Jacobi);
 
-	for (index_t i = 0; i < n; ++i)
-	{
-		auto c = CMath::sign(U[i * m] * result_U[i * m]);
-		for (index_t j = 0; j < m; ++j)
-			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
-	}
-	for (index_t i = 0; i < (index_t)s.size(); ++i)
-		EXPECT_NEAR(s[i], result_s[i], 1e-7);
+    for (index_t i = 0; i < n; ++i)
+    {
+        auto c = CMath::sign(U[i * m] * result_U[i * m]);
+        for (index_t j = 0; j < m; ++j)
+            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
+    }
+    for (index_t i = 0; i < (index_t)s.size(); ++i)
+        EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_svd_jacobi_fullU)
+template <typename ST>
+void check_SGMatrix_svd_jacobi_fullU()
 {
-	const index_t m = 5, n = 3;
-	float64_t data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
-	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
-	                    0.28540373, 0.06264684, 0.56204061};
-	float64_t result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	float64_t result_U[] = {
-	    -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
-	    -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
-	    -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
-	    -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
-	    0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
+    const index_t m = 5, n = 3;
+    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+                 0.28540373, 0.06264684, 0.56204061};
+    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+    ST result_U[] = {
+            -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
+            -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
+            -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
+            -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
+            0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
-	SGMatrix<float64_t> A(data, m, n, false);
-	SGMatrix<float64_t> U(m, m);
-	SGVector<float64_t> s(n);
+    SGMatrix<ST> A(data, m, n, false);
+    SGMatrix<ST> U(m, m);
+    SGVector<ST> s(n);
 
-	svd(A, s, U, false, SVDAlgorithm::Jacobi);
+    svd(A, s, U, false, SVDAlgorithm::Jacobi);
 
-	for (index_t i = 0; i < n; ++i)
-	{
-		auto c = CMath::sign(U[i * m] * result_U[i * m]);
-		for (index_t j = 0; j < m; ++j)
-			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
-	}
-	for (index_t i = 0; i < (index_t)s.size(); ++i)
-		EXPECT_NEAR(s[i], result_s[i], 1e-7);
+    for (index_t i = 0; i < n; ++i)
+    {
+        auto c = CMath::sign(U[i * m] * result_U[i * m]);
+        for (index_t j = 0; j < m; ++j)
+            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
+    }
+    for (index_t i = 0; i < (index_t)s.size(); ++i)
+        EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
-TEST(LinalgBackendEigen, SGMatrix_svd_bdc_thinU)
+template <typename ST>
+void check_SGMatrix_svd_bdc_thinU()
 {
-	const index_t m = 5, n = 3;
-	float64_t data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
-	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
-	                    0.28540373, 0.06264684, 0.56204061};
-	float64_t result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	float64_t result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-	                        -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-	                        0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-	                        -0.12681555, -0.53830325, 0.69323293};
+    const index_t m = 5, n = 3;
+    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+                 0.28540373, 0.06264684, 0.56204061};
+    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+    ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
+                     -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+                     0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+                     -0.12681555, -0.53830325, 0.69323293};
 
-	SGMatrix<float64_t> A(data, m, n, false);
-	SGMatrix<float64_t> U(m, n);
-	SGVector<float64_t> s(n);
+    SGMatrix<ST> A(data, m, n, false);
+    SGMatrix<ST> U(m, n);
+    SGVector<ST> s(n);
 
-	svd(A, s, U, true, SVDAlgorithm::BidiagonalDivideConquer);
+    svd(A, s, U, true, SVDAlgorithm::BidiagonalDivideConquer);
 
-	for (index_t i = 0; i < n; ++i)
-	{
-		auto c = CMath::sign(U[i * m] * result_U[i * m]);
-		for (index_t j = 0; j < m; ++j)
-			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
-	}
-	for (index_t i = 0; i < (index_t)s.size(); ++i)
-		EXPECT_NEAR(s[i], result_s[i], 1e-7);
+    for (index_t i = 0; i < n; ++i)
+    {
+        auto c = CMath::sign(U[i * m] * result_U[i * m]);
+        for (index_t j = 0; j < m; ++j)
+            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
+    }
+    for (index_t i = 0; i < (index_t)s.size(); ++i)
+        EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_svd_bdc_fullU)
+template <typename ST>
+void check_SGMatrix_svd_bdc_fullU()
 {
-	const index_t m = 5, n = 3;
-	float64_t data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
-	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
-	                    0.28540373, 0.06264684, 0.56204061};
-	float64_t result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	float64_t result_U[] = {
-	    -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
-	    -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
-	    -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
-	    -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
-	    0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
+    const index_t m = 5, n = 3;
+    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+                 0.28540373, 0.06264684, 0.56204061};
+    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+    ST result_U[] = {
+            -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
+            -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
+            -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
+            -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
+            0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
-	SGMatrix<float64_t> A(data, m, n, false);
-	SGMatrix<float64_t> U(m, m);
-	SGVector<float64_t> s(n);
+    SGMatrix<ST> A(data, m, n, false);
+    SGMatrix<ST> U(m, m);
+    SGVector<ST> s(n);
 
-	svd(A, s, U, false, SVDAlgorithm::BidiagonalDivideConquer);
+    svd(A, s, U, false, SVDAlgorithm::BidiagonalDivideConquer);
 
-	for (index_t i = 0; i < n; ++i)
-	{
-		auto c = CMath::sign(U[i * m] * result_U[i * m]);
-		for (index_t j = 0; j < m; ++j)
-			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
-	}
-	for (index_t i = 0; i < (index_t)s.size(); ++i)
-		EXPECT_NEAR(s[i], result_s[i], 1e-7);
+    for (index_t i = 0; i < n; ++i)
+    {
+        auto c = CMath::sign(U[i * m] * result_U[i * m]);
+        for (index_t j = 0; j < m; ++j)
+            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
+    }
+    for (index_t i = 0; i < (index_t)s.size(); ++i)
+        EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 #endif
 
-TEST(LinalgBackendEigen, SGMatrix_trace)
+template <typename ST>
+void check_SGMatrix_trace()
 {
-	const index_t n = 4;
+    const index_t n = 4;
 
-	SGMatrix<float64_t> A(n, n);
-	for (index_t i = 0; i < n*n; ++i)
-		A[i] = i;
+    SGMatrix<ST> A(n, n);
+    for (index_t i = 0; i < n*n; ++i)
+        A[i] = i;
 
-	float64_t tr = 0;
-	for (index_t i = 0; i < n; ++i)
-		tr += A.get_element(i, i);
+    ST tr = 0;
+    for (index_t i = 0; i < n; ++i)
+        tr += A.get_element(i, i);
 
-	EXPECT_NEAR(trace(A), tr, 1e-15);
+    EXPECT_NEAR(trace(A), tr, 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_trace_dot)
+template <typename ST>
+void check_SGMatrix_trace_dot()
 {
-	const index_t m = 2;
-	float64_t data_A[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194};
-	float64_t data_B[] = {0.30786772, 0.25503552, 0.34367041, 0.66491478};
+    const index_t n = 2;
+    SGMatrix<ST> A(n, n), B(n, n);
+    for (index_t i = 0; i < n*n; ++i) {
+        A[i] = i;
+        B[i] = i * 2;
+    }
 
-	SGMatrix<float64_t> A(data_A, m, m, false);
-	SGMatrix<float64_t> B(data_B, m, m, false);
+    auto C = matrix_prod(A, B);
+    auto tr = 0.0;
+    for (auto i : range(n))
+        tr += C(i, i);
 
-	auto C = matrix_prod(A, B);
-	auto tr = 0.0;
-	for (auto i : range(m))
-		tr += C(i, i);
-
-	EXPECT_NEAR(tr, trace_dot(A, B), 1e-15);
+    EXPECT_NEAR(tr, trace_dot(A, B), 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_transpose_matrix)
+template <typename ST>
+void check_SGMatrix_transpose_matrix()
 {
-	const index_t m = 5, n = 3;
-	float64_t data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
-	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
-	                    0.28540373, 0.06264684, 0.56204061};
+    const index_t m = 5, n = 3;
+    SGMatrix<ST> A(m, n);
+    linalg::range_fill(A, static_cast<ST>(1));
 
-	SGMatrix<float64_t> A(data, m, n, false);
+    auto T = transpose_matrix(A);
 
-	auto T = transpose_matrix(A);
-
-	for (index_t i = 0; i < m; ++i)
-		for (index_t j = 0; j < n; ++j)
-			EXPECT_NEAR(A.get_element(i, j), T.get_element(j, i), 1e-15);
+    for (index_t i = 0; i < m; ++i)
+        for (index_t j = 0; j < n; ++j)
+            EXPECT_NEAR(A.get_element(i, j), T.get_element(j, i), 1e-15);
 }
 
-TEST(LinalgBackendEigen, SGVector_triangular_solver_lower)
+template <typename ST>
+void check_SGVector_triangular_solver_lower()
 {
-	const index_t n = 3;
-	float64_t data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
-	                      0.,          -0.27048649, -0.05919915,
-	                      0.,          0.,          0.11869106};
-	float64_t data_b[] = {0.39461571, 0.6816856, 0.43323709};
-	float64_t result[] = {-0.42455592, -0.72571316, 0.17192745};
+    const index_t n = 3;
+    ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
+                   0.,          -0.27048649, -0.05919915,
+                   0.,          0.,          0.11869106};
+    ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
+    ST result[] = {-0.42455592, -0.72571316, 0.17192745};
 
-	SGMatrix<float64_t> L(data_L, n, n, false);
-	SGVector<float64_t> b(data_b, n, false);
+    SGMatrix<ST> L(data_L, n, n, false);
+    SGVector<ST> b(data_b, n, false);
 
-	auto x = triangular_solver(L, b, true);
+    auto x = triangular_solver(L, b, true);
 
-	for (index_t i = 0; i < (index_t)x.size(); ++i)
-		EXPECT_NEAR(x[i], result[i], 1E-6);
+    for (index_t i = 0; i < (index_t)x.size(); ++i)
+        EXPECT_NEAR(x[i], result[i], 1E-6);
 }
 
-TEST(LinalgBackendEigen, SGVector_triangular_solver_upper)
+template <typename ST>
+void check_SGVector_triangular_solver_upper()
 {
-	const index_t n = 3;
-	float64_t data_U[] = {-0.92947874, 0.,          0.,
-	                      -1.1432887,  -0.27048649, 0.,
-	                      -0.87119086, -0.05919915, 0.11869106};
-	float64_t data_b[] = {0.39461571, 0.6816856, 0.43323709};
-	float64_t result[] = {0.23681135, -3.31909306, 3.65012412};
+    const index_t n = 3;
+    ST data_U[] = {-0.92947874, 0.,          0.,
+                   -1.1432887,  -0.27048649, 0.,
+                   -0.87119086, -0.05919915, 0.11869106};
+    ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
+    ST result[] = {0.23681135, -3.31909306, 3.65012412};
 
-	SGMatrix<float64_t> U(data_U, n, n, false);
-	SGVector<float64_t> b(data_b, n, false);
+    SGMatrix<ST> U(data_U, n, n, false);
+    SGVector<ST> b(data_b, n, false);
 
-	auto x = triangular_solver(U, b, false);
+    auto x = triangular_solver(U, b, false);
 
-	for (index_t i = 0; i < (index_t)x.size(); ++i)
-		EXPECT_NEAR(x[i], result[i], 1E-6);
+    for (index_t i = 0; i < (index_t)x.size(); ++i)
+        EXPECT_NEAR(x[i], result[i], 1E-6);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_triangular_solver_lower)
+template <typename ST>
+void check_SGMatrix_triangular_solver_lower()
 {
-	const index_t n = 3, m = 2;
-	float64_t data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
-	                      0.,          -0.27048649, -0.05919915,
-	                      0.,          0.,          0.11869106};
-	float64_t data_B[] = {0.76775073, 0.88471312, 0.34795225,
-	                      0.94311546, 0.59630347, 0.65820143};
-	float64_t result[] = {-0.82600139, 0.22050986, -3.02127745,
-	                      -1.01467136, 2.08424024, -0.86262387};
+    const index_t n = 3, m = 2;
+    ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
+                   0.,          -0.27048649, -0.05919915,
+                   0.,          0.,          0.11869106};
+    ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
+                   0.94311546, 0.59630347, 0.65820143};
+    ST result[] = {-0.82600139, 0.22050986, -3.02127745,
+                   -1.01467136, 2.08424024, -0.86262387};
 
-	SGMatrix<float64_t> L(data_L, n, n, false);
-	SGMatrix<float64_t> B(data_B, n, m, false);
+    SGMatrix<ST> L(data_L, n, n, false);
+    SGMatrix<ST> B(data_B, n, m, false);
 
-	auto X = triangular_solver(L, B, true);
+    auto X = triangular_solver(L, B, true);
 
-	for (index_t i = 0; i < (index_t)X.size(); ++i)
-		EXPECT_NEAR(X[i], result[i], 1E-6);
+    for (index_t i = 0; i < (index_t)X.size(); ++i)
+    EXPECT_NEAR(X[i], result[i], 1E-6);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_triangular_solver_upper)
+template <typename ST>
+void check_SGMatrix_triangular_solver_upper()
 {
-	const index_t n = 3, m = 2;
-	float64_t data_U[] = {-0.92947874, 0.,          0.,
-	                      -1.1432887,  -0.27048649, 0.,
-	                      -0.87119086, -0.05919915, 0.11869106};
-	float64_t data_B[] = {0.76775073, 0.88471312, 0.34795225,
-	                      0.94311546, 0.59630347, 0.65820143};
-	float64_t result[] = {1.238677,    -3.91243241, 2.9315793,
-	                      -2.00784647, -3.41825732, 5.54550138};
+    const index_t n = 3, m = 2;
+    ST data_U[] = {-0.92947874, 0.,          0.,
+                   -1.1432887,  -0.27048649, 0.,
+                   -0.87119086, -0.05919915, 0.11869106};
+    ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
+                   0.94311546, 0.59630347, 0.65820143};
+    ST result[] = {1.238677,    -3.91243241, 2.9315793,
+                   -2.00784647, -3.41825732, 5.54550138};
 
-	SGMatrix<float64_t> L(data_U, n, n, false);
-	SGMatrix<float64_t> B(data_B, n, m, false);
+    SGMatrix<ST> L(data_U, n, n, false);
+    SGMatrix<ST> B(data_B, n, m, false);
 
-	auto X = triangular_solver(L, B, false);
+    auto X = triangular_solver(L, B, false);
 
-	for (index_t i = 0; i < (index_t)X.size(); ++i)
-		EXPECT_NEAR(X[i], result[i], 1E-6);
+    for (index_t i = 0; i < (index_t)X.size(); ++i)
+    EXPECT_NEAR(X[i], result[i], 1E-6);
 }
 
-TEST(LinalgBackendEigen, SGVector_zero)
-{
-	const index_t n = 16;
-	SGVector<float64_t> a(n);
-	zero(a);
 
-	for (index_t i = 0; i < n; ++i)
-		EXPECT_EQ(a[i], 0);
+template <typename ST>
+void check_SGVector_zero()
+{
+    const index_t n = 16;
+    SGVector<ST> a(n);
+    zero(a);
+
+    for (index_t i = 0; i < n; ++i)
+        EXPECT_EQ(a[i], 0);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_zero)
+template <typename ST>
+void check_SGMatrix_zero()
 {
-	const index_t nrows = 3, ncols = 4;
-	SGMatrix<float64_t> A(nrows, ncols);
-	zero(A);
+    const index_t nrows = 3, ncols = 4;
+    SGMatrix<ST> A(nrows, ncols);
+    zero(A);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_EQ(A[i], 0);
+    for (index_t i = 0; i < nrows*ncols; ++i)
+        EXPECT_EQ(A[i], 0);
 }
 
-TEST(LinalgBackendEigen, SGMatrix_rank_update)
+template <typename ST>
+void check_SGMatrix_rank_update()
 {
-	const index_t size = 2;
-	SGMatrix<float64_t> A(size, size);
-	SGVector<float64_t> b(size);
-	Map<MatrixXd> A_eig(A.matrix, size, size);
-	Map<VectorXd> b_eig(b.vector, size);
+    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+    typedef Matrix<ST, 1, Dynamic> Vxd;
 
-	A(0, 0) = 2.0;
-	A(1, 0) = 1.0;
-	A(0, 1) = 1.0;
-	A(1, 1) = 2.5;
-	b[0] = 2;
-	b[1] = 3;
+    const index_t size = 2;
+    SGMatrix<ST> A(size, size);
+    SGVector<ST> b(size);
+    Map<Mxx> A_eig(A.matrix, size, size);
+    Map<Vxd> b_eig(b.vector, size);
 
-	auto A2 = A.clone();
-	Map<MatrixXd> A2_eig(A2.matrix, size, size);
-	A2(0, 0) += b[0] * b[0];
-	A2(0, 1) += b[0] * b[1];
-	A2(1, 0) += b[1] * b[0];
-	A2(1, 1) += b[1] * b[1];
+    A(0, 0) = 2.0;
+    A(1, 0) = 1.0;
+    A(0, 1) = 1.0;
+    A(1, 1) = 2.5;
+    b[0] = 2;
+    b[1] = 3;
 
-	rank_update(A, b);
-	EXPECT_NEAR((A2_eig - A_eig).norm(), 0.0, 1e-14);
+    auto A2 = A.clone();
+    Map<Mxx> A2_eig(A2.matrix, size, size);
+    A2(0, 0) += b[0] * b[0];
+    A2(0, 1) += b[0] * b[1];
+    A2(1, 0) += b[1] * b[0];
+    A2(1, 1) += b[1] * b[1];
 
-	rank_update(A, b, -1.);
-	EXPECT_NEAR((A_eig - A_eig).norm(), 0.0, 1e-14);
+    rank_update(A, b, static_cast<ST>(1));
+    EXPECT_NEAR((A2_eig - A_eig).norm(), 0, 1e-14);
+
+    rank_update(A, b, static_cast<ST>(-1));
+    EXPECT_NEAR((A_eig - A_eig).norm(), 0, 1e-14);
+}
+
+
+// test types based on shogun/mathematics/linalg/LinalgBackendBase.h
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
+{
+    check_SGVector_add<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add)
+{
+    check_SGMatrix_add<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_in_place)
+{
+    check_SGVector_add_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_in_place)
+{
+    check_SGMatrix_add_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_allocated)
+{
+    check_SGVector_add_col_vec_allocated<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_in_place)
+{
+    check_SGVector_add_col_vec_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_allocated)
+{
+    check_SGMatrix_add_col_vec_allocated<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_in_place)
+{
+    check_SGMatrix_add_col_vec_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, add_diag)
+{
+    check_add_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, add_ridge)
+{
+    check_add_ridge<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, add_vector)
+{
+    check_add_vector<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_scalar)
+{
+    check_SGVector_add_scalar<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_scalar)
+{
+    check_SGMatrix_add_scalar<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_center_matrix)
+{
+    check_SGMatrix_center_matrix<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_lower)
+{
+    check_SGMatrix_cholesky_llt_lower<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_upper)
+{
+    check_SGMatrix_cholesky_llt_upper<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_upper)
+{
+    check_SGMatrix_cholesky_rank_update_upper<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_lower)
+{
+    check_SGMatrix_cholesky_rank_update_lower<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_ldlt_lower)
+{
+    check_SGMatrix_cholesky_ldlt_lower<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_solver)
+{
+    check_SGMatrix_cholesky_solver<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_ldlt_solver)
+{
+    check_SGMatrix_ldlt_solver<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cross_entropy)
+{
+    check_SGMatrix_cross_entropy<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_psd)
+{
+    check_SGMatrix_pinv_psd<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_2x4)
+{
+    check_SGMatrix_pinv_2x4<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_4x2)
+{
+    check_SGMatrix_pinv_4x2<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_dot)
+{
+    check_SGVector_dot<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver)
+{
+    check_eigensolver<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver_symmetric)
+{
+    check_eigensolver_symmetric<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product)
+{
+    check_SGMatrix_elementwise_product<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product_in_place)
+{
+    check_SGMatrix_elementwise_product_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_elementwise_product)
+{
+    check_SGMatrix_block_elementwise_product<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product)
+{
+    check_SGVector_elementwise_product<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product_in_place)
+{
+    check_SGVector_elementwise_product_in_place<TypeParam>();
+}
+
+// TODO: write test for int types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_exponent)
+{
+    check_SGVector_exponent<TypeParam>();
+}
+
+// TODO: write test for int types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_exponent)
+{
+    check_SGMatrix_exponent<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_identity)
+{
+    check_SGMatrix_identity<TypeParam>();
+}
+
+// TODO: write test for int types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, logistic)
+{
+    check_logistic<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod)
+{
+    check_SGMatrix_SGVector_matrix_prod<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_matrix_prod_transpose)
+{
+    check_SGVector_matrix_prod_transpose<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place)
+{
+    check_SGMatrix_SGVector_matrix_prod_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place_transpose)
+{
+    check_SGMatrix_SGVector_matrix_prod_in_place_transpose<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product)
+{
+    check_SGMatrix_matrix_product<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A)
+{
+    check_SGMatrix_matrix_product_transpose_A<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_B)
+{
+    check_SGMatrix_matrix_product_transpose_B<TypeParam>();
+}
+
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A_B)
+{
+    check_SGMatrix_matrix_product_transpose_A_B<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place)
+{
+    check_SGMatrix_matrix_product_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_A)
+{
+    check_SGMatrix_matrix_product_in_place_transpose_A<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_B)
+{
+    check_SGMatrix_matrix_product_in_place_transpose_B<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_A_B)
+{
+    check_SGMatrix_matrix_product_in_place_transpose_A_B<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_max)
+{
+    check_SGVector_max<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_max)
+{
+    check_SGMatrix_max<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_mean)
+{
+    check_SGVector_mean<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_mean)
+{
+    check_SGMatrix_mean<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_multiply_by_logistic_derivative)
+{
+    check_SGMatrix_multiply_by_logistic_derivative<TypeParam>();
+}
+
+// TODO: write test for int types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_multiply_by_rectified_linear_derivative)
+{
+    check_SGMatrix_multiply_by_rectified_linear_derivative<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_norm)
+{
+    check_SGVector_norm<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_qr_solver)
+{
+    check_SGVector_qr_solver<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_qr_solver)
+{
+    check_SGMatrix_qr_solver<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_range_fill)
+{
+    check_SGVector_range_fill<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_range_fill)
+{
+    check_SGMatrix_range_fill<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rectified_linear)
+{
+    check_SGMatrix_rectified_linear<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale)
+{
+    check_SGVector_scale<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale)
+{
+    check_SGMatrix_scale<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale_in_place)
+{
+    check_SGVector_scale_in_place<TypeParam>();
+}
+
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale_in_place)
+{
+    check_SGMatrix_scale_in_place<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_set_const)
+{
+    check_SGVector_set_const<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_set_const)
+{
+    check_SGMatrix_set_const<TypeParam>();
+}
+
+// TODO: extend to all types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_softmax)
+{
+    check_SGMatrix_softmax<TypeParam>();
+}
+
+// FIXME: CMath::Pow only accepts float or complex types
+//TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_squared_error)
+//{
+//    check_SGMatrix_squared_error<TypeParam>();
+//}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_sum)
+{
+    check_SGVector_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum)
+{
+    check_SGMatrix_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum_no_diag)
+{
+    check_SGMatrix_sum_no_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_with_diag)
+{
+    check_SGMatrix_symmetric_with_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_no_diag)
+{
+    check_SGMatrix_symmetric_no_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_exception)
+{
+    check_SGMatrix_symmetric_exception<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_sum)
+{
+    check_SGMatrix_block_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_with_diag)
+{
+    check_SGMatrix_symmetric_block_with_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_no_diag)
+{
+    check_SGMatrix_symmetric_block_no_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_exception)
+{
+    check_SGMatrix_symmetric_block_exception<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum)
+{
+    check_SGMatrix_colwise_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum_no_diag)
+{
+    check_SGMatrix_colwise_sum_no_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_colwise_sum)
+{
+    check_SGMatrix_block_colwise_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum)
+{
+    check_SGMatrix_rowwise_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum_no_diag)
+{
+    check_SGMatrix_rowwise_sum_no_diag<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_rowwise_sum)
+{
+    check_SGMatrix_block_rowwise_sum<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_thinU)
+{
+    check_SGMatrix_svd_jacobi_thinU<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_fullU)
+{
+    check_SGMatrix_svd_jacobi_fullU<TypeParam>();
+}
+
+
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_thinU)
+{
+    check_SGMatrix_svd_bdc_thinU<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_fullU)
+{
+    check_SGMatrix_svd_bdc_fullU<TypeParam>();
+}
+#endif
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace)
+{
+    check_SGMatrix_trace<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace_dot)
+{
+    check_SGMatrix_trace_dot<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_transpose_matrix)
+{
+    check_SGMatrix_transpose_matrix<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_lower)
+{
+    check_SGVector_triangular_solver_lower<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_upper)
+{
+    check_SGVector_triangular_solver_upper<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_lower)
+{
+    check_SGMatrix_triangular_solver_lower<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_upper)
+{
+    check_SGMatrix_triangular_solver_upper<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_zero)
+{
+    check_SGVector_zero<TypeParam>();
+}
+
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_zero)
+{
+    check_SGMatrix_zero<TypeParam>();
+}
+
+// TODO: extend to int types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_rank_update)
+{
+    check_SGMatrix_rank_update<TypeParam>();
 }

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -13,25 +13,14 @@ using namespace Eigen;
 
 // Tolerance values for tests
 template <typename T>
-// default tolerance
 T get_epsilon()
 {
-	return 0;
-}
-template <>
-float32_t get_epsilon()
-{
-	return 1e-5;
-}
-template <>
-float64_t get_epsilon()
-{
-	return 1e-9;
+	return std::numeric_limits<T>::epsilon() * 100;
 }
 template <>
 floatmax_t get_epsilon()
 {
-	return 1e-12;
+	return 1e-13;
 }
 
 template <typename T>

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -12,30 +12,57 @@ using namespace linalg;
 using namespace Eigen;
 
 // Tolerance values for tests
-template<typename T>
+template <typename T>
 // default tolerance
-T get_epsilon() {return 0;}
-template<>
-float32_t get_epsilon() {return 1e-5;}
-template<>
-float64_t get_epsilon() {return 1e-9;}
-template<>
-floatmax_t get_epsilon() {return 1e-12;}
+T get_epsilon()
+{
+	return 0;
+}
+template <>
+float32_t get_epsilon()
+{
+	return 1e-5;
+}
+template <>
+float64_t get_epsilon()
+{
+	return 1e-9;
+}
+template <>
+floatmax_t get_epsilon()
+{
+	return 1e-12;
+}
 
 template <typename T>
-class LinalgBackendEigenAllTypesTest: public ::testing::Test { };
+class LinalgBackendEigenAllTypesTest : public ::testing::Test
+{
+};
 template <typename T>
-class LinalgBackendEigenNonComplexTypesTest: public ::testing::Test { };
+class LinalgBackendEigenNonComplexTypesTest : public ::testing::Test
+{
+};
 template <typename T>
-class LinalgBackendEigenRealTypesTest: public ::testing::Test { };
+class LinalgBackendEigenRealTypesTest : public ::testing::Test
+{
+};
 template <typename T>
-class LinalgBackendEigenNonIntegerTypesTest: public ::testing::Test { };
+class LinalgBackendEigenNonIntegerTypesTest : public ::testing::Test
+{
+};
 
 // TODO: make global definitions
-// Definition of the 4 groups of Shogun types (shogun/mathematics/linalg/LinalgBackendBase.h)
+// Definition of the 4 groups of Shogun types
+// (shogun/mathematics/linalg/LinalgBackendBase.h)
 // TODO: add bool, chars and complex128_t types
-typedef ::testing::Types<int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t, float64_t, floatmax_t> AllTypes;
-typedef ::testing::Types<int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t, float64_t, floatmax_t> NonComplexTypes;
+typedef ::testing::Types<
+    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
+    float64_t, floatmax_t>
+    AllTypes;
+typedef ::testing::Types<
+    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
+    float64_t, floatmax_t>
+    NonComplexTypes;
 typedef ::testing::Types<float32_t, float64_t, floatmax_t> RealTypes;
 // TODO: add complex128_t type
 typedef ::testing::Types<float32_t, float64_t, floatmax_t> NonIntegerTypes;
@@ -45,9 +72,9 @@ TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, NonComplexTypes);
 TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, RealTypes);
 TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, NonIntegerTypes);
 
-
 template <typename ST>
-void check_SGVector_add() {
+void check_SGVector_add()
+{
 
 	const ST alpha = 1;
 	const ST beta = 2;
@@ -58,17 +85,18 @@ void check_SGVector_add() {
 	for (index_t i = 0; i < 9; ++i)
 	{
 		A[i] = i;
-		B[i] = 2*i;
+		B[i] = 2 * i;
 	}
 
 	auto result = add(A, B, alpha, beta);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * A[i] + beta * B[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
-void check_SGMatrix_add() {
+void check_SGMatrix_add()
+{
 
 	const ST alpha = 1;
 	const ST beta = 2;
@@ -80,17 +108,18 @@ void check_SGMatrix_add() {
 	for (index_t i = 0; i < nrows*ncols; ++i)
 	{
 		A[i] = i;
-		B[i] = 2*i;
+		B[i] = 2 * i;
 	}
 
 	auto result = add(A, B, alpha, beta);
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * A[i] + beta * B[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
-void check_SGVector_add_in_place() {
+void check_SGVector_add_in_place()
+{
 	const ST alpha = 1;
 	const ST beta = 2;
 
@@ -98,19 +127,20 @@ void check_SGVector_add_in_place() {
 
 	for (index_t i = 0; i < 9; ++i)
 	{
-	A[i] = i;
-	B[i] = 2*i;
-	C[i] = i;
+		A[i] = i;
+		B[i] = 2 * i;
+		C[i] = i;
 	}
 
 	add(A, B, A, alpha, beta);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * C[i] + beta * B[i], A[i], get_epsilon<ST>());
 }
 
 template <typename ST>
-void check_SGMatrix_add_in_place() {
+void check_SGMatrix_add_in_place()
+{
 
 	const ST alpha = 1;
 	const ST beta = 2;
@@ -123,18 +153,19 @@ void check_SGMatrix_add_in_place() {
 	for (index_t i = 0; i < nrows*ncols; ++i)
 	{
 		A[i] = i;
-		B[i] = 3*i;
+		B[i] = 3 * i;
 		C[i] = i;
 	}
 
 	add(A, B, A, alpha, beta);
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * C[i] + beta * B[i], A[i], get_epsilon<ST>());
 }
 
 template <typename ST>
-void check_SGVector_add_col_vec_allocated() {
+void check_SGVector_add_col_vec_allocated()
+{
 
 	const ST alpha = 1;
 	const ST beta = 2;
@@ -153,7 +184,9 @@ void check_SGVector_add_col_vec_allocated() {
 	add_col_vec(A, col, b, result, alpha, beta);
 
 	for (index_t i = 0; i < nrows; ++i)
-		EXPECT_NEAR(result[i], alpha * A.get_element(i, col) + beta * b[i], get_epsilon<ST>());
+		EXPECT_NEAR(
+		    result[i], alpha * A.get_element(i, col) + beta * b[i],
+		    get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -170,12 +203,14 @@ void check_SGVector_add_col_vec_in_place()
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 2*i;
+		b[i] = 2 * i;
 
 	add_col_vec(A, col, b, b, alpha, beta);
 
 	for (index_t i = 0; i < nrows; ++i)
-		EXPECT_NEAR(b[i], alpha*A.get_element(i, col)+beta*2*i, get_epsilon<ST>());
+		EXPECT_NEAR(
+		    b[i], alpha * A.get_element(i, col) + beta * 2 * i,
+		    get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -193,14 +228,14 @@ void check_SGMatrix_add_col_vec_allocated()
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 3*i;
+		b[i] = 3 * i;
 
 	add_col_vec(A, col, b, result, alpha, beta);
 
 	for (index_t i = 0; i < nrows; ++i)
 		EXPECT_NEAR(
-			result.get_element(i, col),
-			alpha * A.get_element(i, col) + beta * b[i], get_epsilon<ST>());
+		    result.get_element(i, col),
+		    alpha * A.get_element(i, col) + beta * b[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -217,16 +252,18 @@ void check_SGMatrix_add_col_vec_in_place()
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
-		b[i] = 3*i;
+		b[i] = 3 * i;
 
 	add_col_vec(A, col, b, A, alpha, beta);
 
 	for (index_t i = 0; i < nrows; ++i)
 		for (index_t j = 0; j < ncols; ++j)
 		{
-			ST a = i+j*nrows;
+			ST a = i + j * nrows;
 			if (j == col)
-				EXPECT_NEAR(A.get_element(i, j), alpha*a+beta*b[i], get_epsilon<ST>());
+				EXPECT_NEAR(
+				    A.get_element(i, j), alpha * a + beta * b[i],
+				    get_epsilon<ST>());
 			else
 				EXPECT_EQ(A.get_element(i,j), a);
 		}
@@ -363,12 +400,8 @@ template <typename ST>
 void check_SGMatrix_center_matrix()
 {
 	const index_t n = 3;
-	ST data[] = {0.5, 0.3, 0.4,
-				 0.4, 0.5, 0.3,
-				 0.3, 0.4, 0.5};
-	ST result[] = {0.1, -0.1, 0.0,
-				   0.0, 0.1, -0.1,
-				   -0.1, 0.0, 0.1};
+	ST data[] = {0.5, 0.3, 0.4, 0.4, 0.5, 0.3, 0.3, 0.4, 0.5};
+	ST result[] = {0.1, -0.1, 0.0, 0.0, 0.1, -0.1, -0.1, 0.0, 0.1};
 
 	SGMatrix<ST> m(data, n, n, false);
 
@@ -394,11 +427,9 @@ void check_SGMatrix_cholesky_llt_lower()
 	//lower triangular cholesky decomposition
 	SGMatrix<ST> L = cholesky_factor(m);
 
-
-	Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
-	Map<Mxx> map_L(L.matrix,L.num_rows,L.num_cols);
-	EXPECT_NEAR((map_A-map_L*map_L.transpose()).norm(),
-		0.0, 1E-6);
+	Map<Mxx> map_A(m.matrix, m.num_rows, m.num_cols);
+	Map<Mxx> map_L(L.matrix, L.num_rows, L.num_cols);
+	EXPECT_NEAR((map_A - map_L * map_L.transpose()).norm(), 0.0, 1E-6);
 	EXPECT_EQ(m.num_rows, L.num_rows);
 	EXPECT_EQ(m.num_cols, L.num_cols);
 }
@@ -417,12 +448,11 @@ void check_SGMatrix_cholesky_llt_upper()
 	m(1,1)=2.5;
 
 	//upper triangular cholesky decomposition
-	SGMatrix<ST> U = cholesky_factor(m,false);
+	SGMatrix<ST> U = cholesky_factor(m, false);
 
-	Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
-	Map<Mxx> map_U(U.matrix,U.num_rows,U.num_cols);
-	EXPECT_NEAR((map_A-map_U.transpose()*map_U).norm(),
-	0.0, 1E-6);
+	Map<Mxx> map_A(m.matrix, m.num_rows, m.num_cols);
+	Map<Mxx> map_U(U.matrix, U.num_rows, U.num_cols);
+	EXPECT_NEAR((map_A - map_U.transpose() * map_U).norm(), 0.0, 1E-6);
 	EXPECT_EQ(m.num_rows, U.num_rows);
 	EXPECT_EQ(m.num_cols, U.num_cols);
 }
@@ -457,10 +487,12 @@ void check_SGMatrix_cholesky_rank_update_upper()
 	A2(1, 1) += b[1] * b[1];
 
 	cholesky_rank_update(U, b, alpha, false);
-	EXPECT_NEAR((A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(
+	    (A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
 
 	cholesky_rank_update(U, b, -alpha, false);
-	EXPECT_NEAR((A_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(
+	    (A_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -493,10 +525,12 @@ void check_SGMatrix_cholesky_rank_update_lower()
 	A2(1, 1) += b[1] * b[1];
 
 	cholesky_rank_update(L, b, alpha);
-	EXPECT_NEAR((A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(
+	    (A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
 
 	cholesky_rank_update(L, b, -alpha);
-	EXPECT_NEAR((A_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(
+	    (A_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -632,8 +666,7 @@ void check_SGMatrix_pinv_psd()
 {
 	ST A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
 	// inverse generated by scipy pinv
-	ST scipy_result_data[] = {0.75, 0.5,  0.25, 0.5, 1.0,
-									 0.5,  0.25, 0.5,  0.75};
+	ST scipy_result_data[] = {0.75, 0.5, 0.25, 0.5, 1.0, 0.5, 0.25, 0.5, 0.75};
 
 	SGMatrix<ST> A(A_data, 3, 3, false);
 	SGMatrix<ST> result(scipy_result_data, 3, 3, false);
@@ -651,7 +684,8 @@ void check_SGMatrix_pinv_psd()
 	{
 		for (auto j : range(3))
 		{
-			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
 			EXPECT_NEAR(result(i, j), A_pinvh(i, j), get_epsilon<ST>());
 			EXPECT_NEAR(result(i, j), A_pinv(i, j), get_epsilon<ST>());
 		}
@@ -682,7 +716,8 @@ void check_SGMatrix_pinv_2x4()
 	{
 		for (auto j : range(2))
 		{
-			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
 		}
 	}
 
@@ -725,7 +760,8 @@ void check_SGMatrix_pinv_4x2()
 	{
 		for (auto j : range(2))
 		{
-		EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
 		}
 	}
 	// compare with results from scipy
@@ -758,16 +794,15 @@ void check_eigensolver()
 {
 	const index_t n = 4;
 	ST data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
-				 0.62323516, 0.16837367, 0.85027625, 0.60165948,
-				 0.04898732, 0.96701123, 0.51683275, 0.51116495,
-				 0.18277926, 0.6179262,  0.43745891, 0.63685464};
+	             0.62323516, 0.16837367, 0.85027625, 0.60165948,
+	             0.04898732, 0.96701123, 0.51683275, 0.51116495,
+	             0.18277926, 0.6179262,  0.43745891, 0.63685464};
 	ST result_eigenvectors[] = {
-			-0.63494074, 0.75831593,  -0.1401403109, 0.04656076,
-			 0.82257205,  -0.286718557, -0.44196422, -0.214091861,
-			-0.005932,   -0.20233723, -0.52285555, 0.82803776,
-			-0.23930111, -0.56199714, -0.57298901, -0.54642272};
-	ST result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101,
-							   2.0981937};
+	    -0.63494074, 0.75831593,   -0.1401403109, 0.04656076,
+	    0.82257205,  -0.286718557, -0.44196422,   -0.214091861,
+	    -0.005932,   -0.20233723,  -0.52285555,   0.82803776,
+	    -0.23930111, -0.56199714,  -0.57298901,   -0.54642272};
+	ST result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101, 2.0981937};
 
 	SGMatrix<ST> m(data, n, n, false);
 	SGMatrix<ST> eigenvectors(n, n);
@@ -782,11 +817,11 @@ void check_eigensolver()
 		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
 
 		auto s =
-				CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
+		    CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
 		for (index_t j = 0; j < n; ++j)
 			EXPECT_NEAR(
-					eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-					1e-6);
+			    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
+			    1e-6);
 	}
 }
 
@@ -795,16 +830,16 @@ void check_eigensolver_symmetric()
 {
 	const index_t n = 4;
 	ST data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
-						0.80575314, 0.16837367, 0.96701123, 0.6179262,
-						0.04898732, 0.96701123, 0.51683275, 0.43745891,
-						0.69989667, 0.6179262,  0.43745891, 0.63685464};
+	             0.80575314, 0.16837367, 0.96701123, 0.6179262,
+	             0.04898732, 0.96701123, 0.51683275, 0.43745891,
+	             0.69989667, 0.6179262,  0.43745891, 0.63685464};
 	ST result_eigenvectors[] = {
-			-0.54618542, 0.69935447,  -0.45219663, 0.09001671,
-			-0.56171388, -0.41397154, 0.17642953,  0.69424612,
-			-0.46818396, 0.16780603,  0.73247599,  -0.46489119,
-			0.40861077,  0.55800718,  0.47735703,  0.542029037};
+	    -0.54618542, 0.69935447,  -0.45219663, 0.09001671,
+	    -0.56171388, -0.41397154, 0.17642953,  0.69424612,
+	    -0.46818396, 0.16780603,  0.73247599,  -0.46489119,
+	    0.40861077,  0.55800718,  0.47735703,  0.542029037};
 	ST result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
-							   2.18587989};
+	                           2.18587989};
 
 	SGMatrix<ST> m(data, n, n, false);
 	SGMatrix<ST> eigenvectors(n, n);
@@ -819,11 +854,11 @@ void check_eigensolver_symmetric()
 		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
 
 		auto s =
-				CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
+		    CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
 		for (index_t j = 0; j < n; ++j)
 			EXPECT_NEAR(
-					eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-					1e-6);
+			    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
+			    1e-6);
 	}
 }
 
@@ -837,7 +872,7 @@ void check_SGMatrix_elementwise_product()
 	for (auto i : range(m * m))
 	{
 		A[i] = i;
-		B[i] = 2*i;
+		B[i] = 2 * i;
 	}
 
 	auto result = element_prod(A, B);
@@ -876,7 +911,7 @@ void check_SGMatrix_elementwise_product_in_place()
 	for (auto i : range(m * m))
 	{
 		A[i] = i;
-		B[i] = 2*i;
+		B[i] = 2 * i;
 	}
 
 	element_prod(A, B, result);
@@ -906,8 +941,8 @@ void check_SGMatrix_block_elementwise_product()
 	const index_t nrows = 2;
 	const index_t ncols = 3;
 
-	SGMatrix<ST> A(nrows,ncols);
-	SGMatrix<ST> B(ncols,nrows);
+	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<ST> B(ncols, nrows);
 
 	for (auto i : range(nrows))
 		for (auto j : range(ncols))
@@ -1045,8 +1080,8 @@ void check_SGMatrix_identity()
 template <typename ST>
 void check_logistic()
 {
-	SGMatrix<ST> A(3,3);
-	SGMatrix<ST> B(3,3);
+	SGMatrix<ST> A(3, 3);
+	SGMatrix<ST> B(3, 3);
 
 	for (index_t i = 0; i < 9; ++i)
 		A[i] = i;
@@ -1071,7 +1106,7 @@ void check_SGMatrix_SGVector_matrix_prod()
 	{
 		for (index_t j = 0; j < rows; ++j)
 			A(j, i) = i * rows + j;
-		b[i]= 2 * i;
+		b[i] = 2 * i;
 	}
 
 	auto x = matrix_prod(A, b);
@@ -1288,13 +1323,11 @@ void check_SGMatrix_matrix_product_in_place_transpose_A()
 
 	ST ref[] = {5, 14, 14, 50, 23, 86};
 
-
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
 	for (index_t i = 0; i < dim1*dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
-
 
 template <typename ST>
 void check_SGMatrix_matrix_product_in_place_transpose_B()
@@ -1329,9 +1362,9 @@ void check_SGMatrix_matrix_product_in_place_transpose_A_B()
 	SGMatrix<ST> cal(dim1, dim3);
 
 	for (index_t i = 0; i < dim1*dim2; ++i)
-	A[i] = i;
+		A[i] = i;
 	for (index_t i = 0; i < dim2*dim3; ++i)
-	B[i] = i;
+		B[i] = i;
 	cal.zero();
 
 	linalg::matrix_prod(A, B, cal, true, true);
@@ -1402,7 +1435,7 @@ void check_SGMatrix_multiply_by_logistic_derivative()
 	SGMatrix<ST> A(3, 3);
 	SGMatrix<ST> B(3, 3);
 
-	for (ST i = 9; i < 9; i+=9)
+	for (ST i = 9; i < 9; i += 9)
 	{
 		A[i] = i / 9;
 		B[i] = i;
@@ -1455,9 +1488,8 @@ template <typename ST>
 void check_SGVector_qr_solver()
 {
 	const index_t n = 3;
-	ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
-				   0.30492837, 0.39708534, 0.40466969,
-				   0.36415317, 0.04407589, 0.9095746};
+	ST data_A[] = {0.02800922, 0.99326012, 0.15204902, 0.30492837, 0.39708534,
+	               0.40466969, 0.36415317, 0.04407589, 0.9095746};
 	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
 	ST result[] = {0.07135206, 1.56393127, -0.23141312};
 
@@ -1474,13 +1506,12 @@ template <typename ST>
 void check_SGMatrix_qr_solver()
 {
 	const index_t n = 3, m = 2;
-	ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
-				   0.30492837, 0.39708534, 0.40466969,
-				   0.36415317, 0.04407589, 0.9095746};
+	ST data_A[] = {0.02800922, 0.99326012, 0.15204902, 0.30492837, 0.39708534,
+	               0.40466969, 0.36415317, 0.04407589, 0.9095746};
 	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-				   0.94311546, 0.59630347, 0.65820143};
+	               0.94311546, 0.59630347, 0.65820143};
 	ST result[] = {-0.73834587, 4.22750496, -1.37484721,
-				   -1.14718091, 4.49142548, -1.08282992};
+	               -1.14718091, 4.49142548, -1.08282992};
 
 	SGMatrix<ST> A(data_A, n, n, false);
 	SGMatrix<ST> B(data_B, n, m, false);
@@ -1526,7 +1557,8 @@ void check_SGMatrix_rectified_linear()
 	linalg::rectified_linear(A, B);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(CMath::max(static_cast<ST>(0.0), A[i]), B[i], get_epsilon<ST>());
+		EXPECT_NEAR(
+		    CMath::max(static_cast<ST>(0.0), A[i]), B[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -1556,7 +1588,7 @@ void check_SGMatrix_scale()
 	auto result = scale(A, alpha);
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*A[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * A[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -1587,7 +1619,7 @@ void check_SGMatrix_scale_in_place()
 	scale(A, A, alpha);
 
 	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha*i, A[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * i, A[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -1615,7 +1647,6 @@ void check_SGMatrix_set_const()
 	for (index_t i = 0; i < nrows*ncols; ++i)
 		EXPECT_NEAR(a[i], value, get_epsilon<ST>());
 }
-
 
 template <typename ST>
 void check_SGMatrix_softmax()
@@ -1645,8 +1676,8 @@ void check_SGMatrix_softmax()
 		EXPECT_NEAR(ref[i], A[i], get_epsilon<ST>());
 }
 
-//template <typename ST>
-//void check_SGMatrix_squared_error()
+// template <typename ST>
+// void check_SGMatrix_squared_error()
 //{
 //    SGMatrix<ST> A(4, 3);
 //    SGMatrix<ST> B(4, 3);
@@ -1668,7 +1699,6 @@ void check_SGMatrix_softmax()
 //    auto result = linalg::squared_error(A, B);
 //        EXPECT_NEAR(ref, result, 1e-15);
 //}
-
 
 template <typename ST>
 void check_SGVector_sum()
@@ -1789,7 +1819,7 @@ void check_SGMatrix_symmetric_block_with_diag()
 			mat(j, i) = mat(i, j);
 		}
 
-	ST sum = sum_symmetric(linalg::block(mat,1,1,2,2));
+	ST sum = sum_symmetric(linalg::block(mat, 1, 1, 2, 2));
 	EXPECT_NEAR(sum, 28, get_epsilon<ST>());
 }
 
@@ -1807,7 +1837,7 @@ void check_SGMatrix_symmetric_block_no_diag()
 			mat(j, i) = mat(i, j);
 		}
 
-	ST sum = sum_symmetric(linalg::block(mat,1,1,2,2), true);
+	ST sum = sum_symmetric(linalg::block(mat, 1, 1, 2, 2), true);
 	EXPECT_NEAR(sum, 26, get_epsilon<ST>());
 }
 
@@ -1885,7 +1915,6 @@ void check_SGMatrix_block_colwise_sum()
 	}
 }
 
-
 template <typename ST>
 void check_SGMatrix_rowwise_sum()
 {
@@ -1946,15 +1975,14 @@ template <typename ST>
 void check_SGMatrix_svd_jacobi_thinU()
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-				 0.28540373, 0.06264684, 0.56204061};
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
+	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
+	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
 	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
 	ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-					 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-					 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-					 -0.12681555, -0.53830325, 0.69323293};
+	                 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+	                 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+	                 -0.12681555, -0.53830325, 0.69323293};
 
 	SGMatrix<ST> A(data, m, n, false);
 	SGMatrix<ST> U(m, n);
@@ -1976,17 +2004,16 @@ template <typename ST>
 void check_SGMatrix_svd_jacobi_fullU()
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-				 0.28540373, 0.06264684, 0.56204061};
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
+	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
+	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
 	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
 	ST result_U[] = {
-			-0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
-			-0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
-			-0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
-			-0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
-			0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
+	    -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
+	    -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
+	    -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
+	    -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
+	    0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
 	SGMatrix<ST> A(data, m, n, false);
 	SGMatrix<ST> U(m, m);
@@ -2009,15 +2036,14 @@ template <typename ST>
 void check_SGMatrix_svd_bdc_thinU()
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-				 0.28540373, 0.06264684, 0.56204061};
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
+	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
+	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
 	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
 	ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-					 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-					 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-					 -0.12681555, -0.53830325, 0.69323293};
+	                 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+	                 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+	                 -0.12681555, -0.53830325, 0.69323293};
 
 	SGMatrix<ST> A(data, m, n, false);
 	SGMatrix<ST> U(m, n);
@@ -2039,17 +2065,16 @@ template <typename ST>
 void check_SGMatrix_svd_bdc_fullU()
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-				 0.28540373, 0.06264684, 0.56204061};
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
+	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
+	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
 	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
 	ST result_U[] = {
-			-0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
-			-0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
-			-0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
-			-0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
-			0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
+	    -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
+	    -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
+	    -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
+	    -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
+	    0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
 	SGMatrix<ST> A(data, m, n, false);
 	SGMatrix<ST> U(m, m);
@@ -2089,7 +2114,8 @@ void check_SGMatrix_trace_dot()
 {
 	const index_t n = 2;
 	SGMatrix<ST> A(n, n), B(n, n);
-	for (index_t i = 0; i < n*n; ++i) {
+	for (index_t i = 0; i < n * n; ++i)
+	{
 		A[i] = i;
 		B[i] = i * 2;
 	}
@@ -2113,16 +2139,16 @@ void check_SGMatrix_transpose_matrix()
 
 	for (index_t i = 0; i < m; ++i)
 		for (index_t j = 0; j < n; ++j)
-			EXPECT_NEAR(A.get_element(i, j), T.get_element(j, i), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    A.get_element(i, j), T.get_element(j, i), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_triangular_solver_lower()
 {
 	const index_t n = 3;
-	ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
-				   0.,          -0.27048649, -0.05919915,
-				   0.,          0.,          0.11869106};
+	ST data_L[] = {-0.92947874, -1.1432887, -0.87119086, 0.,        -0.27048649,
+	               -0.05919915, 0.,         0.,          0.11869106};
 	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
 	ST result[] = {-0.42455592, -0.72571316, 0.17192745};
 
@@ -2140,8 +2166,8 @@ void check_SGVector_triangular_solver_upper()
 {
 	const index_t n = 3;
 	ST data_U[] = {-0.92947874, 0.,          0.,
-				   -1.1432887,  -0.27048649, 0.,
-				   -0.87119086, -0.05919915, 0.11869106};
+	               -1.1432887,  -0.27048649, 0.,
+	               -0.87119086, -0.05919915, 0.11869106};
 	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
 	ST result[] = {0.23681135, -3.31909306, 3.65012412};
 
@@ -2158,13 +2184,12 @@ template <typename ST>
 void check_SGMatrix_triangular_solver_lower()
 {
 	const index_t n = 3, m = 2;
-	ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
-				   0.,          -0.27048649, -0.05919915,
-				   0.,          0.,          0.11869106};
+	ST data_L[] = {-0.92947874, -1.1432887, -0.87119086, 0.,        -0.27048649,
+	               -0.05919915, 0.,         0.,          0.11869106};
 	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-				   0.94311546, 0.59630347, 0.65820143};
+	               0.94311546, 0.59630347, 0.65820143};
 	ST result[] = {-0.82600139, 0.22050986, -3.02127745,
-				   -1.01467136, 2.08424024, -0.86262387};
+	               -1.01467136, 2.08424024, -0.86262387};
 
 	SGMatrix<ST> L(data_L, n, n, false);
 	SGMatrix<ST> B(data_B, n, m, false);
@@ -2172,7 +2197,7 @@ void check_SGMatrix_triangular_solver_lower()
 	auto X = triangular_solver(L, B, true);
 
 	for (index_t i = 0; i < (index_t)X.size(); ++i)
-	EXPECT_NEAR(X[i], result[i], 1e-6	);
+		EXPECT_NEAR(X[i], result[i], 1e-6);
 }
 
 template <typename ST>
@@ -2180,12 +2205,12 @@ void check_SGMatrix_triangular_solver_upper()
 {
 	const index_t n = 3, m = 2;
 	ST data_U[] = {-0.92947874, 0.,          0.,
-				   -1.1432887,  -0.27048649, 0.,
-				   -0.87119086, -0.05919915, 0.11869106};
+	               -1.1432887,  -0.27048649, 0.,
+	               -0.87119086, -0.05919915, 0.11869106};
 	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-				   0.94311546, 0.59630347, 0.65820143};
+	               0.94311546, 0.59630347, 0.65820143};
 	ST result[] = {1.238677,    -3.91243241, 2.9315793,
-				   -2.00784647, -3.41825732, 5.54550138};
+	               -2.00784647, -3.41825732, 5.54550138};
 
 	SGMatrix<ST> L(data_U, n, n, false);
 	SGMatrix<ST> B(data_B, n, m, false);
@@ -2193,9 +2218,8 @@ void check_SGMatrix_triangular_solver_upper()
 	auto X = triangular_solver(L, B, false);
 
 	for (index_t i = 0; i < (index_t)X.size(); ++i)
-	EXPECT_NEAR(X[i], result[i], 1e-6);
+		EXPECT_NEAR(X[i], result[i], 1e-6);
 }
-
 
 template <typename ST>
 void check_SGVector_zero()
@@ -2251,7 +2275,6 @@ void check_SGMatrix_rank_update()
 	rank_update(A, b, static_cast<ST>(-1));
 	EXPECT_NEAR((A_eig - A_eig).norm(), 0, get_epsilon<ST>());
 }
-
 
 // test types based on shogun/mathematics/linalg/LinalgBackendBase.h
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
@@ -2399,7 +2422,8 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product)
 	check_SGMatrix_elementwise_product<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product_in_place)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product_in_place)
 {
 	check_SGMatrix_elementwise_product_in_place<TypeParam>();
 }
@@ -2414,7 +2438,8 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product)
 	check_SGVector_elementwise_product<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product_in_place)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGVector_elementwise_product_in_place)
 {
 	check_SGVector_elementwise_product_in_place<TypeParam>();
 }
@@ -2452,12 +2477,15 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_matrix_prod_transpose)
 	check_SGVector_matrix_prod_transpose<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place)
 {
 	check_SGMatrix_SGVector_matrix_prod_in_place<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place_transpose)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_SGVector_matrix_prod_in_place_transpose)
 {
 	check_SGMatrix_SGVector_matrix_prod_in_place_transpose<TypeParam>();
 }
@@ -2477,8 +2505,8 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_B)
 	check_SGMatrix_matrix_product_transpose_B<TypeParam>();
 }
 
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A_B)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A_B)
 {
 	check_SGMatrix_matrix_product_transpose_A_B<TypeParam>();
 }
@@ -2488,17 +2516,23 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place)
 	check_SGMatrix_matrix_product_in_place<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_A)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_matrix_product_in_place_transpose_A)
 {
 	check_SGMatrix_matrix_product_in_place_transpose_A<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_B)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_matrix_product_in_place_transpose_B)
 {
 	check_SGMatrix_matrix_product_in_place_transpose_B<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_A_B)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_matrix_product_in_place_transpose_A_B)
 {
 	check_SGMatrix_matrix_product_in_place_transpose_A_B<TypeParam>();
 }
@@ -2523,13 +2557,16 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_mean)
 	check_SGMatrix_mean<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_multiply_by_logistic_derivative)
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_multiply_by_logistic_derivative)
 {
 	check_SGMatrix_multiply_by_logistic_derivative<TypeParam>();
 }
 
 // TODO: write test for int types
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_multiply_by_rectified_linear_derivative)
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest,
+    SGMatrix_multiply_by_rectified_linear_derivative)
 {
 	check_SGMatrix_multiply_by_rectified_linear_derivative<TypeParam>();
 }
@@ -2579,7 +2616,6 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale_in_place)
 	check_SGVector_scale_in_place<TypeParam>();
 }
 
-
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale_in_place)
 {
 	check_SGMatrix_scale_in_place<TypeParam>();
@@ -2602,7 +2638,7 @@ TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_softmax)
 }
 
 // FIXME: CMath::Pow only accepts float or complex types
-//TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_squared_error)
+// TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_squared_error)
 //{
 //    check_SGMatrix_squared_error<TypeParam>();
 //}
@@ -2697,7 +2733,6 @@ TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_fullU)
 	check_SGMatrix_svd_jacobi_fullU<TypeParam>();
 }
 
-
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_thinU)
 {
@@ -2725,22 +2760,26 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_transpose_matrix)
 	check_SGMatrix_transpose_matrix<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_lower)
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_lower)
 {
 	check_SGVector_triangular_solver_lower<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_upper)
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_upper)
 {
 	check_SGVector_triangular_solver_upper<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_lower)
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_lower)
 {
 	check_SGMatrix_triangular_solver_lower<TypeParam>();
 }
 
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_upper)
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_upper)
 {
 	check_SGMatrix_triangular_solver_upper<TypeParam>();
 }
@@ -2777,7 +2816,7 @@ TEST(LinalgBackendEigen, SGMatrix_squared_error)
 	float64_t ref = 0;
 	for (index_t i = 0; i < size; i++)
 		ref += CMath::pow(A[i] - B[i], 2);
-			ref *= 0.5;
+	ref *= 0.5;
 
 	auto result = linalg::squared_error(A, B);
 	EXPECT_NEAR(ref, result, 1e-15);

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -49,133 +49,133 @@ TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, NonIntegerTypes);
 template <typename ST>
 void check_SGVector_add() {
 
-    const ST alpha = 1;
-    const ST beta = 2;
+	const ST alpha = 1;
+	const ST beta = 2;
 
-    SGVector<ST> A(9);
-    SGVector<ST> B(9);
+	SGVector<ST> A(9);
+	SGVector<ST> B(9);
 
-    for (index_t i = 0; i < 9; ++i)
-    {
-        A[i] = i;
-        B[i] = 2*i;
-    }
+	for (index_t i = 0; i < 9; ++i)
+	{
+		A[i] = i;
+		B[i] = 2*i;
+	}
 
-    auto result = add(A, B, alpha, beta);
+	auto result = add(A, B, alpha, beta);
 
-    for (index_t i = 0; i < 9; ++i)
-        EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_add() {
 
-    const ST alpha = 1;
-    const ST beta = 2;
-    const index_t nrows = 2, ncols = 3;
+	const ST alpha = 1;
+	const ST beta = 2;
+	const index_t nrows = 2, ncols = 3;
 
-    SGMatrix<ST> A(nrows, ncols);
-    SGMatrix<ST> B(nrows, ncols);
+	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<ST> B(nrows, ncols);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-    {
-        A[i] = i;
-        B[i] = 2*i;
-    }
+	for (index_t i = 0; i < nrows*ncols; ++i)
+	{
+		A[i] = i;
+		B[i] = 2*i;
+	}
 
-    auto result = add(A, B, alpha, beta);
+	auto result = add(A, B, alpha, beta);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], 1e-15);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(alpha*A[i]+beta*B[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_add_in_place() {
-    const ST alpha = 1;
-    const ST beta = 2;
+	const ST alpha = 1;
+	const ST beta = 2;
 
-    SGVector<ST> A(9), B(9), C(9);
+	SGVector<ST> A(9), B(9), C(9);
 
-    for (index_t i = 0; i < 9; ++i)
-    {
-    A[i] = i;
-    B[i] = 2*i;
-    C[i] = i;
-    }
+	for (index_t i = 0; i < 9; ++i)
+	{
+	A[i] = i;
+	B[i] = 2*i;
+	C[i] = i;
+	}
 
-    add(A, B, A, alpha, beta);
+	add(A, B, A, alpha, beta);
 
-    for (index_t i = 0; i < 9; ++i)
-    EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_add_in_place() {
 
-    const ST alpha = 1;
-    const ST beta = 2;
-    const index_t nrows = 2, ncols = 3;
+	const ST alpha = 1;
+	const ST beta = 2;
+	const index_t nrows = 2, ncols = 3;
 
-    SGMatrix<ST> A(nrows, ncols);
-    SGMatrix<ST> B(nrows, ncols);
-    SGMatrix<ST> C(nrows, ncols);
+	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<ST> B(nrows, ncols);
+	SGMatrix<ST> C(nrows, ncols);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-    {
-        A[i] = i;
-        B[i] = 3*i;
-        C[i] = i;
-    }
+	for (index_t i = 0; i < nrows*ncols; ++i)
+	{
+		A[i] = i;
+		B[i] = 3*i;
+		C[i] = i;
+	}
 
-    add(A, B, A, alpha, beta);
+	add(A, B, A, alpha, beta);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], 1e-15);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(alpha*C[i]+beta*B[i], A[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_add_col_vec_allocated() {
 
-    const ST alpha = 1;
-    const ST beta = 2;
-    const index_t nrows = 2, ncols = 3;
-    const index_t col = 1;
+	const ST alpha = 1;
+	const ST beta = 2;
+	const index_t nrows = 2, ncols = 3;
+	const index_t col = 1;
 
-    SGMatrix<ST> A(nrows, ncols);
-    SGVector<ST> b(nrows);
-    SGVector<ST> result(nrows);
+	SGMatrix<ST> A(nrows, ncols);
+	SGVector<ST> b(nrows);
+	SGVector<ST> result(nrows);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < nrows; ++i)
-        b[i] = 3 * i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 3 * i;
 
-    add_col_vec(A, col, b, result, alpha, beta);
+	add_col_vec(A, col, b, result, alpha, beta);
 
-    for (index_t i = 0; i < nrows; ++i)
-        EXPECT_NEAR(result[i], alpha * A.get_element(i, col) + beta * b[i], 1e-15);
+	for (index_t i = 0; i < nrows; ++i)
+		EXPECT_NEAR(result[i], alpha * A.get_element(i, col) + beta * b[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_add_col_vec_in_place()
 {
-    const ST alpha = 0;
-    const ST beta = 3;
-    const index_t nrows = 2, ncols = 3;
-    const index_t col = 1;
+	const ST alpha = 0;
+	const ST beta = 3;
+	const index_t nrows = 2, ncols = 3;
+	const index_t col = 1;
 
-    SGMatrix<ST> A(nrows, ncols);
-    SGVector<ST> b(nrows);
+	SGMatrix<ST> A(nrows, ncols);
+	SGVector<ST> b(nrows);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < nrows; ++i)
-        b[i] = 2*i;
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < nrows; ++i)
+		b[i] = 2*i;
 
-    add_col_vec(A, col, b, b, alpha, beta);
+	add_col_vec(A, col, b, b, alpha, beta);
 
-    for (index_t i = 0; i < nrows; ++i)
-        EXPECT_NEAR(b[i], alpha*A.get_element(i, col)+beta*2*i, 1e-15);
+	for (index_t i = 0; i < nrows; ++i)
+		EXPECT_NEAR(b[i], alpha*A.get_element(i, col)+beta*2*i, get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -199,8 +199,8 @@ void check_SGMatrix_add_col_vec_allocated()
 
 	for (index_t i = 0; i < nrows; ++i)
 		EXPECT_NEAR(
-		    result.get_element(i, col),
-		    alpha * A.get_element(i, col) + beta * b[i], 1e-15);
+			result.get_element(i, col),
+			alpha * A.get_element(i, col) + beta * b[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -226,7 +226,7 @@ void check_SGMatrix_add_col_vec_in_place()
 		{
 			ST a = i+j*nrows;
 			if (j == col)
-				EXPECT_NEAR(A.get_element(i, j), alpha*a+beta*b[i], 1e-15);
+				EXPECT_NEAR(A.get_element(i, j), alpha*a+beta*b[i], get_epsilon<ST>());
 			else
 				EXPECT_EQ(A.get_element(i,j), a);
 		}
@@ -322,7 +322,7 @@ void check_add_vector()
 	add_vector(A, b, A, alpha, beta);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
-		EXPECT_NEAR(A[i], result[i], 1e-15);
+		EXPECT_NEAR(A[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -339,7 +339,7 @@ void check_SGVector_add_scalar()
 	add_scalar(a, s);
 
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
-		EXPECT_NEAR(a[i], orig[i] + s, 1e-15);
+		EXPECT_NEAR(a[i], orig[i] + s, get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -356,7 +356,7 @@ void check_SGMatrix_add_scalar()
 	add_scalar(a, s);
 
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
-		EXPECT_NEAR(a[i], orig[i] + s, 1e-15);
+		EXPECT_NEAR(a[i], orig[i] + s, get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -364,18 +364,18 @@ void check_SGMatrix_center_matrix()
 {
 	const index_t n = 3;
 	ST data[] = {0.5, 0.3, 0.4,
-	             0.4, 0.5, 0.3,
-	             0.3, 0.4, 0.5};
+				 0.4, 0.5, 0.3,
+				 0.3, 0.4, 0.5};
 	ST result[] = {0.1, -0.1, 0.0,
-	               0.0, 0.1, -0.1,
-	               -0.1, 0.0, 0.1};
+				   0.0, 0.1, -0.1,
+				   -0.1, 0.0, 0.1};
 
 	SGMatrix<ST> m(data, n, n, false);
 
 	center_matrix(m);
 
 	for (index_t i = 0; i < (index_t)m.size(); ++i)
-		EXPECT_NEAR(m[i], result[i], 1e-7);
+		EXPECT_NEAR(m[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
@@ -383,7 +383,8 @@ void check_SGMatrix_cholesky_llt_lower()
 {
 	const index_t size=2;
 	SGMatrix<ST> m(size, size);
-	typedef Matrix<ST, Dynamic, Dynamic> Mxx; // need to adapt the Eigen::Matrix to ST type
+	// need to adapt the Eigen::Matrix to ST type
+	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
 
 	m(0,0)=2.0;
 	m(0,1)=1.0;
@@ -397,7 +398,7 @@ void check_SGMatrix_cholesky_llt_lower()
 	Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
 	Map<Mxx> map_L(L.matrix,L.num_rows,L.num_cols);
 	EXPECT_NEAR((map_A-map_L*map_L.transpose()).norm(),
-		0.0, 1E-6); // need to change the treshold to work with floats
+		0.0, 1E-6);
 	EXPECT_EQ(m.num_rows, L.num_rows);
 	EXPECT_EQ(m.num_cols, L.num_cols);
 }
@@ -405,1243 +406,1243 @@ void check_SGMatrix_cholesky_llt_lower()
 template <typename ST>
 void check_SGMatrix_cholesky_llt_upper()
 {
-    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
 
-    const index_t size=2;
-    SGMatrix<ST> m(size, size);
+	const index_t size=2;
+	SGMatrix<ST> m(size, size);
 
-    m(0,0)=2.0;
-    m(0,1)=1.0;
-    m(1,0)=1.0;
-    m(1,1)=2.5;
+	m(0,0)=2.0;
+	m(0,1)=1.0;
+	m(1,0)=1.0;
+	m(1,1)=2.5;
 
-    //upper triangular cholesky decomposition
-    SGMatrix<ST> U = cholesky_factor(m,false);
+	//upper triangular cholesky decomposition
+	SGMatrix<ST> U = cholesky_factor(m,false);
 
-    Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
-    Map<Mxx> map_U(U.matrix,U.num_rows,U.num_cols);
-    EXPECT_NEAR((map_A-map_U.transpose()*map_U).norm(),
-    0.0, 1E-6); // need to change the treshold to work with floats
-    EXPECT_EQ(m.num_rows, U.num_rows);
-    EXPECT_EQ(m.num_cols, U.num_cols);
+	Map<Mxx> map_A(m.matrix,m.num_rows,m.num_cols);
+	Map<Mxx> map_U(U.matrix,U.num_rows,U.num_cols);
+	EXPECT_NEAR((map_A-map_U.transpose()*map_U).norm(),
+	0.0, 1E-6);
+	EXPECT_EQ(m.num_rows, U.num_rows);
+	EXPECT_EQ(m.num_cols, U.num_cols);
 }
 
 template <typename ST>
 void check_SGMatrix_cholesky_rank_update_upper()
 {
-    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
-    typedef Matrix<ST, Dynamic, 1> Vx;
+	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+	typedef Matrix<ST, Dynamic, 1> Vx;
 
-    const index_t size = 2;
-    ST alpha = 1;
-    SGMatrix<ST> A(size, size);
-    SGMatrix<ST> U(size, size);
-    SGVector<ST> b(size);
-    Map<Mxx> A_eig(A.matrix, size, size);
-    Map<Mxx> U_eig(U.matrix, size, size);
-    Map<Vx> b_eig(b.vector, size);
+	const index_t size = 2;
+	ST alpha = 1;
+	SGMatrix<ST> A(size, size);
+	SGMatrix<ST> U(size, size);
+	SGVector<ST> b(size);
+	Map<Mxx> A_eig(A.matrix, size, size);
+	Map<Mxx> U_eig(U.matrix, size, size);
+	Map<Vx> b_eig(b.vector, size);
 
-    U(0, 0) = 2.0;
-    U(0, 1) = 1.0;
-    U(1, 1) = 2.5;
-    b[0] = 2;
-    b[1] = 3;
-    A_eig = U_eig.transpose() * U_eig;
+	U(0, 0) = 2.0;
+	U(0, 1) = 1.0;
+	U(1, 1) = 2.5;
+	b[0] = 2;
+	b[1] = 3;
+	A_eig = U_eig.transpose() * U_eig;
 
-    auto A2 = A.clone();
-    Map<Mxx> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
-    A2(0, 0) += b[0] * b[0];
-    A2(0, 1) += b[0] * b[1];
-    A2(1, 0) += b[1] * b[0];
-    A2(1, 1) += b[1] * b[1];
+	auto A2 = A.clone();
+	Map<Mxx> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
+	A2(0, 0) += b[0] * b[0];
+	A2(0, 1) += b[0] * b[1];
+	A2(1, 0) += b[1] * b[0];
+	A2(1, 1) += b[1] * b[1];
 
-    cholesky_rank_update(U, b, alpha, false);
-    EXPECT_NEAR((A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, 1e-5);  // need to change the treshold to work with floats
+	cholesky_rank_update(U, b, alpha, false);
+	EXPECT_NEAR((A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
 
-    cholesky_rank_update(U, b, -alpha, false);
-    EXPECT_NEAR((A_eig - U_eig.transpose() * U_eig).norm(), 0.0, 1e-5);  // need to change the treshold to work with floats
+	cholesky_rank_update(U, b, -alpha, false);
+	EXPECT_NEAR((A_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_cholesky_rank_update_lower()
 {
-    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
-    typedef Matrix<ST, Dynamic, 1> Vx;
+	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+	typedef Matrix<ST, Dynamic, 1> Vx;
 
-    const index_t size = 2;
-    ST alpha = 1;
-    SGMatrix<ST> A(size, size);
-    SGMatrix<ST> L(size, size);
-    SGVector<ST> b(size);
-    Map<Mxx> A_eig(A.matrix, size, size);
-    Map<Mxx> L_eig(L.matrix, size, size);
-    Map<Vx> b_eig(b.vector, size);
+	const index_t size = 2;
+	ST alpha = 1;
+	SGMatrix<ST> A(size, size);
+	SGMatrix<ST> L(size, size);
+	SGVector<ST> b(size);
+	Map<Mxx> A_eig(A.matrix, size, size);
+	Map<Mxx> L_eig(L.matrix, size, size);
+	Map<Vx> b_eig(b.vector, size);
 
-    L(0, 0) = 2.0;
-    L(1, 0) = 1.0;
-    L(1, 1) = 2.5;
-    b[0] = 2;
-    b[1] = 3;
-    A_eig = L_eig * L_eig.transpose();
+	L(0, 0) = 2.0;
+	L(1, 0) = 1.0;
+	L(1, 1) = 2.5;
+	b[0] = 2;
+	b[1] = 3;
+	A_eig = L_eig * L_eig.transpose();
 
-    auto A2 = A.clone();
-    Map<Mxx> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
-    A2(0, 0) += b[0] * b[0];
-    A2(0, 1) += b[0] * b[1];
-    A2(1, 0) += b[1] * b[0];
-    A2(1, 1) += b[1] * b[1];
+	auto A2 = A.clone();
+	Map<Mxx> A2_eig(A2.matrix, A2.num_rows, A2.num_cols);
+	A2(0, 0) += b[0] * b[0];
+	A2(0, 1) += b[0] * b[1];
+	A2(1, 0) += b[1] * b[0];
+	A2(1, 1) += b[1] * b[1];
 
-    cholesky_rank_update(L, b, alpha);
-    EXPECT_NEAR((A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, 1e-5);
+	cholesky_rank_update(L, b, alpha);
+	EXPECT_NEAR((A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
 
-    cholesky_rank_update(L, b, -alpha);
-    EXPECT_NEAR((A_eig - L_eig * L_eig.transpose()).norm(), 0.0, 1e-5);
+	cholesky_rank_update(L, b, -alpha);
+	EXPECT_NEAR((A_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_cholesky_ldlt_lower()
 {
-    const index_t size = 3;
-    SGMatrix<ST> m(size, size);
-    m(0, 0) = 0.0;
-    m(0, 1) = 0.0;
-    m(0, 2) = 0.0;
-    m(1, 0) = 0.0;
-    m(1, 1) = 1.0;
-    m(1, 2) = 2.0;
-    m(2, 0) = 0.0;
-    m(2, 1) = 2.0;
-    m(2, 2) = 3.0;
+	const index_t size = 3;
+	SGMatrix<ST> m(size, size);
+	m(0, 0) = 0.0;
+	m(0, 1) = 0.0;
+	m(0, 2) = 0.0;
+	m(1, 0) = 0.0;
+	m(1, 1) = 1.0;
+	m(1, 2) = 2.0;
+	m(2, 0) = 0.0;
+	m(2, 1) = 2.0;
+	m(2, 2) = 3.0;
 
-    SGMatrix<ST> L(size, size);
-    SGVector<ST> d(size);
-    SGVector<index_t> p(size);
+	SGMatrix<ST> L(size, size);
+	SGVector<ST> d(size);
+	SGVector<index_t> p(size);
 
-    linalg::ldlt_factor(m, L, d, p);
+	linalg::ldlt_factor(m, L, d, p);
 
-    EXPECT_NEAR(d[0], 3.0, 1e-15);
-    EXPECT_NEAR(d[1], -0.333333333333333, 1e-7);
-    EXPECT_NEAR(d[2], 0.0, 1e-15);
+	EXPECT_NEAR(d[0], 3.0, get_epsilon<ST>());
+	EXPECT_NEAR(d[1], -0.333333333333333, get_epsilon<ST>());
+	EXPECT_NEAR(d[2], 0.0, get_epsilon<ST>());
 
-    EXPECT_NEAR(L(0, 0), 1.0, 1e-15);
-    EXPECT_NEAR(L(0, 1), 0.0, 1e-15);
-    EXPECT_NEAR(L(0, 2), 0.0, 1e-15);
-    EXPECT_NEAR(L(1, 0), 0.666666666666666, 1e-7);
-    EXPECT_NEAR(L(1, 1), 1.0, 1e-15);
-    EXPECT_NEAR(L(1, 2), 0.0, 1e-15);
-    EXPECT_NEAR(L(2, 0), 0.0, 1e-15);
-    EXPECT_NEAR(L(2, 1), 0.0, 1e-15);
-    EXPECT_NEAR(L(2, 2), 1.0, 1e-15);
+	EXPECT_NEAR(L(0, 0), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(0, 1), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(0, 2), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(1, 0), 0.666666666666666, get_epsilon<ST>());
+	EXPECT_NEAR(L(1, 1), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(1, 2), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(2, 0), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(2, 1), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(2, 2), 1.0, get_epsilon<ST>());
 
-    EXPECT_EQ(p[0], 2);
-    EXPECT_EQ(p[1], 1);
-    EXPECT_EQ(p[2], 2);
+	EXPECT_EQ(p[0], 2);
+	EXPECT_EQ(p[1], 1);
+	EXPECT_EQ(p[2], 2);
 }
 
 template <typename ST>
 void check_SGMatrix_cholesky_solver()
 {
-    const index_t size=2;
-    SGMatrix<ST> A(size, size);
-    A(0,0)=2.0;
-    A(0,1)=1.0;
-    A(1,0)=1.0;
-    A(1,1)=2.5;
+	const index_t size=2;
+	SGMatrix<ST> A(size, size);
+	A(0,0)=2.0;
+	A(0,1)=1.0;
+	A(1,0)=1.0;
+	A(1,1)=2.5;
 
-    SGVector<ST> b(size);
-    b[0] = 10;
-    b[1] = 13;
+	SGVector<ST> b(size);
+	b[0] = 10;
+	b[1] = 13;
 
-    SGVector<ST> x_ref(size);
-    x_ref[0] = 3;
-    x_ref[1] = 4;
+	SGVector<ST> x_ref(size);
+	x_ref[0] = 3;
+	x_ref[1] = 4;
 
-    SGMatrix<ST> L = cholesky_factor(A);
-    SGVector<ST> x_cal = cholesky_solver(L, b);
+	SGMatrix<ST> L = cholesky_factor(A);
+	SGVector<ST> x_cal = cholesky_solver(L, b);
 
-    EXPECT_NEAR(x_ref[0], x_cal[0], 1E-15);
-    EXPECT_NEAR(x_ref[1], x_cal[1], 1E-15);
-    EXPECT_EQ(x_ref.size(), x_cal.size());
+	EXPECT_NEAR(x_ref[0], x_cal[0], get_epsilon<ST>());
+	EXPECT_NEAR(x_ref[1], x_cal[1], get_epsilon<ST>());
+	EXPECT_EQ(x_ref.size(), x_cal.size());
 }
 
 template <typename ST>
 void check_SGMatrix_ldlt_solver()
 {
-    const index_t size = 3;
-    SGMatrix<ST> A(size, size);
-    A(0, 0) = 0.0;
-    A(0, 1) = 0.0;
-    A(0, 2) = 0.0;
-    A(1, 0) = 0.0;
-    A(1, 1) = 1.0;
-    A(1, 2) = 2.0;
-    A(2, 0) = 0.0;
-    A(2, 1) = 2.0;
-    A(2, 2) = 3.0;
+	const index_t size = 3;
+	SGMatrix<ST> A(size, size);
+	A(0, 0) = 0.0;
+	A(0, 1) = 0.0;
+	A(0, 2) = 0.0;
+	A(1, 0) = 0.0;
+	A(1, 1) = 1.0;
+	A(1, 2) = 2.0;
+	A(2, 0) = 0.0;
+	A(2, 1) = 2.0;
+	A(2, 2) = 3.0;
 
-    SGVector<ST> b(size);
-    b[0] = 0.0;
-    b[1] = 5.0;
-    b[2] = 11.0;
+	SGVector<ST> b(size);
+	b[0] = 0.0;
+	b[1] = 5.0;
+	b[2] = 11.0;
 
-    SGVector<ST> x_ref(size), x(size);
-    x_ref[0] = 0.0;
-    x_ref[1] = 7.0;
-    x_ref[2] = -1.0;
+	SGVector<ST> x_ref(size), x(size);
+	x_ref[0] = 0.0;
+	x_ref[1] = 7.0;
+	x_ref[2] = -1.0;
 
-    SGMatrix<ST> L(size, size);
-    SGVector<ST> d(size);
-    SGVector<index_t> p(size);
+	SGMatrix<ST> L(size, size);
+	SGVector<ST> d(size);
+	SGVector<index_t> p(size);
 
-    linalg::ldlt_factor(A, L, d, p, true);
-    x = linalg::ldlt_solver(L, d, p, b, true);
-    for (auto i : range(size))
-        EXPECT_NEAR(x[i], x_ref[i], 1e-6);
+	linalg::ldlt_factor(A, L, d, p, true);
+	x = linalg::ldlt_solver(L, d, p, b, true);
+	for (auto i : range(size))
+		EXPECT_NEAR(x[i], x_ref[i], get_epsilon<ST>());
 
-    linalg::ldlt_factor(A, L, d, p, false);
-    x = linalg::ldlt_solver(L, d, p, b, false);
-    for (auto i : range(size))
-        EXPECT_NEAR(x[i], x_ref[i], 1e-6);
+	linalg::ldlt_factor(A, L, d, p, false);
+	x = linalg::ldlt_solver(L, d, p, b, false);
+	for (auto i : range(size))
+		EXPECT_NEAR(x[i], x_ref[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_cross_entropy()
 {
-    SGMatrix<ST> A(4, 3);
-    SGMatrix<ST> B(4, 3);
+	SGMatrix<ST> A(4, 3);
+	SGMatrix<ST> B(4, 3);
 
-    uint32_t size = A.num_rows * A.num_cols;
-    for (ST i = 0; i < size; ++i)
-    {
-        A[i] = i / size;
-        B[i] = (i / size) * 0.5;
-    }
+	uint32_t size = A.num_rows * A.num_cols;
+	for (ST i = 0; i < size; ++i)
+	{
+		A[i] = i / size;
+		B[i] = (i / size) * 0.5;
+	}
 
-    float64_t ref = 0;
-    for (uint32_t i = 0; i < size; i++)
-        ref += A[i] * std::log(B[i] + 1e-30);
-    ref *= -1;
+	float64_t ref = 0;
+	for (uint32_t i = 0; i < size; i++)
+		ref += A[i] * std::log(B[i] + 1e-15);
+	ref *= -1;
 
-    auto result = linalg::cross_entropy(A, B);
-    EXPECT_NEAR(ref, result, 1e-6);
+	auto result = linalg::cross_entropy(A, B);
+	EXPECT_NEAR(ref, result, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_pinv_psd()
 {
-    ST A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
-    // inverse generated by scipy pinv
-    ST scipy_result_data[] = {0.75, 0.5,  0.25, 0.5, 1.0,
-                                     0.5,  0.25, 0.5,  0.75};
+	ST A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
+	// inverse generated by scipy pinv
+	ST scipy_result_data[] = {0.75, 0.5,  0.25, 0.5, 1.0,
+									 0.5,  0.25, 0.5,  0.75};
 
-    SGMatrix<ST> A(A_data, 3, 3, false);
-    SGMatrix<ST> result(scipy_result_data, 3, 3, false);
+	SGMatrix<ST> A(A_data, 3, 3, false);
+	SGMatrix<ST> result(scipy_result_data, 3, 3, false);
 
-    SGMatrix<ST> identity_matrix(3, 3);
-    linalg::identity(identity_matrix);
-    // using symmetric eigen solver
-    SGMatrix<ST> A_pinvh(3, 3);
-    linalg::pinvh(A, A_pinvh);
-    // using singular value decomposition
-    SGMatrix<ST> A_pinv(3, 3);
-    linalg::pinv(A, A_pinv);
-    SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinvh);
-    for (auto i : range(3))
-    {
-        for (auto j : range(3))
-        {
-            EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-6);
-            EXPECT_NEAR(result(i, j), A_pinvh(i, j), 1e-6);
-            EXPECT_NEAR(result(i, j), A_pinv(i, j), 1e-6);
-        }
-    }
-    // no memory errors
-    EXPECT_NO_THROW(linalg::pinvh(A, A));
+	SGMatrix<ST> identity_matrix(3, 3);
+	linalg::identity(identity_matrix);
+	// using symmetric eigen solver
+	SGMatrix<ST> A_pinvh(3, 3);
+	linalg::pinvh(A, A_pinvh);
+	// using singular value decomposition
+	SGMatrix<ST> A_pinv(3, 3);
+	linalg::pinv(A, A_pinv);
+	SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinvh);
+	for (auto i : range(3))
+	{
+		for (auto j : range(3))
+		{
+			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(result(i, j), A_pinvh(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(result(i, j), A_pinv(i, j), get_epsilon<ST>());
+		}
+	}
+	// no memory errors
+	EXPECT_NO_THROW(linalg::pinvh(A, A));
 }
 
 template <typename ST>
 void check_SGMatrix_pinv_2x4()
 {
-    SGMatrix<ST> A(2, 4);
-    A(0, 0) = 1;
-    A(0, 1) = 1;
-    A(0, 2) = 1;
-    A(0, 3) = 1;
-    A(1, 0) = 5;
-    A(1, 1) = 7;
-    A(1, 2) = 7;
-    A(1, 3) = 9;
+	SGMatrix<ST> A(2, 4);
+	A(0, 0) = 1;
+	A(0, 1) = 1;
+	A(0, 2) = 1;
+	A(0, 3) = 1;
+	A(1, 0) = 5;
+	A(1, 1) = 7;
+	A(1, 2) = 7;
+	A(1, 3) = 9;
 
-    SGMatrix<ST> identity_matrix(2, 2);
-    linalg::identity(identity_matrix);
-    SGMatrix<ST> A_pinverse(4, 2);
-    linalg::pinv(A, A_pinverse);
-    SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinverse);
-    for (auto i : range(2))
-    {
-        for (auto j : range(2))
-        {
-            EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-6);
-        }
-    }
+	SGMatrix<ST> identity_matrix(2, 2);
+	linalg::identity(identity_matrix);
+	SGMatrix<ST> A_pinverse(4, 2);
+	linalg::pinv(A, A_pinverse);
+	SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinverse);
+	for (auto i : range(2))
+	{
+		for (auto j : range(2))
+		{
+			EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+		}
+	}
 
-    // compare result with scipy pinv
-    EXPECT_NEAR(A_pinverse(0, 0), 2.0, 1e-6);
-    EXPECT_NEAR(A_pinverse(0, 1), -0.25, 1e-6);
+	// compare result with scipy pinv
+	EXPECT_NEAR(A_pinverse(0, 0), 2.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(0, 1), -0.25, get_epsilon<ST>());
 
-    EXPECT_NEAR(A_pinverse(1, 0), 0.25, 1e-6);
-    EXPECT_NEAR(A_pinverse(1, 1), 0.0, 1e-6);
+	EXPECT_NEAR(A_pinverse(1, 0), 0.25, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(1, 1), 0.0, get_epsilon<ST>());
 
-    EXPECT_NEAR(A_pinverse(2, 0), 0.25, 1e-6);
-    EXPECT_NEAR(A_pinverse(2, 1), 0.0, 1e-6);
+	EXPECT_NEAR(A_pinverse(2, 0), 0.25, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(2, 1), 0.0, get_epsilon<ST>());
 
-    EXPECT_NEAR(A_pinverse(3, 0), -1.5, 1e-6);
-    EXPECT_NEAR(A_pinverse(3, 1), 0.25, 1e-6);
+	EXPECT_NEAR(A_pinverse(3, 0), -1.5, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(3, 1), 0.25, get_epsilon<ST>());
 
-    // incorrect dimension
-    EXPECT_THROW(linalg::pinv(A, A), ShogunException);
+	// incorrect dimension
+	EXPECT_THROW(linalg::pinv(A, A), ShogunException);
 }
 
 template <typename ST>
 void check_SGMatrix_pinv_4x2()
 {
-    SGMatrix<ST> A(4, 2);
-    A(0, 0) = 2.0;
-    A(0, 1) = -0.25;
-    A(1, 0) = 0.25;
-    A(1, 1) = 0.0;
-    A(2, 0) = 0.25;
-    A(2, 1) = 0.0;
-    A(3, 0) = -1.5;
-    A(3, 1) = 0.25;
+	SGMatrix<ST> A(4, 2);
+	A(0, 0) = 2.0;
+	A(0, 1) = -0.25;
+	A(1, 0) = 0.25;
+	A(1, 1) = 0.0;
+	A(2, 0) = 0.25;
+	A(2, 1) = 0.0;
+	A(3, 0) = -1.5;
+	A(3, 1) = 0.25;
 
-    SGMatrix<ST> identity_matrix(2, 2);
-    linalg::identity(identity_matrix);
-    SGMatrix<ST> A_pinverse(2, 4);
-    linalg::pinv(A, A_pinverse);
-    SGMatrix<ST> I_check = linalg::matrix_prod(A_pinverse, A);
-    for (auto i : range(2))
-    {
-        for (auto j : range(2))
-        {
-        EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), 1e-05);
-        }
-    }
-    // compare with results from scipy
-    EXPECT_NEAR(A_pinverse(0, 0), 1.0, 1e-05);
-    EXPECT_NEAR(A_pinverse(0, 1), 1.0, 1e-05);
-    EXPECT_NEAR(A_pinverse(0, 2), 1.0, 1e-05);
-    EXPECT_NEAR(A_pinverse(0, 3), 1.0, 1e-05);
+	SGMatrix<ST> identity_matrix(2, 2);
+	linalg::identity(identity_matrix);
+	SGMatrix<ST> A_pinverse(2, 4);
+	linalg::pinv(A, A_pinverse);
+	SGMatrix<ST> I_check = linalg::matrix_prod(A_pinverse, A);
+	for (auto i : range(2))
+	{
+		for (auto j : range(2))
+		{
+		EXPECT_NEAR(identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+		}
+	}
+	// compare with results from scipy
+	EXPECT_NEAR(A_pinverse(0, 0), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(0, 1), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(0, 2), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(0, 3), 1.0, get_epsilon<ST>());
 
-    EXPECT_NEAR(A_pinverse(1, 0), 5.0, 1e-05);
-    EXPECT_NEAR(A_pinverse(1, 1), 7.0, 1e-05);
-    EXPECT_NEAR(A_pinverse(1, 2), 7.0, 1e-05);
-    EXPECT_NEAR(A_pinverse(1, 3), 9.0, 1e-05);
+	EXPECT_NEAR(A_pinverse(1, 0), 5.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(1, 1), 7.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(1, 2), 7.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(1, 3), 9.0, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_dot()
 {
-    const index_t size = 3;
-    SGVector<ST> a(size), b(size);
-    a.range_fill(0);
-    b.range_fill(0);
+	const index_t size = 3;
+	SGVector<ST> a(size), b(size);
+	a.range_fill(0);
+	b.range_fill(0);
 
-    auto result = dot(a, b);
+	auto result = dot(a, b);
 
-    EXPECT_NEAR(result, 5, 1E-15);
+	EXPECT_NEAR(result, 5, 1E-15);
 }
 
 template <typename ST>
 void check_eigensolver()
 {
-    const index_t n = 4;
-    ST data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
-                        0.62323516, 0.16837367, 0.85027625, 0.60165948,
-                        0.04898732, 0.96701123, 0.51683275, 0.51116495,
-                        0.18277926, 0.6179262,  0.43745891, 0.63685464};
-    ST result_eigenvectors[] = {
-            -0.63494074, 0.75831593,  -0.14014031, 0.04656076,
-            0.82257205,  -0.28671857, -0.44196422, -0.21409185,
-            -0.005932,   -0.20233724, -0.52285555, 0.82803776,
-            -0.23930111, -0.56199714, -0.57298901, -0.54642272};
-    ST result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101,
-                                      2.0981937};
+	const index_t n = 4;
+	ST data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
+				 0.62323516, 0.16837367, 0.85027625, 0.60165948,
+				 0.04898732, 0.96701123, 0.51683275, 0.51116495,
+				 0.18277926, 0.6179262,  0.43745891, 0.63685464};
+	ST result_eigenvectors[] = {
+			-0.63494074, 0.75831593,  -0.1401403109, 0.04656076,
+			 0.82257205,  -0.286718557, -0.44196422, -0.214091861,
+			-0.005932,   -0.20233723, -0.52285555, 0.82803776,
+			-0.23930111, -0.56199714, -0.57298901, -0.54642272};
+	ST result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101,
+							   2.0981937};
 
-    SGMatrix<ST> m(data, n, n, false);
-    SGMatrix<ST> eigenvectors(n, n);
-    SGVector<ST> eigenvalues(n);
+	SGMatrix<ST> m(data, n, n, false);
+	SGMatrix<ST> eigenvectors(n, n);
+	SGVector<ST> eigenvalues(n);
 
-    eigen_solver(m, eigenvalues, eigenvectors);
+	eigen_solver(m, eigenvalues, eigenvectors);
 
-    auto args = CMath::argsort(eigenvalues);
-    for (index_t i = 0; i < n; ++i)
-    {
-    index_t idx = args[i];
-    EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
+	auto args = CMath::argsort(eigenvalues);
+	for (index_t i = 0; i < n; ++i)
+	{
+		index_t idx = args[i];
+		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
 
-    auto s =
-            CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
-    for (index_t j = 0; j < n; ++j)
-        EXPECT_NEAR(
-                eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-        1e-6);
-    }
+		auto s =
+				CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
+		for (index_t j = 0; j < n; ++j)
+			EXPECT_NEAR(
+					eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
+					1e-6);
+	}
 }
 
 template <typename ST>
 void check_eigensolver_symmetric()
 {
-    const index_t n = 4;
-    ST data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
-                        0.80575314, 0.16837367, 0.96701123, 0.6179262,
-                        0.04898732, 0.96701123, 0.51683275, 0.43745891,
-                        0.69989667, 0.6179262,  0.43745891, 0.63685464};
-    ST result_eigenvectors[] = {
-            -0.54618542, 0.69935447,  -0.45219663, 0.09001671,
-            -0.56171388, -0.41397154, 0.17642953,  0.69424612,
-            -0.46818396, 0.16780603,  0.73247599,  -0.46489119,
-            0.40861077,  0.55800718,  0.47735703,  0.542029037};
-    ST result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
-                                      2.18587989};
+	const index_t n = 4;
+	ST data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
+						0.80575314, 0.16837367, 0.96701123, 0.6179262,
+						0.04898732, 0.96701123, 0.51683275, 0.43745891,
+						0.69989667, 0.6179262,  0.43745891, 0.63685464};
+	ST result_eigenvectors[] = {
+			-0.54618542, 0.69935447,  -0.45219663, 0.09001671,
+			-0.56171388, -0.41397154, 0.17642953,  0.69424612,
+			-0.46818396, 0.16780603,  0.73247599,  -0.46489119,
+			0.40861077,  0.55800718,  0.47735703,  0.542029037};
+	ST result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
+							   2.18587989};
 
-    SGMatrix<ST> m(data, n, n, false);
-    SGMatrix<ST> eigenvectors(n, n);
-    SGVector<ST> eigenvalues(n);
+	SGMatrix<ST> m(data, n, n, false);
+	SGMatrix<ST> eigenvectors(n, n);
+	SGVector<ST> eigenvalues(n);
 
-    eigen_solver(m, eigenvalues, eigenvectors);
+	eigen_solver(m, eigenvalues, eigenvectors);
 
-    auto args = CMath::argsort(eigenvalues);
-    for (index_t i = 0; i < n; ++i)
-    {
-        index_t idx = args[i];
-        EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-5);
+	auto args = CMath::argsort(eigenvalues);
+	for (index_t i = 0; i < n; ++i)
+	{
+		index_t idx = args[i];
+		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
 
-        auto s =
-                CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
-        for (index_t j = 0; j < n; ++j)
-            EXPECT_NEAR(
-                    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-            1e-5);
-    }
+		auto s =
+				CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
+		for (index_t j = 0; j < n; ++j)
+			EXPECT_NEAR(
+					eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
+					1e-6);
+	}
 }
 
 template <typename ST>
 void check_SGMatrix_elementwise_product()
 {
-    const auto m = 2;
-    SGMatrix<ST> A(m, m);
-    SGMatrix<ST> B(m, m);
+	const auto m = 2;
+	SGMatrix<ST> A(m, m);
+	SGMatrix<ST> B(m, m);
 
-    for (auto i : range(m * m))
-    {
-        A[i] = i;
-        B[i] = 2*i;
-    }
+	for (auto i : range(m * m))
+	{
+		A[i] = i;
+		B[i] = 2*i;
+	}
 
-    auto result = element_prod(A, B);
+	auto result = element_prod(A, B);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), get_epsilon<ST>());
 
-    result = element_prod(A, B, true, false);
+	result = element_prod(A, B, true, false);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
 
-    result = element_prod(A, B, false, true);
+	result = element_prod(A, B, false, true);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
 
-    result = element_prod(A, B, true, true);
+	result = element_prod(A, B, true, true);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_elementwise_product_in_place()
 {
-    const auto m = 2;
-    SGMatrix<ST> A(m, m);
-    SGMatrix<ST> B(m, m);
-    SGMatrix<ST> result(m, m);
+	const auto m = 2;
+	SGMatrix<ST> A(m, m);
+	SGMatrix<ST> B(m, m);
+	SGMatrix<ST> result(m, m);
 
-    for (auto i : range(m * m))
-    {
-        A[i] = i;
-        B[i] = 2*i;
-    }
+	for (auto i : range(m * m))
+	{
+		A[i] = i;
+		B[i] = 2*i;
+	}
 
-    element_prod(A, B, result);
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+	element_prod(A, B, result);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), get_epsilon<ST>());
 
-    element_prod(A, B, result, true, false);
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+	element_prod(A, B, result, true, false);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
 
-    element_prod(A, B, result, false, true);
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+	element_prod(A, B, result, false, true);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
 
-    element_prod(A, B, result, true, true);
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
+	element_prod(A, B, result, true, true);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_block_elementwise_product()
 {
-    const index_t nrows = 2;
-    const index_t ncols = 3;
+	const index_t nrows = 2;
+	const index_t ncols = 3;
 
-    SGMatrix<ST> A(nrows,ncols);
-    SGMatrix<ST> B(ncols,nrows);
+	SGMatrix<ST> A(nrows,ncols);
+	SGMatrix<ST> B(ncols,nrows);
 
-    for (auto i : range(nrows))
-        for (auto j : range(ncols))
-        {
-            A(i, j) = i * 10 + j + 1;
-            B(j, i) = i + j;
-        }
+	for (auto i : range(nrows))
+		for (auto j : range(ncols))
+		{
+			A(i, j) = i * 10 + j + 1;
+			B(j, i) = i + j;
+		}
 
-    const auto m = 2;
-    auto A_block = linalg::block(A, 0, 0, m, m);
-    auto B_block = linalg::block(B, 0, 0, m, m);
-    auto result = element_prod(A_block, B_block);
+	const auto m = 2;
+	auto A_block = linalg::block(A, 0, 0, m, m);
+	auto B_block = linalg::block(B, 0, 0, m, m);
+	auto result = element_prod(A_block, B_block);
 
-    ASSERT_EQ(result.num_rows, m);
-    ASSERT_EQ(result.num_cols, m);
+	ASSERT_EQ(result.num_rows, m);
+	ASSERT_EQ(result.num_cols, m);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), get_epsilon<ST>());
 
-    result = element_prod(A_block, B_block, true, false);
+	result = element_prod(A_block, B_block, true, false);
 
-    ASSERT_EQ(result.num_rows, m);
-    ASSERT_EQ(result.num_cols, m);
+	ASSERT_EQ(result.num_rows, m);
+	ASSERT_EQ(result.num_cols, m);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
 
-    result = element_prod(A_block, B_block, false, true);
+	result = element_prod(A_block, B_block, false, true);
 
-    ASSERT_EQ(result.num_rows, m);
-    ASSERT_EQ(result.num_cols, m);
+	ASSERT_EQ(result.num_rows, m);
+	ASSERT_EQ(result.num_cols, m);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(i, j) * B(j, i), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(i, j) * B(j, i), get_epsilon<ST>());
 
-    result = element_prod(A_block, B_block, true, true);
+	result = element_prod(A_block, B_block, true, true);
 
-    ASSERT_EQ(result.num_rows, m);
-    ASSERT_EQ(result.num_cols, m);
+	ASSERT_EQ(result.num_rows, m);
+	ASSERT_EQ(result.num_cols, m);
 
-    for (auto i : range(m))
-        for (auto j : range(m))
-            EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), 1E-15);
+	for (auto i : range(m))
+		for (auto j : range(m))
+			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_elementwise_product()
 {
-    const index_t len = 4;
-    SGVector<ST> a(len);
-    SGVector<ST> b(len);
-    SGVector<ST> c(len);
+	const index_t len = 4;
+	SGVector<ST> a(len);
+	SGVector<ST> b(len);
+	SGVector<ST> c(len);
 
-    for (index_t i = 0; i < len; ++i)
-    {
-        a[i] = i;
-        b[i] = 2 * i;
-    }
+	for (index_t i = 0; i < len; ++i)
+	{
+		a[i] = i;
+		b[i] = 2 * i;
+	}
 
-    c = element_prod(a, b);
+	c = element_prod(a, b);
 
-    for (index_t i = 0; i < len; ++i)
-        EXPECT_NEAR(a[i] * b[i], c[i], 1e-15);
+	for (index_t i = 0; i < len; ++i)
+		EXPECT_NEAR(a[i] * b[i], c[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_elementwise_product_in_place()
 {
-    const index_t len = 4;
-    SGVector<ST> a(len);
-    SGVector<ST> b(len);
-    SGVector<ST> c(len);
+	const index_t len = 4;
+	SGVector<ST> a(len);
+	SGVector<ST> b(len);
+	SGVector<ST> c(len);
 
-    for (index_t i = 0; i < len; ++i)
-    {
-        a[i] = i;
-        b[i] = 2 * i;
-        c[i] = i;
-    }
+	for (index_t i = 0; i < len; ++i)
+	{
+		a[i] = i;
+		b[i] = 2 * i;
+		c[i] = i;
+	}
 
-    element_prod(a, b, a);
-    for (index_t i = 0; i < len; ++i)
-        EXPECT_NEAR(c[i] * b[i], a[i], 1e-15);
+	element_prod(a, b, a);
+	for (index_t i = 0; i < len; ++i)
+		EXPECT_NEAR(c[i] * b[i], a[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_exponent()
 {
-    const index_t len = 4;
-    SGVector<ST> a(len);
-    a[0] = 0;
-    a[1] = 1;
-    a[2] = 2;
-    a[3] = 3;
-    auto result = exponent(a);
+	const index_t len = 4;
+	SGVector<ST> a(len);
+	a[0] = 0;
+	a[1] = 1;
+	a[2] = 2;
+	a[3] = 3;
+	auto result = exponent(a);
 
-    EXPECT_NEAR(result[0], 1.0, 1E-15);
-    EXPECT_NEAR(result[1], 2.718281828459045, 1E-6);
-    EXPECT_NEAR(result[2], 7.3890560989306495, 1E-6);
-    EXPECT_NEAR(result[3], 20.085536923187664, 1E-6);
+	EXPECT_NEAR(result[0], 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(result[1], 2.718281828459045, get_epsilon<ST>());
+	EXPECT_NEAR(result[2], 7.3890560989306495, get_epsilon<ST>());
+	EXPECT_NEAR(result[3], 20.085536923187664, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_exponent()
 {
-    const index_t n = 2;
-    SGMatrix<ST> a(n, n);
-    a[0] = 0;
-    a[1] = 1;
-    a[2] = 2;
-    a[3] = 3;
-    auto result = exponent(a);
+	const index_t n = 2;
+	SGMatrix<ST> a(n, n);
+	a[0] = 0;
+	a[1] = 1;
+	a[2] = 2;
+	a[3] = 3;
+	auto result = exponent(a);
 
-    EXPECT_NEAR(result[0], 1.0, 1E-15);
-    EXPECT_NEAR(result[1], 2.718281828459045, 1E-6);
-    EXPECT_NEAR(result[2], 7.3890560989306495, 1E-6);
-    EXPECT_NEAR(result[3], 20.085536923187664, 1E-6);
+	EXPECT_NEAR(result[0], 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(result[1], 2.718281828459045, get_epsilon<ST>());
+	EXPECT_NEAR(result[2], 7.3890560989306495, get_epsilon<ST>());
+	EXPECT_NEAR(result[3], 20.085536923187664, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_identity()
 {
-    const index_t n = 4;
-    SGMatrix<ST> A(n, n);
-    identity(A);
+	const index_t n = 4;
+	SGMatrix<ST> A(n, n);
+	identity(A);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = 0; j < n; ++j)
-            EXPECT_EQ(A.get_element(i, j), (i==j));
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = 0; j < n; ++j)
+			EXPECT_EQ(A.get_element(i, j), (i==j));
 }
 
 template <typename ST>
 void check_logistic()
 {
-    SGMatrix<ST> A(3,3);
-    SGMatrix<ST> B(3,3);
+	SGMatrix<ST> A(3,3);
+	SGMatrix<ST> B(3,3);
 
-    for (index_t i = 0; i < 9; ++i)
-        A[i] = i;
-    B.zero();
+	for (index_t i = 0; i < 9; ++i)
+		A[i] = i;
+	B.zero();
 
-    linalg::logistic(A, B);
+	linalg::logistic(A, B);
 
-    for (index_t i = 0; i < 9; ++i)
-        EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], 1e-7);
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_SGVector_matrix_prod()
 {
-    const index_t rows=4;
-    const index_t cols=3;
+	const index_t rows=4;
+	const index_t cols=3;
 
-    SGMatrix<ST> A(rows, cols);
-    SGVector<ST> b(cols);
+	SGMatrix<ST> A(rows, cols);
+	SGVector<ST> b(cols);
 
-    for (index_t i = 0; i < cols; ++i)
-    {
-        for (index_t j = 0; j < rows; ++j)
-            A(j, i) = i * rows + j;
-        b[i]= 2 * i;
-    }
+	for (index_t i = 0; i < cols; ++i)
+	{
+		for (index_t j = 0; j < rows; ++j)
+			A(j, i) = i * rows + j;
+		b[i]= 2 * i;
+	}
 
-    auto x = matrix_prod(A, b);
+	auto x = matrix_prod(A, b);
 
-    ST ref[] = {40, 46, 52, 58};
+	ST ref[] = {40, 46, 52, 58};
 
-    EXPECT_EQ(x.vlen, A.num_rows);
-    for (index_t i = 0; i < rows; ++i)
-        EXPECT_NEAR(x[i], ref[i], 1e-15);
+	EXPECT_EQ(x.vlen, A.num_rows);
+	for (index_t i = 0; i < rows; ++i)
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_matrix_prod_transpose()
 {
-    const index_t rows=4;
-    const index_t cols=3;
+	const index_t rows=4;
+	const index_t cols=3;
 
-    SGMatrix<ST> A(cols, rows);
-    SGVector<ST> b(cols);
+	SGMatrix<ST> A(cols, rows);
+	SGVector<ST> b(cols);
 
-    for (index_t i = 0; i < cols; ++i)
-    {
-        for (index_t j = 0; j < rows; ++j)
-            A(i, j) = i * cols + j;
-        b[i] = 2 * i;
-    }
+	for (index_t i = 0; i < cols; ++i)
+	{
+		for (index_t j = 0; j < rows; ++j)
+			A(i, j) = i * cols + j;
+		b[i] = 2 * i;
+	}
 
-    auto x = matrix_prod(A, b, true);
+	auto x = matrix_prod(A, b, true);
 
-    ST ref[] = {30, 36, 42};
+	ST ref[] = {30, 36, 42};
 
-    EXPECT_EQ(x.vlen, A.num_cols);
-    for (index_t i = 0; i < cols; ++i)
-        EXPECT_NEAR(x[i], ref[i], 1e-15);
+	EXPECT_EQ(x.vlen, A.num_cols);
+	for (index_t i = 0; i < cols; ++i)
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_SGVector_matrix_prod_in_place()
 {
-    const index_t rows=4;
-    const index_t cols=3;
+	const index_t rows=4;
+	const index_t cols=3;
 
-    SGMatrix<ST> A(rows, cols);
-    SGVector<ST> b(cols);
-    SGVector<ST> x(rows);
+	SGMatrix<ST> A(rows, cols);
+	SGVector<ST> b(cols);
+	SGVector<ST> x(rows);
 
-    for (index_t i = 0; i<cols; ++i)
-    {
-        for (index_t j = 0; j < rows; ++j)
-            A(j, i) = i * rows + j;
-        b[i] = 2 * i;
-    }
+	for (index_t i = 0; i<cols; ++i)
+	{
+		for (index_t j = 0; j < rows; ++j)
+			A(j, i) = i * rows + j;
+		b[i] = 2 * i;
+	}
 
-    matrix_prod(A, b, x);
+	matrix_prod(A, b, x);
 
-    ST ref[] = {40, 46, 52, 58};
+	ST ref[] = {40, 46, 52, 58};
 
-    for (index_t i = 0; i < cols; ++i)
-        EXPECT_NEAR(x[i], ref[i], 1e-15);
+	for (index_t i = 0; i < cols; ++i)
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_SGVector_matrix_prod_in_place_transpose()
 {
-    const index_t rows=4;
-    const index_t cols=3;
+	const index_t rows=4;
+	const index_t cols=3;
 
-    SGMatrix<ST> A(cols, rows);
-    SGVector<ST> b(cols);
-    SGVector<ST> x(rows);
+	SGMatrix<ST> A(cols, rows);
+	SGVector<ST> b(cols);
+	SGVector<ST> x(rows);
 
-    for (index_t i = 0; i < cols; ++i)
-    {
-        for (index_t j = 0; j < rows; ++j)
-            A(i, j) = i * cols + j;
-        b[i] = 2 * i;
-    }
+	for (index_t i = 0; i < cols; ++i)
+	{
+		for (index_t j = 0; j < rows; ++j)
+			A(i, j) = i * cols + j;
+		b[i] = 2 * i;
+	}
 
-    matrix_prod(A, b, x, true);
+	matrix_prod(A, b, x, true);
 
-    ST ref[] = {30, 36, 42};
+	ST ref[] = {30, 36, 42};
 
-    for (index_t i = 0; i < cols; ++i)
-        EXPECT_NEAR(x[i], ref[i], 1e-15);
+	for (index_t i = 0; i < cols; ++i)
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product()
 {
-    const index_t dim1 = 2, dim2 = 4, dim3 = 2;
-    SGMatrix<ST> A(dim1, dim2);
-    SGMatrix<ST> B(dim2, dim3);
+	const index_t dim1 = 2, dim2 = 4, dim3 = 2;
+	SGMatrix<ST> A(dim1, dim2);
+	SGMatrix<ST> B(dim2, dim3);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
 
-    auto cal = linalg::matrix_prod(A, B);
+	auto cal = linalg::matrix_prod(A, B);
 
-    ST ref[] = {28, 34, 76, 98};
+	ST ref[] = {28, 34, 76, 98};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product_transpose_A()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim2, dim1);
-    SGMatrix<ST> B(dim2, dim3);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim2, dim1);
+	SGMatrix<ST> B(dim2, dim3);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
 
-    auto cal = linalg::matrix_prod(A, B, true);
+	auto cal = linalg::matrix_prod(A, B, true);
 
-    ST ref[] = {5, 14, 14, 50, 23, 86};
+	ST ref[] = {5, 14, 14, 50, 23, 86};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product_transpose_B()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim1, dim2);
-    SGMatrix<ST> B(dim3, dim2);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim1, dim2);
+	SGMatrix<ST> B(dim3, dim2);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
 
-    auto cal = linalg::matrix_prod(A, B, false, true);
+	auto cal = linalg::matrix_prod(A, B, false, true);
 
-    ST ref[] = {30, 39, 36, 48, 42, 57};
+	ST ref[] = {30, 39, 36, 48, 42, 57};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product_transpose_A_B()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim2, dim1);
-    SGMatrix<ST> B(dim3, dim2);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim2, dim1);
+	SGMatrix<ST> B(dim3, dim2);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
 
-    auto cal = linalg::matrix_prod(A, B, true, true);
+	auto cal = linalg::matrix_prod(A, B, true, true);
 
-    ST ref[] = {15, 42, 18, 54, 21, 66};
+	ST ref[] = {15, 42, 18, 54, 21, 66};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product_in_place()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim1, dim2);
-    SGMatrix<ST> B(dim2, dim3);
-    SGMatrix<ST> cal(dim1, dim3);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim1, dim2);
+	SGMatrix<ST> B(dim2, dim3);
+	SGMatrix<ST> cal(dim1, dim3);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
-    cal.zero();
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
+	cal.zero();
 
-    linalg::matrix_prod(A, B, cal);
+	linalg::matrix_prod(A, B, cal);
 
-    ST ref[] = {10, 13, 28, 40, 46, 67};
+	ST ref[] = {10, 13, 28, 40, 46, 67};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product_in_place_transpose_A()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim2, dim1);
-    SGMatrix<ST> B(dim2, dim3);
-    SGMatrix<ST> cal(dim1, dim3);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim2, dim1);
+	SGMatrix<ST> B(dim2, dim3);
+	SGMatrix<ST> cal(dim1, dim3);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
-    cal.zero();
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
+	cal.zero();
 
-    linalg::matrix_prod(A, B, cal, true);
+	linalg::matrix_prod(A, B, cal, true);
 
-    ST ref[] = {5, 14, 14, 50, 23, 86};
+	ST ref[] = {5, 14, 14, 50, 23, 86};
 
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 
 template <typename ST>
 void check_SGMatrix_matrix_product_in_place_transpose_B()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim1, dim2);
-    SGMatrix<ST> B(dim3, dim2);
-    SGMatrix<ST> cal(dim1, dim3);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim1, dim2);
+	SGMatrix<ST> B(dim3, dim2);
+	SGMatrix<ST> cal(dim1, dim3);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-        A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-        B[i] = i;
-    cal.zero();
+	for (index_t i = 0; i < dim1*dim2; ++i)
+		A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+		B[i] = i;
+	cal.zero();
 
-    linalg::matrix_prod(A, B, cal, false, true);
+	linalg::matrix_prod(A, B, cal, false, true);
 
-    ST ref[] = {30, 39, 36, 48, 42, 57};
+	ST ref[] = {30, 39, 36, 48, 42, 57};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-        EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGMatrix_matrix_product_in_place_transpose_A_B()
 {
-    const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-    SGMatrix<ST> A(dim2, dim1);
-    SGMatrix<ST> B(dim3, dim2);
-    SGMatrix<ST> cal(dim1, dim3);
+	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
+	SGMatrix<ST> A(dim2, dim1);
+	SGMatrix<ST> B(dim3, dim2);
+	SGMatrix<ST> cal(dim1, dim3);
 
-    for (index_t i = 0; i < dim1*dim2; ++i)
-    A[i] = i;
-    for (index_t i = 0; i < dim2*dim3; ++i)
-    B[i] = i;
-    cal.zero();
+	for (index_t i = 0; i < dim1*dim2; ++i)
+	A[i] = i;
+	for (index_t i = 0; i < dim2*dim3; ++i)
+	B[i] = i;
+	cal.zero();
 
-    linalg::matrix_prod(A, B, cal, true, true);
+	linalg::matrix_prod(A, B, cal, true, true);
 
-    ST ref[] = {15, 42, 18, 54, 21, 66};
+	ST ref[] = {15, 42, 18, 54, 21, 66};
 
-    EXPECT_EQ(dim1, cal.num_rows);
-    EXPECT_EQ(dim3, cal.num_cols);
-    for (index_t i = 0; i < dim1*dim3; ++i)
-    EXPECT_EQ(ref[i], cal[i]);
+	EXPECT_EQ(dim1, cal.num_rows);
+	EXPECT_EQ(dim3, cal.num_cols);
+	for (index_t i = 0; i < dim1*dim3; ++i)
+		EXPECT_EQ(ref[i], cal[i]);
 }
 
 template <typename ST>
 void check_SGVector_max()
 {
-    SGVector<ST> A(9);
+	SGVector<ST> A(9);
 
-    ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 4};
+	ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 4};
 
-    for (index_t i = 0; i < A.size(); ++i)
-        A[i] = a[i];
+	for (index_t i = 0; i < A.size(); ++i)
+		A[i] = a[i];
 
-    EXPECT_NEAR(8, max(A), 1e-15);
+	EXPECT_NEAR(8, max(A), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_max()
 {
-    const index_t nrows = 3, ncols = 3;
-    SGMatrix<ST> A(nrows, ncols);
+	const index_t nrows = 3, ncols = 3;
+	SGMatrix<ST> A(nrows, ncols);
 
-    ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 12};
+	ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 12};
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        A[i] = a[i];
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = a[i];
 
-    EXPECT_NEAR(12, max(A), 1e-15);
+	EXPECT_NEAR(12, max(A), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_mean()
 {
-    const index_t size = 9;
-    SGVector<ST> vec(size);
-    vec.range_fill(0);
+	const index_t size = 9;
+	SGVector<ST> vec(size);
+	vec.range_fill(0);
 
-    auto result = mean(vec);
+	auto result = mean(vec);
 
-    EXPECT_NEAR(result, 4, 1E-15);
+	EXPECT_NEAR(result, 4, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_mean()
 {
-    const index_t nrows = 3, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	const index_t nrows = 3, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    auto result = mean(mat);
+	auto result = mean(mat);
 
-    EXPECT_NEAR(result, 4, 1E-15);
+	EXPECT_NEAR(result, 4, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_multiply_by_logistic_derivative()
 {
-    SGMatrix<ST> A(3, 3);
-    SGMatrix<ST> B(3, 3);
+	SGMatrix<ST> A(3, 3);
+	SGMatrix<ST> B(3, 3);
 
-    for (ST i = 9; i < 9; i+=9)
-    {
-        A[i] = i / 9;
-        B[i] = i;
-    }
+	for (ST i = 9; i < 9; i+=9)
+	{
+		A[i] = i / 9;
+		B[i] = i;
+	}
 
-    linalg::multiply_by_logistic_derivative(A, B);
+	linalg::multiply_by_logistic_derivative(A, B);
 
-    for (index_t i = 0; i < 9; ++i)
-        EXPECT_NEAR(i * A[i] * (1.0 - A[i]), B[i], 1e-15);
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(i * A[i] * (1.0 - A[i]), B[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_multiply_by_rectified_linear_derivative()
 {
-    SGMatrix<ST> A(3, 3);
-    SGMatrix<ST> B(3, 3);
+	SGMatrix<ST> A(3, 3);
+	SGMatrix<ST> B(3, 3);
 
-    for (ST i = 0; i < 9; ++i)
-    {
-        A[i] = i * 0.5 - 0.5;
-        B[i] = i;
-    }
+	for (ST i = 0; i < 9; ++i)
+	{
+		A[i] = i * 0.5 - 0.5;
+		B[i] = i;
+	}
 
-    multiply_by_rectified_linear_derivative(A, B);
+	multiply_by_rectified_linear_derivative(A, B);
 
-    for (index_t i = 0; i < 9; ++i)
-        EXPECT_NEAR(i * (A[i] != 0), B[i], 1e-15);
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(i * (A[i] != 0), B[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_norm()
 {
-    const index_t n = 24; // evaluates to norm=70
-    SGVector<ST> v(n);
-    ST gt = 0;
-    for (index_t i = 0; i < n; ++i)
-    {
-        v[i] = i;
-        gt += i * i;
-    }
+	const index_t n = 24;
+	SGVector<ST> v(n);
+	ST gt = 0;
+	for (index_t i = 0; i < n; ++i)
+	{
+		v[i] = i;
+		gt += i * i;
+	}
 
-    gt = std::sqrt(gt);
+	gt = std::sqrt(gt);
 
-    auto result = norm(v);
+	auto result = norm(v);
 
-    EXPECT_NEAR(result, gt, 1E-15);
+	EXPECT_NEAR(result, gt, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_qr_solver()
 {
-    const index_t n = 3;
-    ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
-                   0.30492837, 0.39708534, 0.40466969,
-                   0.36415317, 0.04407589, 0.9095746};
-    ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
-    ST result[] = {0.07135206, 1.56393127, -0.23141312};
+	const index_t n = 3;
+	ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
+				   0.30492837, 0.39708534, 0.40466969,
+				   0.36415317, 0.04407589, 0.9095746};
+	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
+	ST result[] = {0.07135206, 1.56393127, -0.23141312};
 
-    SGMatrix<ST> A(data_A, n, n, false);
-    SGVector<ST> b(data_b, n, false);
+	SGMatrix<ST> A(data_A, n, n, false);
+	SGVector<ST> b(data_b, n, false);
 
-    auto x = qr_solver(A, b);
+	auto x = qr_solver(A, b);
 
-    for (index_t i = 0; i < x.size(); ++i)
-        EXPECT_NEAR(x[i], result[i], 1E-6);
+	for (index_t i = 0; i < x.size(); ++i)
+		EXPECT_NEAR(x[i], result[i], 1e-6);
 }
 
 template <typename ST>
 void check_SGMatrix_qr_solver()
 {
-    const index_t n = 3, m = 2;
-    ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
-                   0.30492837, 0.39708534, 0.40466969,
-                   0.36415317, 0.04407589, 0.9095746};
-    ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-                   0.94311546, 0.59630347, 0.65820143};
-    ST result[] = {-0.73834587, 4.22750496, -1.37484721,
-                   -1.14718091, 4.49142548, -1.08282992};
+	const index_t n = 3, m = 2;
+	ST data_A[] = {0.02800922, 0.99326012, 0.15204902,
+				   0.30492837, 0.39708534, 0.40466969,
+				   0.36415317, 0.04407589, 0.9095746};
+	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
+				   0.94311546, 0.59630347, 0.65820143};
+	ST result[] = {-0.73834587, 4.22750496, -1.37484721,
+				   -1.14718091, 4.49142548, -1.08282992};
 
-    SGMatrix<ST> A(data_A, n, n, false);
-    SGMatrix<ST> B(data_B, n, m, false);
+	SGMatrix<ST> A(data_A, n, n, false);
+	SGMatrix<ST> B(data_B, n, m, false);
 
-    auto X = qr_solver(A, B);
+	auto X = qr_solver(A, B);
 
-    for (index_t i = 0; i < (index_t)X.size(); ++i)
-        EXPECT_NEAR(X[i], result[i], 1E-5);
+	for (index_t i = 0; i < (index_t)X.size(); ++i)
+		EXPECT_NEAR(X[i], result[i], 1e-5);
 }
 
 template <typename ST>
 void check_SGVector_range_fill()
 {
-    const index_t size = 5;
-    SGVector<ST> vec(size);
-    ST start = 1;  // FIXME: this is a bit awkward
-    range_fill(vec, start);
+	const index_t size = 5;
+	SGVector<ST> vec(size);
+	ST start = 1;
+	range_fill(vec, start);
 
-    for (index_t i = 0; i < size; ++i)
-        EXPECT_NEAR(vec[i], i + 1, 1E-15);
+	for (index_t i = 0; i < size; ++i)
+		EXPECT_NEAR(vec[i], i + 1, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_range_fill()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
-    ST start = 1;
-    range_fill(mat, start);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
+	ST start = 1;
+	range_fill(mat, start);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_NEAR(mat[i], i + 1, 1E-15);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(mat[i], i + 1, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_rectified_linear()
 {
-    SGMatrix<ST> A(3, 3);
-    SGMatrix<ST> B(3, 3);
-    ST start = 1;
-    range_fill(A, start);
+	SGMatrix<ST> A(3, 3);
+	SGMatrix<ST> B(3, 3);
+	ST start = 1;
+	range_fill(A, start);
 
-    linalg::rectified_linear(A, B);
+	linalg::rectified_linear(A, B);
 
-    for (index_t i = 0; i < 9; ++i)
-        EXPECT_NEAR(CMath::max(static_cast<ST>(0.0), A[i]), B[i], 1e-15);
+	for (index_t i = 0; i < 9; ++i)
+		EXPECT_NEAR(CMath::max(static_cast<ST>(0.0), A[i]), B[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_scale()
 {
-    const index_t size = 5;
-    const ST alpha = 2;
-    SGVector<ST> a(size);
-    a.range_fill(0);
+	const index_t size = 5;
+	const ST alpha = 2;
+	SGVector<ST> a(size);
+	a.range_fill(0);
 
-    auto result = scale(a, alpha);
+	auto result = scale(a, alpha);
 
-    for (index_t i = 0; i < size; ++i)
-        EXPECT_NEAR(alpha * a[i], result[i], 1e-15);
+	for (index_t i = 0; i < size; ++i)
+		EXPECT_NEAR(alpha * a[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_scale()
 {
-    const ST alpha = 2;
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> A(nrows, ncols);
+	const ST alpha = 2;
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> A(nrows, ncols);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        A[i] = i;
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
 
-    auto result = scale(A, alpha);
+	auto result = scale(A, alpha);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_NEAR(alpha*A[i], result[i], 1e-15);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(alpha*A[i], result[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_scale_in_place()
 {
-    const index_t size = 5;
-    const ST alpha = 2;
-    SGVector<ST> a(size);
-    a.range_fill(0);
+	const index_t size = 5;
+	const ST alpha = 2;
+	SGVector<ST> a(size);
+	a.range_fill(0);
 
-    scale(a, a, alpha);
+	scale(a, a, alpha);
 
-    for (index_t i = 0; i < size; ++i)
-        EXPECT_NEAR(alpha * i, a[i], 1e-15);
+	for (index_t i = 0; i < size; ++i)
+		EXPECT_NEAR(alpha * i, a[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_scale_in_place()
 {
-    const ST alpha = 2;
-    const index_t nrows = 2, ncols = 3;
+	const ST alpha = 2;
+	const index_t nrows = 2, ncols = 3;
 
-    SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<ST> A(nrows, ncols);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        A[i] = i;
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		A[i] = i;
 
-    scale(A, A, alpha);
+	scale(A, A, alpha);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_NEAR(alpha*i, A[i], 1e-15);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(alpha*i, A[i], get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_set_const()
 {
-    const index_t size = 5;
-    const ST value = 2;
-    SGVector<ST> a(size);
+	const index_t size = 5;
+	const ST value = 2;
+	SGVector<ST> a(size);
 
-    set_const(a, value);
+	set_const(a, value);
 
-    for (index_t i = 0; i < size; ++i)
-        EXPECT_NEAR(a[i], value, 1E-15);
+	for (index_t i = 0; i < size; ++i)
+		EXPECT_NEAR(a[i], value, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_set_const()
 {
-    const index_t nrows = 2, ncols = 3;
-    const ST value = 2;
-    SGMatrix<ST> a(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	const ST value = 2;
+	SGMatrix<ST> a(nrows, ncols);
 
-    set_const(a, value);
+	set_const(a, value);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_NEAR(a[i], value, 1E-15);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_NEAR(a[i], value, get_epsilon<ST>());
 }
 
 
 template <typename ST>
 void check_SGMatrix_softmax()
 {
-    SGMatrix<ST> A(4, 3);
-    SGMatrix<ST> ref(4, 3);
+	SGMatrix<ST> A(4, 3);
+	SGMatrix<ST> ref(4, 3);
 
-    for (ST i = 0; i < 12; ++i)
-        A[i] = i / 12;
+	for (ST i = 0; i < 12; ++i)
+		A[i] = i / 12;
 
-    for (index_t i = 0; i < 12; ++i)
-        ref[i] = std::exp(A[i]);
+	for (index_t i = 0; i < 12; ++i)
+		ref[i] = std::exp(A[i]);
 
-    for (index_t j = 0; j < ref.num_cols; ++j)
-    {
-        ST sum = 0;
-        for (index_t i = 0; i < ref.num_rows; ++i)
-            sum += ref(i, j);
+	for (index_t j = 0; j < ref.num_cols; ++j)
+	{
+		ST sum = 0;
+		for (index_t i = 0; i < ref.num_rows; ++i)
+			sum += ref(i, j);
 
-        for (index_t i = 0; i < ref.num_rows; ++i)
-            ref(i, j) /= sum;
-    }
+		for (index_t i = 0; i < ref.num_rows; ++i)
+			ref(i, j) /= sum;
+	}
 
-    linalg::softmax(A);
+	linalg::softmax(A);
 
-    for (index_t i = 0; i < 12; ++i)
-        EXPECT_NEAR(ref[i], A[i], 1e-7);
+	for (index_t i = 0; i < 12; ++i)
+		EXPECT_NEAR(ref[i], A[i], get_epsilon<ST>());
 }
 
 //template <typename ST>
@@ -1672,932 +1673,932 @@ void check_SGMatrix_softmax()
 template <typename ST>
 void check_SGVector_sum()
 {
-    const index_t size = 10;
-    SGVector<ST> vec(size);
-    vec.range_fill(0);
+	const index_t size = 10;
+	SGVector<ST> vec(size);
+	vec.range_fill(0);
 
-    auto result = sum(vec);
+	auto result = sum(vec);
 
-    EXPECT_NEAR(result, 45, 1E-15);
+	EXPECT_NEAR(result, 45, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_sum()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    auto result = sum(mat);
+	auto result = sum(mat);
 
-    EXPECT_NEAR(result, 15, 1E-15);
+	EXPECT_NEAR(result, 15, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_sum_no_diag()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    auto result = sum(mat, true);
+	auto result = sum(mat, true);
 
-    EXPECT_NEAR(result, 12, 1E-15);
+	EXPECT_NEAR(result, 12, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_symmetric_with_diag()
 {
-    const index_t n = 3;
-    SGMatrix<ST> mat(n, n);
-    mat.set_const(1);
+	const index_t n = 3;
+	SGMatrix<ST> mat(n, n);
+	mat.set_const(1);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = i + 1; j < n; ++j)
-        {
-            mat(i, j) = i * 10 + j + 1;
-            mat(j, i) = mat(i, j);
-        }
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = i + 1; j < n; ++j)
+		{
+			mat(i, j) = i * 10 + j + 1;
+			mat(j, i) = mat(i, j);
+		}
 
-    EXPECT_NEAR(sum_symmetric(mat), 39, 1E-15);
+	EXPECT_NEAR(sum_symmetric(mat), 39, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_symmetric_no_diag()
 {
-    const index_t n = 3;
-    SGMatrix<ST> mat(n, n);
-    mat.set_const(1);
+	const index_t n = 3;
+	SGMatrix<ST> mat(n, n);
+	mat.set_const(1);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = i + 1; j < n; ++j)
-        {
-            mat(i, j) = i * 10 + j + 1;
-            mat(j, i) = mat(i, j);
-        }
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = i + 1; j < n; ++j)
+		{
+			mat(i, j) = i * 10 + j + 1;
+			mat(j, i) = mat(i, j);
+		}
 
-    EXPECT_NEAR(sum_symmetric(mat, true), 36, 1E-15);
+	EXPECT_NEAR(sum_symmetric(mat, true), 36, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_symmetric_exception()
 {
-    const index_t n = 3;
-    SGMatrix<ST> mat(n, n + 1);
-    mat.set_const(1.0);
+	const index_t n = 3;
+	SGMatrix<ST> mat(n, n + 1);
+	mat.set_const(1.0);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = i + 1; j < n; ++j)
-        {
-            mat(i, j) = i * 10 + j + 1;
-            mat(j, i) = mat(i, j);
-        }
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = i + 1; j < n; ++j)
+		{
+			mat(i, j) = i * 10 + j + 1;
+			mat(j, i) = mat(i, j);
+		}
 
-    EXPECT_THROW(sum_symmetric(mat), ShogunException);
+	EXPECT_THROW(sum_symmetric(mat), ShogunException);
 }
 
 template <typename ST>
 void check_SGMatrix_block_sum()
 {
-    const index_t n = 3;
-    SGMatrix<ST> mat(n, n);
+	const index_t n = 3;
+	SGMatrix<ST> mat(n, n);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = 0; j < n; ++j)
-            mat(i, j)=i * 10 + j + 1;
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = 0; j < n; ++j)
+			mat(i, j)=i * 10 + j + 1;
 
-    auto result = sum(linalg::block(mat, 0, 0, 2, 3));
-    EXPECT_NEAR(result, 42.0, 1E-15);
+	auto result = sum(linalg::block(mat, 0, 0, 2, 3));
+	EXPECT_NEAR(result, 42.0, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_symmetric_block_with_diag()
 {
-    const index_t n = 3;
-    SGMatrix<ST> mat(n, n);
-    mat.set_const(1);
+	const index_t n = 3;
+	SGMatrix<ST> mat(n, n);
+	mat.set_const(1);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = i + 1; j < n; ++j)
-        {
-            mat(i, j) = i * 10 + j + 1;
-            mat(j, i) = mat(i, j);
-        }
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = i + 1; j < n; ++j)
+		{
+			mat(i, j) = i * 10 + j + 1;
+			mat(j, i) = mat(i, j);
+		}
 
-    ST sum = sum_symmetric(linalg::block(mat,1,1,2,2));
-    EXPECT_NEAR(sum, 28, 1E-15);
+	ST sum = sum_symmetric(linalg::block(mat,1,1,2,2));
+	EXPECT_NEAR(sum, 28, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_symmetric_block_no_diag()
 {
-    const index_t n = 3;
-    SGMatrix<ST> mat(n, n);
-    mat.set_const(1);
+	const index_t n = 3;
+	SGMatrix<ST> mat(n, n);
+	mat.set_const(1);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = i + 1; j < n; ++j)
-        {
-            mat(i, j) = i * 10 + j + 1;
-            mat(j, i) = mat(i, j);
-        }
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = i + 1; j < n; ++j)
+		{
+			mat(i, j) = i * 10 + j + 1;
+			mat(j, i) = mat(i, j);
+		}
 
-    ST sum = sum_symmetric(linalg::block(mat,1,1,2,2), true);
-    EXPECT_NEAR(sum, 26, 1E-15);
+	ST sum = sum_symmetric(linalg::block(mat,1,1,2,2), true);
+	EXPECT_NEAR(sum, 26, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_symmetric_block_exception()
 {
-    const index_t n = 3;
-    SGMatrix<float64_t> mat(n, n);
-    mat.set_const(1.0);
+	const index_t n = 3;
+	SGMatrix<float64_t> mat(n, n);
+	mat.set_const(1.0);
 
-    for (index_t i = 0; i < n; ++i)
-        for (index_t j = i + 1; j < n; ++j)
-        {
-            mat(i, j) = i * 10 + j + 1;
-            mat(j, i) = mat(i, j);
-        }
+	for (index_t i = 0; i < n; ++i)
+		for (index_t j = i + 1; j < n; ++j)
+		{
+			mat(i, j) = i * 10 + j + 1;
+			mat(j, i) = mat(i, j);
+		}
 
-    EXPECT_THROW(sum_symmetric(linalg::block(mat,1,1,2,3)), ShogunException);
+	EXPECT_THROW(sum_symmetric(linalg::block(mat,1,1,2,3)), ShogunException);
 }
 
 template <typename ST>
 void check_SGMatrix_colwise_sum()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    SGVector<ST> result = colwise_sum(mat);
+	SGVector<ST> result = colwise_sum(mat);
 
-    for (index_t j = 0; j < ncols; ++j)
-    {
-        ST sum = 0;
-        for (index_t i = 0; i < nrows; ++i)
-            sum += mat(i, j);
-        EXPECT_NEAR(sum, result[j], 1E-15);
-    }
+	for (index_t j = 0; j < ncols; ++j)
+	{
+		ST sum = 0;
+		for (index_t i = 0; i < nrows; ++i)
+			sum += mat(i, j);
+		EXPECT_NEAR(sum, result[j], get_epsilon<ST>());
+	}
 }
 
 template <typename ST>
 void check_SGMatrix_colwise_sum_no_diag()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    SGVector<ST> result = colwise_sum(mat, true);
+	SGVector<ST> result = colwise_sum(mat, true);
 
-    EXPECT_NEAR(result[0], 1, 1E-15);
-    EXPECT_NEAR(result[1], 2, 1E-15);
-    EXPECT_NEAR(result[2], 9, 1E-15);
+	EXPECT_NEAR(result[0], 1, get_epsilon<ST>());
+	EXPECT_NEAR(result[1], 2, get_epsilon<ST>());
+	EXPECT_NEAR(result[2], 9, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_block_colwise_sum()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<float64_t> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<float64_t> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows; ++i)
-        for (index_t j = 0; j < ncols; ++j)
-            mat(i, j) = i * 10 + j + 1;
+	for (index_t i = 0; i < nrows; ++i)
+		for (index_t j = 0; j < ncols; ++j)
+			mat(i, j) = i * 10 + j + 1;
 
-    auto result = colwise_sum(linalg::block(mat, 0, 0, 2, 3));
+	auto result = colwise_sum(linalg::block(mat, 0, 0, 2, 3));
 
-    for (index_t j = 0; j < ncols; ++j)
-    {
-        ST sum = 0;
-        for (index_t i = 0; i < nrows; ++i)
-            sum += mat(i, j);
-        EXPECT_NEAR(sum, result[j], 1E-15);
-    }
+	for (index_t j = 0; j < ncols; ++j)
+	{
+		ST sum = 0;
+		for (index_t i = 0; i < nrows; ++i)
+			sum += mat(i, j);
+		EXPECT_NEAR(sum, result[j], get_epsilon<ST>());
+	}
 }
 
 
 template <typename ST>
 void check_SGMatrix_rowwise_sum()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    SGVector<ST> result = rowwise_sum(mat);
+	SGVector<ST> result = rowwise_sum(mat);
 
-    for (index_t i = 0; i < nrows; ++i)
-    {
-        ST sum = 0;
-        for (index_t j = 0; j < ncols; ++j)
-            sum += mat(i, j);
-        EXPECT_NEAR(sum, result[i], 1E-15);
-    }
+	for (index_t i = 0; i < nrows; ++i)
+	{
+		ST sum = 0;
+		for (index_t j = 0; j < ncols; ++j)
+			sum += mat(i, j);
+		EXPECT_NEAR(sum, result[i], get_epsilon<ST>());
+	}
 }
 
 template <typename ST>
 void check_SGMatrix_rowwise_sum_no_diag()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows * ncols; ++i)
-        mat[i] = i;
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		mat[i] = i;
 
-    SGVector<ST> result = rowwise_sum(mat, true);
+	SGVector<ST> result = rowwise_sum(mat, true);
 
-    EXPECT_NEAR(result[0], 6, 1E-15);
-    EXPECT_NEAR(result[1], 6, 1E-15);
+	EXPECT_NEAR(result[0], 6, get_epsilon<ST>());
+	EXPECT_NEAR(result[1], 6, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_block_rowwise_sum()
 {
-    const index_t nrows = 2, ncols = 3;
-    SGMatrix<ST> mat(nrows, ncols);
+	const index_t nrows = 2, ncols = 3;
+	SGMatrix<ST> mat(nrows, ncols);
 
-    for (index_t i = 0; i < nrows; ++i)
-        for (index_t j = 0; j < ncols; ++j)
-            mat(i, j) = i * 10 + j + 1;
+	for (index_t i = 0; i < nrows; ++i)
+		for (index_t j = 0; j < ncols; ++j)
+			mat(i, j) = i * 10 + j + 1;
 
-    auto result = rowwise_sum(linalg::block(mat, 0, 0, 2, 3));
+	auto result = rowwise_sum(linalg::block(mat, 0, 0, 2, 3));
 
-    for (index_t i = 0; i < nrows; ++i)
-    {
-        ST sum = 0;
-        for (index_t j = 0; j < ncols; ++j)
-            sum += mat(i, j);
-        EXPECT_NEAR(sum, result[i], 1E-15);
-    }
+	for (index_t i = 0; i < nrows; ++i)
+	{
+		ST sum = 0;
+		for (index_t j = 0; j < ncols; ++j)
+			sum += mat(i, j);
+		EXPECT_NEAR(sum, result[i], get_epsilon<ST>());
+	}
 }
 
 template <typename ST>
 void check_SGMatrix_svd_jacobi_thinU()
 {
-    const index_t m = 5, n = 3;
-    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-                 0.28540373, 0.06264684, 0.56204061};
-    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-    ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-                     -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-                     0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-                     -0.12681555, -0.53830325, 0.69323293};
+	const index_t m = 5, n = 3;
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+				 0.28540373, 0.06264684, 0.56204061};
+	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
+					 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+					 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+					 -0.12681555, -0.53830325, 0.69323293};
 
-    SGMatrix<ST> A(data, m, n, false);
-    SGMatrix<ST> U(m, n);
-    SGVector<ST> s(n);
+	SGMatrix<ST> A(data, m, n, false);
+	SGMatrix<ST> U(m, n);
+	SGVector<ST> s(n);
 
-    svd(A, s, U, true, SVDAlgorithm::Jacobi);
+	svd(A, s, U, true, SVDAlgorithm::Jacobi);
 
-    for (index_t i = 0; i < n; ++i)
-    {
-        auto c = CMath::sign(U[i * m] * result_U[i * m]);
-        for (index_t j = 0; j < m; ++j)
-            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
-    }
-    for (index_t i = 0; i < (index_t)s.size(); ++i)
-        EXPECT_NEAR(s[i], result_s[i], 1e-6);
+	for (index_t i = 0; i < n; ++i)
+	{
+		auto c = CMath::sign(U[i * m] * result_U[i * m]);
+		for (index_t j = 0; j < m; ++j)
+			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
+	}
+	for (index_t i = 0; i < (index_t)s.size(); ++i)
+		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
 template <typename ST>
 void check_SGMatrix_svd_jacobi_fullU()
 {
-    const index_t m = 5, n = 3;
-    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-                 0.28540373, 0.06264684, 0.56204061};
-    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-    ST result_U[] = {
-            -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
-            -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
-            -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
-            -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
-            0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
+	const index_t m = 5, n = 3;
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+				 0.28540373, 0.06264684, 0.56204061};
+	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	ST result_U[] = {
+			-0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
+			-0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
+			-0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
+			-0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
+			0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
-    SGMatrix<ST> A(data, m, n, false);
-    SGMatrix<ST> U(m, m);
-    SGVector<ST> s(n);
+	SGMatrix<ST> A(data, m, n, false);
+	SGMatrix<ST> U(m, m);
+	SGVector<ST> s(n);
 
-    svd(A, s, U, false, SVDAlgorithm::Jacobi);
+	svd(A, s, U, false, SVDAlgorithm::Jacobi);
 
-    for (index_t i = 0; i < n; ++i)
-    {
-        auto c = CMath::sign(U[i * m] * result_U[i * m]);
-        for (index_t j = 0; j < m; ++j)
-            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
-    }
-    for (index_t i = 0; i < (index_t)s.size(); ++i)
-        EXPECT_NEAR(s[i], result_s[i], 1e-6);
+	for (index_t i = 0; i < n; ++i)
+	{
+		auto c = CMath::sign(U[i * m] * result_U[i * m]);
+		for (index_t j = 0; j < m; ++j)
+			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
+	}
+	for (index_t i = 0; i < (index_t)s.size(); ++i)
+		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 template <typename ST>
 void check_SGMatrix_svd_bdc_thinU()
 {
-    const index_t m = 5, n = 3;
-    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-                 0.28540373, 0.06264684, 0.56204061};
-    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-    ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-                     -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-                     0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-                     -0.12681555, -0.53830325, 0.69323293};
+	const index_t m = 5, n = 3;
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+				 0.28540373, 0.06264684, 0.56204061};
+	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
+					 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+					 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+					 -0.12681555, -0.53830325, 0.69323293};
 
-    SGMatrix<ST> A(data, m, n, false);
-    SGMatrix<ST> U(m, n);
-    SGVector<ST> s(n);
+	SGMatrix<ST> A(data, m, n, false);
+	SGMatrix<ST> U(m, n);
+	SGVector<ST> s(n);
 
-    svd(A, s, U, true, SVDAlgorithm::BidiagonalDivideConquer);
+	svd(A, s, U, true, SVDAlgorithm::BidiagonalDivideConquer);
 
-    for (index_t i = 0; i < n; ++i)
-    {
-        auto c = CMath::sign(U[i * m] * result_U[i * m]);
-        for (index_t j = 0; j < m; ++j)
-            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
-    }
-    for (index_t i = 0; i < (index_t)s.size(); ++i)
-        EXPECT_NEAR(s[i], result_s[i], 1e-6);
+	for (index_t i = 0; i < n; ++i)
+	{
+		auto c = CMath::sign(U[i * m] * result_U[i * m]);
+		for (index_t j = 0; j < m; ++j)
+			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
+	}
+	for (index_t i = 0; i < (index_t)s.size(); ++i)
+		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
 template <typename ST>
 void check_SGMatrix_svd_bdc_fullU()
 {
-    const index_t m = 5, n = 3;
-    ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
-                 0.30786772, 0.25503552, 0.34367041, 0.66491478,
-                 0.20488809, 0.5734351,  0.87179189, 0.07139643,
-                 0.28540373, 0.06264684, 0.56204061};
-    ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-    ST result_U[] = {
-            -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
-            -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
-            -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
-            -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
-            0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
+	const index_t m = 5, n = 3;
+	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+				 0.30786772, 0.25503552, 0.34367041, 0.66491478,
+				 0.20488809, 0.5734351,  0.87179189, 0.07139643,
+				 0.28540373, 0.06264684, 0.56204061};
+	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	ST result_U[] = {
+			-0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
+			-0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
+			-0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
+			-0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
+			0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
-    SGMatrix<ST> A(data, m, n, false);
-    SGMatrix<ST> U(m, m);
-    SGVector<ST> s(n);
+	SGMatrix<ST> A(data, m, n, false);
+	SGMatrix<ST> U(m, m);
+	SGVector<ST> s(n);
 
-    svd(A, s, U, false, SVDAlgorithm::BidiagonalDivideConquer);
+	svd(A, s, U, false, SVDAlgorithm::BidiagonalDivideConquer);
 
-    for (index_t i = 0; i < n; ++i)
-    {
-        auto c = CMath::sign(U[i * m] * result_U[i * m]);
-        for (index_t j = 0; j < m; ++j)
-            EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
-    }
-    for (index_t i = 0; i < (index_t)s.size(); ++i)
-        EXPECT_NEAR(s[i], result_s[i], 1e-6);
+	for (index_t i = 0; i < n; ++i)
+	{
+		auto c = CMath::sign(U[i * m] * result_U[i * m]);
+		for (index_t j = 0; j < m; ++j)
+			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
+	}
+	for (index_t i = 0; i < (index_t)s.size(); ++i)
+		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 #endif
 
 template <typename ST>
 void check_SGMatrix_trace()
 {
-    const index_t n = 4;
+	const index_t n = 4;
 
-    SGMatrix<ST> A(n, n);
-    for (index_t i = 0; i < n*n; ++i)
-        A[i] = i;
+	SGMatrix<ST> A(n, n);
+	for (index_t i = 0; i < n*n; ++i)
+		A[i] = i;
 
-    ST tr = 0;
-    for (index_t i = 0; i < n; ++i)
-        tr += A.get_element(i, i);
+	ST tr = 0;
+	for (index_t i = 0; i < n; ++i)
+		tr += A.get_element(i, i);
 
-    EXPECT_NEAR(trace(A), tr, 1e-15);
+	EXPECT_NEAR(trace(A), tr, get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_trace_dot()
 {
-    const index_t n = 2;
-    SGMatrix<ST> A(n, n), B(n, n);
-    for (index_t i = 0; i < n*n; ++i) {
-        A[i] = i;
-        B[i] = i * 2;
-    }
+	const index_t n = 2;
+	SGMatrix<ST> A(n, n), B(n, n);
+	for (index_t i = 0; i < n*n; ++i) {
+		A[i] = i;
+		B[i] = i * 2;
+	}
 
-    auto C = matrix_prod(A, B);
-    auto tr = 0.0;
-    for (auto i : range(n))
-        tr += C(i, i);
+	auto C = matrix_prod(A, B);
+	auto tr = 0.0;
+	for (auto i : range(n))
+		tr += C(i, i);
 
-    EXPECT_NEAR(tr, trace_dot(A, B), 1e-15);
+	EXPECT_NEAR(tr, trace_dot(A, B), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGMatrix_transpose_matrix()
 {
-    const index_t m = 5, n = 3;
-    SGMatrix<ST> A(m, n);
-    linalg::range_fill(A, static_cast<ST>(1));
+	const index_t m = 5, n = 3;
+	SGMatrix<ST> A(m, n);
+	linalg::range_fill(A, static_cast<ST>(1));
 
-    auto T = transpose_matrix(A);
+	auto T = transpose_matrix(A);
 
-    for (index_t i = 0; i < m; ++i)
-        for (index_t j = 0; j < n; ++j)
-            EXPECT_NEAR(A.get_element(i, j), T.get_element(j, i), 1e-15);
+	for (index_t i = 0; i < m; ++i)
+		for (index_t j = 0; j < n; ++j)
+			EXPECT_NEAR(A.get_element(i, j), T.get_element(j, i), get_epsilon<ST>());
 }
 
 template <typename ST>
 void check_SGVector_triangular_solver_lower()
 {
-    const index_t n = 3;
-    ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
-                   0.,          -0.27048649, -0.05919915,
-                   0.,          0.,          0.11869106};
-    ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
-    ST result[] = {-0.42455592, -0.72571316, 0.17192745};
+	const index_t n = 3;
+	ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
+				   0.,          -0.27048649, -0.05919915,
+				   0.,          0.,          0.11869106};
+	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
+	ST result[] = {-0.42455592, -0.72571316, 0.17192745};
 
-    SGMatrix<ST> L(data_L, n, n, false);
-    SGVector<ST> b(data_b, n, false);
+	SGMatrix<ST> L(data_L, n, n, false);
+	SGVector<ST> b(data_b, n, false);
 
-    auto x = triangular_solver(L, b, true);
+	auto x = triangular_solver(L, b, true);
 
-    for (index_t i = 0; i < (index_t)x.size(); ++i)
-        EXPECT_NEAR(x[i], result[i], 1E-6);
+	for (index_t i = 0; i < (index_t)x.size(); ++i)
+		EXPECT_NEAR(x[i], result[i], 1e-6);
 }
 
 template <typename ST>
 void check_SGVector_triangular_solver_upper()
 {
-    const index_t n = 3;
-    ST data_U[] = {-0.92947874, 0.,          0.,
-                   -1.1432887,  -0.27048649, 0.,
-                   -0.87119086, -0.05919915, 0.11869106};
-    ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
-    ST result[] = {0.23681135, -3.31909306, 3.65012412};
+	const index_t n = 3;
+	ST data_U[] = {-0.92947874, 0.,          0.,
+				   -1.1432887,  -0.27048649, 0.,
+				   -0.87119086, -0.05919915, 0.11869106};
+	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
+	ST result[] = {0.23681135, -3.31909306, 3.65012412};
 
-    SGMatrix<ST> U(data_U, n, n, false);
-    SGVector<ST> b(data_b, n, false);
+	SGMatrix<ST> U(data_U, n, n, false);
+	SGVector<ST> b(data_b, n, false);
 
-    auto x = triangular_solver(U, b, false);
+	auto x = triangular_solver(U, b, false);
 
-    for (index_t i = 0; i < (index_t)x.size(); ++i)
-        EXPECT_NEAR(x[i], result[i], 1E-6);
+	for (index_t i = 0; i < (index_t)x.size(); ++i)
+		EXPECT_NEAR(x[i], result[i], 1e-6);
 }
 
 template <typename ST>
 void check_SGMatrix_triangular_solver_lower()
 {
-    const index_t n = 3, m = 2;
-    ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
-                   0.,          -0.27048649, -0.05919915,
-                   0.,          0.,          0.11869106};
-    ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-                   0.94311546, 0.59630347, 0.65820143};
-    ST result[] = {-0.82600139, 0.22050986, -3.02127745,
-                   -1.01467136, 2.08424024, -0.86262387};
+	const index_t n = 3, m = 2;
+	ST data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
+				   0.,          -0.27048649, -0.05919915,
+				   0.,          0.,          0.11869106};
+	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
+				   0.94311546, 0.59630347, 0.65820143};
+	ST result[] = {-0.82600139, 0.22050986, -3.02127745,
+				   -1.01467136, 2.08424024, -0.86262387};
 
-    SGMatrix<ST> L(data_L, n, n, false);
-    SGMatrix<ST> B(data_B, n, m, false);
+	SGMatrix<ST> L(data_L, n, n, false);
+	SGMatrix<ST> B(data_B, n, m, false);
 
-    auto X = triangular_solver(L, B, true);
+	auto X = triangular_solver(L, B, true);
 
-    for (index_t i = 0; i < (index_t)X.size(); ++i)
-    EXPECT_NEAR(X[i], result[i], 1E-6);
+	for (index_t i = 0; i < (index_t)X.size(); ++i)
+	EXPECT_NEAR(X[i], result[i], 1e-6	);
 }
 
 template <typename ST>
 void check_SGMatrix_triangular_solver_upper()
 {
-    const index_t n = 3, m = 2;
-    ST data_U[] = {-0.92947874, 0.,          0.,
-                   -1.1432887,  -0.27048649, 0.,
-                   -0.87119086, -0.05919915, 0.11869106};
-    ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-                   0.94311546, 0.59630347, 0.65820143};
-    ST result[] = {1.238677,    -3.91243241, 2.9315793,
-                   -2.00784647, -3.41825732, 5.54550138};
+	const index_t n = 3, m = 2;
+	ST data_U[] = {-0.92947874, 0.,          0.,
+				   -1.1432887,  -0.27048649, 0.,
+				   -0.87119086, -0.05919915, 0.11869106};
+	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
+				   0.94311546, 0.59630347, 0.65820143};
+	ST result[] = {1.238677,    -3.91243241, 2.9315793,
+				   -2.00784647, -3.41825732, 5.54550138};
 
-    SGMatrix<ST> L(data_U, n, n, false);
-    SGMatrix<ST> B(data_B, n, m, false);
+	SGMatrix<ST> L(data_U, n, n, false);
+	SGMatrix<ST> B(data_B, n, m, false);
 
-    auto X = triangular_solver(L, B, false);
+	auto X = triangular_solver(L, B, false);
 
-    for (index_t i = 0; i < (index_t)X.size(); ++i)
-    EXPECT_NEAR(X[i], result[i], 1E-6);
+	for (index_t i = 0; i < (index_t)X.size(); ++i)
+	EXPECT_NEAR(X[i], result[i], 1e-6);
 }
 
 
 template <typename ST>
 void check_SGVector_zero()
 {
-    const index_t n = 16;
-    SGVector<ST> a(n);
-    zero(a);
+	const index_t n = 16;
+	SGVector<ST> a(n);
+	zero(a);
 
-    for (index_t i = 0; i < n; ++i)
-        EXPECT_EQ(a[i], 0);
+	for (index_t i = 0; i < n; ++i)
+		EXPECT_EQ(a[i], 0);
 }
 
 template <typename ST>
 void check_SGMatrix_zero()
 {
-    const index_t nrows = 3, ncols = 4;
-    SGMatrix<ST> A(nrows, ncols);
-    zero(A);
+	const index_t nrows = 3, ncols = 4;
+	SGMatrix<ST> A(nrows, ncols);
+	zero(A);
 
-    for (index_t i = 0; i < nrows*ncols; ++i)
-        EXPECT_EQ(A[i], 0);
+	for (index_t i = 0; i < nrows*ncols; ++i)
+		EXPECT_EQ(A[i], 0);
 }
 
 template <typename ST>
 void check_SGMatrix_rank_update()
 {
-    typedef Matrix<ST, Dynamic, Dynamic> Mxx;
-    typedef Matrix<ST, 1, Dynamic> Vxd;
+	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+	typedef Matrix<ST, 1, Dynamic> Vxd;
 
-    const index_t size = 2;
-    SGMatrix<ST> A(size, size);
-    SGVector<ST> b(size);
-    Map<Mxx> A_eig(A.matrix, size, size);
-    Map<Vxd> b_eig(b.vector, size);
+	const index_t size = 2;
+	SGMatrix<ST> A(size, size);
+	SGVector<ST> b(size);
+	Map<Mxx> A_eig(A.matrix, size, size);
+	Map<Vxd> b_eig(b.vector, size);
 
-    A(0, 0) = 2.0;
-    A(1, 0) = 1.0;
-    A(0, 1) = 1.0;
-    A(1, 1) = 2.5;
-    b[0] = 2;
-    b[1] = 3;
+	A(0, 0) = 2.0;
+	A(1, 0) = 1.0;
+	A(0, 1) = 1.0;
+	A(1, 1) = 2.5;
+	b[0] = 2;
+	b[1] = 3;
 
-    auto A2 = A.clone();
-    Map<Mxx> A2_eig(A2.matrix, size, size);
-    A2(0, 0) += b[0] * b[0];
-    A2(0, 1) += b[0] * b[1];
-    A2(1, 0) += b[1] * b[0];
-    A2(1, 1) += b[1] * b[1];
+	auto A2 = A.clone();
+	Map<Mxx> A2_eig(A2.matrix, size, size);
+	A2(0, 0) += b[0] * b[0];
+	A2(0, 1) += b[0] * b[1];
+	A2(1, 0) += b[1] * b[0];
+	A2(1, 1) += b[1] * b[1];
 
-    rank_update(A, b, static_cast<ST>(1));
-    EXPECT_NEAR((A2_eig - A_eig).norm(), 0, 1e-14);
+	rank_update(A, b, static_cast<ST>(1));
+	EXPECT_NEAR((A2_eig - A_eig).norm(), 0, get_epsilon<ST>());
 
-    rank_update(A, b, static_cast<ST>(-1));
-    EXPECT_NEAR((A_eig - A_eig).norm(), 0, 1e-14);
+	rank_update(A, b, static_cast<ST>(-1));
+	EXPECT_NEAR((A_eig - A_eig).norm(), 0, get_epsilon<ST>());
 }
 
 
 // test types based on shogun/mathematics/linalg/LinalgBackendBase.h
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
 {
-    check_SGVector_add<TypeParam>();
+	check_SGVector_add<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add)
 {
-    check_SGMatrix_add<TypeParam>();
+	check_SGMatrix_add<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_in_place)
 {
-    check_SGVector_add_in_place<TypeParam>();
+	check_SGVector_add_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_in_place)
 {
-    check_SGMatrix_add_in_place<TypeParam>();
+	check_SGMatrix_add_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_allocated)
 {
-    check_SGVector_add_col_vec_allocated<TypeParam>();
+	check_SGVector_add_col_vec_allocated<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_in_place)
 {
-    check_SGVector_add_col_vec_in_place<TypeParam>();
+	check_SGVector_add_col_vec_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_allocated)
 {
-    check_SGMatrix_add_col_vec_allocated<TypeParam>();
+	check_SGMatrix_add_col_vec_allocated<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_in_place)
 {
-    check_SGMatrix_add_col_vec_in_place<TypeParam>();
+	check_SGMatrix_add_col_vec_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, add_diag)
 {
-    check_add_diag<TypeParam>();
+	check_add_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, add_ridge)
 {
-    check_add_ridge<TypeParam>();
+	check_add_ridge<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, add_vector)
 {
-    check_add_vector<TypeParam>();
+	check_add_vector<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_scalar)
 {
-    check_SGVector_add_scalar<TypeParam>();
+	check_SGVector_add_scalar<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_scalar)
 {
-    check_SGMatrix_add_scalar<TypeParam>();
+	check_SGMatrix_add_scalar<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_center_matrix)
 {
-    check_SGMatrix_center_matrix<TypeParam>();
+	check_SGMatrix_center_matrix<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_lower)
 {
-    check_SGMatrix_cholesky_llt_lower<TypeParam>();
+	check_SGMatrix_cholesky_llt_lower<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_upper)
 {
-    check_SGMatrix_cholesky_llt_upper<TypeParam>();
+	check_SGMatrix_cholesky_llt_upper<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_upper)
 {
-    check_SGMatrix_cholesky_rank_update_upper<TypeParam>();
+	check_SGMatrix_cholesky_rank_update_upper<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_lower)
 {
-    check_SGMatrix_cholesky_rank_update_lower<TypeParam>();
+	check_SGMatrix_cholesky_rank_update_lower<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_ldlt_lower)
 {
-    check_SGMatrix_cholesky_ldlt_lower<TypeParam>();
+	check_SGMatrix_cholesky_ldlt_lower<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_solver)
 {
-    check_SGMatrix_cholesky_solver<TypeParam>();
+	check_SGMatrix_cholesky_solver<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_ldlt_solver)
 {
-    check_SGMatrix_ldlt_solver<TypeParam>();
+	check_SGMatrix_ldlt_solver<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cross_entropy)
 {
-    check_SGMatrix_cross_entropy<TypeParam>();
+	check_SGMatrix_cross_entropy<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_psd)
 {
-    check_SGMatrix_pinv_psd<TypeParam>();
+	check_SGMatrix_pinv_psd<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_2x4)
 {
-    check_SGMatrix_pinv_2x4<TypeParam>();
+	check_SGMatrix_pinv_2x4<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_4x2)
 {
-    check_SGMatrix_pinv_4x2<TypeParam>();
+	check_SGMatrix_pinv_4x2<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_dot)
 {
-    check_SGVector_dot<TypeParam>();
+	check_SGVector_dot<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver)
 {
-    check_eigensolver<TypeParam>();
+	check_eigensolver<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver_symmetric)
 {
-    check_eigensolver_symmetric<TypeParam>();
+	check_eigensolver_symmetric<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product)
 {
-    check_SGMatrix_elementwise_product<TypeParam>();
+	check_SGMatrix_elementwise_product<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product_in_place)
 {
-    check_SGMatrix_elementwise_product_in_place<TypeParam>();
+	check_SGMatrix_elementwise_product_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_elementwise_product)
 {
-    check_SGMatrix_block_elementwise_product<TypeParam>();
+	check_SGMatrix_block_elementwise_product<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product)
 {
-    check_SGVector_elementwise_product<TypeParam>();
+	check_SGVector_elementwise_product<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product_in_place)
 {
-    check_SGVector_elementwise_product_in_place<TypeParam>();
+	check_SGVector_elementwise_product_in_place<TypeParam>();
 }
 
 // TODO: write test for int types
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_exponent)
 {
-    check_SGVector_exponent<TypeParam>();
+	check_SGVector_exponent<TypeParam>();
 }
 
 // TODO: write test for int types
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_exponent)
 {
-    check_SGMatrix_exponent<TypeParam>();
+	check_SGMatrix_exponent<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_identity)
 {
-    check_SGMatrix_identity<TypeParam>();
+	check_SGMatrix_identity<TypeParam>();
 }
 
 // TODO: write test for int types
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, logistic)
 {
-    check_logistic<TypeParam>();
+	check_logistic<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod)
 {
-    check_SGMatrix_SGVector_matrix_prod<TypeParam>();
+	check_SGMatrix_SGVector_matrix_prod<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_matrix_prod_transpose)
 {
-    check_SGVector_matrix_prod_transpose<TypeParam>();
+	check_SGVector_matrix_prod_transpose<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place)
 {
-    check_SGMatrix_SGVector_matrix_prod_in_place<TypeParam>();
+	check_SGMatrix_SGVector_matrix_prod_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place_transpose)
 {
-    check_SGMatrix_SGVector_matrix_prod_in_place_transpose<TypeParam>();
+	check_SGMatrix_SGVector_matrix_prod_in_place_transpose<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product)
 {
-    check_SGMatrix_matrix_product<TypeParam>();
+	check_SGMatrix_matrix_product<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A)
 {
-    check_SGMatrix_matrix_product_transpose_A<TypeParam>();
+	check_SGMatrix_matrix_product_transpose_A<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_B)
 {
-    check_SGMatrix_matrix_product_transpose_B<TypeParam>();
+	check_SGMatrix_matrix_product_transpose_B<TypeParam>();
 }
 
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A_B)
 {
-    check_SGMatrix_matrix_product_transpose_A_B<TypeParam>();
+	check_SGMatrix_matrix_product_transpose_A_B<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place)
 {
-    check_SGMatrix_matrix_product_in_place<TypeParam>();
+	check_SGMatrix_matrix_product_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_A)
 {
-    check_SGMatrix_matrix_product_in_place_transpose_A<TypeParam>();
+	check_SGMatrix_matrix_product_in_place_transpose_A<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_B)
 {
-    check_SGMatrix_matrix_product_in_place_transpose_B<TypeParam>();
+	check_SGMatrix_matrix_product_in_place_transpose_B<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place_transpose_A_B)
 {
-    check_SGMatrix_matrix_product_in_place_transpose_A_B<TypeParam>();
+	check_SGMatrix_matrix_product_in_place_transpose_A_B<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_max)
 {
-    check_SGVector_max<TypeParam>();
+	check_SGVector_max<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_max)
 {
-    check_SGMatrix_max<TypeParam>();
+	check_SGMatrix_max<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_mean)
 {
-    check_SGVector_mean<TypeParam>();
+	check_SGVector_mean<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_mean)
 {
-    check_SGMatrix_mean<TypeParam>();
+	check_SGMatrix_mean<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_multiply_by_logistic_derivative)
 {
-    check_SGMatrix_multiply_by_logistic_derivative<TypeParam>();
+	check_SGMatrix_multiply_by_logistic_derivative<TypeParam>();
 }
 
 // TODO: write test for int types
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_multiply_by_rectified_linear_derivative)
 {
-    check_SGMatrix_multiply_by_rectified_linear_derivative<TypeParam>();
+	check_SGMatrix_multiply_by_rectified_linear_derivative<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_norm)
 {
-    check_SGVector_norm<TypeParam>();
+	check_SGVector_norm<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_qr_solver)
 {
-    check_SGVector_qr_solver<TypeParam>();
+	check_SGVector_qr_solver<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_qr_solver)
 {
-    check_SGMatrix_qr_solver<TypeParam>();
+	check_SGMatrix_qr_solver<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_range_fill)
 {
-    check_SGVector_range_fill<TypeParam>();
+	check_SGVector_range_fill<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_range_fill)
 {
-    check_SGMatrix_range_fill<TypeParam>();
+	check_SGMatrix_range_fill<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rectified_linear)
 {
-    check_SGMatrix_rectified_linear<TypeParam>();
+	check_SGMatrix_rectified_linear<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale)
 {
-    check_SGVector_scale<TypeParam>();
+	check_SGVector_scale<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale)
 {
-    check_SGMatrix_scale<TypeParam>();
+	check_SGMatrix_scale<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale_in_place)
 {
-    check_SGVector_scale_in_place<TypeParam>();
+	check_SGVector_scale_in_place<TypeParam>();
 }
 
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale_in_place)
 {
-    check_SGMatrix_scale_in_place<TypeParam>();
+	check_SGMatrix_scale_in_place<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_set_const)
 {
-    check_SGVector_set_const<TypeParam>();
+	check_SGVector_set_const<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_set_const)
 {
-    check_SGMatrix_set_const<TypeParam>();
+	check_SGMatrix_set_const<TypeParam>();
 }
 
 // TODO: extend to all types
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_softmax)
 {
-    check_SGMatrix_softmax<TypeParam>();
+	check_SGMatrix_softmax<TypeParam>();
 }
 
 // FIXME: CMath::Pow only accepts float or complex types
@@ -2608,176 +2609,176 @@ TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_softmax)
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_sum)
 {
-    check_SGVector_sum<TypeParam>();
+	check_SGVector_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum)
 {
-    check_SGMatrix_sum<TypeParam>();
+	check_SGMatrix_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum_no_diag)
 {
-    check_SGMatrix_sum_no_diag<TypeParam>();
+	check_SGMatrix_sum_no_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_with_diag)
 {
-    check_SGMatrix_symmetric_with_diag<TypeParam>();
+	check_SGMatrix_symmetric_with_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_no_diag)
 {
-    check_SGMatrix_symmetric_no_diag<TypeParam>();
+	check_SGMatrix_symmetric_no_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_exception)
 {
-    check_SGMatrix_symmetric_exception<TypeParam>();
+	check_SGMatrix_symmetric_exception<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_sum)
 {
-    check_SGMatrix_block_sum<TypeParam>();
+	check_SGMatrix_block_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_with_diag)
 {
-    check_SGMatrix_symmetric_block_with_diag<TypeParam>();
+	check_SGMatrix_symmetric_block_with_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_no_diag)
 {
-    check_SGMatrix_symmetric_block_no_diag<TypeParam>();
+	check_SGMatrix_symmetric_block_no_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_exception)
 {
-    check_SGMatrix_symmetric_block_exception<TypeParam>();
+	check_SGMatrix_symmetric_block_exception<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum)
 {
-    check_SGMatrix_colwise_sum<TypeParam>();
+	check_SGMatrix_colwise_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum_no_diag)
 {
-    check_SGMatrix_colwise_sum_no_diag<TypeParam>();
+	check_SGMatrix_colwise_sum_no_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_colwise_sum)
 {
-    check_SGMatrix_block_colwise_sum<TypeParam>();
+	check_SGMatrix_block_colwise_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum)
 {
-    check_SGMatrix_rowwise_sum<TypeParam>();
+	check_SGMatrix_rowwise_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum_no_diag)
 {
-    check_SGMatrix_rowwise_sum_no_diag<TypeParam>();
+	check_SGMatrix_rowwise_sum_no_diag<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_rowwise_sum)
 {
-    check_SGMatrix_block_rowwise_sum<TypeParam>();
+	check_SGMatrix_block_rowwise_sum<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_thinU)
 {
-    check_SGMatrix_svd_jacobi_thinU<TypeParam>();
+	check_SGMatrix_svd_jacobi_thinU<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_fullU)
 {
-    check_SGMatrix_svd_jacobi_fullU<TypeParam>();
+	check_SGMatrix_svd_jacobi_fullU<TypeParam>();
 }
 
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_thinU)
 {
-    check_SGMatrix_svd_bdc_thinU<TypeParam>();
+	check_SGMatrix_svd_bdc_thinU<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_fullU)
 {
-    check_SGMatrix_svd_bdc_fullU<TypeParam>();
+	check_SGMatrix_svd_bdc_fullU<TypeParam>();
 }
 #endif
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace)
 {
-    check_SGMatrix_trace<TypeParam>();
+	check_SGMatrix_trace<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace_dot)
 {
-    check_SGMatrix_trace_dot<TypeParam>();
+	check_SGMatrix_trace_dot<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_transpose_matrix)
 {
-    check_SGMatrix_transpose_matrix<TypeParam>();
+	check_SGMatrix_transpose_matrix<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_lower)
 {
-    check_SGVector_triangular_solver_lower<TypeParam>();
+	check_SGVector_triangular_solver_lower<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_upper)
 {
-    check_SGVector_triangular_solver_upper<TypeParam>();
+	check_SGVector_triangular_solver_upper<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_lower)
 {
-    check_SGMatrix_triangular_solver_lower<TypeParam>();
+	check_SGMatrix_triangular_solver_lower<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_upper)
 {
-    check_SGMatrix_triangular_solver_upper<TypeParam>();
+	check_SGMatrix_triangular_solver_upper<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_zero)
 {
-    check_SGVector_zero<TypeParam>();
+	check_SGVector_zero<TypeParam>();
 }
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_zero)
 {
-    check_SGMatrix_zero<TypeParam>();
+	check_SGMatrix_zero<TypeParam>();
 }
 
 // TODO: extend to int types
 TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_rank_update)
 {
-    check_SGMatrix_rank_update<TypeParam>();
+	check_SGMatrix_rank_update<TypeParam>();
 }
 
 // TODO: implement typed testing for SE
 TEST(LinalgBackendEigen, SGMatrix_squared_error)
 {
-    SGMatrix<float64_t> A(4, 3);
-    SGMatrix<float64_t> B(4, 3);
+	SGMatrix<float64_t> A(4, 3);
+	SGMatrix<float64_t> B(4, 3);
 
-    int32_t size = A.num_rows * A.num_cols;
-    for (float64_t i = 0; i < size; ++i)
-    {
-        A[i] = i / size;
-        B[i] = (i / size) * 0.5;
-    }
+	int32_t size = A.num_rows * A.num_cols;
+	for (float64_t i = 0; i < size; ++i)
+	{
+		A[i] = i / size;
+		B[i] = (i / size) * 0.5;
+	}
 
-    float64_t ref = 0;
-    for (index_t i = 0; i < size; i++)
-        ref += CMath::pow(A[i] - B[i], 2);
-            ref *= 0.5;
+	float64_t ref = 0;
+	for (index_t i = 0; i < size; i++)
+		ref += CMath::pow(A[i] - B[i], 2);
+			ref *= 0.5;
 
-    auto result = linalg::squared_error(A, B);
-    EXPECT_NEAR(ref, result, 1e-15);
+	auto result = linalg::squared_error(A, B);
+	EXPECT_NEAR(ref, result, 1e-15);
 }

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -43,10 +43,10 @@ class LinalgBackendEigenNonIntegerTypesTest : public ::testing::Test
 // TODO: make global definitions
 // Definition of the 4 groups of Shogun types
 // (shogun/mathematics/linalg/LinalgBackendBase.h)
-// TODO: add bool, chars and complex128_t types
+// TODO: add bool and complex128_t types
 typedef ::testing::Types<
     int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
-    float64_t, floatmax_t>
+    float64_t, floatmax_t, char>
     AllTypes;
 typedef ::testing::Types<
     int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
@@ -61,15 +61,13 @@ TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, NonComplexTypes);
 TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, RealTypes);
 TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, NonIntegerTypes);
 
-template <typename ST>
-void check_SGVector_add()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
 {
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 
-	const ST alpha = 1;
-	const ST beta = 2;
-
-	SGVector<ST> A(9);
-	SGVector<ST> B(9);
+	SGVector<TypeParam> A(9);
+	SGVector<TypeParam> B(9);
 
 	for (index_t i = 0; i < 9; ++i)
 	{
@@ -80,21 +78,20 @@ void check_SGVector_add()
 	auto result = add(A, B, alpha, beta);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(alpha * A[i] + beta * B[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(
+		    alpha * A[i] + beta * B[i], result[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_add()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add)
 {
-
-	const ST alpha = 1;
-	const ST beta = 2;
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 	const index_t nrows = 2, ncols = 3;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGMatrix<ST> B(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGMatrix<TypeParam> B(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 	{
 		A[i] = i;
 		B[i] = 2 * i;
@@ -102,17 +99,17 @@ void check_SGMatrix_add()
 
 	auto result = add(A, B, alpha, beta);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha * A[i] + beta * B[i], result[i], get_epsilon<ST>());
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(
+		    alpha * A[i] + beta * B[i], result[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_add_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_in_place)
 {
-	const ST alpha = 1;
-	const ST beta = 2;
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 
-	SGVector<ST> A(9), B(9), C(9);
+	SGVector<TypeParam> A(9), B(9), C(9);
 
 	for (index_t i = 0; i < 9; ++i)
 	{
@@ -124,22 +121,20 @@ void check_SGVector_add_in_place()
 	add(A, B, A, alpha, beta);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(alpha * C[i] + beta * B[i], A[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * C[i] + beta * B[i], A[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_add_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_in_place)
 {
-
-	const ST alpha = 1;
-	const ST beta = 2;
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 	const index_t nrows = 2, ncols = 3;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGMatrix<ST> B(nrows, ncols);
-	SGMatrix<ST> C(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGMatrix<TypeParam> B(nrows, ncols);
+	SGMatrix<TypeParam> C(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 	{
 		A[i] = i;
 		B[i] = 3 * i;
@@ -148,22 +143,20 @@ void check_SGMatrix_add_in_place()
 
 	add(A, B, A, alpha, beta);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha * C[i] + beta * B[i], A[i], get_epsilon<ST>());
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(alpha * C[i] + beta * B[i], A[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_add_col_vec_allocated()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_allocated)
 {
-
-	const ST alpha = 1;
-	const ST beta = 2;
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 	const index_t nrows = 2, ncols = 3;
 	const index_t col = 1;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGVector<ST> b(nrows);
-	SGVector<ST> result(nrows);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGVector<TypeParam> b(nrows);
+	SGVector<TypeParam> result(nrows);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = i;
@@ -175,21 +168,20 @@ void check_SGVector_add_col_vec_allocated()
 	for (index_t i = 0; i < nrows; ++i)
 		EXPECT_NEAR(
 		    result[i], alpha * A.get_element(i, col) + beta * b[i],
-		    get_epsilon<ST>());
+		    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_add_col_vec_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_in_place)
 {
-	const ST alpha = 0;
-	const ST beta = 3;
+	const TypeParam alpha = 0;
+	const TypeParam beta = 3;
 	const index_t nrows = 2, ncols = 3;
 	const index_t col = 1;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGVector<ST> b(nrows);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGVector<TypeParam> b(nrows);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
 		b[i] = 2 * i;
@@ -199,22 +191,21 @@ void check_SGVector_add_col_vec_in_place()
 	for (index_t i = 0; i < nrows; ++i)
 		EXPECT_NEAR(
 		    b[i], alpha * A.get_element(i, col) + beta * 2 * i,
-		    get_epsilon<ST>());
+		    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_add_col_vec_allocated()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_allocated)
 {
-	const ST alpha = 0;
-	const ST beta = 2;
+	const TypeParam alpha = 0;
+	const TypeParam beta = 2;
 	const index_t nrows = 2, ncols = 3;
 	const index_t col = 1;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGVector<ST> b(nrows);
-	SGMatrix<ST> result(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGVector<TypeParam> b(nrows);
+	SGMatrix<TypeParam> result(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
 		b[i] = 3 * i;
@@ -224,21 +215,21 @@ void check_SGMatrix_add_col_vec_allocated()
 	for (index_t i = 0; i < nrows; ++i)
 		EXPECT_NEAR(
 		    result.get_element(i, col),
-		    alpha * A.get_element(i, col) + beta * b[i], get_epsilon<ST>());
+		    alpha * A.get_element(i, col) + beta * b[i],
+		    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_add_col_vec_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_in_place)
 {
-	const ST alpha = 1;
-	const ST beta = 2;
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 	const index_t nrows = 2, ncols = 3;
 	const index_t col = 1;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGVector<ST> b(nrows);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGVector<TypeParam> b(nrows);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = i;
 	for (index_t i = 0; i < nrows; ++i)
 		b[i] = 3 * i;
@@ -248,21 +239,20 @@ void check_SGMatrix_add_col_vec_in_place()
 	for (index_t i = 0; i < nrows; ++i)
 		for (index_t j = 0; j < ncols; ++j)
 		{
-			ST a = i + j * nrows;
+			TypeParam a = i + j * nrows;
 			if (j == col)
 				EXPECT_NEAR(
 				    A.get_element(i, j), alpha * a + beta * b[i],
-				    get_epsilon<ST>());
+				    get_epsilon<TypeParam>());
 			else
-				EXPECT_EQ(A.get_element(i,j), a);
+				EXPECT_EQ(A.get_element(i, j), a);
 		}
 }
 
-template <typename ST>
-void check_add_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, add_diag)
 {
-	SGMatrix<ST> A1(2, 3);
-	SGVector<ST> b1(2);
+	SGMatrix<TypeParam> A1(2, 3);
+	SGVector<TypeParam> b1(2);
 
 	A1(0, 0) = 1;
 	A1(0, 1) = 2;
@@ -274,33 +264,32 @@ void check_add_diag()
 	b1[0] = 1;
 	b1[1] = 2;
 
-	const ST alpha = 1.0;
-	const ST beta = 2.0;
+	const TypeParam alpha = 1.0;
+	const TypeParam beta = 2.0;
 
 	add_diag(A1, b1, alpha, beta);
 
-	EXPECT_NEAR(A1(0, 0), 3, 1e-15);
-	EXPECT_NEAR(A1(0, 1), 2, 1e-15);
-	EXPECT_NEAR(A1(0, 2), 3, 1e-15);
-	EXPECT_NEAR(A1(1, 0), 4, 1e-15);
-	EXPECT_NEAR(A1(1, 1), 9, 1e-15);
-	EXPECT_NEAR(A1(1, 2), 6, 1e-15);
+	EXPECT_NEAR(A1(0, 0), 3, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(0, 1), 2, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(0, 2), 3, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(1, 0), 4, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(1, 1), 9, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(1, 2), 6, get_epsilon<TypeParam>());
 
 	// test error cases
-	SGMatrix<ST> A2(2, 2);
-	SGVector<ST> b2(3);
-	SGMatrix<ST> A3;
-	SGVector<ST> b3;
+	SGMatrix<TypeParam> A2(2, 2);
+	SGVector<TypeParam> b2(3);
+	SGMatrix<TypeParam> A3;
+	SGVector<TypeParam> b3;
 	EXPECT_THROW(add_diag(A2, b2), ShogunException);
 	EXPECT_THROW(add_diag(A2, b3), ShogunException);
 	EXPECT_THROW(add_diag(A3, b2), ShogunException);
 	EXPECT_THROW(add_diag(A3, b3), ShogunException);
 }
 
-template <typename ST>
-void check_add_ridge()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, add_ridge)
 {
-	SGMatrix<ST> A1(2, 3);
+	SGMatrix<TypeParam> A1(2, 3);
 
 	A1(0, 0) = 1;
 	A1(0, 1) = 2;
@@ -309,32 +298,31 @@ void check_add_ridge()
 	A1(1, 1) = 5;
 	A1(1, 2) = 6;
 
-	const ST alpha = 1.0;
+	const TypeParam alpha = 1.0;
 
 	add_ridge(A1, alpha);
 
-	EXPECT_NEAR(A1(0, 0), 2, 1e-15);
-	EXPECT_NEAR(A1(0, 1), 2, 1e-15);
-	EXPECT_NEAR(A1(0, 2), 3, 1e-15);
-	EXPECT_NEAR(A1(1, 0), 4, 1e-15);
-	EXPECT_NEAR(A1(1, 1), 6, 1e-15);
-	EXPECT_NEAR(A1(1, 2), 6, 1e-15);
+	EXPECT_NEAR(A1(0, 0), 2, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(0, 1), 2, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(0, 2), 3, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(1, 0), 4, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(1, 1), 6, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A1(1, 2), 6, get_epsilon<TypeParam>());
 
 	// test error cases
-	SGMatrix<ST> A2;
+	SGMatrix<TypeParam> A2;
 	EXPECT_THROW(add_ridge(A2, alpha), ShogunException);
 }
 
-template <typename ST>
-void check_add_vector()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, add_vector)
 {
-	const ST alpha = 1;
-	const ST beta = 2;
+	const TypeParam alpha = 1;
+	const TypeParam beta = 2;
 	const index_t nrows = 2, ncols = 3;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGMatrix<ST> result(nrows, ncols);
-	SGVector<ST> b(nrows);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGMatrix<TypeParam> result(nrows, ncols);
+	SGVector<TypeParam> b(nrows);
 
 	for (index_t i = 0; i < nrows; ++i)
 		b[i] = 3 * i;
@@ -348,73 +336,69 @@ void check_add_vector()
 	add_vector(A, b, A, alpha, beta);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
-		EXPECT_NEAR(A[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(A[i], result[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_add_scalar()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_scalar)
 {
 	const index_t n = 4;
-	ST s = -0.3;
+	TypeParam s = -0.3;
 
-	SGVector<ST> a(n);
+	SGVector<TypeParam> a(n);
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
 		a[i] = i;
-	SGVector<ST> orig = a.clone();
+	SGVector<TypeParam> orig = a.clone();
 
 	add_scalar(a, s);
 
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
-		EXPECT_NEAR(a[i], orig[i] + s, get_epsilon<ST>());
+		EXPECT_NEAR(a[i], orig[i] + s, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_add_scalar()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_scalar)
 {
 	const index_t r = 4, c = 3;
-	ST s = 0.4;
+	TypeParam s = 0.4;
 
-	SGMatrix<ST> a(r, c);
+	SGMatrix<TypeParam> a(r, c);
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
 		a[i] = i;
-	SGMatrix<ST> orig = a.clone();
+	SGMatrix<TypeParam> orig = a.clone();
 
 	add_scalar(a, s);
 
 	for (index_t i = 0; i < (index_t)a.size(); ++i)
-		EXPECT_NEAR(a[i], orig[i] + s, get_epsilon<ST>());
+		EXPECT_NEAR(a[i], orig[i] + s, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_center_matrix()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_center_matrix)
 {
 	const index_t n = 3;
-	ST data[] = {0.5, 0.3, 0.4, 0.4, 0.5, 0.3, 0.3, 0.4, 0.5};
-	ST result[] = {0.1, -0.1, 0.0, 0.0, 0.1, -0.1, -0.1, 0.0, 0.1};
+	TypeParam data[] = {0.5, 0.3, 0.4, 0.4, 0.5, 0.3, 0.3, 0.4, 0.5};
+	TypeParam result[] = {0.1, -0.1, 0.0, 0.0, 0.1, -0.1, -0.1, 0.0, 0.1};
 
-	SGMatrix<ST> m(data, n, n, false);
+	SGMatrix<TypeParam> m(data, n, n, false);
 
 	center_matrix(m);
 
 	for (index_t i = 0; i < (index_t)m.size(); ++i)
-		EXPECT_NEAR(m[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(m[i], result[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_cholesky_llt_lower()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_lower)
 {
-	const index_t size=2;
-	SGMatrix<ST> m(size, size);
-	// need to adapt the Eigen::Matrix to ST type
-	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+	const index_t size = 2;
+	SGMatrix<TypeParam> m(size, size);
+	// need to adapt the Eigen::Matrix to TypeParam type
+	typedef Matrix<TypeParam, Dynamic, Dynamic> Mxx;
 
-	m(0,0)=2.0;
-	m(0,1)=1.0;
-	m(1,0)=1.0;
-	m(1,1)=2.5;
+	m(0, 0) = 2.0;
+	m(0, 1) = 1.0;
+	m(1, 0) = 1.0;
+	m(1, 1) = 2.5;
 
-	//lower triangular cholesky decomposition
-	SGMatrix<ST> L = cholesky_factor(m);
+	// lower triangular cholesky decomposition
+	SGMatrix<TypeParam> L = cholesky_factor(m);
 
 	Map<Mxx> map_A(m.matrix, m.num_rows, m.num_cols);
 	Map<Mxx> map_L(L.matrix, L.num_rows, L.num_cols);
@@ -423,21 +407,20 @@ void check_SGMatrix_cholesky_llt_lower()
 	EXPECT_EQ(m.num_cols, L.num_cols);
 }
 
-template <typename ST>
-void check_SGMatrix_cholesky_llt_upper()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_upper)
 {
-	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
+	typedef Matrix<TypeParam, Dynamic, Dynamic> Mxx;
 
-	const index_t size=2;
-	SGMatrix<ST> m(size, size);
+	const index_t size = 2;
+	SGMatrix<TypeParam> m(size, size);
 
-	m(0,0)=2.0;
-	m(0,1)=1.0;
-	m(1,0)=1.0;
-	m(1,1)=2.5;
+	m(0, 0) = 2.0;
+	m(0, 1) = 1.0;
+	m(1, 0) = 1.0;
+	m(1, 1) = 2.5;
 
-	//upper triangular cholesky decomposition
-	SGMatrix<ST> U = cholesky_factor(m, false);
+	// upper triangular cholesky decomposition
+	SGMatrix<TypeParam> U = cholesky_factor(m, false);
 
 	Map<Mxx> map_A(m.matrix, m.num_rows, m.num_cols);
 	Map<Mxx> map_U(U.matrix, U.num_rows, U.num_cols);
@@ -446,17 +429,16 @@ void check_SGMatrix_cholesky_llt_upper()
 	EXPECT_EQ(m.num_cols, U.num_cols);
 }
 
-template <typename ST>
-void check_SGMatrix_cholesky_rank_update_upper()
+TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_upper)
 {
-	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
-	typedef Matrix<ST, Dynamic, 1> Vx;
+	typedef Matrix<TypeParam, Dynamic, Dynamic> Mxx;
+	typedef Matrix<TypeParam, Dynamic, 1> Vx;
 
 	const index_t size = 2;
-	ST alpha = 1;
-	SGMatrix<ST> A(size, size);
-	SGMatrix<ST> U(size, size);
-	SGVector<ST> b(size);
+	TypeParam alpha = 1;
+	SGMatrix<TypeParam> A(size, size);
+	SGMatrix<TypeParam> U(size, size);
+	SGVector<TypeParam> b(size);
 	Map<Mxx> A_eig(A.matrix, size, size);
 	Map<Mxx> U_eig(U.matrix, size, size);
 	Map<Vx> b_eig(b.vector, size);
@@ -477,24 +459,25 @@ void check_SGMatrix_cholesky_rank_update_upper()
 
 	cholesky_rank_update(U, b, alpha, false);
 	EXPECT_NEAR(
-	    (A2_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
+	    (A2_eig - U_eig.transpose() * U_eig).norm(), 0.0,
+	    get_epsilon<TypeParam>());
 
 	cholesky_rank_update(U, b, -alpha, false);
 	EXPECT_NEAR(
-	    (A_eig - U_eig.transpose() * U_eig).norm(), 0.0, get_epsilon<ST>());
+	    (A_eig - U_eig.transpose() * U_eig).norm(), 0.0,
+	    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_cholesky_rank_update_lower()
+TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_lower)
 {
-	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
-	typedef Matrix<ST, Dynamic, 1> Vx;
+	typedef Matrix<TypeParam, Dynamic, Dynamic> Mxx;
+	typedef Matrix<TypeParam, Dynamic, 1> Vx;
 
 	const index_t size = 2;
-	ST alpha = 1;
-	SGMatrix<ST> A(size, size);
-	SGMatrix<ST> L(size, size);
-	SGVector<ST> b(size);
+	TypeParam alpha = 1;
+	SGMatrix<TypeParam> A(size, size);
+	SGMatrix<TypeParam> L(size, size);
+	SGVector<TypeParam> b(size);
 	Map<Mxx> A_eig(A.matrix, size, size);
 	Map<Mxx> L_eig(L.matrix, size, size);
 	Map<Vx> b_eig(b.vector, size);
@@ -515,18 +498,19 @@ void check_SGMatrix_cholesky_rank_update_lower()
 
 	cholesky_rank_update(L, b, alpha);
 	EXPECT_NEAR(
-	    (A2_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
+	    (A2_eig - L_eig * L_eig.transpose()).norm(), 0.0,
+	    get_epsilon<TypeParam>());
 
 	cholesky_rank_update(L, b, -alpha);
 	EXPECT_NEAR(
-	    (A_eig - L_eig * L_eig.transpose()).norm(), 0.0, get_epsilon<ST>());
+	    (A_eig - L_eig * L_eig.transpose()).norm(), 0.0,
+	    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_cholesky_ldlt_lower()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_ldlt_lower)
 {
 	const index_t size = 3;
-	SGMatrix<ST> m(size, size);
+	SGMatrix<TypeParam> m(size, size);
 	m(0, 0) = 0.0;
 	m(0, 1) = 0.0;
 	m(0, 2) = 0.0;
@@ -537,62 +521,60 @@ void check_SGMatrix_cholesky_ldlt_lower()
 	m(2, 1) = 2.0;
 	m(2, 2) = 3.0;
 
-	SGMatrix<ST> L(size, size);
-	SGVector<ST> d(size);
+	SGMatrix<TypeParam> L(size, size);
+	SGVector<TypeParam> d(size);
 	SGVector<index_t> p(size);
 
 	linalg::ldlt_factor(m, L, d, p);
 
-	EXPECT_NEAR(d[0], 3.0, get_epsilon<ST>());
-	EXPECT_NEAR(d[1], -0.333333333333333, get_epsilon<ST>());
-	EXPECT_NEAR(d[2], 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(d[0], 3.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(d[1], -0.333333333333333, get_epsilon<TypeParam>());
+	EXPECT_NEAR(d[2], 0.0, get_epsilon<TypeParam>());
 
-	EXPECT_NEAR(L(0, 0), 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(0, 1), 0.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(0, 2), 0.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(1, 0), 0.666666666666666, get_epsilon<ST>());
-	EXPECT_NEAR(L(1, 1), 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(1, 2), 0.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(2, 0), 0.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(2, 1), 0.0, get_epsilon<ST>());
-	EXPECT_NEAR(L(2, 2), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(L(0, 0), 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(0, 1), 0.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(0, 2), 0.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(1, 0), 0.666666666666666, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(1, 1), 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(1, 2), 0.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(2, 0), 0.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(2, 1), 0.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(L(2, 2), 1.0, get_epsilon<TypeParam>());
 
 	EXPECT_EQ(p[0], 2);
 	EXPECT_EQ(p[1], 1);
 	EXPECT_EQ(p[2], 2);
 }
 
-template <typename ST>
-void check_SGMatrix_cholesky_solver()
+TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_solver)
 {
-	const index_t size=2;
-	SGMatrix<ST> A(size, size);
-	A(0,0)=2.0;
-	A(0,1)=1.0;
-	A(1,0)=1.0;
-	A(1,1)=2.5;
+	const index_t size = 2;
+	SGMatrix<TypeParam> A(size, size);
+	A(0, 0) = 2.0;
+	A(0, 1) = 1.0;
+	A(1, 0) = 1.0;
+	A(1, 1) = 2.5;
 
-	SGVector<ST> b(size);
+	SGVector<TypeParam> b(size);
 	b[0] = 10;
 	b[1] = 13;
 
-	SGVector<ST> x_ref(size);
+	SGVector<TypeParam> x_ref(size);
 	x_ref[0] = 3;
 	x_ref[1] = 4;
 
-	SGMatrix<ST> L = cholesky_factor(A);
-	SGVector<ST> x_cal = cholesky_solver(L, b);
+	SGMatrix<TypeParam> L = cholesky_factor(A);
+	SGVector<TypeParam> x_cal = cholesky_solver(L, b);
 
-	EXPECT_NEAR(x_ref[0], x_cal[0], get_epsilon<ST>());
-	EXPECT_NEAR(x_ref[1], x_cal[1], get_epsilon<ST>());
+	EXPECT_NEAR(x_ref[0], x_cal[0], get_epsilon<TypeParam>());
+	EXPECT_NEAR(x_ref[1], x_cal[1], get_epsilon<TypeParam>());
 	EXPECT_EQ(x_ref.size(), x_cal.size());
 }
 
-template <typename ST>
-void check_SGMatrix_ldlt_solver()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_ldlt_solver)
 {
 	const index_t size = 3;
-	SGMatrix<ST> A(size, size);
+	SGMatrix<TypeParam> A(size, size);
 	A(0, 0) = 0.0;
 	A(0, 1) = 0.0;
 	A(0, 2) = 0.0;
@@ -603,39 +585,38 @@ void check_SGMatrix_ldlt_solver()
 	A(2, 1) = 2.0;
 	A(2, 2) = 3.0;
 
-	SGVector<ST> b(size);
+	SGVector<TypeParam> b(size);
 	b[0] = 0.0;
 	b[1] = 5.0;
 	b[2] = 11.0;
 
-	SGVector<ST> x_ref(size), x(size);
+	SGVector<TypeParam> x_ref(size), x(size);
 	x_ref[0] = 0.0;
 	x_ref[1] = 7.0;
 	x_ref[2] = -1.0;
 
-	SGMatrix<ST> L(size, size);
-	SGVector<ST> d(size);
+	SGMatrix<TypeParam> L(size, size);
+	SGVector<TypeParam> d(size);
 	SGVector<index_t> p(size);
 
 	linalg::ldlt_factor(A, L, d, p, true);
 	x = linalg::ldlt_solver(L, d, p, b, true);
 	for (auto i : range(size))
-		EXPECT_NEAR(x[i], x_ref[i], get_epsilon<ST>());
+		EXPECT_NEAR(x[i], x_ref[i], get_epsilon<TypeParam>());
 
 	linalg::ldlt_factor(A, L, d, p, false);
 	x = linalg::ldlt_solver(L, d, p, b, false);
 	for (auto i : range(size))
-		EXPECT_NEAR(x[i], x_ref[i], get_epsilon<ST>());
+		EXPECT_NEAR(x[i], x_ref[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_cross_entropy()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cross_entropy)
 {
-	SGMatrix<ST> A(4, 3);
-	SGMatrix<ST> B(4, 3);
+	SGMatrix<TypeParam> A(4, 3);
+	SGMatrix<TypeParam> B(4, 3);
 
 	uint32_t size = A.num_rows * A.num_cols;
-	for (ST i = 0; i < size; ++i)
+	for (TypeParam i = 0; i < size; ++i)
 	{
 		A[i] = i / size;
 		B[i] = (i / size) * 0.5;
@@ -647,46 +628,45 @@ void check_SGMatrix_cross_entropy()
 	ref *= -1;
 
 	auto result = linalg::cross_entropy(A, B);
-	EXPECT_NEAR(ref, result, get_epsilon<ST>());
+	EXPECT_NEAR(ref, result, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_pinv_psd()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_psd)
 {
-	ST A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
+	TypeParam A_data[] = {2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0};
 	// inverse generated by scipy pinv
-	ST scipy_result_data[] = {0.75, 0.5, 0.25, 0.5, 1.0, 0.5, 0.25, 0.5, 0.75};
+	TypeParam scipy_result_data[] = {0.75, 0.5,  0.25, 0.5, 1.0,
+	                                 0.5,  0.25, 0.5,  0.75};
 
-	SGMatrix<ST> A(A_data, 3, 3, false);
-	SGMatrix<ST> result(scipy_result_data, 3, 3, false);
+	SGMatrix<TypeParam> A(A_data, 3, 3, false);
+	SGMatrix<TypeParam> result(scipy_result_data, 3, 3, false);
 
-	SGMatrix<ST> identity_matrix(3, 3);
+	SGMatrix<TypeParam> identity_matrix(3, 3);
 	linalg::identity(identity_matrix);
 	// using symmetric eigen solver
-	SGMatrix<ST> A_pinvh(3, 3);
+	SGMatrix<TypeParam> A_pinvh(3, 3);
 	linalg::pinvh(A, A_pinvh);
 	// using singular value decomposition
-	SGMatrix<ST> A_pinv(3, 3);
+	SGMatrix<TypeParam> A_pinv(3, 3);
 	linalg::pinv(A, A_pinv);
-	SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinvh);
+	SGMatrix<TypeParam> I_check = linalg::matrix_prod(A, A_pinvh);
 	for (auto i : range(3))
 	{
 		for (auto j : range(3))
 		{
 			EXPECT_NEAR(
-			    identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
-			EXPECT_NEAR(result(i, j), A_pinvh(i, j), get_epsilon<ST>());
-			EXPECT_NEAR(result(i, j), A_pinv(i, j), get_epsilon<ST>());
+			    identity_matrix(i, j), I_check(i, j), get_epsilon<TypeParam>());
+			EXPECT_NEAR(result(i, j), A_pinvh(i, j), get_epsilon<TypeParam>());
+			EXPECT_NEAR(result(i, j), A_pinv(i, j), get_epsilon<TypeParam>());
 		}
 	}
 	// no memory errors
 	EXPECT_NO_THROW(linalg::pinvh(A, A));
 }
 
-template <typename ST>
-void check_SGMatrix_pinv_2x4()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_2x4)
 {
-	SGMatrix<ST> A(2, 4);
+	SGMatrix<TypeParam> A(2, 4);
 	A(0, 0) = 1;
 	A(0, 1) = 1;
 	A(0, 2) = 1;
@@ -696,41 +676,40 @@ void check_SGMatrix_pinv_2x4()
 	A(1, 2) = 7;
 	A(1, 3) = 9;
 
-	SGMatrix<ST> identity_matrix(2, 2);
+	SGMatrix<TypeParam> identity_matrix(2, 2);
 	linalg::identity(identity_matrix);
-	SGMatrix<ST> A_pinverse(4, 2);
+	SGMatrix<TypeParam> A_pinverse(4, 2);
 	linalg::pinv(A, A_pinverse);
-	SGMatrix<ST> I_check = linalg::matrix_prod(A, A_pinverse);
+	SGMatrix<TypeParam> I_check = linalg::matrix_prod(A, A_pinverse);
 	for (auto i : range(2))
 	{
 		for (auto j : range(2))
 		{
 			EXPECT_NEAR(
-			    identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+			    identity_matrix(i, j), I_check(i, j), get_epsilon<TypeParam>());
 		}
 	}
 
 	// compare result with scipy pinv
-	EXPECT_NEAR(A_pinverse(0, 0), 2.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(0, 1), -0.25, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(0, 0), 2.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(0, 1), -0.25, get_epsilon<TypeParam>());
 
-	EXPECT_NEAR(A_pinverse(1, 0), 0.25, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(1, 1), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(1, 0), 0.25, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(1, 1), 0.0, get_epsilon<TypeParam>());
 
-	EXPECT_NEAR(A_pinverse(2, 0), 0.25, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(2, 1), 0.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(2, 0), 0.25, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(2, 1), 0.0, get_epsilon<TypeParam>());
 
-	EXPECT_NEAR(A_pinverse(3, 0), -1.5, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(3, 1), 0.25, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(3, 0), -1.5, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(3, 1), 0.25, get_epsilon<TypeParam>());
 
 	// incorrect dimension
 	EXPECT_THROW(linalg::pinv(A, A), ShogunException);
 }
 
-template <typename ST>
-void check_SGMatrix_pinv_4x2()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_4x2)
 {
-	SGMatrix<ST> A(4, 2);
+	SGMatrix<TypeParam> A(4, 2);
 	A(0, 0) = 2.0;
 	A(0, 1) = -0.25;
 	A(1, 0) = 0.25;
@@ -740,62 +719,61 @@ void check_SGMatrix_pinv_4x2()
 	A(3, 0) = -1.5;
 	A(3, 1) = 0.25;
 
-	SGMatrix<ST> identity_matrix(2, 2);
+	SGMatrix<TypeParam> identity_matrix(2, 2);
 	linalg::identity(identity_matrix);
-	SGMatrix<ST> A_pinverse(2, 4);
+	SGMatrix<TypeParam> A_pinverse(2, 4);
 	linalg::pinv(A, A_pinverse);
-	SGMatrix<ST> I_check = linalg::matrix_prod(A_pinverse, A);
+	SGMatrix<TypeParam> I_check = linalg::matrix_prod(A_pinverse, A);
 	for (auto i : range(2))
 	{
 		for (auto j : range(2))
 		{
 			EXPECT_NEAR(
-			    identity_matrix(i, j), I_check(i, j), get_epsilon<ST>());
+			    identity_matrix(i, j), I_check(i, j), get_epsilon<TypeParam>());
 		}
 	}
 	// compare with results from scipy
-	EXPECT_NEAR(A_pinverse(0, 0), 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(0, 1), 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(0, 2), 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(0, 3), 1.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(0, 0), 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(0, 1), 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(0, 2), 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(0, 3), 1.0, get_epsilon<TypeParam>());
 
-	EXPECT_NEAR(A_pinverse(1, 0), 5.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(1, 1), 7.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(1, 2), 7.0, get_epsilon<ST>());
-	EXPECT_NEAR(A_pinverse(1, 3), 9.0, get_epsilon<ST>());
+	EXPECT_NEAR(A_pinverse(1, 0), 5.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(1, 1), 7.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(1, 2), 7.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(A_pinverse(1, 3), 9.0, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_dot()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_dot)
 {
 	const index_t size = 3;
-	SGVector<ST> a(size), b(size);
+	SGVector<TypeParam> a(size), b(size);
 	a.range_fill(0);
 	b.range_fill(0);
 
 	auto result = dot(a, b);
 
-	EXPECT_NEAR(result, 5, 1E-15);
+	EXPECT_NEAR(result, 5, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_eigensolver()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver)
 {
 	const index_t n = 4;
-	ST data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
-	             0.62323516, 0.16837367, 0.85027625, 0.60165948,
-	             0.04898732, 0.96701123, 0.51683275, 0.51116495,
-	             0.18277926, 0.6179262,  0.43745891, 0.63685464};
-	ST result_eigenvectors[] = {
+	TypeParam data[] = {0.09987322, 0.80575314, 0.79068641, 0.69989667,
+	                    0.62323516, 0.16837367, 0.85027625, 0.60165948,
+	                    0.04898732, 0.96701123, 0.51683275, 0.51116495,
+	                    0.18277926, 0.6179262,  0.43745891, 0.63685464};
+	TypeParam result_eigenvectors[] = {
 	    -0.63494074, 0.75831593,   -0.1401403109, 0.04656076,
 	    0.82257205,  -0.286718557, -0.44196422,   -0.214091861,
 	    -0.005932,   -0.20233723,  -0.52285555,   0.82803776,
 	    -0.23930111, -0.56199714,  -0.57298901,   -0.54642272};
-	ST result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101, 2.0981937};
+	TypeParam result_eigenvalues[] = {-0.6470538, -0.19125664, 0.16205101,
+	                                  2.0981937};
 
-	SGMatrix<ST> m(data, n, n, false);
-	SGMatrix<ST> eigenvectors(n, n);
-	SGVector<ST> eigenvalues(n);
+	SGMatrix<TypeParam> m(data, n, n, false);
+	SGMatrix<TypeParam> eigenvectors(n, n);
+	SGVector<TypeParam> eigenvalues(n);
 
 	eigen_solver(m, eigenvalues, eigenvectors);
 
@@ -814,25 +792,24 @@ void check_eigensolver()
 	}
 }
 
-template <typename ST>
-void check_eigensolver_symmetric()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver_symmetric)
 {
 	const index_t n = 4;
-	ST data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
-	             0.80575314, 0.16837367, 0.96701123, 0.6179262,
-	             0.04898732, 0.96701123, 0.51683275, 0.43745891,
-	             0.69989667, 0.6179262,  0.43745891, 0.63685464};
-	ST result_eigenvectors[] = {
+	TypeParam data[] = {0.09987322, 0.80575314, 0.04898732, 0.69989667,
+	                    0.80575314, 0.16837367, 0.96701123, 0.6179262,
+	                    0.04898732, 0.96701123, 0.51683275, 0.43745891,
+	                    0.69989667, 0.6179262,  0.43745891, 0.63685464};
+	TypeParam result_eigenvectors[] = {
 	    -0.54618542, 0.69935447,  -0.45219663, 0.09001671,
 	    -0.56171388, -0.41397154, 0.17642953,  0.69424612,
 	    -0.46818396, 0.16780603,  0.73247599,  -0.46489119,
 	    0.40861077,  0.55800718,  0.47735703,  0.542029037};
-	ST result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
-	                           2.18587989};
+	TypeParam result_eigenvalues[] = {-1.00663298, -0.18672196, 0.42940933,
+	                                  2.18587989};
 
-	SGMatrix<ST> m(data, n, n, false);
-	SGMatrix<ST> eigenvectors(n, n);
-	SGVector<ST> eigenvalues(n);
+	SGMatrix<TypeParam> m(data, n, n, false);
+	SGMatrix<TypeParam> eigenvectors(n, n);
+	SGVector<TypeParam> eigenvalues(n);
 
 	eigen_solver(m, eigenvalues, eigenvectors);
 
@@ -840,23 +817,22 @@ void check_eigensolver_symmetric()
 	for (index_t i = 0; i < n; ++i)
 	{
 		index_t idx = args[i];
-		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-6);
+		EXPECT_NEAR(eigenvalues[idx], result_eigenvalues[i], 1e-5);
 
 		auto s =
 		    CMath::sign(eigenvectors[idx * n] * result_eigenvectors[i * n]);
 		for (index_t j = 0; j < n; ++j)
 			EXPECT_NEAR(
 			    eigenvectors[idx * n + j], s * result_eigenvectors[i * n + j],
-			    1e-6);
+			    1e-5);
 	}
 }
 
-template <typename ST>
-void check_SGMatrix_elementwise_product()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product)
 {
 	const auto m = 2;
-	SGMatrix<ST> A(m, m);
-	SGMatrix<ST> B(m, m);
+	SGMatrix<TypeParam> A(m, m);
+	SGMatrix<TypeParam> B(m, m);
 
 	for (auto i : range(m * m))
 	{
@@ -868,34 +844,38 @@ void check_SGMatrix_elementwise_product()
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(i, j) * B(i, j), get_epsilon<TypeParam>());
 
 	result = element_prod(A, B, true, false);
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(i, j), get_epsilon<TypeParam>());
 
 	result = element_prod(A, B, false, true);
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(i, j), get_epsilon<TypeParam>());
 
 	result = element_prod(A, B, true, true);
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(j, i), get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_elementwise_product_in_place()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product_in_place)
 {
 	const auto m = 2;
-	SGMatrix<ST> A(m, m);
-	SGMatrix<ST> B(m, m);
-	SGMatrix<ST> result(m, m);
+	SGMatrix<TypeParam> A(m, m);
+	SGMatrix<TypeParam> B(m, m);
+	SGMatrix<TypeParam> result(m, m);
 
 	for (auto i : range(m * m))
 	{
@@ -906,32 +886,35 @@ void check_SGMatrix_elementwise_product_in_place()
 	element_prod(A, B, result);
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(i, j) * B(i, j), get_epsilon<TypeParam>());
 
 	element_prod(A, B, result, true, false);
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(i, j), get_epsilon<TypeParam>());
 
 	element_prod(A, B, result, false, true);
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(i, j), get_epsilon<TypeParam>());
 
 	element_prod(A, B, result, true, true);
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(j, i), get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_block_elementwise_product()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_elementwise_product)
 {
 	const index_t nrows = 2;
 	const index_t ncols = 3;
 
-	SGMatrix<ST> A(nrows, ncols);
-	SGMatrix<ST> B(ncols, nrows);
+	SGMatrix<TypeParam> A(nrows, ncols);
+	SGMatrix<TypeParam> B(ncols, nrows);
 
 	for (auto i : range(nrows))
 		for (auto j : range(ncols))
@@ -950,7 +933,8 @@ void check_SGMatrix_block_elementwise_product()
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(i, j) * B(i, j), get_epsilon<TypeParam>());
 
 	result = element_prod(A_block, B_block, true, false);
 
@@ -959,7 +943,8 @@ void check_SGMatrix_block_elementwise_product()
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(i, j), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(i, j), get_epsilon<TypeParam>());
 
 	result = element_prod(A_block, B_block, false, true);
 
@@ -968,7 +953,8 @@ void check_SGMatrix_block_elementwise_product()
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(i, j) * B(j, i), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(i, j) * B(j, i), get_epsilon<TypeParam>());
 
 	result = element_prod(A_block, B_block, true, true);
 
@@ -977,16 +963,16 @@ void check_SGMatrix_block_elementwise_product()
 
 	for (auto i : range(m))
 		for (auto j : range(m))
-			EXPECT_NEAR(result(i, j), A(j, i) * B(j, i), get_epsilon<ST>());
+			EXPECT_NEAR(
+			    result(i, j), A(j, i) * B(j, i), get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_elementwise_product()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product)
 {
 	const index_t len = 4;
-	SGVector<ST> a(len);
-	SGVector<ST> b(len);
-	SGVector<ST> c(len);
+	SGVector<TypeParam> a(len);
+	SGVector<TypeParam> b(len);
+	SGVector<TypeParam> c(len);
 
 	for (index_t i = 0; i < len; ++i)
 	{
@@ -997,16 +983,16 @@ void check_SGVector_elementwise_product()
 	c = element_prod(a, b);
 
 	for (index_t i = 0; i < len; ++i)
-		EXPECT_NEAR(a[i] * b[i], c[i], get_epsilon<ST>());
+		EXPECT_NEAR(a[i] * b[i], c[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_elementwise_product_in_place()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGVector_elementwise_product_in_place)
 {
 	const index_t len = 4;
-	SGVector<ST> a(len);
-	SGVector<ST> b(len);
-	SGVector<ST> c(len);
+	SGVector<TypeParam> a(len);
+	SGVector<TypeParam> b(len);
+	SGVector<TypeParam> c(len);
 
 	for (index_t i = 0; i < len; ++i)
 	{
@@ -1017,60 +1003,57 @@ void check_SGVector_elementwise_product_in_place()
 
 	element_prod(a, b, a);
 	for (index_t i = 0; i < len; ++i)
-		EXPECT_NEAR(c[i] * b[i], a[i], get_epsilon<ST>());
+		EXPECT_NEAR(c[i] * b[i], a[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_exponent()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_exponent)
 {
 	const index_t len = 4;
-	SGVector<ST> a(len);
+	SGVector<TypeParam> a(len);
 	a[0] = 0;
 	a[1] = 1;
 	a[2] = 2;
 	a[3] = 3;
 	auto result = exponent(a);
 
-	EXPECT_NEAR(result[0], 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(result[1], 2.718281828459045, get_epsilon<ST>());
-	EXPECT_NEAR(result[2], 7.3890560989306495, get_epsilon<ST>());
-	EXPECT_NEAR(result[3], 20.085536923187664, get_epsilon<ST>());
+	EXPECT_NEAR(result[0], 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[1], 2.718281828459045, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[2], 7.3890560989306495, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[3], 20.085536923187664, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_exponent()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_exponent)
 {
 	const index_t n = 2;
-	SGMatrix<ST> a(n, n);
+	SGMatrix<TypeParam> a(n, n);
 	a[0] = 0;
 	a[1] = 1;
 	a[2] = 2;
 	a[3] = 3;
 	auto result = exponent(a);
 
-	EXPECT_NEAR(result[0], 1.0, get_epsilon<ST>());
-	EXPECT_NEAR(result[1], 2.718281828459045, get_epsilon<ST>());
-	EXPECT_NEAR(result[2], 7.3890560989306495, get_epsilon<ST>());
-	EXPECT_NEAR(result[3], 20.085536923187664, get_epsilon<ST>());
+	EXPECT_NEAR(result[0], 1.0, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[1], 2.718281828459045, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[2], 7.3890560989306495, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[3], 20.085536923187664, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_identity()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_identity)
 {
 	const index_t n = 4;
-	SGMatrix<ST> A(n, n);
+	SGMatrix<TypeParam> A(n, n);
 	identity(A);
 
 	for (index_t i = 0; i < n; ++i)
 		for (index_t j = 0; j < n; ++j)
-			EXPECT_EQ(A.get_element(i, j), (i==j));
+			EXPECT_EQ(A.get_element(i, j), (i == j));
 }
 
-template <typename ST>
-void check_logistic()
+// TODO: write test for int types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, logistic)
 {
-	SGMatrix<ST> A(3, 3);
-	SGMatrix<ST> B(3, 3);
+	SGMatrix<TypeParam> A(3, 3);
+	SGMatrix<TypeParam> B(3, 3);
 
 	for (index_t i = 0; i < 9; ++i)
 		A[i] = i;
@@ -1079,17 +1062,17 @@ void check_logistic()
 	linalg::logistic(A, B);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(1.0 / (1 + std::exp(-1 * A[i])), B[i], get_epsilon<ST>());
+		EXPECT_NEAR(
+		    1.0 / (1 + std::exp(-1 * A[i])), B[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_SGVector_matrix_prod()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod)
 {
-	const index_t rows=4;
-	const index_t cols=3;
+	const index_t rows = 4;
+	const index_t cols = 3;
 
-	SGMatrix<ST> A(rows, cols);
-	SGVector<ST> b(cols);
+	SGMatrix<TypeParam> A(rows, cols);
+	SGVector<TypeParam> b(cols);
 
 	for (index_t i = 0; i < cols; ++i)
 	{
@@ -1100,21 +1083,20 @@ void check_SGMatrix_SGVector_matrix_prod()
 
 	auto x = matrix_prod(A, b);
 
-	ST ref[] = {40, 46, 52, 58};
+	TypeParam ref[] = {40, 46, 52, 58};
 
 	EXPECT_EQ(x.vlen, A.num_rows);
 	for (index_t i = 0; i < rows; ++i)
-		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_matrix_prod_transpose()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_matrix_prod_transpose)
 {
-	const index_t rows=4;
-	const index_t cols=3;
+	const index_t rows = 4;
+	const index_t cols = 3;
 
-	SGMatrix<ST> A(cols, rows);
-	SGVector<ST> b(cols);
+	SGMatrix<TypeParam> A(cols, rows);
+	SGVector<TypeParam> b(cols);
 
 	for (index_t i = 0; i < cols; ++i)
 	{
@@ -1125,24 +1107,24 @@ void check_SGVector_matrix_prod_transpose()
 
 	auto x = matrix_prod(A, b, true);
 
-	ST ref[] = {30, 36, 42};
+	TypeParam ref[] = {30, 36, 42};
 
 	EXPECT_EQ(x.vlen, A.num_cols);
 	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_SGVector_matrix_prod_in_place()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place)
 {
-	const index_t rows=4;
-	const index_t cols=3;
+	const index_t rows = 4;
+	const index_t cols = 3;
 
-	SGMatrix<ST> A(rows, cols);
-	SGVector<ST> b(cols);
-	SGVector<ST> x(rows);
+	SGMatrix<TypeParam> A(rows, cols);
+	SGVector<TypeParam> b(cols);
+	SGVector<TypeParam> x(rows);
 
-	for (index_t i = 0; i<cols; ++i)
+	for (index_t i = 0; i < cols; ++i)
 	{
 		for (index_t j = 0; j < rows; ++j)
 			A(j, i) = i * rows + j;
@@ -1151,21 +1133,22 @@ void check_SGMatrix_SGVector_matrix_prod_in_place()
 
 	matrix_prod(A, b, x);
 
-	ST ref[] = {40, 46, 52, 58};
+	TypeParam ref[] = {40, 46, 52, 58};
 
 	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_SGVector_matrix_prod_in_place_transpose()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_SGVector_matrix_prod_in_place_transpose)
 {
-	const index_t rows=4;
-	const index_t cols=3;
+	const index_t rows = 4;
+	const index_t cols = 3;
 
-	SGMatrix<ST> A(cols, rows);
-	SGVector<ST> b(cols);
-	SGVector<ST> x(rows);
+	SGMatrix<TypeParam> A(cols, rows);
+	SGVector<TypeParam> b(cols);
+	SGVector<TypeParam> x(rows);
 
 	for (index_t i = 0; i < cols; ++i)
 	{
@@ -1176,255 +1159,250 @@ void check_SGMatrix_SGVector_matrix_prod_in_place_transpose()
 
 	matrix_prod(A, b, x, true);
 
-	ST ref[] = {30, 36, 42};
+	TypeParam ref[] = {30, 36, 42};
 
 	for (index_t i = 0; i < cols; ++i)
-		EXPECT_NEAR(x[i], ref[i], get_epsilon<ST>());
+		EXPECT_NEAR(x[i], ref[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product)
 {
 	const index_t dim1 = 2, dim2 = 4, dim3 = 2;
-	SGMatrix<ST> A(dim1, dim2);
-	SGMatrix<ST> B(dim2, dim3);
+	SGMatrix<TypeParam> A(dim1, dim2);
+	SGMatrix<TypeParam> B(dim2, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 
 	auto cal = linalg::matrix_prod(A, B);
 
-	ST ref[] = {28, 34, 76, 98};
+	TypeParam ref[] = {28, 34, 76, 98};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_transpose_A()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim2, dim1);
-	SGMatrix<ST> B(dim2, dim3);
+	SGMatrix<TypeParam> A(dim2, dim1);
+	SGMatrix<TypeParam> B(dim2, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 
 	auto cal = linalg::matrix_prod(A, B, true);
 
-	ST ref[] = {5, 14, 14, 50, 23, 86};
+	TypeParam ref[] = {5, 14, 14, 50, 23, 86};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_transpose_B()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_B)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim1, dim2);
-	SGMatrix<ST> B(dim3, dim2);
+	SGMatrix<TypeParam> A(dim1, dim2);
+	SGMatrix<TypeParam> B(dim3, dim2);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 
 	auto cal = linalg::matrix_prod(A, B, false, true);
 
-	ST ref[] = {30, 39, 36, 48, 42, 57};
+	TypeParam ref[] = {30, 39, 36, 48, 42, 57};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_transpose_A_B()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A_B)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim2, dim1);
-	SGMatrix<ST> B(dim3, dim2);
+	SGMatrix<TypeParam> A(dim2, dim1);
+	SGMatrix<TypeParam> B(dim3, dim2);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 
 	auto cal = linalg::matrix_prod(A, B, true, true);
 
-	ST ref[] = {15, 42, 18, 54, 21, 66};
+	TypeParam ref[] = {15, 42, 18, 54, 21, 66};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim1, dim2);
-	SGMatrix<ST> B(dim2, dim3);
-	SGMatrix<ST> cal(dim1, dim3);
+	SGMatrix<TypeParam> A(dim1, dim2);
+	SGMatrix<TypeParam> B(dim2, dim3);
+	SGMatrix<TypeParam> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 	cal.zero();
 
 	linalg::matrix_prod(A, B, cal);
 
-	ST ref[] = {10, 13, 28, 40, 46, 67};
+	TypeParam ref[] = {10, 13, 28, 40, 46, 67};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_in_place_transpose_A()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_matrix_product_in_place_transpose_A)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim2, dim1);
-	SGMatrix<ST> B(dim2, dim3);
-	SGMatrix<ST> cal(dim1, dim3);
+	SGMatrix<TypeParam> A(dim2, dim1);
+	SGMatrix<TypeParam> B(dim2, dim3);
+	SGMatrix<TypeParam> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 	cal.zero();
 
 	linalg::matrix_prod(A, B, cal, true);
 
-	ST ref[] = {5, 14, 14, 50, 23, 86};
+	TypeParam ref[] = {5, 14, 14, 50, 23, 86};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_in_place_transpose_B()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_matrix_product_in_place_transpose_B)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim1, dim2);
-	SGMatrix<ST> B(dim3, dim2);
-	SGMatrix<ST> cal(dim1, dim3);
+	SGMatrix<TypeParam> A(dim1, dim2);
+	SGMatrix<TypeParam> B(dim3, dim2);
+	SGMatrix<TypeParam> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 	cal.zero();
 
 	linalg::matrix_prod(A, B, cal, false, true);
 
-	ST ref[] = {30, 39, 36, 48, 42, 57};
+	TypeParam ref[] = {30, 39, 36, 48, 42, 57};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGMatrix_matrix_product_in_place_transpose_A_B()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest,
+    SGMatrix_matrix_product_in_place_transpose_A_B)
 {
 	const index_t dim1 = 2, dim2 = 3, dim3 = 3;
-	SGMatrix<ST> A(dim2, dim1);
-	SGMatrix<ST> B(dim3, dim2);
-	SGMatrix<ST> cal(dim1, dim3);
+	SGMatrix<TypeParam> A(dim2, dim1);
+	SGMatrix<TypeParam> B(dim3, dim2);
+	SGMatrix<TypeParam> cal(dim1, dim3);
 
-	for (index_t i = 0; i < dim1*dim2; ++i)
+	for (index_t i = 0; i < dim1 * dim2; ++i)
 		A[i] = i;
-	for (index_t i = 0; i < dim2*dim3; ++i)
+	for (index_t i = 0; i < dim2 * dim3; ++i)
 		B[i] = i;
 	cal.zero();
 
 	linalg::matrix_prod(A, B, cal, true, true);
 
-	ST ref[] = {15, 42, 18, 54, 21, 66};
+	TypeParam ref[] = {15, 42, 18, 54, 21, 66};
 
 	EXPECT_EQ(dim1, cal.num_rows);
 	EXPECT_EQ(dim3, cal.num_cols);
-	for (index_t i = 0; i < dim1*dim3; ++i)
+	for (index_t i = 0; i < dim1 * dim3; ++i)
 		EXPECT_EQ(ref[i], cal[i]);
 }
 
-template <typename ST>
-void check_SGVector_max()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_max)
 {
-	SGVector<ST> A(9);
+	SGVector<TypeParam> A(9);
 
-	ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 4};
+	TypeParam a[] = {1, 2, 5, 8, 3, 1, 0, 2, 4};
 
 	for (index_t i = 0; i < A.size(); ++i)
 		A[i] = a[i];
 
-	EXPECT_NEAR(8, max(A), get_epsilon<ST>());
+	EXPECT_NEAR(8, max(A), get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_max()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_max)
 {
 	const index_t nrows = 3, ncols = 3;
-	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
 
-	ST a[] = {1, 2, 5, 8, 3, 1, 0, 2, 12};
+	TypeParam a[] = {1, 2, 5, 8, 3, 1, 0, 2, 12};
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = a[i];
 
-	EXPECT_NEAR(12, max(A), get_epsilon<ST>());
+	EXPECT_NEAR(12, max(A), get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_mean()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_mean)
 {
 	const index_t size = 9;
-	SGVector<ST> vec(size);
+	SGVector<TypeParam> vec(size);
 	vec.range_fill(0);
 
 	auto result = mean(vec);
 
-	EXPECT_NEAR(result, 4, get_epsilon<ST>());
+	EXPECT_NEAR(result, 4, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_mean()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_mean)
 {
 	const index_t nrows = 3, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
 	auto result = mean(mat);
 
-	EXPECT_NEAR(result, 4, get_epsilon<ST>());
+	EXPECT_NEAR(result, 4, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_multiply_by_logistic_derivative()
+TYPED_TEST(
+    LinalgBackendEigenAllTypesTest, SGMatrix_multiply_by_logistic_derivative)
 {
-	SGMatrix<ST> A(3, 3);
-	SGMatrix<ST> B(3, 3);
+	SGMatrix<TypeParam> A(3, 3);
+	SGMatrix<TypeParam> B(3, 3);
 
-	for (ST i = 9; i < 9; i += 9)
+	for (TypeParam i = 9; i < 9; i += 9)
 	{
 		A[i] = i / 9;
 		B[i] = i;
@@ -1433,16 +1411,17 @@ void check_SGMatrix_multiply_by_logistic_derivative()
 	linalg::multiply_by_logistic_derivative(A, B);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(i * A[i] * (1.0 - A[i]), B[i], get_epsilon<ST>());
+		EXPECT_NEAR(i * A[i] * (1.0 - A[i]), B[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_multiply_by_rectified_linear_derivative()
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest,
+    SGMatrix_multiply_by_rectified_linear_derivative)
 {
-	SGMatrix<ST> A(3, 3);
-	SGMatrix<ST> B(3, 3);
+	SGMatrix<TypeParam> A(3, 3);
+	SGMatrix<TypeParam> B(3, 3);
 
-	for (ST i = 0; i < 9; ++i)
+	for (TypeParam i = 0; i < 9; ++i)
 	{
 		A[i] = i * 0.5 - 0.5;
 		B[i] = i;
@@ -1451,15 +1430,14 @@ void check_SGMatrix_multiply_by_rectified_linear_derivative()
 	multiply_by_rectified_linear_derivative(A, B);
 
 	for (index_t i = 0; i < 9; ++i)
-		EXPECT_NEAR(i * (A[i] != 0), B[i], get_epsilon<ST>());
+		EXPECT_NEAR(i * (A[i] != 0), B[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_norm()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_norm)
 {
 	const index_t n = 24;
-	SGVector<ST> v(n);
-	ST gt = 0;
+	SGVector<TypeParam> v(n);
+	TypeParam gt = 0;
 	for (index_t i = 0; i < n; ++i)
 	{
 		v[i] = i;
@@ -1470,20 +1448,20 @@ void check_SGVector_norm()
 
 	auto result = norm(v);
 
-	EXPECT_NEAR(result, gt, get_epsilon<ST>());
+	EXPECT_NEAR(result, gt, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_qr_solver()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_qr_solver)
 {
 	const index_t n = 3;
-	ST data_A[] = {0.02800922, 0.99326012, 0.15204902, 0.30492837, 0.39708534,
-	               0.40466969, 0.36415317, 0.04407589, 0.9095746};
-	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
-	ST result[] = {0.07135206, 1.56393127, -0.23141312};
+	TypeParam data_A[] = {0.02800922, 0.99326012, 0.15204902,
+	                      0.30492837, 0.39708534, 0.40466969,
+	                      0.36415317, 0.04407589, 0.9095746};
+	TypeParam data_b[] = {0.39461571, 0.6816856, 0.43323709};
+	TypeParam result[] = {0.07135206, 1.56393127, -0.23141312};
 
-	SGMatrix<ST> A(data_A, n, n, false);
-	SGVector<ST> b(data_b, n, false);
+	SGMatrix<TypeParam> A(data_A, n, n, false);
+	SGVector<TypeParam> b(data_b, n, false);
 
 	auto x = qr_solver(A, b);
 
@@ -1491,19 +1469,19 @@ void check_SGVector_qr_solver()
 		EXPECT_NEAR(x[i], result[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGMatrix_qr_solver()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_qr_solver)
 {
 	const index_t n = 3, m = 2;
-	ST data_A[] = {0.02800922, 0.99326012, 0.15204902, 0.30492837, 0.39708534,
-	               0.40466969, 0.36415317, 0.04407589, 0.9095746};
-	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-	               0.94311546, 0.59630347, 0.65820143};
-	ST result[] = {-0.73834587, 4.22750496, -1.37484721,
-	               -1.14718091, 4.49142548, -1.08282992};
+	TypeParam data_A[] = {0.02800922, 0.99326012, 0.15204902,
+	                      0.30492837, 0.39708534, 0.40466969,
+	                      0.36415317, 0.04407589, 0.9095746};
+	TypeParam data_B[] = {0.76775073, 0.88471312, 0.34795225,
+	                      0.94311546, 0.59630347, 0.65820143};
+	TypeParam result[] = {-0.73834587, 4.22750496, -1.37484721,
+	                      -1.14718091, 4.49142548, -1.08282992};
 
-	SGMatrix<ST> A(data_A, n, n, false);
-	SGMatrix<ST> B(data_B, n, m, false);
+	SGMatrix<TypeParam> A(data_A, n, n, false);
+	SGMatrix<TypeParam> B(data_B, n, m, false);
 
 	auto X = qr_solver(A, B);
 
@@ -1511,139 +1489,131 @@ void check_SGMatrix_qr_solver()
 		EXPECT_NEAR(X[i], result[i], 1e-5);
 }
 
-template <typename ST>
-void check_SGVector_range_fill()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_range_fill)
 {
 	const index_t size = 5;
-	SGVector<ST> vec(size);
-	ST start = 1;
+	SGVector<TypeParam> vec(size);
+	TypeParam start = 1;
 	range_fill(vec, start);
 
 	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(vec[i], i + 1, get_epsilon<ST>());
+		EXPECT_NEAR(vec[i], i + 1, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_range_fill()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_range_fill)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
-	ST start = 1;
+	SGMatrix<TypeParam> mat(nrows, ncols);
+	TypeParam start = 1;
 	range_fill(mat, start);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(mat[i], i + 1, get_epsilon<ST>());
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(mat[i], i + 1, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_rectified_linear()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rectified_linear)
 {
-	SGMatrix<ST> A(3, 3);
-	SGMatrix<ST> B(3, 3);
-	ST start = 1;
+	SGMatrix<TypeParam> A(3, 3);
+	SGMatrix<TypeParam> B(3, 3);
+	TypeParam start = 1;
 	range_fill(A, start);
 
 	linalg::rectified_linear(A, B);
 
 	for (index_t i = 0; i < 9; ++i)
 		EXPECT_NEAR(
-		    CMath::max(static_cast<ST>(0.0), A[i]), B[i], get_epsilon<ST>());
+		    CMath::max(static_cast<TypeParam>(0.0), A[i]), B[i],
+		    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_scale()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale)
 {
 	const index_t size = 5;
-	const ST alpha = 2;
-	SGVector<ST> a(size);
+	const TypeParam alpha = 2;
+	SGVector<TypeParam> a(size);
 	a.range_fill(0);
 
 	auto result = scale(a, alpha);
 
 	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(alpha * a[i], result[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * a[i], result[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_scale()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale)
 {
-	const ST alpha = 2;
+	const TypeParam alpha = 2;
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = i;
 
 	auto result = scale(A, alpha);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha * A[i], result[i], get_epsilon<ST>());
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(alpha * A[i], result[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_scale_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale_in_place)
 {
 	const index_t size = 5;
-	const ST alpha = 2;
-	SGVector<ST> a(size);
+	const TypeParam alpha = 2;
+	SGVector<TypeParam> a(size);
 	a.range_fill(0);
 
 	scale(a, a, alpha);
 
 	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(alpha * i, a[i], get_epsilon<ST>());
+		EXPECT_NEAR(alpha * i, a[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_scale_in_place()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale_in_place)
 {
-	const ST alpha = 2;
+	const TypeParam alpha = 2;
 	const index_t nrows = 2, ncols = 3;
 
-	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		A[i] = i;
 
 	scale(A, A, alpha);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(alpha * i, A[i], get_epsilon<ST>());
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(alpha * i, A[i], get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_set_const()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_set_const)
 {
 	const index_t size = 5;
-	const ST value = 2;
-	SGVector<ST> a(size);
+	const TypeParam value = 2;
+	SGVector<TypeParam> a(size);
 
 	set_const(a, value);
 
 	for (index_t i = 0; i < size; ++i)
-		EXPECT_NEAR(a[i], value, get_epsilon<ST>());
+		EXPECT_NEAR(a[i], value, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_set_const()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_set_const)
 {
 	const index_t nrows = 2, ncols = 3;
-	const ST value = 2;
-	SGMatrix<ST> a(nrows, ncols);
+	const TypeParam value = 2;
+	SGMatrix<TypeParam> a(nrows, ncols);
 
 	set_const(a, value);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
-		EXPECT_NEAR(a[i], value, get_epsilon<ST>());
+	for (index_t i = 0; i < nrows * ncols; ++i)
+		EXPECT_NEAR(a[i], value, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_softmax()
+// TODO: extend to all types
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_softmax)
 {
-	SGMatrix<ST> A(4, 3);
-	SGMatrix<ST> ref(4, 3);
+	SGMatrix<TypeParam> A(4, 3);
+	SGMatrix<TypeParam> ref(4, 3);
 
-	for (ST i = 0; i < 12; ++i)
+	for (TypeParam i = 0; i < 12; ++i)
 		A[i] = i / 12;
 
 	for (index_t i = 0; i < 12; ++i)
@@ -1651,7 +1621,7 @@ void check_SGMatrix_softmax()
 
 	for (index_t j = 0; j < ref.num_cols; ++j)
 	{
-		ST sum = 0;
+		TypeParam sum = 0;
 		for (index_t i = 0; i < ref.num_rows; ++i)
 			sum += ref(i, j);
 
@@ -1662,78 +1632,50 @@ void check_SGMatrix_softmax()
 	linalg::softmax(A);
 
 	for (index_t i = 0; i < 12; ++i)
-		EXPECT_NEAR(ref[i], A[i], get_epsilon<ST>());
+		EXPECT_NEAR(ref[i], A[i], get_epsilon<TypeParam>());
 }
 
-// template <typename ST>
-// void check_SGMatrix_squared_error()
-//{
-//    SGMatrix<ST> A(4, 3);
-//    SGMatrix<ST> B(4, 3);
-//
-//    ST size = A.num_rows * A.num_cols;
-//    for (ST i = 0; i < size; i+=2)
-//    {
-//        A[i] = i / size;
-//        B[i] = (i / size) * 2;
-//    }
-//
-//    ST ref = 0;
-//    for (index_t i = 0; i < size; i++)
-//        ref += CMath::pow(A[i] - B[i], 2);
-//    ref *= 0.5;
-//
-//    printf("%d", ref);
-//
-//    auto result = linalg::squared_error(A, B);
-//        EXPECT_NEAR(ref, result, 1e-15);
-//}
-
-template <typename ST>
-void check_SGVector_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_sum)
 {
 	const index_t size = 10;
-	SGVector<ST> vec(size);
+	SGVector<TypeParam> vec(size);
 	vec.range_fill(0);
 
 	auto result = sum(vec);
 
-	EXPECT_NEAR(result, 45, get_epsilon<ST>());
+	EXPECT_NEAR(result, 45, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
 	auto result = sum(mat);
 
-	EXPECT_NEAR(result, 15, get_epsilon<ST>());
+	EXPECT_NEAR(result, 15, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_sum_no_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum_no_diag)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
 	auto result = sum(mat, true);
 
-	EXPECT_NEAR(result, 12, get_epsilon<ST>());
+	EXPECT_NEAR(result, 12, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_symmetric_with_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_with_diag)
 {
 	const index_t n = 3;
-	SGMatrix<ST> mat(n, n);
+	SGMatrix<TypeParam> mat(n, n);
 	mat.set_const(1);
 
 	for (index_t i = 0; i < n; ++i)
@@ -1743,14 +1685,13 @@ void check_SGMatrix_symmetric_with_diag()
 			mat(j, i) = mat(i, j);
 		}
 
-	EXPECT_NEAR(sum_symmetric(mat), 39, get_epsilon<ST>());
+	EXPECT_NEAR(sum_symmetric(mat), 39, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_symmetric_no_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_no_diag)
 {
 	const index_t n = 3;
-	SGMatrix<ST> mat(n, n);
+	SGMatrix<TypeParam> mat(n, n);
 	mat.set_const(1);
 
 	for (index_t i = 0; i < n; ++i)
@@ -1760,14 +1701,13 @@ void check_SGMatrix_symmetric_no_diag()
 			mat(j, i) = mat(i, j);
 		}
 
-	EXPECT_NEAR(sum_symmetric(mat, true), 36, get_epsilon<ST>());
+	EXPECT_NEAR(sum_symmetric(mat, true), 36, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_symmetric_exception()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_exception)
 {
 	const index_t n = 3;
-	SGMatrix<ST> mat(n, n + 1);
+	SGMatrix<TypeParam> mat(n, n + 1);
 	mat.set_const(1.0);
 
 	for (index_t i = 0; i < n; ++i)
@@ -1780,25 +1720,23 @@ void check_SGMatrix_symmetric_exception()
 	EXPECT_THROW(sum_symmetric(mat), ShogunException);
 }
 
-template <typename ST>
-void check_SGMatrix_block_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_sum)
 {
 	const index_t n = 3;
-	SGMatrix<ST> mat(n, n);
+	SGMatrix<TypeParam> mat(n, n);
 
 	for (index_t i = 0; i < n; ++i)
 		for (index_t j = 0; j < n; ++j)
-			mat(i, j)=i * 10 + j + 1;
+			mat(i, j) = i * 10 + j + 1;
 
 	auto result = sum(linalg::block(mat, 0, 0, 2, 3));
-	EXPECT_NEAR(result, 42.0, get_epsilon<ST>());
+	EXPECT_NEAR(result, 42.0, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_symmetric_block_with_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_with_diag)
 {
 	const index_t n = 3;
-	SGMatrix<ST> mat(n, n);
+	SGMatrix<TypeParam> mat(n, n);
 	mat.set_const(1);
 
 	for (index_t i = 0; i < n; ++i)
@@ -1808,15 +1746,14 @@ void check_SGMatrix_symmetric_block_with_diag()
 			mat(j, i) = mat(i, j);
 		}
 
-	ST sum = sum_symmetric(linalg::block(mat, 1, 1, 2, 2));
-	EXPECT_NEAR(sum, 28, get_epsilon<ST>());
+	TypeParam sum = sum_symmetric(linalg::block(mat, 1, 1, 2, 2));
+	EXPECT_NEAR(sum, 28, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_symmetric_block_no_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_no_diag)
 {
 	const index_t n = 3;
-	SGMatrix<ST> mat(n, n);
+	SGMatrix<TypeParam> mat(n, n);
 	mat.set_const(1);
 
 	for (index_t i = 0; i < n; ++i)
@@ -1826,12 +1763,11 @@ void check_SGMatrix_symmetric_block_no_diag()
 			mat(j, i) = mat(i, j);
 		}
 
-	ST sum = sum_symmetric(linalg::block(mat, 1, 1, 2, 2), true);
-	EXPECT_NEAR(sum, 26, get_epsilon<ST>());
+	TypeParam sum = sum_symmetric(linalg::block(mat, 1, 1, 2, 2), true);
+	EXPECT_NEAR(sum, 26, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_symmetric_block_exception()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_exception)
 {
 	const index_t n = 3;
 	SGMatrix<float64_t> mat(n, n);
@@ -1844,47 +1780,45 @@ void check_SGMatrix_symmetric_block_exception()
 			mat(j, i) = mat(i, j);
 		}
 
-	EXPECT_THROW(sum_symmetric(linalg::block(mat,1,1,2,3)), ShogunException);
+	EXPECT_THROW(
+	    sum_symmetric(linalg::block(mat, 1, 1, 2, 3)), ShogunException);
 }
 
-template <typename ST>
-void check_SGMatrix_colwise_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
-	SGVector<ST> result = colwise_sum(mat);
+	SGVector<TypeParam> result = colwise_sum(mat);
 
 	for (index_t j = 0; j < ncols; ++j)
 	{
-		ST sum = 0;
+		TypeParam sum = 0;
 		for (index_t i = 0; i < nrows; ++i)
 			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[j], get_epsilon<ST>());
+		EXPECT_NEAR(sum, result[j], get_epsilon<TypeParam>());
 	}
 }
 
-template <typename ST>
-void check_SGMatrix_colwise_sum_no_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum_no_diag)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
-	SGVector<ST> result = colwise_sum(mat, true);
+	SGVector<TypeParam> result = colwise_sum(mat, true);
 
-	EXPECT_NEAR(result[0], 1, get_epsilon<ST>());
-	EXPECT_NEAR(result[1], 2, get_epsilon<ST>());
-	EXPECT_NEAR(result[2], 9, get_epsilon<ST>());
+	EXPECT_NEAR(result[0], 1, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[1], 2, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[2], 9, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_block_colwise_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_colwise_sum)
 {
 	const index_t nrows = 2, ncols = 3;
 	SGMatrix<float64_t> mat(nrows, ncols);
@@ -1897,53 +1831,50 @@ void check_SGMatrix_block_colwise_sum()
 
 	for (index_t j = 0; j < ncols; ++j)
 	{
-		ST sum = 0;
+		TypeParam sum = 0;
 		for (index_t i = 0; i < nrows; ++i)
 			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[j], get_epsilon<ST>());
+		EXPECT_NEAR(sum, result[j], get_epsilon<TypeParam>());
 	}
 }
 
-template <typename ST>
-void check_SGMatrix_rowwise_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
-	SGVector<ST> result = rowwise_sum(mat);
+	SGVector<TypeParam> result = rowwise_sum(mat);
 
 	for (index_t i = 0; i < nrows; ++i)
 	{
-		ST sum = 0;
+		TypeParam sum = 0;
 		for (index_t j = 0; j < ncols; ++j)
 			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[i], get_epsilon<ST>());
+		EXPECT_NEAR(sum, result[i], get_epsilon<TypeParam>());
 	}
 }
 
-template <typename ST>
-void check_SGMatrix_rowwise_sum_no_diag()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum_no_diag)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows * ncols; ++i)
 		mat[i] = i;
 
-	SGVector<ST> result = rowwise_sum(mat, true);
+	SGVector<TypeParam> result = rowwise_sum(mat, true);
 
-	EXPECT_NEAR(result[0], 6, get_epsilon<ST>());
-	EXPECT_NEAR(result[1], 6, get_epsilon<ST>());
+	EXPECT_NEAR(result[0], 6, get_epsilon<TypeParam>());
+	EXPECT_NEAR(result[1], 6, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_block_rowwise_sum()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_rowwise_sum)
 {
 	const index_t nrows = 2, ncols = 3;
-	SGMatrix<ST> mat(nrows, ncols);
+	SGMatrix<TypeParam> mat(nrows, ncols);
 
 	for (index_t i = 0; i < nrows; ++i)
 		for (index_t j = 0; j < ncols; ++j)
@@ -1953,29 +1884,29 @@ void check_SGMatrix_block_rowwise_sum()
 
 	for (index_t i = 0; i < nrows; ++i)
 	{
-		ST sum = 0;
+		TypeParam sum = 0;
 		for (index_t j = 0; j < ncols; ++j)
 			sum += mat(i, j);
-		EXPECT_NEAR(sum, result[i], get_epsilon<ST>());
+		EXPECT_NEAR(sum, result[i], get_epsilon<TypeParam>());
 	}
 }
 
-template <typename ST>
-void check_SGMatrix_svd_jacobi_thinU()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_thinU)
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
-	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
-	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
-	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-	                 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-	                 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-	                 -0.12681555, -0.53830325, 0.69323293};
+	TypeParam data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
+	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
+	                    0.28540373, 0.06264684, 0.56204061};
+	TypeParam result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	TypeParam result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
+	                        -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+	                        0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+	                        -0.12681555, -0.53830325, 0.69323293};
 
-	SGMatrix<ST> A(data, m, n, false);
-	SGMatrix<ST> U(m, n);
-	SGVector<ST> s(n);
+	SGMatrix<TypeParam> A(data, m, n, false);
+	SGMatrix<TypeParam> U(m, n);
+	SGVector<TypeParam> s(n);
 
 	svd(A, s, U, true, SVDAlgorithm::Jacobi);
 
@@ -1983,30 +1914,30 @@ void check_SGMatrix_svd_jacobi_thinU()
 	{
 		auto c = CMath::sign(U[i * m] * result_U[i * m]);
 		for (index_t j = 0; j < m; ++j)
-			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
+			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
 	}
 	for (index_t i = 0; i < (index_t)s.size(); ++i)
 		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGMatrix_svd_jacobi_fullU()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_fullU)
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
-	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
-	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
-	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	ST result_U[] = {
+	TypeParam data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
+	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
+	                    0.28540373, 0.06264684, 0.56204061};
+	TypeParam result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	TypeParam result_U[] = {
 	    -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
 	    -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
 	    -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
 	    -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
 	    0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
-	SGMatrix<ST> A(data, m, n, false);
-	SGMatrix<ST> U(m, m);
-	SGVector<ST> s(n);
+	SGMatrix<TypeParam> A(data, m, n, false);
+	SGMatrix<TypeParam> U(m, m);
+	SGVector<TypeParam> s(n);
 
 	svd(A, s, U, false, SVDAlgorithm::Jacobi);
 
@@ -2014,29 +1945,29 @@ void check_SGMatrix_svd_jacobi_fullU()
 	{
 		auto c = CMath::sign(U[i * m] * result_U[i * m]);
 		for (index_t j = 0; j < m; ++j)
-			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-7);
+			EXPECT_NEAR(U[i * m + j], c * result_U[i * m + j], 1e-6);
 	}
 	for (index_t i = 0; i < (index_t)s.size(); ++i)
 		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
-template <typename ST>
-void check_SGMatrix_svd_bdc_thinU()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_thinU)
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
-	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
-	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
-	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	ST result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
-	                 -0.46186125, -0.69145782, 0.29548428,  0.5718984,
-	                 0.31771648,  -0.08101592, -0.27461424, 0.37170223,
-	                 -0.12681555, -0.53830325, 0.69323293};
+	TypeParam data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
+	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
+	                    0.28540373, 0.06264684, 0.56204061};
+	TypeParam result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	TypeParam result_U[] = {-0.60700926, -0.16647013, -0.56501385, -0.26696629,
+	                        -0.46186125, -0.69145782, 0.29548428,  0.5718984,
+	                        0.31771648,  -0.08101592, -0.27461424, 0.37170223,
+	                        -0.12681555, -0.53830325, 0.69323293};
 
-	SGMatrix<ST> A(data, m, n, false);
-	SGMatrix<ST> U(m, n);
-	SGVector<ST> s(n);
+	SGMatrix<TypeParam> A(data, m, n, false);
+	SGMatrix<TypeParam> U(m, n);
+	SGVector<TypeParam> s(n);
 
 	svd(A, s, U, true, SVDAlgorithm::BidiagonalDivideConquer);
 
@@ -2050,24 +1981,24 @@ void check_SGMatrix_svd_bdc_thinU()
 		EXPECT_NEAR(s[i], result_s[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGMatrix_svd_bdc_fullU()
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_fullU)
 {
 	const index_t m = 5, n = 3;
-	ST data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194, 0.30786772,
-	             0.25503552, 0.34367041, 0.66491478, 0.20488809, 0.5734351,
-	             0.87179189, 0.07139643, 0.28540373, 0.06264684, 0.56204061};
-	ST result_s[] = {1.75382524, 0.56351367, 0.41124883};
-	ST result_U[] = {
+	TypeParam data[] = {0.68764958, 0.11456779, 0.75164207, 0.50436194,
+	                    0.30786772, 0.25503552, 0.34367041, 0.66491478,
+	                    0.20488809, 0.5734351,  0.87179189, 0.07139643,
+	                    0.28540373, 0.06264684, 0.56204061};
+	TypeParam result_s[] = {1.75382524, 0.56351367, 0.41124883};
+	TypeParam result_U[] = {
 	    -0.60700926, -0.16647013, -0.56501385, -0.26696629, -0.46186125,
 	    -0.69145782, 0.29548428,  0.5718984,   0.31771648,  -0.08101592,
 	    -0.27461424, 0.37170223,  -0.12681555, -0.53830325, 0.69323293,
 	    -0.27809756, -0.68975171, -0.11662812, 0.38274703,  0.53554354,
 	    0.025973184, 0.520631112, -0.56921636, 0.62571522,  0.11287970};
 
-	SGMatrix<ST> A(data, m, n, false);
-	SGMatrix<ST> U(m, m);
-	SGVector<ST> s(n);
+	SGMatrix<TypeParam> A(data, m, n, false);
+	SGMatrix<TypeParam> U(m, m);
+	SGVector<TypeParam> s(n);
 
 	svd(A, s, U, false, SVDAlgorithm::BidiagonalDivideConquer);
 
@@ -2082,27 +2013,25 @@ void check_SGMatrix_svd_bdc_fullU()
 }
 #endif
 
-template <typename ST>
-void check_SGMatrix_trace()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace)
 {
 	const index_t n = 4;
 
-	SGMatrix<ST> A(n, n);
-	for (index_t i = 0; i < n*n; ++i)
+	SGMatrix<TypeParam> A(n, n);
+	for (index_t i = 0; i < n * n; ++i)
 		A[i] = i;
 
-	ST tr = 0;
+	TypeParam tr = 0;
 	for (index_t i = 0; i < n; ++i)
 		tr += A.get_element(i, i);
 
-	EXPECT_NEAR(trace(A), tr, get_epsilon<ST>());
+	EXPECT_NEAR(trace(A), tr, get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_trace_dot()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace_dot)
 {
 	const index_t n = 2;
-	SGMatrix<ST> A(n, n), B(n, n);
+	SGMatrix<TypeParam> A(n, n), B(n, n);
 	for (index_t i = 0; i < n * n; ++i)
 	{
 		A[i] = i;
@@ -2114,35 +2043,36 @@ void check_SGMatrix_trace_dot()
 	for (auto i : range(n))
 		tr += C(i, i);
 
-	EXPECT_NEAR(tr, trace_dot(A, B), get_epsilon<ST>());
+	EXPECT_NEAR(tr, trace_dot(A, B), get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGMatrix_transpose_matrix()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_transpose_matrix)
 {
 	const index_t m = 5, n = 3;
-	SGMatrix<ST> A(m, n);
-	linalg::range_fill(A, static_cast<ST>(1));
+	SGMatrix<TypeParam> A(m, n);
+	linalg::range_fill(A, static_cast<TypeParam>(1));
 
 	auto T = transpose_matrix(A);
 
 	for (index_t i = 0; i < m; ++i)
 		for (index_t j = 0; j < n; ++j)
 			EXPECT_NEAR(
-			    A.get_element(i, j), T.get_element(j, i), get_epsilon<ST>());
+			    A.get_element(i, j), T.get_element(j, i),
+			    get_epsilon<TypeParam>());
 }
 
-template <typename ST>
-void check_SGVector_triangular_solver_lower()
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_lower)
 {
 	const index_t n = 3;
-	ST data_L[] = {-0.92947874, -1.1432887, -0.87119086, 0.,        -0.27048649,
-	               -0.05919915, 0.,         0.,          0.11869106};
-	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
-	ST result[] = {-0.42455592, -0.72571316, 0.17192745};
+	TypeParam data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
+	                      0.,          -0.27048649, -0.05919915,
+	                      0.,          0.,          0.11869106};
+	TypeParam data_b[] = {0.39461571, 0.6816856, 0.43323709};
+	TypeParam result[] = {-0.42455592, -0.72571316, 0.17192745};
 
-	SGMatrix<ST> L(data_L, n, n, false);
-	SGVector<ST> b(data_b, n, false);
+	SGMatrix<TypeParam> L(data_L, n, n, false);
+	SGVector<TypeParam> b(data_b, n, false);
 
 	auto x = triangular_solver(L, b, true);
 
@@ -2150,18 +2080,18 @@ void check_SGVector_triangular_solver_lower()
 		EXPECT_NEAR(x[i], result[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGVector_triangular_solver_upper()
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_upper)
 {
 	const index_t n = 3;
-	ST data_U[] = {-0.92947874, 0.,          0.,
-	               -1.1432887,  -0.27048649, 0.,
-	               -0.87119086, -0.05919915, 0.11869106};
-	ST data_b[] = {0.39461571, 0.6816856, 0.43323709};
-	ST result[] = {0.23681135, -3.31909306, 3.65012412};
+	TypeParam data_U[] = {-0.92947874, 0.,          0.,
+	                      -1.1432887,  -0.27048649, 0.,
+	                      -0.87119086, -0.05919915, 0.11869106};
+	TypeParam data_b[] = {0.39461571, 0.6816856, 0.43323709};
+	TypeParam result[] = {0.23681135, -3.31909306, 3.65012412};
 
-	SGMatrix<ST> U(data_U, n, n, false);
-	SGVector<ST> b(data_b, n, false);
+	SGMatrix<TypeParam> U(data_U, n, n, false);
+	SGVector<TypeParam> b(data_b, n, false);
 
 	auto x = triangular_solver(U, b, false);
 
@@ -2169,19 +2099,20 @@ void check_SGVector_triangular_solver_upper()
 		EXPECT_NEAR(x[i], result[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGMatrix_triangular_solver_lower()
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_lower)
 {
 	const index_t n = 3, m = 2;
-	ST data_L[] = {-0.92947874, -1.1432887, -0.87119086, 0.,        -0.27048649,
-	               -0.05919915, 0.,         0.,          0.11869106};
-	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-	               0.94311546, 0.59630347, 0.65820143};
-	ST result[] = {-0.82600139, 0.22050986, -3.02127745,
-	               -1.01467136, 2.08424024, -0.86262387};
+	TypeParam data_L[] = {-0.92947874, -1.1432887,  -0.87119086,
+	                      0.,          -0.27048649, -0.05919915,
+	                      0.,          0.,          0.11869106};
+	TypeParam data_B[] = {0.76775073, 0.88471312, 0.34795225,
+	                      0.94311546, 0.59630347, 0.65820143};
+	TypeParam result[] = {-0.82600139, 0.22050986, -3.02127745,
+	                      -1.01467136, 2.08424024, -0.86262387};
 
-	SGMatrix<ST> L(data_L, n, n, false);
-	SGMatrix<ST> B(data_B, n, m, false);
+	SGMatrix<TypeParam> L(data_L, n, n, false);
+	SGMatrix<TypeParam> B(data_B, n, m, false);
 
 	auto X = triangular_solver(L, B, true);
 
@@ -2189,20 +2120,20 @@ void check_SGMatrix_triangular_solver_lower()
 		EXPECT_NEAR(X[i], result[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGMatrix_triangular_solver_upper()
+TYPED_TEST(
+    LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_upper)
 {
 	const index_t n = 3, m = 2;
-	ST data_U[] = {-0.92947874, 0.,          0.,
-	               -1.1432887,  -0.27048649, 0.,
-	               -0.87119086, -0.05919915, 0.11869106};
-	ST data_B[] = {0.76775073, 0.88471312, 0.34795225,
-	               0.94311546, 0.59630347, 0.65820143};
-	ST result[] = {1.238677,    -3.91243241, 2.9315793,
-	               -2.00784647, -3.41825732, 5.54550138};
+	TypeParam data_U[] = {-0.92947874, 0.,          0.,
+	                      -1.1432887,  -0.27048649, 0.,
+	                      -0.87119086, -0.05919915, 0.11869106};
+	TypeParam data_B[] = {0.76775073, 0.88471312, 0.34795225,
+	                      0.94311546, 0.59630347, 0.65820143};
+	TypeParam result[] = {1.238677,    -3.91243241, 2.9315793,
+	                      -2.00784647, -3.41825732, 5.54550138};
 
-	SGMatrix<ST> L(data_U, n, n, false);
-	SGMatrix<ST> B(data_B, n, m, false);
+	SGMatrix<TypeParam> L(data_U, n, n, false);
+	SGMatrix<TypeParam> B(data_B, n, m, false);
 
 	auto X = triangular_solver(L, B, false);
 
@@ -2210,37 +2141,34 @@ void check_SGMatrix_triangular_solver_upper()
 		EXPECT_NEAR(X[i], result[i], 1e-6);
 }
 
-template <typename ST>
-void check_SGVector_zero()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_zero)
 {
 	const index_t n = 16;
-	SGVector<ST> a(n);
+	SGVector<TypeParam> a(n);
 	zero(a);
 
 	for (index_t i = 0; i < n; ++i)
 		EXPECT_EQ(a[i], 0);
 }
 
-template <typename ST>
-void check_SGMatrix_zero()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_zero)
 {
 	const index_t nrows = 3, ncols = 4;
-	SGMatrix<ST> A(nrows, ncols);
+	SGMatrix<TypeParam> A(nrows, ncols);
 	zero(A);
 
-	for (index_t i = 0; i < nrows*ncols; ++i)
+	for (index_t i = 0; i < nrows * ncols; ++i)
 		EXPECT_EQ(A[i], 0);
 }
 
-template <typename ST>
-void check_SGMatrix_rank_update()
+TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rank_update)
 {
-	typedef Matrix<ST, Dynamic, Dynamic> Mxx;
-	typedef Matrix<ST, 1, Dynamic> Vxd;
+	typedef Matrix<TypeParam, Dynamic, Dynamic> Mxx;
+	typedef Matrix<TypeParam, 1, Dynamic> Vxd;
 
 	const index_t size = 2;
-	SGMatrix<ST> A(size, size);
-	SGVector<ST> b(size);
+	SGMatrix<TypeParam> A(size, size);
+	SGVector<TypeParam> b(size);
 	Map<Mxx> A_eig(A.matrix, size, size);
 	Map<Vxd> b_eig(b.vector, size);
 
@@ -2258,542 +2186,17 @@ void check_SGMatrix_rank_update()
 	A2(1, 0) += b[1] * b[0];
 	A2(1, 1) += b[1] * b[1];
 
-	rank_update(A, b, static_cast<ST>(1));
-	EXPECT_NEAR((A2_eig - A_eig).norm(), 0, get_epsilon<ST>());
+	rank_update(A, b, static_cast<TypeParam>(1));
+	EXPECT_NEAR((A2_eig - A_eig).norm(), 0, get_epsilon<TypeParam>());
 
-	rank_update(A, b, static_cast<ST>(-1));
-	EXPECT_NEAR((A_eig - A_eig).norm(), 0, get_epsilon<ST>());
+	rank_update(A, b, static_cast<TypeParam>(-1));
+	EXPECT_NEAR((A_eig - A_eig).norm(), 0, get_epsilon<TypeParam>());
 }
 
-// test types based on shogun/mathematics/linalg/LinalgBackendBase.h
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_squared_error)
 {
-	check_SGVector_add<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add)
-{
-	check_SGMatrix_add<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_in_place)
-{
-	check_SGVector_add_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_in_place)
-{
-	check_SGMatrix_add_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_allocated)
-{
-	check_SGVector_add_col_vec_allocated<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_col_vec_in_place)
-{
-	check_SGVector_add_col_vec_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_allocated)
-{
-	check_SGMatrix_add_col_vec_allocated<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_col_vec_in_place)
-{
-	check_SGMatrix_add_col_vec_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, add_diag)
-{
-	check_add_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, add_ridge)
-{
-	check_add_ridge<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, add_vector)
-{
-	check_add_vector<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add_scalar)
-{
-	check_SGVector_add_scalar<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_add_scalar)
-{
-	check_SGMatrix_add_scalar<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_center_matrix)
-{
-	check_SGMatrix_center_matrix<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_lower)
-{
-	check_SGMatrix_cholesky_llt_lower<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_llt_upper)
-{
-	check_SGMatrix_cholesky_llt_upper<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_upper)
-{
-	check_SGMatrix_cholesky_rank_update_upper<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_rank_update_lower)
-{
-	check_SGMatrix_cholesky_rank_update_lower<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cholesky_ldlt_lower)
-{
-	check_SGMatrix_cholesky_ldlt_lower<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenRealTypesTest, SGMatrix_cholesky_solver)
-{
-	check_SGMatrix_cholesky_solver<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_ldlt_solver)
-{
-	check_SGMatrix_ldlt_solver<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_cross_entropy)
-{
-	check_SGMatrix_cross_entropy<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_psd)
-{
-	check_SGMatrix_pinv_psd<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_2x4)
-{
-	check_SGMatrix_pinv_2x4<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_pinv_4x2)
-{
-	check_SGMatrix_pinv_4x2<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_dot)
-{
-	check_SGVector_dot<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver)
-{
-	check_eigensolver<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, eigensolver_symmetric)
-{
-	check_eigensolver_symmetric<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product)
-{
-	check_SGMatrix_elementwise_product<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest, SGMatrix_elementwise_product_in_place)
-{
-	check_SGMatrix_elementwise_product_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_elementwise_product)
-{
-	check_SGMatrix_block_elementwise_product<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_elementwise_product)
-{
-	check_SGVector_elementwise_product<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest, SGVector_elementwise_product_in_place)
-{
-	check_SGVector_elementwise_product_in_place<TypeParam>();
-}
-
-// TODO: write test for int types
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_exponent)
-{
-	check_SGVector_exponent<TypeParam>();
-}
-
-// TODO: write test for int types
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_exponent)
-{
-	check_SGMatrix_exponent<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_identity)
-{
-	check_SGMatrix_identity<TypeParam>();
-}
-
-// TODO: write test for int types
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, logistic)
-{
-	check_logistic<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod)
-{
-	check_SGMatrix_SGVector_matrix_prod<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_matrix_prod_transpose)
-{
-	check_SGVector_matrix_prod_transpose<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest, SGMatrix_SGVector_matrix_prod_in_place)
-{
-	check_SGMatrix_SGVector_matrix_prod_in_place<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest,
-    SGMatrix_SGVector_matrix_prod_in_place_transpose)
-{
-	check_SGMatrix_SGVector_matrix_prod_in_place_transpose<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product)
-{
-	check_SGMatrix_matrix_product<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A)
-{
-	check_SGMatrix_matrix_product_transpose_A<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_B)
-{
-	check_SGMatrix_matrix_product_transpose_B<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_transpose_A_B)
-{
-	check_SGMatrix_matrix_product_transpose_A_B<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_matrix_product_in_place)
-{
-	check_SGMatrix_matrix_product_in_place<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest,
-    SGMatrix_matrix_product_in_place_transpose_A)
-{
-	check_SGMatrix_matrix_product_in_place_transpose_A<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest,
-    SGMatrix_matrix_product_in_place_transpose_B)
-{
-	check_SGMatrix_matrix_product_in_place_transpose_B<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest,
-    SGMatrix_matrix_product_in_place_transpose_A_B)
-{
-	check_SGMatrix_matrix_product_in_place_transpose_A_B<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_max)
-{
-	check_SGVector_max<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_max)
-{
-	check_SGMatrix_max<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_mean)
-{
-	check_SGVector_mean<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_mean)
-{
-	check_SGMatrix_mean<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenAllTypesTest, SGMatrix_multiply_by_logistic_derivative)
-{
-	check_SGMatrix_multiply_by_logistic_derivative<TypeParam>();
-}
-
-// TODO: write test for int types
-TYPED_TEST(
-    LinalgBackendEigenNonIntegerTypesTest,
-    SGMatrix_multiply_by_rectified_linear_derivative)
-{
-	check_SGMatrix_multiply_by_rectified_linear_derivative<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_norm)
-{
-	check_SGVector_norm<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_qr_solver)
-{
-	check_SGVector_qr_solver<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_qr_solver)
-{
-	check_SGMatrix_qr_solver<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_range_fill)
-{
-	check_SGVector_range_fill<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_range_fill)
-{
-	check_SGMatrix_range_fill<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rectified_linear)
-{
-	check_SGMatrix_rectified_linear<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale)
-{
-	check_SGVector_scale<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale)
-{
-	check_SGMatrix_scale<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_scale_in_place)
-{
-	check_SGVector_scale_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_scale_in_place)
-{
-	check_SGMatrix_scale_in_place<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_set_const)
-{
-	check_SGVector_set_const<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_set_const)
-{
-	check_SGMatrix_set_const<TypeParam>();
-}
-
-// TODO: extend to all types
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_softmax)
-{
-	check_SGMatrix_softmax<TypeParam>();
-}
-
-// FIXME: CMath::Pow only accepts float or complex types
-// TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_squared_error)
-//{
-//    check_SGMatrix_squared_error<TypeParam>();
-//}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_sum)
-{
-	check_SGVector_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum)
-{
-	check_SGMatrix_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_sum_no_diag)
-{
-	check_SGMatrix_sum_no_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_with_diag)
-{
-	check_SGMatrix_symmetric_with_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_no_diag)
-{
-	check_SGMatrix_symmetric_no_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_exception)
-{
-	check_SGMatrix_symmetric_exception<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_sum)
-{
-	check_SGMatrix_block_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_with_diag)
-{
-	check_SGMatrix_symmetric_block_with_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_no_diag)
-{
-	check_SGMatrix_symmetric_block_no_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_symmetric_block_exception)
-{
-	check_SGMatrix_symmetric_block_exception<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum)
-{
-	check_SGMatrix_colwise_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_colwise_sum_no_diag)
-{
-	check_SGMatrix_colwise_sum_no_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_colwise_sum)
-{
-	check_SGMatrix_block_colwise_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum)
-{
-	check_SGMatrix_rowwise_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_rowwise_sum_no_diag)
-{
-	check_SGMatrix_rowwise_sum_no_diag<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_block_rowwise_sum)
-{
-	check_SGMatrix_block_rowwise_sum<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_thinU)
-{
-	check_SGMatrix_svd_jacobi_thinU<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_jacobi_fullU)
-{
-	check_SGMatrix_svd_jacobi_fullU<TypeParam>();
-}
-
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_thinU)
-{
-	check_SGMatrix_svd_bdc_thinU<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_svd_bdc_fullU)
-{
-	check_SGMatrix_svd_bdc_fullU<TypeParam>();
-}
-#endif
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace)
-{
-	check_SGMatrix_trace<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_trace_dot)
-{
-	check_SGMatrix_trace_dot<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_transpose_matrix)
-{
-	check_SGMatrix_transpose_matrix<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_lower)
-{
-	check_SGVector_triangular_solver_lower<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenNonIntegerTypesTest, SGVector_triangular_solver_upper)
-{
-	check_SGVector_triangular_solver_upper<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_lower)
-{
-	check_SGMatrix_triangular_solver_lower<TypeParam>();
-}
-
-TYPED_TEST(
-    LinalgBackendEigenNonIntegerTypesTest, SGMatrix_triangular_solver_upper)
-{
-	check_SGMatrix_triangular_solver_upper<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_zero)
-{
-	check_SGVector_zero<TypeParam>();
-}
-
-TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_zero)
-{
-	check_SGMatrix_zero<TypeParam>();
-}
-
-// TODO: extend to int types
-TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGMatrix_rank_update)
-{
-	check_SGMatrix_rank_update<TypeParam>();
-}
-
-// TODO: implement typed testing for SE
-TEST(LinalgBackendEigen, SGMatrix_squared_error)
-{
-	SGMatrix<float64_t> A(4, 3);
-	SGMatrix<float64_t> B(4, 3);
+	SGMatrix<TypeParam> A(4, 3);
+	SGMatrix<TypeParam> B(4, 3);
 
 	int32_t size = A.num_rows * A.num_cols;
 	for (float64_t i = 0; i < size; ++i)
@@ -2804,9 +2207,9 @@ TEST(LinalgBackendEigen, SGMatrix_squared_error)
 
 	float64_t ref = 0;
 	for (index_t i = 0; i < size; i++)
-		ref += CMath::pow(A[i] - B[i], 2);
+		ref += std::pow(A[i] - B[i], 2);
 	ref *= 0.5;
 
 	auto result = linalg::squared_error(A, B);
-	EXPECT_NEAR(ref, result, 1e-15);
+	EXPECT_NEAR(ref, result, get_epsilon<TypeParam>());
 }


### PR DESCRIPTION
Refactored all the linalg Eigen3 operations in `Eigen3_operations_unittest.cc` as suggested in #4383.

In addtion to typed testing, changes include:
* Decreased tolerance for `float` type tests to work with `float32_t`, `float64_t` and `floatmax_t`
* Different values in tests where the same code has to work with both `int` and `float` types

I did not add `complex128_t`, `bool` or `char` tests at this point.

I just need help writing a test for `SGMatrix_squared_error` as this potentially requires changing CMath::pow (mentioned in #4383). At this point I left the original test.

I know it's quite a large number of lines changed in one PR, but this is mainly a code refactor and the tests are almost identical.

All tests run fine locally!