### PR TITLE
AnyParameterProperties refactor

### DIFF
--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -28,13 +28,9 @@ namespace shogun
 		GRADIENT_AVAILABLE = 1
 	};
 	/** @brief Class AnyParameterProperties keeps track of parameter properties.
-	 *
-	 * Currently there are three types of parameters:
-	 * -# HYPERPARAMETER: the parameter determines how the training is
-	 * performed, e.g. regularisation
-	 * -# GRADIENT_PARAM: the parameter is used in gradient updates
-	 * -# MODEL_PARAM: model parameter that is trained, e.g. weight and bias
-	 * vectors and bias
+	 * The parameter properties can be either true or false.
+	 * These properties describe if a parameter is for example a hyperparameter
+	 * or if it has a gradient.
 	 */
 	class AnyParameterProperties
 	{
@@ -43,12 +39,20 @@ namespace shogun
 		static const int32_t GRADIENT_PARAM = 0x00000010;
 		static const int32_t MODEL_PARAM = 0x00000100;
 
-		/** default constructor where all parameter types are switched to false
+		/** Default constructor where all parameter properties are false
 		 */
 		AnyParameterProperties() : m_description(), m_mask_attribute(0x00000000)
 		{
 		}
-		/** legacy constructor */
+		/** Constructor
+		 * @param description parameter description
+		 * @param hyperparameter set to true for parameters that determine
+		 * how training is performed, e.g. regularisation parameters
+		 * @param gradient set to true for parameters required for gradient
+		 * updates
+		 * @param model set to true for parameters used in inference, e.g.
+		 * weights and bias
+		 * */
 		AnyParameterProperties(
 		    std::string description,
 		    EModelSelectionAvailability model_selection = MS_NOT_AVAILABLE,
@@ -65,13 +69,15 @@ namespace shogun
 			if (hyperparameter)
 				m_mask_attribute |= HYPERPARAMETER;
 		}
-		/** mask constructor */
-		AnyParameterProperties(std::string description, int32_t mask_attribute)
+		/** Mask constructor
+		 * @param description parameter description
+		 * @param attribute_mask mask encoding parameter properties
+		 * */
 		    : m_description(description)
 		{
 			m_mask_attribute = mask_attribute;
 		}
-		/** copy contructor */
+		/** Copy contructor */
 		AnyParameterProperties(const AnyParameterProperties& other)
 		    : m_description(other.m_description),
 		      m_model_selection(other.m_model_selection),
@@ -79,12 +85,11 @@ namespace shogun
 		      m_mask_attribute(other.m_mask_attribute)
 		{
 		}
-		/** description getter */
+		const std::string& get_description() const
 		std::string get_description() const
 		{
 			return m_description;
 		}
-		/** model selection flag getter */
 		EModelSelectionAvailability get_model_selection() const
 		{
 			EModelSelectionAvailability return_val;
@@ -95,7 +100,6 @@ namespace shogun
 			return return_val;
 		}
 
-		/** gradient flag getter */
 		EGradientAvailability get_gradient() const
 		{
 			EGradientAvailability return_val;
@@ -106,7 +110,6 @@ namespace shogun
 			return return_val;
 		}
 
-		/** hyperparameter flag getter */
 		bool get_hyperparameter() const
 		{
 			bool return_val;
@@ -121,7 +124,7 @@ namespace shogun
 		std::string m_description;
 		EModelSelectionAvailability m_model_selection;
 		EGradientAvailability m_gradient;
-		/** mask to store all param flags*/
+		int32_t m_attribute_mask;
 		int32_t m_mask_attribute;
 	};
 

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -1,3 +1,9 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann, Gil Hoben
+ */
+
 #ifndef __ANYPARAMETER_H__
 #define __ANYPARAMETER_H__
 
@@ -27,7 +33,7 @@ namespace shogun
 	 * -# HYPERPARAMETER: the parameter determines how the training is
 	 * performed, e.g. regularisation
 	 * -# GRADIENT_PARAM: the parameter is used in gradient updates
-	 * -# MODELSELECTION_PARAM: model parameter that is trained, e.g. weight
+	 * -# MODEL_PARAM: model parameter that is trained, e.g. weight and bias
 	 * vectors and bias
 	 */
 	class AnyParameterProperties
@@ -35,7 +41,7 @@ namespace shogun
 	public:
 		static const int32_t HYPERPARAMETER = 0x00000001;
 		static const int32_t GRADIENT_PARAM = 0x00000010;
-		static const int32_t MODELSELECTION_PARAM = 0x00000100;
+		static const int32_t MODEL_PARAM = 0x00000100;
 
 		/** default constructor where all parameter types are switched to false
 		 */
@@ -53,7 +59,7 @@ namespace shogun
 		{
 			m_mask_attribute = 0x00000000;
 			if (model_selection)
-				m_mask_attribute |= MODELSELECTION_PARAM;
+				m_mask_attribute |= MODEL_PARAM;
 			if (gradient)
 				m_mask_attribute |= GRADIENT_PARAM;
 			if (hyperparameter)
@@ -82,7 +88,7 @@ namespace shogun
 		EModelSelectionAvailability get_model_selection() const
 		{
 			EModelSelectionAvailability return_val;
-			if (m_mask_attribute & MODELSELECTION_PARAM)
+			if (m_mask_attribute & HYPERPARAMETER)
 				return_val = EModelSelectionAvailability::MS_AVAILABLE;
 			else
 				return_val = EModelSelectionAvailability::MS_NOT_AVAILABLE;
@@ -169,6 +175,6 @@ namespace shogun
 		Any m_value;
 		AnyParameterProperties m_properties;
 	};
-}
+} // namespace shogun
 
 #endif

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -35,13 +35,14 @@ namespace shogun
 	class AnyParameterProperties
 	{
 	public:
-		static const int32_t HYPERPARAMETER = 0x00000001;
-		static const int32_t GRADIENT_PARAM = 0x00000010;
-		static const int32_t MODEL_PARAM = 0x00000100;
+		static const int32_t HYPER = 1u << 0;
+		static const int32_t GRADIENT = 1u << 1;
+		static const int32_t MODEL = 1u << 2;
 
 		/** Default constructor where all parameter properties are false
 		 */
-		AnyParameterProperties() : m_description(), m_mask_attribute(0x00000000)
+		AnyParameterProperties()
+		    : m_description("No description given"), m_attribute_mask(0)
 		{
 		}
 		/** Constructor
@@ -55,69 +56,50 @@ namespace shogun
 		 * */
 		AnyParameterProperties(
 		    std::string description,
-		    EModelSelectionAvailability model_selection = MS_NOT_AVAILABLE,
+		    EModelSelectionAvailability hyperparameter = MS_NOT_AVAILABLE,
 		    EGradientAvailability gradient = GRADIENT_NOT_AVAILABLE,
-		    bool hyperparameter = false)
-		    : m_description(description), m_model_selection(model_selection),
+		    bool model = false)
+		    : m_description(description), m_model_selection(hyperparameter),
 		      m_gradient(gradient)
 		{
-			m_mask_attribute = 0x00000000;
-			if (model_selection)
-				m_mask_attribute |= MODEL_PARAM;
-			if (gradient)
-				m_mask_attribute |= GRADIENT_PARAM;
-			if (hyperparameter)
-				m_mask_attribute |= HYPERPARAMETER;
+			m_attribute_mask = (hyperparameter << 0 & HYPER) |
+			                   (gradient << 1 & GRADIENT) |
+			                   (model << 2 & MODEL);
 		}
 		/** Mask constructor
 		 * @param description parameter description
 		 * @param attribute_mask mask encoding parameter properties
 		 * */
