### PR TITLE
Removed some uses of m_model_selection_parameters [WIP]

### DIFF
--- a/examples/undocumented/libshogun/modelselection_m_model_sel_rem_test.cpp
+++ b/examples/undocumented/libshogun/modelselection_m_model_sel_rem_test.cpp
@@ -1,0 +1,139 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann, Soeren Sonnenburg, Jacob Walker, Roman Votyakov, 
+ *          Sergey Lisitsyn
+ */
+
+#include <shogun/base/init.h>
+#include <shogun/lib/config.h>
+#include <shogun/evaluation/CrossValidation.h>
+#include <shogun/evaluation/ContingencyTableEvaluation.h>
+#include <shogun/evaluation/StratifiedCrossValidationSplitting.h>
+#include <shogun/modelselection/GridSearchModelSelection.h>
+#include <shogun/modelselection/ModelSelectionParameters.h>
+#include <shogun/modelselection/ModelSelectionParameter.h>
+#include <shogun/modelselection/ParameterCombination.h>
+#include <shogun/labels/BinaryLabels.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/classifier/svm/LibLinear.h>
+
+#include <iostream>
+
+using namespace shogun;
+
+void print_message(FILE* target, const char* str)
+{
+	fprintf(target, "%s", str);
+}
+
+CModelSelectionParameters* create_param_tree()
+{
+	CModelSelectionParameters* root=new CModelSelectionParameters();
+
+	CModelSelectionParameters* c1=new CModelSelectionParameters("C1");
+	root->append_child(c1);
+	c1->build_values(-2.0, 2.0, R_EXP);
+
+	CModelSelectionParameters* c2=new CModelSelectionParameters("C2");
+	root->append_child(c2);
+	c2->build_values(-2.0, 2.0, R_EXP);
+
+	return root;
+}
+
+int main(int argc, char **argv)
+{
+	init_shogun(&print_message, &print_message, &print_message);
+
+#ifdef HAVE_LAPACK
+	int32_t num_subsets=5;
+	int32_t num_vectors=11;
+
+	/* create some data */
+	SGMatrix<float64_t> matrix(2, num_vectors);
+	for (int32_t i=0; i<num_vectors*2; i++)
+		matrix.matrix[i]=i;
+
+	/* create num_feautres 2-dimensional vectors */
+	CDenseFeatures<float64_t>* features=new CDenseFeatures<float64_t>(matrix);
+
+	/* create three labels */
+	CBinaryLabels* labels=new CBinaryLabels(num_vectors);
+	for (index_t i=0; i<num_vectors; ++i)
+		labels->set_label(i, i%2==0 ? 1 : -1);
+
+	/* create linear classifier (use -s 2 option to avoid warnings) */
+	CLibLinear* classifier=new CLibLinear(L2R_L2LOSS_SVC);
+	
+	ParametersMap parameters = classifier->filter(ParameterProperties::HYPER);
+	std::cout << "Model selection parameters (hyper): " << std::endl;
+
+	CModelSelectionParameter* p2 = new CModelSelectionParameter();
+	double temp_value = 3;
+	
+	for (ParametersMap::iterator it=parameters.begin(); it!=parameters.end(); ++it)
+	{
+		std::cout << "Parameter name: " << it->first.name();
+		std::cout << " = " << classifier->get<double>(it->first.name()) << std::endl;
+
+		p2->add_param<double>(it->first.name(), &temp_value);
+	}
+
+	ParametersMap parameters2 = p2->filter(ParameterProperties::HYPER);
+	std::cout << "p2 (hyper): " << std::endl;
+
+	for (ParametersMap::iterator it=parameters2.begin(); it!=parameters2.end(); ++it)
+	{
+		std::cout << "Parameter name: " << it->first.name();
+		std::cout << " = " << p2->get<double>(it->first.name()) << std::endl;
+	}
+
+	/* splitting strategy */
+	CStratifiedCrossValidationSplitting* splitting_strategy=
+			new CStratifiedCrossValidationSplitting(labels, num_subsets);
+
+	/* accuracy evaluation */
+	CContingencyTableEvaluation* evaluation_criterium=
+			new CContingencyTableEvaluation(ACCURACY);
+
+	/* cross validation class for evaluation in model selection */
+	CCrossValidation* cross=new CCrossValidation(classifier, features, labels,
+			splitting_strategy, evaluation_criterium);
+
+	/* print all parameter available for modelselection
+	 * Dont worry if yours is not included, simply write to the mailing list */
+	//classifier->print_modsel_params();
+
+	/* model parameter selection, deletion is handled by modsel class (SG_UNREF) */
+	CModelSelectionParameters* param_tree=create_param_tree();
+	param_tree->print_tree();
+
+	/* handles all of the above structures in memory */
+	CGridSearchModelSelection* grid_search=new CGridSearchModelSelection(
+			cross, param_tree);
+
+	/* set autolocking to false to get rid of warnings */
+	cross->set_autolock(false);
+
+	CParameterCombination* best_combination=grid_search->select_model();
+	// SG_SPRINT("best parameter(s):\n");
+	// best_combination->print_tree();
+
+	// best_combination->apply_to_machine(classifier);
+	// CCrossValidationResult* result=(CCrossValidationResult*)cross->evaluate();
+
+	// if (result->get_result_type() != CROSSVALIDATION_RESULT)
+	// 	SG_SERROR("Evaluation result is not of type CCrossValidationResult!");
+
+	// result->print_result();
+
+	/* clean up */
+	// SG_UNREF(result);
+	// SG_UNREF(best_combination);
+	// SG_UNREF(grid_search);
+#endif // HAVE_LAPACK
+	exit_shogun();
+
+	return 0;
+}

