### PR TITLE
Improve (again) Signal handling.

### DIFF
--- a/src/shogun/base/init.cpp
+++ b/src/shogun/base/init.cpp
@@ -93,8 +93,10 @@ namespace shogun
 		sg_print_warning=print_warning;
 		sg_print_error=print_error;
 
-		// Set up signal handler
+		// Set up signal handlers
 		std::signal(SIGINT, sg_signal->handler);
+		std::signal(SIGTSTP, sg_signal->handler);
+		std::signal(SIGQUIT, sg_signal->handler);
 
 		init_from_env();
 	}

--- a/src/shogun/lib/Signal.cpp
+++ b/src/shogun/lib/Signal.cpp
@@ -49,10 +49,10 @@ int CSignal::interactive_signal()
 			what_action=SIGINT;
 			break;
 		case 'C':
-			what_action=SIGTSTP;
+			what_action=SIGQUIT;
 			break;
 		case 'P':
-			what_action=SIGQUIT;
+			what_action=SIGTSTP;
 			break;
 		default:
 			break;

--- a/src/shogun/lib/Signal.cpp
+++ b/src/shogun/lib/Signal.cpp
@@ -15,6 +15,7 @@ using namespace shogun;
 using namespace rxcpp;
 
 bool CSignal::m_active = true;
+bool CSignal::m_interactive = true;
 CSignal::SGSubjectS* CSignal::m_subject = new rxcpp::subjects::subject<int>();
 
 CSignal::SGObservableS* CSignal::m_observable =
@@ -30,47 +31,68 @@ CSignal::~CSignal()
 {
 }
 
+
+int CSignal::interactive_signal()
+{
+	int what_action=-1;
+	SG_SPRINT(
+			"\n[ShogunSignalHandler] "
+					"Immediately return to prompt / "
+					"Prematurely finish computations / "
+					"Pause current computation / "
+					"Do nothing (I/C/P/D)? ")
+	char answer = getchar();
+	getchar();
+	switch (answer)
+	{
+		case 'I':
+			what_action=SIGINT;
+			break;
+		case 'C':
+			what_action=SIGTSTP;
+			break;
+		case 'P':
+			what_action=SIGQUIT;
+			break;
+		default:
+			break;
+	}
+	return what_action;
+}
+
 void CSignal::handler(int signal)
 {
 	/* If the handler is not enabled exit */
 	if (!m_active)
 		exit(-1);
 
-	if (signal == SIGINT)
+	/* If we are using interactive mode, ask the user what to do */
+	if (m_interactive)
+		signal = interactive_signal();
+
+	/* Check which signal we have received */
+	switch(signal)
 	{
-		SG_SPRINT(
-		    "\n[ShogunSignalHandler] "
-		    "Immediately return to prompt / "
-		    "Prematurely finish computations / "
-		    "Pause current computation / "
-		    "Do nothing (I/C/P/D)? ")
-		char answer = getchar();
-		getchar();
-		switch (answer)
-		{
-		case 'I':
+		case -1:
+			SG_SPRINT("[ShogunSignalHandler] Continuing...\n");
+		case SIGINT:
 			SG_SPRINT("[ShogunSignalHandler] Killing the application...\n");
 			m_subscriber->on_completed();
 			exit(0);
 			break;
-		case 'C':
+		case SIGQUIT:
 			SG_SPRINT(
-			    "[ShogunSignalHandler] Terminating"
-			    " prematurely current algorithm...\n");
+				"[ShogunSignalHandler] Terminating"
+						" prematurely current algorithm...\n");
 			m_subscriber->on_next(SG_BLOCK_COMP);
 			break;
-		case 'P':
+		case SIGTSTP:
 			SG_SPRINT("[ShogunSignalHandler] Pausing current computation...")
 			m_subscriber->on_next(SG_PAUSE_COMP);
 			break;
 		default:
-			SG_SPRINT("[ShogunSignalHandler] Continuing...\n")
+			SG_SPRINT("[ShogunSignalHandler] Unknown signal %d received\n", signal)
 			break;
-		}
-	}
-	else
-	{
-		SG_SPRINT("[ShogunSignalHandler] Unknown signal %d received\n", signal)
 	}
 }
 