+		AnyParameterProperties(std::string description, int32_t attribute_mask)
 		    : m_description(description)
 		{
-			m_mask_attribute = mask_attribute;
+			m_attribute_mask = attribute_mask;
 		}
 		/** Copy contructor */
 		AnyParameterProperties(const AnyParameterProperties& other)
 		    : m_description(other.m_description),
 		      m_model_selection(other.m_model_selection),
 		      m_gradient(other.m_gradient),
-		      m_mask_attribute(other.m_mask_attribute)
+		      m_attribute_mask(other.m_attribute_mask)
 		{
 		}
 		const std::string& get_description() const
-		std::string get_description() const
 		{
 			return m_description;
 		}
 		EModelSelectionAvailability get_model_selection() const
 		{
-			EModelSelectionAvailability return_val;
-			if (m_mask_attribute & HYPERPARAMETER)
-				return_val = EModelSelectionAvailability::MS_AVAILABLE;
-			else
-				return_val = EModelSelectionAvailability::MS_NOT_AVAILABLE;
-			return return_val;
+			return static_cast<EModelSelectionAvailability>(
+			    (m_attribute_mask & HYPER) > 0);
 		}
-
 		EGradientAvailability get_gradient() const
 		{
-			EGradientAvailability return_val;
-			if (m_mask_attribute & GRADIENT_PARAM)
-				return_val = EGradientAvailability::GRADIENT_AVAILABLE;
-			else
-				return_val = EGradientAvailability::GRADIENT_NOT_AVAILABLE;
-			return return_val;
+			return static_cast<EGradientAvailability>(
+			    (m_attribute_mask & GRADIENT) > 0);
 		}
