### PR TITLE
Add meta example features-char-string

### DIFF
--- a/doc/readme/INTERFACES.md
+++ b/doc/readme/INTERFACES.md
@@ -54,7 +54,7 @@ This needs `shogun.oct` to be visible, which is either in `path/to/build/src/int
 
 Running an example:
 
-    python path/to/octave_example.py
+    octave path/to/octave_example.m
 
 ### Ruby
 This needs `shogun.rb` to be visible, which is either in `path/to/build/src/interfaces/ruby_modular/` or in something similar to `path/to/shogun-install/lib/x86_64-linux-gnu/site_ruby`

--- a/examples/meta/generator/parse.py
+++ b/examples/meta/generator/parse.py
@@ -104,7 +104,8 @@ class FastParser:
         'ShortRealMatrix': 'SHOGUNSGTYPE',
         'RealMatrix': 'SHOGUNSGTYPE',
         'LongRealMatrix': 'SHOGUNSGTYPE',
-        'ComplexMatrix': 'SHOGUNSGTYPE'
+        'ComplexMatrix': 'SHOGUNSGTYPE',
+        'StringCharList':'SHOGUNSGTYPE'
     }
 
     t_INTLITERAL = "-?[0-9]+"

--- a/examples/meta/generator/targets/cpp.json
+++ b/examples/meta/generator/targets/cpp.json
@@ -45,7 +45,8 @@
     "Type": {
         "RealFeatures": "DenseFeatures<float64_t>",
         "RealSubsetFeatures": "DenseSubsetFeatures<float64_t>",
-        "StringCharFeatures": "CStringFeatures<char>",
+        "StringCharFeatures": "StringFeatures<char>",
+        "StringCharList": "SGStringList<char>",
         "Default": "$typeName",
         "bool": "bool",
         "string": "char*",
@@ -96,7 +97,11 @@
             "get_int_vector": "$object->get<SGVector<int32_t>>($arguments)",
             "get_real": "$object->get<float64_t>($arguments)",
             "get_real_vector": "$object->get<SGVector<float64_t>>($arguments)",
-            "get_real_matrix": "$object->get<SGMatrix<float64_t>>($arguments)"
+            "get_real_matrix": "$object->get<SGMatrix<float64_t>>($arguments)",
+            "get_int_string_list": "$object->get<SGStringList<int32_t>>($arguments)",
+            "get_bool_string_list": "$object->get<SGStringList<bool>>($arguments)",
+            "get_char_string_list": "$object->get<SGStringList<char>>($arguments)",
+            "get_real_string_list": "$object->get<SGStringList<float64_t>>($arguments)"
         },
         "StaticCall": "C$typeName::$method($arguments)",
         "GlobalCall": "$method($arguments)",

--- a/examples/meta/generator/targets/csharp.json
+++ b/examples/meta/generator/targets/csharp.json
@@ -62,7 +62,8 @@
         "ShortRealMatrix": "float[,]",
         "RealMatrix": "double[,]",
         "LongRealMatrix": "double[,]",
-        "ComplexMatrix": "Complex[,]"
+        "ComplexMatrix": "Complex[,]",
+        "StringCharList": "String[]"
     },
     "Expr": {
         "StringLiteral": "\"$literal\"",

--- a/examples/meta/generator/targets/java.json
+++ b/examples/meta/generator/targets/java.json
@@ -5,7 +5,8 @@
         "IncludeEnums": true,
         "IncludeGlobalFunctions": false,
         "DependencyListElement": "import org.shogun.$typeName;",
-        "DependencyListSeparator": "\n"
+        "DependencyListSeparator": "\n",
+        "ExcludeImport": ["StringCharList"]
     },
     "Statement": "$statement;\n",
     "Comment": "//$comment\n",
@@ -68,7 +69,8 @@
         "ShortRealMatrix": "FloatMatrix",
         "RealMatrix": "DoubleMatrix",
         "LongRealMatrix": "DoubleMatrix",
-        "ComplexMatrix": "DoubleMatrix"
+        "ComplexMatrix": "DoubleMatrix",
+        "StringCharList": "String[]"
     },
     "Expr": {
         "StringLiteral": "\"$literal\"",

--- a/examples/meta/generator/targets/octave.json
+++ b/examples/meta/generator/targets/octave.json
@@ -1,5 +1,5 @@
 {
-    "Program": "shogun\n\n$program",
+    "Program": "shogun;\n\n$program",
     "Statement": "$statement;\n",
     "Comment": "%$comment\n",
     "Init": {

--- a/examples/meta/generator/targets/python.json
+++ b/examples/meta/generator/targets/python.json
@@ -61,7 +61,11 @@
             "get_int_vector": "$object.get($arguments)",
             "get_real": "$object.get($arguments)",
             "get_real_vector": "$object.get($arguments)",
-            "get_real_matrix": "$object.get($arguments)"
+            "get_real_matrix": "$object.get($arguments)",
+            "get_bool_string_list": "$object.get($arguments)",
+            "get_char_string_list": "$object.get($arguments)",
+            "get_real_string_list": "$object.get($arguments)",
+            "get_int_string_list": "$object.get($arguments)"
         },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "$method($arguments$kwargs)",

--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -341,6 +341,10 @@ class Translator:
         if self.targetDict["Dependencies"].get("IncludeGlobalFunctions"):
             dependencies = dependencies.union(globalFunctions)
 
+        if "ExcludeImport" in self.targetDict["Dependencies"]:
+            for item in self.targetDict["Dependencies"].get("ExcludeImport"):
+                dependencies.discard(item)
+
         dependencies = list(dependencies)
 
         translations = list(set(map(self.translateDependencyElement, dependencies)))

--- a/examples/meta/src/features/string_char.sg
+++ b/examples/meta/src/features/string_char.sg
@@ -1,0 +1,11 @@
+File words = csv_file("../../data/words.dat")
+
+#![create_features]
+Features f = string_features(words, enum EAlphabet.RAWBYTE)
+#![create_features]
+
+#![output stat]
+int max_string_length = f.get_int("max_string_length")
+int number_of_strings = f.get_int("num_vectors")
+StringCharList string_list = f.get_char_string_list("string_list")
+#![output stat]

--- a/examples/undocumented/python/features_string_char.py
+++ b/examples/undocumented/python/features_string_char.py
@@ -21,7 +21,7 @@ def features_string_char (strings):
 	f.set_feature_vector(array(['t','e','s','t']), 0)
 
 	#print("strings", f.get_features())
-	return f.get_features(), f
+	return f.get_string_list(), f
 
 if __name__=='__main__':
 	print('StringCharFeatures')

--- a/examples/undocumented/python/features_string_file.py
+++ b/examples/undocumented/python/features_string_file.py
@@ -25,7 +25,7 @@ def features_string_file (directory, fname):
 	#or load fasta file
 	#f.load_fasta('fasta.fa')
 	#print(f.get_features())
-	return f.get_features(), f
+	return f.get_string_list(), f
 
 if __name__=='__main__':
 	print('StringWordFeatures')

--- a/examples/undocumented/python/features_string_ulong.py
+++ b/examples/undocumented/python/features_string_ulong.py
@@ -17,7 +17,7 @@ def features_string_ulong (start=0,order=2,gap=0,rev=False):
     uf.set_feature_vector(array([1,2,3,4,5], dtype=uint64), 0)
 
 
-    return uf.get_features(),uf.get_feature_vector(2), uf.get_num_vectors()
+    return uf.get_string_list(),uf.get_feature_vector(2), uf.get_num_vectors()
 
 if __name__=='__main__':
     print('simple_longint')

--- a/examples/undocumented/python/features_string_word.py
+++ b/examples/undocumented/python/features_string_word.py
@@ -24,7 +24,7 @@ def features_string_word (strings, start, order, gap, rev):
 	wf.set_feature_vector(array([1,2,3,4,5], dtype=uint16), 0)
 
 	#print("strings", wf.get_features())
-	return wf.get_features(), wf
+	return wf.get_string_list(), wf
 
 if __name__=='__main__':
 	print('StringWordFeatures')

--- a/src/interfaces/csharp/swig_typemaps.i
+++ b/src/interfaces/csharp/swig_typemaps.i
@@ -229,9 +229,7 @@ TYPEMAP_SGMATRIX(float64_t, double, double)
 	for (i = 0; i < rows; i++) {
 		sg_memcpy(res, str[i].string, str[i].slen * sizeof(SGTYPE));
 		res = res + cols;
-		SG_FREE(str[i].string);
 	}
-	SG_FREE(str);
 	$result = res;
 }
 
@@ -341,7 +339,7 @@ TYPEMAP_STRINGFEATURES(float64_t, double, double)
 
 	string[] result = new string[size];
 	for (int i = 0; i < size; i++) {
-			result[i] = Marshal.PtrToStringAnsi(ptrarray[i + 1]);
+		result[i] = Marshal.PtrToStringAnsi(ptrarray[i + 1]);
 	}
 
 	Marshal.FreeCoTaskMem(ranks[0]);

--- a/src/interfaces/java/swig_typemaps.i
+++ b/src/interfaces/java/swig_typemaps.i
@@ -693,11 +693,7 @@ TYPEMAP_SGMATRIX(float64_t, double, Double, jdouble, "toDoubleArray", "()[[D", "
 		JCALL4(Set##JAVATYPE##ArrayRegion, jenv, jarr, 0, str[i].slen, arr);
 		JCALL3(SetObjectArrayElement, jenv, res, i, jarr);
 		JCALL1(DeleteLocalRef, jenv, jarr);
-
-		SG_FREE(str[i].string);
-		SG_FREE(arr);
 	}
-	SG_FREE(str);
 	$result = res;
 }
 
@@ -718,7 +714,7 @@ TYPEMAP_STRINGFEATURES(int64_t, int, Int, jint, "Int[][]", "[[I")
 TYPEMAP_STRINGFEATURES(uint64_t, long, Long, jlong, "Long[][]", "[[J")
 TYPEMAP_STRINGFEATURES(long long, long, Long, jlong, "Long[][]", "[[J")
 TYPEMAP_STRINGFEATURES(float32_t, float, Float, jfloat, "Float[][]", "[[F")
-TYPEMAP_STRINGFEATURES(float64_t, double, Double, jdouble, "Doulbe[][]", "[[D")
+TYPEMAP_STRINGFEATURES(float64_t, double, Double, jdouble, "Double[][]", "[[D")
 
 #undef TYPEMAP_STRINGFEATURES
 
@@ -777,9 +773,7 @@ TYPEMAP_STRINGFEATURES(float64_t, double, Double, jdouble, "Doulbe[][]", "[[D")
 		jstring jstr = (jstring)JCALL1(NewStringUTF, jenv, (char *)str[i].string);
 		JCALL3(SetObjectArrayElement, jenv, res, i, jstr);
 		JCALL1(DeleteLocalRef, jenv, jstr);
-		SG_FREE(str[i].string);
 	}
-	SG_FREE(str);
 	$result = res;
 }
 

--- a/src/interfaces/octave/swig_typemaps.i
+++ b/src/interfaces/octave/swig_typemaps.i
@@ -368,21 +368,44 @@ TYPEMAP_STRINGFEATURES_IN(is_matrix_type() && arg.is_uint16_type, uint16NDArray,
 
 /* output typemap for CStringFeatures */
 %define TYPEMAP_STRINGFEATURES_OUT(type,typecode)
+%typemap(out) shogun::SGStringList<char>
+{
+    shogun::SGString<char>* str = $1.strings;
+    int32_t i, num_strings = $1.num_strings;
+
+    Cell c(num_strings, 1);
+
+    for (i = 0; i < num_strings; i++) {
+        c(i)=std::string(str[i].string);
+    }
+
+    $result = c;
+}
+
 %typemap(out) shogun::SGStringList<type>
 {
-    /* TODO STRING OUT TYPEMAPS */
+    shogun::SGString<type>* str = $1.strings;
+    int32_t i, num_strings = $1.num_strings;
+
+    ColumnVector c(dim_vector(num_strings, 1));
+
+    for (i = 0; i < num_strings; i++) {
+        c(i)=*str[i].string;
+    }
+
+    $result = c;
 }
 %enddef
 
-TYPEMAP_STRINGFEATURES_OUT(char,          charMatrix)
-TYPEMAP_STRINGFEATURES_OUT(uint8_t,       uint8NDArray)
-TYPEMAP_STRINGFEATURES_OUT(int16_t,       int16NDArray)
-TYPEMAP_STRINGFEATURES_OUT(uint16_t,      uint16NDArray)
-TYPEMAP_STRINGFEATURES_OUT(int32_t,       int32NDArray)
-TYPEMAP_STRINGFEATURES_OUT(uint32_t,      uint32NDArray)
-TYPEMAP_STRINGFEATURES_OUT(int64_t,       int64NDArray)
-TYPEMAP_STRINGFEATURES_OUT(uint64_t,      uint64NDArray)
-TYPEMAP_STRINGFEATURES_OUT(float64_t,     Matrix)
+TYPEMAP_STRINGFEATURES_OUT(char,          Cell)
+TYPEMAP_STRINGFEATURES_OUT(uint8_t,       ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(int16_t,       ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(uint16_t,      ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(int32_t,       ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(uint32_t,      ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(int64_t,       ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(uint64_t,      ColumnVector)
+TYPEMAP_STRINGFEATURES_OUT(float64_t,     ColumnVector)
 
 #undef TYPEMAP_STRINGFEATURES_OUT
 

--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1350,7 +1350,10 @@ _GETTERS = ["get",
             "get_int",
             "get_real_matrix",
             "get_real_vector",
-            "get_int_vector"
+            "get_int_vector",
+            "get_bool_string_list",
+            "get_char_string_list",
+            "get_int_string_list"
    ]
 
 _FACTORIES = ["distance",

--- a/src/interfaces/swig/shogun.i
+++ b/src/interfaces/swig/shogun.i
@@ -232,6 +232,9 @@ namespace shogun
 %template(get_real) CSGObject::get<float64_t, void>;
 %template(get_int) CSGObject::get<int32_t, void>;
 %template(get_real_matrix) CSGObject::get<SGMatrix<float64_t>, void>;
+%template(get_bool_string_list) CSGObject::get<SGStringList<bool>, void>;
+%template(get_char_string_list) CSGObject::get<SGStringList<char>, void>;
+%template(get_int_string_list) CSGObject::get<SGStringList<int32_t>, void>;
 
 #ifndef SWIGJAVA
 %template(get_real_vector) CSGObject::get<SGVector<float64_t>, void>;

--- a/src/shogun/features/StringFeatures.cpp
+++ b/src/shogun/features/StringFeatures.cpp
@@ -180,7 +180,7 @@ template<class ST> EFeatureClass CStringFeatures<ST>::get_feature_class() const 
 
 template<class ST> EFeatureType CStringFeatures<ST>::get_feature_type() const { return F_UNKNOWN; }
 
-template<class ST> CAlphabet* CStringFeatures<ST>::get_alphabet()
+template<class ST> CAlphabet* CStringFeatures<ST>::get_alphabet() const
 {
 	SG_REF(alphabet);
 	return alphabet;
@@ -983,7 +983,7 @@ template<class ST> bool CStringFeatures<ST>::append_features(SGString<ST>* p_fea
 	return false;
 }
 
-template<class ST> SGStringList<ST> CStringFeatures<ST>::get_features()
+template<class ST> SGStringList<ST> CStringFeatures<ST>::get_string_list() const
 {
 	SGStringList<ST> sl(NULL,0,0,false);
 
@@ -991,7 +991,7 @@ template<class ST> SGStringList<ST> CStringFeatures<ST>::get_features()
 	return sl;
 }
 
-template<class ST> SGString<ST>* CStringFeatures<ST>::get_features(int32_t& num_str, int32_t& max_str_len)
+template<class ST> SGString<ST>* CStringFeatures<ST>::get_features(int32_t& num_str, int32_t& max_str_len) const
 {
 	if (m_subset_stack->has_subsets())
 		SG_ERROR("get features() is not possible on subset")
@@ -1695,6 +1695,8 @@ template<class ST> void CStringFeatures<ST>::init()
 
 	m_parameters->add_vector(&symbol_mask_table, &symbol_mask_table_len, "mask_table", "Symbol mask table - using in higher order mapping");
 	watch_param("mask_table", &symbol_mask_table, &symbol_mask_table_len);
+	watch_method("num_vectors", &CStringFeatures::get_num_vectors);
+	watch_method("string_list", &CStringFeatures::get_string_list);
 }
 
 /** get feature type the char feature can deal with

--- a/src/shogun/features/StringFeatures.h
+++ b/src/shogun/features/StringFeatures.h
@@ -151,7 +151,7 @@ template <class ST> class CStringFeatures : public CFeatures
 		 *
 		 * @return alphabet
 		 */
-		CAlphabet* get_alphabet();
+		CAlphabet* get_alphabet() const;
 
 		/** duplicate feature object
 		 *
@@ -419,10 +419,10 @@ template <class ST> class CStringFeatures : public CFeatures
 		bool append_features(SGString<ST>* p_features, int32_t p_num_vectors,
 				int32_t p_max_string_length);
 
-		/** get_features
-		 * @return features
+		/** get_string_list
+		 * @return string_list
 		 */
-        SGStringList<ST> get_features();
+        SGStringList<ST> get_string_list() const;
 
 		/** get_features
 		 *
@@ -432,7 +432,7 @@ template <class ST> class CStringFeatures : public CFeatures
 		 * @param max_str_len maximal string length (returned)
 		 * @return string features
 		 */
-		virtual SGString<ST>* get_features(int32_t& num_str, int32_t& max_str_len);
+		virtual SGString<ST>* get_features(int32_t& num_str, int32_t& max_str_len) const;
 
 		/** copy_features
 		 *

--- a/src/shogun/lib/SGStringList.cpp
+++ b/src/shogun/lib/SGStringList.cpp
@@ -101,6 +101,24 @@ SGStringList<T> SGStringList<T>::clone() const
 	return SGStringList<T>(strings, num_strings, max_string_length);
 }
 
+template <class T>
+bool SGStringList<T>::equals(const SGStringList<T>& other) const
+{
+	if (this->num_strings!=other.num_strings)
+		return false;
+
+	if (this->max_string_length!=other.max_string_length)
+		return false;
+
+	for (auto i : range(num_strings))
+	{
+		if (!this->strings[i].equals(other.strings[i]))
+			return false;
+	}
+
+	return true;
+}
+
 template class SGStringList<bool>;
 template class SGStringList<char>;
 template class SGStringList<int8_t>;

--- a/src/shogun/lib/SGStringList.h
+++ b/src/shogun/lib/SGStringList.h
@@ -66,6 +66,14 @@ public:
 	 */
 	SGStringList<T> clone() const;
 
+
+	/** Equals method
+	 * @param other SGStringList to compare with
+	 * @return false iff the number of strings, the maximum string length or
+	 * any of the string items are different, true otherwise
+	 */
+	bool equals(const SGStringList<T>& other) const;
+
 protected:
 
 	/** copy data */

--- a/src/shogun/preprocessor/StringPreprocessor.cpp
+++ b/src/shogun/preprocessor/StringPreprocessor.cpp
@@ -110,7 +110,7 @@ namespace shogun
 			string_features = new CStringFeatures<ST>(*string_features);
 		}
 
-		auto string_list = string_features->get_features();
+		auto string_list = string_features->get_string_list();
 
 		apply_to_string_list(string_list);
 

--- a/src/shogun/util/factory.h
+++ b/src/shogun/util/factory.h
@@ -120,8 +120,8 @@ namespace shogun
 	}
 
 	CFeatures* string_features(
-	    CFile* file, EAlphabet alpha = DNA,
-	    EPrimitiveType primitive_type = PT_CHAR)
+	    CFile* file, machine_int_t alphabet_type = DNA,
+	    machine_int_t primitive_type = PT_CHAR)
 	{
 		REQUIRE(file, "No file provided.\n");
 		CFeatures* result = nullptr;
@@ -129,7 +129,7 @@ namespace shogun
 		switch (primitive_type)
 		{
 		case PT_CHAR:
-			result = new CStringFeatures<char>(file, alpha);
+			result = new CStringFeatures<char>(file, static_cast<EAlphabet>(alphabet_type));
 			break;
 		default:
 			SG_SNOTIMPLEMENTED

--- a/tests/unit/features/StringFeatures_unittest.cc
+++ b/tests/unit/features/StringFeatures_unittest.cc
@@ -78,28 +78,13 @@ TEST(StringFeaturesTest,copy_subset)
 	SG_UNREF(subset_copy);
 }
 
-TEST(StringFeaturesTest,clone)
+TEST(StringFeaturesTest,equals)
 {
 	SGStringList<char> strings = generateRandomStringData();
 
 	CStringFeatures<char>* f=new CStringFeatures<char>(strings, ALPHANUM);
-	CStringFeatures<char>* f_clone = (CStringFeatures<char> *) f->clone();
-
-	for (index_t i=0; i<f->get_num_vectors(); ++i)
-	{
-		index_t a_len;
-		index_t b_len;
-		bool a_free;
-		bool b_free;
-
-		char * a_vec = f->get_feature_vector(i, a_len, a_free);
-		char * b_vec = f_clone->get_feature_vector(i, b_len, b_free);
-
-		EXPECT_EQ(a_len, b_len);
-		EXPECT_EQ(a_free, b_free);
-		for (index_t j = 0; j < a_len; ++j)
-			EXPECT_EQ(a_vec[j], b_vec[j]);
-	}
+	CStringFeatures<char>* f_clone = (CStringFeatures<char>*)f->clone();
+	EXPECT_EQ(f->equals(f_clone), true);
 
 	SG_UNREF(f);
 	SG_UNREF(f_clone);

--- a/tests/unit/utils/factory_unittest.cc
+++ b/tests/unit/utils/factory_unittest.cc
@@ -63,7 +63,7 @@ TEST(Factory, string_features_from_file)
 
 	EXPECT_TRUE(obj.get() != nullptr);
 	auto cast = obj->as<CStringFeatures<char>>();
-	auto loaded_string_list = cast->get_features();
+	auto loaded_string_list = cast->get_string_list();
 
 	EXPECT_EQ(loaded_string_list.num_strings, string_list.num_strings);
 	for (auto i : range(loaded_string_list.num_strings))


### PR DESCRIPTION
A simple meta example for CStringFeatures<char>. 

I would like to make changes and add output file for an integration test but I am not sure if the current outputs are enough for that. Currently, it stores "max_string_length", "number_of_strings" and "length_of_first_string". I don't think that is possible to practically check all the values of "strings". 

However, if you don't have a better idea I could add eight variables that store the value of the first vector before and after the change to "test". 