### PR TITLE
Generic CSGObject methods 

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -90,6 +90,17 @@ namespace shogun
 			return map.find(tag) != map.end();
 		}
 
+		ParametersMap filter(ParameterProperties pprop) const {
+			ParametersMap result;
+			std::copy_if(map.cbegin(), map.cend(),
+			        std::inserter(result, result.end()),
+			        [&pprop](const std::pair<BaseTag, AnyParameter>& each)
+			        {
+                         return each.second.get_properties().has_property(pprop);
+                     });
+			return result;
+		}
+
 		ParametersMap map;
 	};
 


### PR DESCRIPTION
Now that all model parameters are stored in the same map and are aware of their function in the ML algorithms we can use this to have more generic getters that use `AnyParameterProperties`. In other words, can start replacing things like `CSGObject::get_modelsel_names` with a generic `CSGObject::get_names(ParameterProperties pprop)`, which can be used for hyperparameters, gradients, and so on.
I think the best is to filter the `ParametersMap` with a `filter` method inside `self` and then use this inside each getter. 