-
-		bool get_hyperparameter() const
+		bool get_model() const
 		{
-			bool return_val;
-			if (m_mask_attribute & HYPERPARAMETER)
-				return_val = true;
-			else
-				return_val = false;
-			return return_val;
+			return static_cast<bool>(m_attribute_mask & MODEL);
 		}
 
 	private:
@@ -125,7 +107,6 @@ namespace shogun
 		EModelSelectionAvailability m_model_selection;
 		EGradientAvailability m_gradient;
 		int32_t m_attribute_mask;
-		int32_t m_mask_attribute;
 	};
 
 	class AnyParameter

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -47,14 +47,11 @@ namespace shogun
 	class AnyParameterProperties
 	{
 	public:
-		static const int32_t HYPER = 1u << 0;
-		static const int32_t GRADIENT = 1u << 1;
-		static const int32_t MODEL = 1u << 2;
-
 		/** Default constructor where all parameter properties are false
 		 */
 		AnyParameterProperties()
-		    : m_description("No description given"), m_attribute_mask(0)
+		    : m_description("No description given"),
+		      m_attribute_mask(ParameterProperties())
 		{
 		}
 		/** Constructor
@@ -74,15 +71,20 @@ namespace shogun
 		    : m_description(description), m_model_selection(hyperparameter),
 		      m_gradient(gradient)
 		{
-			m_attribute_mask = (hyperparameter << 0 & HYPER) |
-			                   (gradient << 1 & GRADIENT) |
-			                   (model << 2 & MODEL);
+			m_attribute_mask = ParameterProperties();
+			if (hyperparameter)
+				m_attribute_mask |= ParameterProperties::HYPER;
+			if (gradient)
+				m_attribute_mask |= ParameterProperties::GRADIENT;
+			if (model)
+				m_attribute_mask |= ParameterProperties::MODEL;
 		}
 		/** Mask constructor
 		 * @param description parameter description
 		 * @param attribute_mask mask encoding parameter properties
 		 * */
-		AnyParameterProperties(std::string description, int32_t attribute_mask)
+		AnyParameterProperties(
+		    std::string description, ParameterProperties attribute_mask)
 		    : m_description(description)
 		{
 			m_attribute_mask = attribute_mask;
@@ -102,23 +104,26 @@ namespace shogun
 		EModelSelectionAvailability get_model_selection() const
 		{
 			return static_cast<EModelSelectionAvailability>(
-			    (m_attribute_mask & HYPER) > 0);
+			    static_cast<int32_t>(
+			        m_attribute_mask & ParameterProperties::HYPER) > 0);
 		}
 		EGradientAvailability get_gradient() const
 		{
 			return static_cast<EGradientAvailability>(
-			    (m_attribute_mask & GRADIENT) > 0);
+			    static_cast<int32_t>(
+			        m_attribute_mask & ParameterProperties::GRADIENT) > 0);
 		}
 		bool get_model() const
 		{
-			return static_cast<bool>(m_attribute_mask & MODEL);
+			return static_cast<bool>(
+			    m_attribute_mask & ParameterProperties::MODEL);
 		}
 
 	private:
 		std::string m_description;
 		EModelSelectionAvailability m_model_selection;
 		EGradientAvailability m_gradient;