--- a/src/shogun/lib/Signal.cpp
+++ b/src/shogun/lib/Signal.cpp
@@ -87,7 +87,7 @@ void CSignal::handler(int signal)
 			m_subscriber->on_next(SG_BLOCK_COMP);
 			break;
 		case SIGTSTP:
-			SG_SPRINT("[ShogunSignalHandler] Pausing current computation...")
+			SG_SPRINT("[ShogunSignalHandler] Pausing current computation...\n")
 			m_subscriber->on_next(SG_PAUSE_COMP);
 			break;
 		default:

--- a/src/shogun/lib/Signal.cpp
+++ b/src/shogun/lib/Signal.cpp
@@ -31,31 +31,30 @@ CSignal::~CSignal()
 {
 }
 
-
 int CSignal::interactive_signal()
 {
-	int what_action=-1;
+	int what_action = -1;
 	SG_SPRINT(
-			"\n[ShogunSignalHandler] "
-					"Immediately return to prompt / "
-					"Prematurely finish computations / "
-					"Pause current computation / "
-					"Do nothing (I/C/P/D)? ")
+	    "\n[ShogunSignalHandler] "
+	    "Immediately return to prompt / "
+	    "Prematurely finish computations / "
+	    "Pause current computation / "
+	    "Do nothing (I/C/P/D)? ")
 	char answer = getchar();
 	getchar();
 	switch (answer)
 	{
-		case 'I':
-			what_action=SIGINT;
-			break;
-		case 'C':
-			what_action=SIGQUIT;
-			break;
-		case 'P':
-			what_action=SIGTSTP;
-			break;
-		default:
-			break;
+	case 'I':
+		what_action = SIGINT;
+		break;
+	case 'C':
+		what_action = SIGQUIT;
+		break;
+	case 'P':
+		what_action = SIGTSTP;
+		break;
+	default:
+		break;
 	}
 	return what_action;
 }
@@ -71,28 +70,28 @@ void CSignal::handler(int signal)
 		signal = interactive_signal();
 
 	/* Check which signal we have received */
-	switch(signal)
+	switch (signal)
 	{
-		case -1:
-			SG_SPRINT("[ShogunSignalHandler] Continuing...\n");
-		case SIGINT:
-			SG_SPRINT("[ShogunSignalHandler] Killing the application...\n");
-			m_subscriber->on_completed();
-			exit(0);
-			break;
-		case SIGQUIT:
-			SG_SPRINT(
-				"[ShogunSignalHandler] Terminating"
-						" prematurely current algorithm...\n");
-			m_subscriber->on_next(SG_BLOCK_COMP);
-			break;
-		case SIGTSTP:
-			SG_SPRINT("[ShogunSignalHandler] Pausing current computation...\n")
-			m_subscriber->on_next(SG_PAUSE_COMP);
-			break;
-		default:
-			SG_SPRINT("[ShogunSignalHandler] Unknown signal %d received\n", signal)
-			break;
+	case -1:
+		SG_SPRINT("[ShogunSignalHandler] Continuing...\n");
+	case SIGINT:
+		SG_SPRINT("[ShogunSignalHandler] Killing the application...\n");
+		m_subscriber->on_completed();
+		exit(0);
+		break;
+	case SIGQUIT:
+		SG_SPRINT(
+		    "[ShogunSignalHandler] Terminating"
+		    " prematurely current algorithm...\n");
+		m_subscriber->on_next(SG_BLOCK_COMP);
+		break;
+	case SIGTSTP:
+		SG_SPRINT("[ShogunSignalHandler] Pausing current computation...\n")
+		m_subscriber->on_next(SG_PAUSE_COMP);
+		break;
+	default:
+		SG_SPRINT("[ShogunSignalHandler] Unknown signal %d received\n", signal)
+		break;
 	}
 }
 

--- a/src/shogun/lib/Signal.h
+++ b/src/shogun/lib/Signal.h
@@ -97,6 +97,11 @@ namespace shogun
 
 	private:
 
+		/**
+		 * Static function which is used to transtate the user's input
+		 * to a signal type ("Pause Computation" --> SIGTSTP)
+		 * @return a signal type
+		 */
 		static int interactive_signal();
 
 		/** Active signal */

--- a/src/shogun/lib/Signal.h
+++ b/src/shogun/lib/Signal.h
@@ -96,7 +96,6 @@ namespace shogun
 		virtual const char* get_name() const { return "Signal"; }
 
 	private:
-
 		/**
 		 * Static function which is used to transtate the user's input
 		 * to a signal type ("Pause Computation" --> SIGTSTP)

--- a/src/shogun/lib/Signal.h
+++ b/src/shogun/lib/Signal.h
@@ -24,7 +24,7 @@ namespace shogun
 	/** @brief Class Signal implements signal handling to e.g. allow CTRL+C to
 	 * cancel a long running process.
 	 *
-	 * -# A signal handler is attached to trap the SIGINT signal.
+	 * -A signal handler is attached to trap the SIGINT signal.
 	 *  Pressing CTRL+C or sending the SIGINT (kill ...) signal to the shogun
 	 *  process will make shogun print a message asking the user to choose an
 	 *  option bewteen: immediately exit the running method and fall back to
@@ -78,6 +78,15 @@ namespace shogun
 		{
 			m_active = enable;
 		}
+
+		/** Set the handler as interactive (the user will select what to do)
+		 *  @param enable true to enable interactive mode, false otherwise.
+		 */
+		void interactive(bool enable)
+		{
+			m_interactive = enable;
+		}
+
 		/**
 		 * Reset handler in case of multiple instantiation
 		 */
@@ -87,8 +96,14 @@ namespace shogun
 		virtual const char* get_name() const { return "Signal"; }
 
 	private:
+
+		static int interactive_signal();
+
 		/** Active signal */
 		static bool m_active;
+
+		/** Interactive handler */
+		static bool m_interactive;
 
 	public:
 		/** Observable */

--- a/tests/unit/lib/Signal_unittest.cc
+++ b/tests/unit/lib/Signal_unittest.cc
@@ -12,9 +12,11 @@
 using namespace shogun;
 using namespace rxcpp;
 
-class SignalFixture : public ::testing::Test {
+class SignalFixture : public ::testing::Test
+{
 protected:
-	virtual void SetUp() {
+	virtual void SetUp()
+	{
 
 		CSignal::reset_handler();
 		on_next_v = 0;
@@ -24,13 +26,16 @@ protected:
 		std::signal(SIGTSTP, tmp.handler);
 		tmp.interactive(false);
 		auto sub = rxcpp::make_subscriber<int>(
-				[&](int v) {
-					if (v == SG_PAUSE_COMP)
-						on_next_v += 2;
-					else
-						on_next_v++;
-				},
-				[&]() { on_complete_v++; fprintf(stderr,"Application Killed");});
+		    [&](int v) {
+			    if (v == SG_PAUSE_COMP)
+				    on_next_v += 2;
+			    else
+				    on_next_v++;
+			},
+		    [&]() {
+			    on_complete_v++;
+			    fprintf(stderr, "Application Killed");
+			});
 
 		tmp.get_observable()->subscribe(sub);
 	}
@@ -42,7 +47,9 @@ protected:
 
 TEST_F(SignalFixture, return_to_prompt_test)
 {
-	EXPECT_EXIT({std::raise(SIGINT);}, ::testing::ExitedWithCode(0), "Application Killed");
+	EXPECT_EXIT(
+	    { std::raise(SIGINT); }, ::testing::ExitedWithCode(0),
+	    "Application Killed");
 }
 
 TEST_F(SignalFixture, prematurely_stop_computation_test)

--- a/tests/unit/lib/Signal_unittest.cc
+++ b/tests/unit/lib/Signal_unittest.cc
@@ -1,37 +1,8 @@
 /*
-* BSD 3-Clause License
-*
-* Copyright (c) 2017, Shogun-Toolbox e.V. <shogun-team@shogun-toolbox.org>
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* * Redistributions of source code must retain the above copyright notice, this
-*   list of conditions and the following disclaimer.
-*
-* * Redistributions in binary form must reproduce the above copyright notice,
-*   this list of conditions and the following disclaimer in the documentation
-*   and/or other materials provided with the distribution.
-*
-* * Neither the name of the copyright holder nor the names of its
-*   contributors may be used to endorse or promote products derived from
-*   this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-* Written (W) 2017 Giovanni De Toni
-*
-*/
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Giovanni De Toni
+ */
 #include <gtest/gtest.h>
 #include <shogun/lib/Signal.h>
 


### PR DESCRIPTION
Before this patch, premature stopping could only be achieved by enabling the interactive signal handler. The user now can prematurely stop algorithms by just pressing specific key combinations without passing through the handler. 