### PR TITLE
Meta examples generation bug fix (fixes #4408)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,20 +484,12 @@ OPTION(TRAVIS_DISABLE_UNIT_TESTS "Disable unit testing to speed up jobs on travi
 OPTION(TRAVIS_DISABLE_META_CPP "Disable cpp meta examples and integration testing to speed up jobs on travis-ci" OFF)
 OPTION(DISABLE_META_INTEGRATION_TESTS "Disable meta integration testing to speed up build" OFF)
 
-IF(EXISTS ${CMAKE_SOURCE_DIR}/examples)
-	IF(ENABLE_TESTING AND NOT BUILD_EXAMPLES)
-		message(STATUS "Tests require (disabled) examples, enabling.")
-	ENDIF()
-	IF(ENABLE_TESTING OR BUILD_EXAMPLES)
-		add_subdirectory(${CMAKE_SOURCE_DIR}/examples)
-	ENDIF()
-
-	IF(BUILD_META_EXAMPLES)
-		# allow meta examples without adding examples dir itself
-		add_subdirectory(${CMAKE_SOURCE_DIR}/examples/meta)
-	ENDIF()
+IF((ENABLE_TESTING AND NOT TRAVIS_DISABLE_UNIT_TESTS AND EXISTS ${CMAKE_SOURCE_DIR}/tests/unit)
+	OR (EXISTS ${CMAKE_SOURCE_DIR}/examples AND BUILD_META_EXAMPLES))
+	# set CTAGS_FILE when tests/unit or examples/meta are added to the project
+	# according to the logic below
+	SET(CTAGS_FILE ${CMAKE_CURRENT_BINARY_DIR}/tags CACHE INTERNAL "" FORCE)
 ENDIF()
-
 IF(ENABLE_TESTING)
 	IF (NOT LIBSHOGUN)
 		MESSAGE(FATAL_ERROR "Cannot compile tests without libshogun!")
@@ -513,8 +505,22 @@ IF(ENABLE_TESTING)
 		ENDIF()
 
 		IF(BUILD_META_EXAMPLES AND NOT DISABLE_META_INTEGRATION_TESTS AND EXISTS ${CMAKE_SOURCE_DIR}/tests/meta)
-            add_subdirectory(${CMAKE_SOURCE_DIR}/tests/meta)
-        ENDIF()
+			add_subdirectory(${CMAKE_SOURCE_DIR}/tests/meta)
+		ENDIF()
+	ENDIF()
+ENDIF()
+
+IF(EXISTS ${CMAKE_SOURCE_DIR}/examples)
+	IF(ENABLE_TESTING AND NOT BUILD_EXAMPLES)
+		message(STATUS "Tests require (disabled) examples, enabling.")
+	ENDIF()
+	IF(ENABLE_TESTING OR BUILD_EXAMPLES)
+		add_subdirectory(${CMAKE_SOURCE_DIR}/examples)
+	ENDIF()
+
+	IF(BUILD_META_EXAMPLES)
+		# allow meta examples without adding examples dir itself
+		add_subdirectory(${CMAKE_SOURCE_DIR}/examples/meta)
 	ENDIF()
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,19 @@ OPTION(TRAVIS_DISABLE_UNIT_TESTS "Disable unit testing to speed up jobs on travi
 OPTION(TRAVIS_DISABLE_META_CPP "Disable cpp meta examples and integration testing to speed up jobs on travis-ci" OFF)
 OPTION(DISABLE_META_INTEGRATION_TESTS "Disable meta integration testing to speed up build" OFF)
 
+IF(EXISTS ${CMAKE_SOURCE_DIR}/examples)
+	IF(ENABLE_TESTING AND NOT BUILD_EXAMPLES)
+		message(STATUS "Tests require (disabled) examples, enabling.")
+	ENDIF()
+	IF(ENABLE_TESTING OR BUILD_EXAMPLES)
+		add_subdirectory(${CMAKE_SOURCE_DIR}/examples)
+	ENDIF()
+
+	IF(BUILD_META_EXAMPLES)
+		# allow meta examples without adding examples dir itself
+		add_subdirectory(${CMAKE_SOURCE_DIR}/examples/meta)
+	ENDIF()
+ENDIF()
 
 IF(ENABLE_TESTING)
 	IF (NOT LIBSHOGUN)
@@ -503,20 +516,6 @@ IF(ENABLE_TESTING)
             add_subdirectory(${CMAKE_SOURCE_DIR}/tests/meta)
         ENDIF()
 	ENDIF()
-ENDIF()
-
-IF(EXISTS ${CMAKE_SOURCE_DIR}/examples)
-	IF(ENABLE_TESTING AND NOT BUILD_EXAMPLES)
-	    message(STATUS "Tests require (disabled) examples, enabling.")
-	ENDIF()
-    IF(ENABLE_TESTING OR BUILD_EXAMPLES)
-	    add_subdirectory(${CMAKE_SOURCE_DIR}/examples)
-	ENDIF()
-
-	IF(BUILD_META_EXAMPLES)
-        # allow meta examples without adding examples dir itself
-        add_subdirectory(${CMAKE_SOURCE_DIR}/examples/meta)
-    ENDIF()
 ENDIF()
 
 IF(EXISTS ${CMAKE_SOURCE_DIR}/doc)

--- a/examples/meta/CMakeLists.txt
+++ b/examples/meta/CMakeLists.txt
@@ -11,7 +11,6 @@ IF(NOT CTAGS_FOUND)
 	message(FATAL_ERROR "Ctags required for meta examples. Install or set BUILD_META_EXAMPLES=OFF.")
 ENDIF()
 
-SET(CTAGS_FILE ${CMAKE_CURRENT_BINARY_DIR}/tags CACHE INTERNAL "" FORCE)
 # TODO: the arg for -R should rather be the where libshogun's headers are residing
 ADD_CUSTOM_COMMAND(OUTPUT ${CTAGS_FILE}
     COMMAND ${CTAGS_EXECUTABLE} -f ${CTAGS_FILE}


### PR DESCRIPTION
As explained in #4408 switching execution order defines Cmake variables properly