-		int32_t m_attribute_mask;
+		ParameterProperties m_attribute_mask;
 	};
 
 	class AnyParameter

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -8,6 +8,7 @@
 #define __ANYPARAMETER_H__
 
 #include <shogun/lib/any.h>
+#include <shogun/lib/bitmask_operators.h>
 
 #include <string>
 
@@ -27,10 +28,21 @@ namespace shogun
 		GRADIENT_NOT_AVAILABLE = 0,
 		GRADIENT_AVAILABLE = 1
 	};
-	/** @brief Class AnyParameterProperties keeps track of parameter properties.
-	 * The parameter properties can be either true or false.
-	 * These properties describe if a parameter is for example a hyperparameter
-	 * or if it has a gradient.
+
+	/** parameter properties */
+	enum class ParameterProperties
+	{
+		HYPER = 1u << 0,
+		GRADIENT = 1u << 1,
+		MODEL = 1u << 2
+	};
+
+	enableEnumClassBitmask(ParameterProperties);
+
+	/** @brief Class AnyParameterProperties keeps track of of parameter meta
+	 * information, such as properties and descriptions The parameter properties
+	 * can be either true or false. These properties describe if a parameter is
+	 * for example a hyperparameter or if it has a gradient.
 	 */
 	class AnyParameterProperties
 	{

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -21,49 +21,102 @@ namespace shogun
 		GRADIENT_NOT_AVAILABLE = 0,
 		GRADIENT_AVAILABLE = 1
 	};
-
+	/** @brief Class AnyParameterProperties keeps track of parameter properties.
+	 *
+	 * Currently there are three types of parameters:
+	 * -# HYPERPARAMETER: the parameter determines how the training is
+	 * performed, e.g. regularisation
+	 * -# GRADIENT_PARAM: the parameter is used in gradient updates
+	 * -# MODELSELECTION_PARAM: model parameter that is trained, e.g. weight
+	 * vectors and bias
+	 */
 	class AnyParameterProperties
 	{
 	public:
-		AnyParameterProperties()
-		    : m_description(), m_model_selection(MS_NOT_AVAILABLE),
-		      m_gradient(GRADIENT_NOT_AVAILABLE)
+		static const int32_t HYPERPARAMETER = 0x00000001;
+		static const int32_t GRADIENT_PARAM = 0x00000010;
+		static const int32_t MODELSELECTION_PARAM = 0x00000100;
+
+		/** default constructor where all parameter types are switched to false
+		 */
+		AnyParameterProperties() : m_description(), m_mask_attribute(0x00000000)
 		{
 		}
+		/** legacy constructor */
 		AnyParameterProperties(
 		    std::string description,
 		    EModelSelectionAvailability model_selection = MS_NOT_AVAILABLE,
-		    EGradientAvailability gradient = GRADIENT_NOT_AVAILABLE)
+		    EGradientAvailability gradient = GRADIENT_NOT_AVAILABLE,
+		    bool hyperparameter = false)
 		    : m_description(description), m_model_selection(model_selection),
 		      m_gradient(gradient)
 		{
+			m_mask_attribute = 0x00000000;
+			if (model_selection)
+				m_mask_attribute |= MODELSELECTION_PARAM;
+			if (gradient)
+				m_mask_attribute |= GRADIENT_PARAM;
+			if (hyperparameter)
+				m_mask_attribute |= HYPERPARAMETER;
 		}
+		/** mask constructor */
+		AnyParameterProperties(std::string description, int32_t mask_attribute)
+		    : m_description(description)
+		{
+			m_mask_attribute = mask_attribute;
+		}
+		/** copy contructor */
 		AnyParameterProperties(const AnyParameterProperties& other)
 		    : m_description(other.m_description),
 		      m_model_selection(other.m_model_selection),