--- a/examples/undocumented/libshogun/modelselection_parameter_combination_test.cpp
+++ b/examples/undocumented/libshogun/modelselection_parameter_combination_test.cpp
@@ -6,6 +6,7 @@
 
 #include <shogun/base/init.h>
 #include <shogun/modelselection/ParameterCombination.h>
+#include <shogun/modelselection/ModelSelectionParameter.h>
 #include <shogun/lib/DynamicObjectArray.h>
 #include <shogun/lib/SGVector.h>
 
@@ -23,37 +24,40 @@ void test_parameter_set_multiplication()
 {
 	SG_SPRINT("\ntest_parameter_set_multiplication()\n");
 
-	DynArray<Parameter*> set1;
-	DynArray<Parameter*> set2;
+	DynArray<CModelSelectionParameter*> set1;
+	DynArray<CModelSelectionParameter*> set2;
 
 	SGVector<float64_t> param_vector(8);
 	SGVector<float64_t>::range_fill_vector(param_vector.vector, param_vector.vlen);
 
-	Parameter parameters[4];
+	CModelSelectionParameter parameters[4];
 
-	parameters[0].add(&param_vector.vector[0], "0");
-	parameters[0].add(&param_vector.vector[1], "1");
+	parameters[0].add_param("0", &param_vector.vector[0]);
+	parameters[0].add_param("1", &param_vector.vector[1]);
 	set1.append_element(&parameters[0]);
 
-	parameters[1].add(&param_vector.vector[2], "2");
-	parameters[1].add(&param_vector.vector[3], "3");
+	parameters[1].add_param("2", &param_vector.vector[2]);
+	parameters[1].add_param("3", &param_vector.vector[3]);
 	set1.append_element(&parameters[1]);
 
-	parameters[2].add(&param_vector.vector[4], "4");
-	parameters[2].add(&param_vector.vector[5], "5");
+	parameters[2].add_param("4", &param_vector.vector[4]);
+	parameters[2].add_param("5", &param_vector.vector[5]);
 	set2.append_element(&parameters[2]);
 
-	parameters[3].add(&param_vector.vector[6], "6");
-	parameters[3].add(&param_vector.vector[7], "7");
+	parameters[3].add_param("6", &param_vector.vector[6]);
+	parameters[3].add_param("7", &param_vector.vector[7]);
 	set2.append_element(&parameters[3]);
 
-	DynArray<Parameter*>* result=new DynArray<Parameter*>();//CParameterCombination::parameter_set_multiplication(set1, set2);
+	DynArray<CModelSelectionParameter*>* result=new DynArray<CModelSelectionParameter*>();//CParameterCombination::parameter_set_multiplication(set1, set2);
 
 	for (index_t i=0; i<result->get_num_elements(); ++i)
 	{
-		Parameter* p=result->get_element(i);
-		for (index_t j=0; j<p->get_num_parameters(); ++j)
-			SG_SPRINT("%s ", p->get_parameter(j)->m_name);
+		CModelSelectionParameter* p=result->get_element(i);
+		ParametersMap parameters = p->filter(ParameterProperties::NONE);
+		for (ParametersMap::iterator it=parameters.begin(); it!=parameters.end(); ++it)
+		{
+			SG_SPRINT("%s ", it->first.name());
+		}
 
 		SG_SPRINT("\n");
 		delete p;
@@ -73,13 +77,13 @@ void test_leaf_sets_multiplication()
 
 	CDynamicObjectArray* current=new CDynamicObjectArray();
 	sets.append_element(current);
-	Parameter* p=new Parameter();
-	p->add(&param_vector.vector[0], "0");
+	CModelSelectionParameter* p=new CModelSelectionParameter();
+	p->add_param("0", &param_vector.vector[0]);
 	CParameterCombination* pc=new CParameterCombination(p);
 	current->append_element(pc);
 
-	p=new Parameter();
-	p->add(&param_vector.vector[1], "1");
+	p=new CModelSelectionParameter();
+	p->add_param("1", &param_vector.vector[1]);
 	pc=new CParameterCombination(p);
 	current->append_element(pc);
 
@@ -101,25 +105,25 @@ void test_leaf_sets_multiplication()
 
 	current=new CDynamicObjectArray();
 	sets.append_element(current);
-	p=new Parameter();
-	p->add(&param_vector.vector[2], "2");
+	p=new CModelSelectionParameter();
+	p->add_param("2", &param_vector.vector[2]);
 	pc=new CParameterCombination(p);
 	current->append_element(pc);
 
-	p=new Parameter();
-	p->add(&param_vector.vector[3], "3");
+	p=new CModelSelectionParameter();
+	p->add_param("3", &param_vector.vector[3]);
 	pc=new CParameterCombination(p);
 	current->append_element(pc);
 
 	current=new CDynamicObjectArray();
 	sets.append_element(current);
-	p=new Parameter();
-	p->add(&param_vector.vector[4], "4");
+	p=new CModelSelectionParameter();
+	p->add_param("4", &param_vector.vector[4]);
 	pc=new CParameterCombination(p);
 	current->append_element(pc);
 
-	p=new Parameter();
-	p->add(&param_vector.vector[5], "5");
+	p=new CModelSelectionParameter();
+	p->add_param("5", &param_vector.vector[5]);
 	pc=new CParameterCombination(p);
 	current->append_element(pc);
 

--- a/examples/undocumented/libshogun/parameter_modsel_parameters.cpp
+++ b/examples/undocumented/libshogun/parameter_modsel_parameters.cpp
@@ -23,8 +23,6 @@ void print_message(FILE* target, const char* str)
 
 void print_modsel_parameters(CSGObject* object)
 {
-	SGStringList<char> modsel_params=object->get_modelsel_names();
-
 	SG_SPRINT("Parameters of %s available for model selection:\n",
 			object->get_name());
 
@@ -34,8 +32,6 @@ void print_modsel_parameters(CSGObject* object)
 		/* extract current name, ddescription and type, and print them */
 		const char* name=modsel_params.strings[i].string;
 		index_t index=object->get_modsel_param_index(name);
-		TSGDataType type=object->m_model_selection_parameters->get_parameter(
-				index)->m_datatype;
 		type.to_string(type_string, 100);
 		SG_SPRINT("\"%s\": \"%s\", %s\n", name,
 				object->get_modsel_param_descr(name), type_string);

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -28,6 +28,7 @@
 
 #include <utility>
 #include <vector>
+#include <map>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace
@@ -47,6 +48,7 @@ template <class T, class K> class CMap;
 struct TParameter;
 template <class T> class DynArray;
 template <class T> class SGStringList;
+typedef std::map<BaseTag, AnyParameter> ParametersMap;
 
 /*******************************************************************************
  * define reference counter macros
@@ -92,8 +94,6 @@ template <class T> class SGStringList;
 		    AnyParameterProperties(description, param_properties);             \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(name, param, pprop);                                 \
-		if (pprop.get_model_selection())                                       \
-			this->m_model_selection_parameters->add(param, name, description); \
 		if (pprop.get_gradient())                                              \
 			this->m_gradient_parameters->add(param, name, description);        \
 	}
@@ -271,28 +271,10 @@ public:
 	 */
 	Version* get_global_version();
 
-	/** @return vector of names of all parameters which are registered for model
-	 * selection */
-	SGStringList<char> get_modelsel_names();
-
-	/** prints all parameter registered for model selection and their type */
+	/** prints all parameter registered for model selection and their type 
+	 * @note keep until PR merge for development tests
+	*/
 	void print_modsel_params();
-
-	/** Returns description of a given parameter string, if it exists. SG_ERROR
-	 * otherwise
-	 *
-	 * @param param_name name of the parameter
-	 * @return description of the parameter
-	 */
-	char* get_modsel_param_descr(const char* param_name);
-
-	/** Returns index of model selection parameter with provided index
-	 *
-	 * @param param_name name of model selection parameter
-	 * @return index of model selection parameter with provided name,
-	 * -1 if there is no such
-	 */
-	index_t get_modsel_param_index(const char* param_name);
 
 	/** Builds a dictionary of all parameters in SGObject as well of those
 	 *  of SGObjects that are parameters of this object. Dictionary maps
@@ -763,6 +745,9 @@ public:
 	 */
 	virtual CSGObject* clone();
 
+	// Stolen from shogun/pull/4432
+	ParametersMap filter(ParameterProperties pprop);
+
 protected:
 	/** Returns an empty instance of own type.
 	 *
@@ -877,9 +862,6 @@ public:
 
 	/** parameters */
 	Parameter* m_parameters;
-
-	/** model selection parameters */
-	Parameter* m_model_selection_parameters;
 
 	/** parameters wrt which we can compute gradients */
 	Parameter* m_gradient_parameters;

--- a/src/shogun/lib/List.h
+++ b/src/shogun/lib/List.h
@@ -87,8 +87,6 @@ class CList : public CSGObject
 							  "Number of elements.");
 			m_parameters->add((CSGObject**) &first, "first",
 							  "First element in list.");
-			m_model_selection_parameters->add((CSGObject**) &first, "first",
-								  "First element in list.");
 
 			first  = NULL;
 			current = NULL;

--- a/src/shogun/modelselection/GridSearchModelSelection.cpp
+++ b/src/shogun/modelselection/GridSearchModelSelection.cpp
@@ -68,9 +68,6 @@ CParameterCombination* CGridSearchModelSelection::select_model(bool print_state)
 			current_combination->print_tree();
 		}
 
-		current_combination->apply_to_modsel_parameter(
-				machine->m_model_selection_parameters);
-
 		/* note that this may implicitly lock and unlockthe machine */
 		CCrossValidationResult* result=
 				(CCrossValidationResult*)(m_machine_eval->evaluate());

--- a/src/shogun/modelselection/ModelSelectionParameter.cpp
+++ b/src/shogun/modelselection/ModelSelectionParameter.cpp
@@ -1,0 +1,35 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Eleftherios Avramidis
+ */
+
+#include <shogun/modelselection/ModelSelectionParameter.h>
+
+using namespace shogun;
+
+CModelSelectionParameter::CModelSelectionParameter()
+{
+	init();
+}
+
+
+void CModelSelectionParameter::init()
+{	
+}
+
+CModelSelectionParameter::~CModelSelectionParameter()
+{
+}
+
+void CModelSelectionParameter::add_parameters(CModelSelectionParameter* params)
+{
+	ParametersMap parameters = params->filter(ParameterProperties::NONE);
+	
+	for (ParametersMap::iterator it=parameters.begin(); it!=parameters.end(); ++it)
+	{
+		double* temp_value = new double();
+		*temp_value = params->get<double>(it->first.name());
+		add_param<double>(it->first.name(), temp_value);
+	}
+}

--- a/src/shogun/modelselection/ModelSelectionParameter.h
+++ b/src/shogun/modelselection/ModelSelectionParameter.h
@@ -1,0 +1,62 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Eleftherios Avramidis
+ */
+
+#ifndef __MODELSELECTIONPARAMETER_H_
+#define __MODELSELECTIONPARAMETER_H_
+
+#include <shogun/lib/config.h>
+
+#include <shogun/base/SGObject.h>
+#include <shogun/base/AnyParameter.h>
+
+namespace shogun
+{
+
+class CModelSelectionParameter: public CSGObject
+{
+public:
+	/** default constructor */
+	CModelSelectionParameter();
+
+	/** destructor */
+	virtual ~CModelSelectionParameter();
+
+	/** @return name of the SGSerializable */
+	virtual const char* get_name() const { return "ModelSelectionParameter"; }
+
+	template<typename T>
+	void add_param(const std::string& name, T* value)
+	{
+		watch_param<T>(name, value);
+	}
+
+	/** getter for number of parameters
+	 * @return number of parameters
+	 */
+	virtual int32_t get_num_parameters()
+	{
+		ParametersMap parameters = filter(ParameterProperties::HYPER);
+		return (int32_t)parameters.size();
+
+		//return m_params.get_num_elements();
+	}
+
+	/** Adds all parameters from another instance to this one
+	 *
+	 * @param params another Parameter instance
+	 *
+	 */
+	void add_parameters(CModelSelectionParameter* params);
+
+private:
+	/** initializer */
+	void init();
+
+protected:
+
+};
+}
+#endif /* __MODELSELECTIONPARAMETER_H_ */

--- a/src/shogun/modelselection/ModelSelectionParameters.cpp
+++ b/src/shogun/modelselection/ModelSelectionParameters.cpp
@@ -5,8 +5,10 @@
  *          Bjoern Esser, Leon Kuchenbecker
  */
 
+#include <shogun/modelselection/ModelSelectionParameter.h>
 #include <shogun/modelselection/ModelSelectionParameters.h>
 #include <shogun/modelselection/ParameterCombination.h>
+#include <shogun/modelselection/ModelSelectionParameter.h>
 #include <shogun/lib/DataType.h>
 #include <shogun/base/Parameter.h>
 #include <shogun/base/DynArray.h>
@@ -292,7 +294,7 @@ CParameterCombination* CModelSelectionParameters::get_single_combination(
 		{
 			Parameter* p=new Parameter();
 			p->add(&m_sgobject, m_node_name);
-		new_root = new CParameterCombination(p);
+			new_root = new CParameterCombination(p);
 		}
 
 		else
@@ -356,15 +358,15 @@ CDynamicObjectArray* CModelSelectionParameters::get_combinations(
 		for (index_t i=0; i<m_values_length; ++i)
 		{
 			// create tree with only one parameter element //
-			Parameter* p=new Parameter();
+			CModelSelectionParameter* p=new CModelSelectionParameter();
 
 			switch (m_value_type)
 			{
 			case MSPT_FLOAT64:
-				p->add(&((float64_t*)m_values)[i], m_node_name);
+				p->add_param<float64_t>(m_node_name, &((float64_t*)m_values)[i]);
 				break;
 			case MSPT_INT32:
-				p->add(&((int32_t*)m_values)[i], m_node_name);;
+				p->add_param<int32_t>(m_node_name, &((int32_t*)m_values)[i]);
 				break;
 			case MSPT_NONE:
 				SG_ERROR("%sValue node has no type!\n", prefix)

--- a/src/shogun/modelselection/ModelSelectionParameters.h
+++ b/src/shogun/modelselection/ModelSelectionParameters.h
@@ -13,6 +13,8 @@
 #include <shogun/base/SGObject.h>
 #include <shogun/lib/DynamicObjectArray.h>
 #include <shogun/lib/SGVector.h>
+#include <shogun/base/AnyParameter.h>
+
 
 namespace shogun
 {

--- a/src/shogun/modelselection/ParameterCombination.h
+++ b/src/shogun/modelselection/ParameterCombination.h
@@ -13,6 +13,8 @@
 #include <shogun/lib/DynamicObjectArray.h>
 #include <shogun/lib/Map.h>
 
+#include <shogun/modelselection/ModelSelectionParameter.h>
+
 namespace shogun
 {
 class CModelSelectionParameters;
@@ -48,7 +50,7 @@ public:
 	 *
 	 * @param param parameter node
 	 */
-	CParameterCombination(Parameter* param);
+	CParameterCombination(CModelSelectionParameter* param);
 
 	/** constructor for an object. Builds parameter combination of the gradient
 	 * parameters.
@@ -79,7 +81,7 @@ public:
 	 *
 	 * @param parameter Parameter instance to apply parameter tree to
 	 */
-	void apply_to_modsel_parameter(Parameter* parameter) const;
+	void apply_to_modsel_parameter(CModelSelectionParameter* parameter) const;
 
 	/** applies this parameter tree to a learning machine (wrapper for
 	 * apply_to_modesel_parameter() method)
@@ -201,9 +203,9 @@ public:
 	 * @param set_2 array of Parameter instances
 	 * @return result array with all combinations
 	 */
-	static DynArray<Parameter*>* parameter_set_multiplication(
-			const DynArray<Parameter*>& set_1,
-			const DynArray<Parameter*>& set_2);
+	static DynArray<CModelSelectionParameter*>* parameter_set_multiplication(
+			const DynArray<CModelSelectionParameter*>& set_1,
+			const DynArray<CModelSelectionParameter*>& set_2);
 
 	/** @return name of the SGSerializable */
 	virtual const char* get_name() const
@@ -320,7 +322,7 @@ private:
 
 protected:
 	/** parameter of combination */
-	Parameter* m_param;
+	CModelSelectionParameter* m_param;
 
 	/** child parameters */
 	CDynamicObjectArray* m_child_nodes;

--- a/src/shogun/modelselection/RandomSearchModelSelection.cpp
+++ b/src/shogun/modelselection/RandomSearchModelSelection.cpp
@@ -79,9 +79,6 @@ CParameterCombination* CRandomSearchModelSelection::select_model(bool print_stat
 			current_combination->print_tree();
 		}
 
-		current_combination->apply_to_modsel_parameter(
-				machine->m_model_selection_parameters);
-
 		/* note that this may implicitly lock and unlockthe machine */
 		CCrossValidationResult* result =
 				(CCrossValidationResult*)(m_machine_eval->evaluate());

--- a/tests/unit/machine/gp/GaussianLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/GaussianLikelihood_unittest.cc
@@ -268,8 +268,6 @@ TEST(GaussianLikelihood,get_first_derivative)
 	// Gaussian likelihood with sigma = 0.13
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood(0.13);
 
-	TParameter* param=likelihood->m_model_selection_parameters->get_parameter("log_sigma");
-
 	SGVector<float64_t> lp_dhyp=likelihood->get_first_derivative(labels, func,
 			param);
 
@@ -313,8 +311,6 @@ TEST(GaussianLikelihood,get_second_derivative)
 	// Gaussian likelihood with sigma = 0.13
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood(0.13);
 
-	TParameter* param=likelihood->m_model_selection_parameters->get_parameter("log_sigma");
-
 	SGVector<float64_t> dlp_dhyp=likelihood->get_second_derivative(labels, func,
 			param);
 
@@ -357,8 +353,6 @@ TEST(GaussianLikelihood,get_third_derivative)
 
 	// Gaussian likelihood with sigma = 0.13
 	CGaussianLikelihood* likelihood=new CGaussianLikelihood(0.13);
-
-	TParameter* param=likelihood->m_model_selection_parameters->get_parameter("log_sigma");
 
 	SGVector<float64_t> d2lp_dhyp=likelihood->get_third_derivative(labels, func,
 			param);

--- a/tests/unit/machine/gp/StudentsTLikelihood_unittest.cc
+++ b/tests/unit/machine/gp/StudentsTLikelihood_unittest.cc
@@ -270,9 +270,6 @@ TEST(StudentsTLikelihood,get_first_derivative)
 	// Stundent's-t likelihood with sigma = 0.17, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(0.17, 3);
 
-	TParameter* param1=likelihood->m_model_selection_parameters->get_parameter("log_sigma");
-	TParameter* param2=likelihood->m_model_selection_parameters->get_parameter("log_df");
-
 	SGVector<float64_t> lp_dhyp1=likelihood->get_first_derivative(labels, func,
 			param1);
 	SGVector<float64_t> lp_dhyp2=likelihood->get_first_derivative(labels, func,
@@ -324,9 +321,6 @@ TEST(StudentsTLikelihood,get_second_derivative)
 	// Stundent's-t likelihood with sigma = 0.17, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(0.17, 3);
 
-	TParameter* param1=likelihood->m_model_selection_parameters->get_parameter("log_sigma");
-	TParameter* param2=likelihood->m_model_selection_parameters->get_parameter("log_df");
-
 	SGVector<float64_t> dlp_dhyp1=likelihood->get_second_derivative(labels,
 			func, param1);
 	SGVector<float64_t> dlp_dhyp2=likelihood->get_second_derivative(labels,
@@ -377,9 +371,6 @@ TEST(StudentsTLikelihood,get_third_derivative)
 
 	// Stundent's-t likelihood with sigma = 0.17, df = 3
 	CStudentsTLikelihood* likelihood=new CStudentsTLikelihood(0.17, 3);
-
-	TParameter* param1=likelihood->m_model_selection_parameters->get_parameter("log_sigma");
-	TParameter* param2=likelihood->m_model_selection_parameters->get_parameter("log_df");
 
 	SGVector<float64_t> d2lp_dhyp1=likelihood->get_third_derivative(labels,
 			func, param1);


### PR DESCRIPTION
This PR is part of the [Parameter.cpp](https://github.com/shogun-toolbox/shogun/projects/6) project.

In this PR we removed m_model_selection_parameters from SGObject. Also, in the future m_parameters and m_gradient_parameters will be removed. These store models' (hyper)parameters which are estimated during the training phase.

The aim is to use the AnyParameter properties to store the value and properties of these parameters. PRs #4412 and #4426 include code with the first steps towards this aim.