-		      m_gradient(other.m_gradient)
+		      m_gradient(other.m_gradient),
+		      m_mask_attribute(other.m_mask_attribute)
 		{
 		}
-
+		/** description getter */
 		std::string get_description() const
 		{
 			return m_description;
 		}
-
+		/** model selection flag getter */
 		EModelSelectionAvailability get_model_selection() const
 		{
-			return m_model_selection;
+			EModelSelectionAvailability return_val;
+			if (m_mask_attribute & MODELSELECTION_PARAM)
+				return_val = EModelSelectionAvailability::MS_AVAILABLE;
+			else
+				return_val = EModelSelectionAvailability::MS_NOT_AVAILABLE;
+			return return_val;
 		}
 
+		/** gradient flag getter */
 		EGradientAvailability get_gradient() const
 		{
-			return m_gradient;
+			EGradientAvailability return_val;
+			if (m_mask_attribute & GRADIENT_PARAM)
+				return_val = EGradientAvailability::GRADIENT_AVAILABLE;
+			else
+				return_val = EGradientAvailability::GRADIENT_NOT_AVAILABLE;
+			return return_val;
+		}
+
+		/** hyperparameter flag getter */
+		bool get_hyperparameter() const
+		{
+			bool return_val;
+			if (m_mask_attribute & HYPERPARAMETER)
+				return_val = true;
+			else
+				return_val = false;
+			return return_val;
 		}
 
 	private:
 		std::string m_description;
 		EModelSelectionAvailability m_model_selection;
 		EGradientAvailability m_gradient;
+		/** mask to store all param flags*/
+		int32_t m_mask_attribute;
 	};
 
 	class AnyParameter

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -675,11 +675,7 @@ protected:
 	template <typename T>
 	void watch_param(
 		const std::string& name, T* value,
-		AnyParameterProperties properties = AnyParameterProperties(
-			"Unknown parameter",
-			AnyParameterProperties::HYPER |
-			AnyParameterProperties::GRADIENT |
-			AnyParameterProperties::MODEL))
+		AnyParameterProperties properties = AnyParameterProperties())
 	{
 		BaseTag tag(name);
 		create_parameter(tag, AnyParameter(make_any_ref(value), properties));
@@ -735,9 +731,9 @@ protected:
 		BaseTag tag(name);
 		AnyParameterProperties properties(
 			"Dynamic parameter",
-			!AnyParameterProperties::HYPER |
-			!AnyParameterProperties::GRADIENT |
-			!AnyParameterProperties::MODEL);
+			ParameterProperties::HYPER |
+			ParameterProperties::GRADIENT |
+            ParameterProperties::MODEL);
 		std::function<T()> bind_method =
 			std::bind(method, dynamic_cast<const S*>(this));
 		create_parameter(tag, AnyParameter(make_any(bind_method), properties));

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -676,7 +676,10 @@ protected:
 	void watch_param(
 		const std::string& name, T* value,
 		AnyParameterProperties properties = AnyParameterProperties(
-		    "Unknown parameter", MS_NOT_AVAILABLE, GRADIENT_NOT_AVAILABLE))
+			"Unknown parameter",
+			AnyParameterProperties::HYPERPARAMETER |
+			AnyParameterProperties::GRADIENT_PARAM |
+			AnyParameterProperties::MODELSELECTION_PARAM))
 	{
 		BaseTag tag(name);
 		create_parameter(tag, AnyParameter(make_any_ref(value), properties));
@@ -694,7 +697,10 @@ protected:
 	void watch_param(
 		const std::string& name, T** value, S* len,
 		AnyParameterProperties properties = AnyParameterProperties(
-		    "Unknown parameter", MS_NOT_AVAILABLE, GRADIENT_NOT_AVAILABLE))
+			"Unknown parameter",
+			AnyParameterProperties::HYPERPARAMETER |
+			AnyParameterProperties::GRADIENT_PARAM |
+			AnyParameterProperties::MODELSELECTION_PARAM))
 	{
 		BaseTag tag(name);
 		create_parameter(
@@ -715,7 +721,10 @@ protected:
 	void watch_param(
 		const std::string& name, T** value, S* rows, S* cols,
 		AnyParameterProperties properties = AnyParameterProperties(
-		    "Unknown parameter", MS_NOT_AVAILABLE, GRADIENT_NOT_AVAILABLE))
+			"Unknown parameter",
+            AnyParameterProperties::HYPERPARAMETER |
+            AnyParameterProperties::GRADIENT_PARAM |
+            AnyParameterProperties::MODELSELECTION_PARAM))
 	{
 		BaseTag tag(name);
 		create_parameter(
@@ -733,7 +742,10 @@ protected:
 	{
 		BaseTag tag(name);
 		AnyParameterProperties properties(
-			"Dynamic parameter", MS_NOT_AVAILABLE, GRADIENT_NOT_AVAILABLE);
+			"Dynamic parameter",
+            AnyParameterProperties::HYPERPARAMETER |
+            AnyParameterProperties::GRADIENT_PARAM |
+            AnyParameterProperties::MODELSELECTION_PARAM);
 		std::function<T()> bind_method =
 			std::bind(method, dynamic_cast<const S*>(this));
 		create_parameter(tag, AnyParameter(make_any(bind_method), properties));

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -679,7 +679,7 @@ protected:
 			"Unknown parameter",
 			AnyParameterProperties::HYPERPARAMETER |
 			AnyParameterProperties::GRADIENT_PARAM |
-			AnyParameterProperties::MODELSELECTION_PARAM))
+			AnyParameterProperties::MODEL_PARAM))
 	{
 		BaseTag tag(name);
 		create_parameter(tag, AnyParameter(make_any_ref(value), properties));
@@ -700,7 +700,7 @@ protected:
 			"Unknown parameter",
 			AnyParameterProperties::HYPERPARAMETER |
 			AnyParameterProperties::GRADIENT_PARAM |
-			AnyParameterProperties::MODELSELECTION_PARAM))
+			AnyParameterProperties::MODEL_PARAM))
 	{
 		BaseTag tag(name);
 		create_parameter(
@@ -724,7 +724,7 @@ protected:
 			"Unknown parameter",
             AnyParameterProperties::HYPERPARAMETER |
             AnyParameterProperties::GRADIENT_PARAM |
-            AnyParameterProperties::MODELSELECTION_PARAM))
+            AnyParameterProperties::MODEL_PARAM))
 	{
 		BaseTag tag(name);
 		create_parameter(
@@ -745,7 +745,7 @@ protected:
 			"Dynamic parameter",
             AnyParameterProperties::HYPERPARAMETER |
             AnyParameterProperties::GRADIENT_PARAM |
-            AnyParameterProperties::MODELSELECTION_PARAM);
+            AnyParameterProperties::MODEL_PARAM);
 		std::function<T()> bind_method =
 			std::bind(method, dynamic_cast<const S*>(this));
 		create_parameter(tag, AnyParameter(make_any(bind_method), properties));

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -677,9 +677,9 @@ protected:
 		const std::string& name, T* value,
 		AnyParameterProperties properties = AnyParameterProperties(
 			"Unknown parameter",
-			AnyParameterProperties::HYPERPARAMETER |
-			AnyParameterProperties::GRADIENT_PARAM |
-			AnyParameterProperties::MODEL_PARAM))
+			AnyParameterProperties::HYPER |
+			AnyParameterProperties::GRADIENT |
+			AnyParameterProperties::MODEL))
 	{
 		BaseTag tag(name);
 		create_parameter(tag, AnyParameter(make_any_ref(value), properties));
@@ -696,11 +696,7 @@ protected:
 	template <typename T, typename S>
 	void watch_param(
 		const std::string& name, T** value, S* len,
-		AnyParameterProperties properties = AnyParameterProperties(
-			"Unknown parameter",
-			AnyParameterProperties::HYPERPARAMETER |
-			AnyParameterProperties::GRADIENT_PARAM |
-			AnyParameterProperties::MODEL_PARAM))
+		AnyParameterProperties properties = AnyParameterProperties())
 	{
 		BaseTag tag(name);
 		create_parameter(
@@ -720,11 +716,7 @@ protected:
 	template <typename T, typename S>
 	void watch_param(
 		const std::string& name, T** value, S* rows, S* cols,
-		AnyParameterProperties properties = AnyParameterProperties(
-			"Unknown parameter",
-            AnyParameterProperties::HYPERPARAMETER |
-            AnyParameterProperties::GRADIENT_PARAM |
-            AnyParameterProperties::MODEL_PARAM))
+		AnyParameterProperties properties = AnyParameterProperties())
 	{
 		BaseTag tag(name);
 		create_parameter(
@@ -743,9 +735,9 @@ protected:
 		BaseTag tag(name);
 		AnyParameterProperties properties(
 			"Dynamic parameter",
-            AnyParameterProperties::HYPERPARAMETER |
-            AnyParameterProperties::GRADIENT_PARAM |
-            AnyParameterProperties::MODEL_PARAM);
+			!AnyParameterProperties::HYPER |
+			!AnyParameterProperties::GRADIENT |
+			!AnyParameterProperties::MODEL);
 		std::function<T()> bind_method =
 			std::bind(method, dynamic_cast<const S*>(this));
 		create_parameter(tag, AnyParameter(make_any(bind_method), properties));

--- a/src/shogun/lib/bitmask_operators.h
+++ b/src/shogun/lib/bitmask_operators.h
@@ -1,0 +1,110 @@
+#ifndef JSS_BITMASK_HPP
+#define JSS_BITMASK_HPP
+
+// (C) Copyright 2015 Just Software Solutions Ltd
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// Boost Software License - Version 1.0 - August 17th, 2003
+//
+// Permission is hereby granted, free of charge, to any person or
+// organization obtaining a copy of the software and accompanying
+// documentation covered by this license (the "Software") to use,
+// reproduce, display, distribute, execute, and transmit the
+// Software, and to prepare derivative works of the Software, and
+// to permit third-parties to whom the Software is furnished to
+// do so, all subject to the following:
+//
+// The copyright notices in the Software and this entire
+// statement, including the above license grant, this restriction
+// and the following disclaimer, must be included in all copies
+// of the Software, in whole or in part, and all derivative works
+// of the Software, unless such copies or derivative works are
+// solely in the form of machine-executable object code generated
+// by a source language processor.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+// KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE
+// LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include<type_traits>
+
+namespace shogun {
+
+    template<typename E>
+    struct enable_bitmask_operators {
+        static constexpr bool enable = false;
+    };
+
+    #define enableEnumClassBitmask(T) template<> \
+    struct enable_bitmask_operators<T> \
+    { \
+        static constexpr bool enable = true; \
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
+    operator|(E lhs, E rhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        return static_cast<E>(
+                static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
+    operator&(E lhs, E rhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        return static_cast<E>(
+                static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
+    operator^(E lhs, E rhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        return static_cast<E>(
+                static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs));
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
+    operator~(E lhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        return static_cast<E>(
+                ~static_cast<underlying>(lhs));
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E &>::type
+    operator|=(E &lhs, E rhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        lhs = static_cast<E>(
+                static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
+        return lhs;
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E &>::type
+    operator&=(E &lhs, E rhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        lhs = static_cast<E>(
+                static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
+        return lhs;
+    }
+
+    template<typename E>
+    typename std::enable_if<enable_bitmask_operators<E>::enable, E &>::type
+    operator^=(E &lhs, E rhs) {
+        typedef typename std::underlying_type<E>::type underlying;
+        lhs = static_cast<E>(
+                static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs));
+        return lhs;
+    }
+}
+#endif


### PR DESCRIPTION
This PR refactors the AnyParameterProperties class to use a mask (`m_mask_attribute`) to store parameter options:
 * HYPERPARAMETER: the parameter determines how the training is performed, e.g. regularisation
 * GRADIENT_PARAM: the parameter is used in gradient updates
 * MODEL_PARAM: model parameter that is trained, e.g. weight and bias
This makes the use of Enums in `AnyParameter.h` not necessary anymore, and the corresponding getter methods can be replaced with `bool` return type.  
The mask uses bit shift operations to keep information in a hexadecimal representation.