### PR TITLE
single get method for python interface

### DIFF
--- a/examples/meta/generator/targets/python.json
+++ b/examples/meta/generator/targets/python.json
@@ -56,7 +56,12 @@
         "RealLiteral": "$number",
         "FloatLiteral": "$number",
         "MethodCall": {
-            "Default": "$object.$method($arguments)"
+            "Default": "$object.$method($arguments)",
+            "get_int": "$object.get($arguments)",
+            "get_int_vector": "$object.get($arguments)",
+            "get_real": "$object.get($arguments)",
+            "get_real_vector": "$object.get($arguments)",
+            "get_real_matrix": "$object.get$arguments)"
         },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "$method($arguments)",

--- a/examples/meta/generator/targets/python.json
+++ b/examples/meta/generator/targets/python.json
@@ -61,7 +61,7 @@
             "get_int_vector": "$object.get($arguments)",
             "get_real": "$object.get($arguments)",
             "get_real_vector": "$object.get($arguments)",
-            "get_real_matrix": "$object.get$arguments)"
+            "get_real_matrix": "$object.get($arguments)"
         },
         "StaticCall": "$typeName.$method($arguments)",
         "GlobalCall": "$method($arguments)",

--- a/examples/undocumented/python/preprocessor_fisherlda.py
+++ b/examples/undocumented/python/preprocessor_fisherlda.py
@@ -19,7 +19,7 @@ def preprocessor_fisherlda (data, labels, method):
 
 	preprocessor=FisherLda(1, method)
 	preprocessor.fit(sg_features, sg_labels)
-	yn = preprocessor.transform(sg_features).get_real_matrix('feature_matrix')
+	yn = preprocessor.transform(sg_features).get('feature_matrix')
 
 	return yn
 

--- a/examples/undocumented/python/structure_multiclass_bmrm.py
+++ b/examples/undocumented/python/structure_multiclass_bmrm.py
@@ -49,7 +49,7 @@ def structure_multiclass_bmrm(fm_train_real=traindat,label_train_multiclass=labe
 	bmrm_out = sosvm.apply()
 	count = 0
 	for i in range(bmrm_out.get_num_labels()):
-		yi_pred = bmrm_out.get_real_vector("labels_vector")[i]
+		yi_pred = bmrm_out.get("labels_vector")[i]
 		if yi_pred == label_train_multiclass[i]:
 			count = count + 1
 

--- a/examples/undocumented/python/structure_multiclass_bmrm.py
+++ b/examples/undocumented/python/structure_multiclass_bmrm.py
@@ -68,7 +68,7 @@ def structure_multiclass_bmrm(fm_train_real=traindat,label_train_multiclass=labe
 	ppbmrm_out = sosvm.apply()
 	count = 0
 	for i in range(ppbmrm_out.get_num_labels()):
-		yi_pred = ppbmrm_out.get_real_vector("labels_vector")[i]
+		yi_pred = ppbmrm_out.get("labels_vector")[i]
 		if yi_pred == label_train_multiclass[i]:
 			count = count + 1
 
@@ -84,7 +84,7 @@ def structure_multiclass_bmrm(fm_train_real=traindat,label_train_multiclass=labe
 	p3bmrm_out = sosvm.apply()
 	count = 0
 	for i in range(p3bmrm_out.get_num_labels()):
-		yi_pred = p3bmrm_out.get_real_vector("labels_vector")[i]
+		yi_pred = p3bmrm_out.get("labels_vector")[i]
 		if yi_pred == label_train_multiclass[i]:
 			count = count + 1
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -474,47 +474,20 @@ namespace shogun
 %pythoncode %{
 def _internal_get_param(self, name):
 
-	try:
-		return self._get(name)
-	except SystemError:
-		pass
-	except Exception:
-		raise
-
-	try:
-		return self._get_real(name)
-	except RuntimeError:
-		pass
-	except Exception:
-		raise
-
-	try:
-		return self._get_int(name)
-	except RuntimeError:
-		pass
-	except Exception:
-		raise
-
-	try:
-		return self._get_real_matrix(name)
-	except RuntimeError:
-		pass
-	except Exception:
-		raise
-
-	try:
-		return self._get_real_vector(name)
-	except RuntimeError:
-		pass
-	except Exception:
-		raise
-
-	try:
-		return self._get_int_vector(name)
-	except RuntimeError:
-		raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
-	except Exception:
-		raise
+	for f in (self._get,
+			self._get_real,
+			self._get_int,
+			self._get_real_matrix,
+			self._get_real_vector,
+			self._get_int_vector
+			):
+		try:
+			return f(name)
+		except (SystemError, RuntimeError):
+			pass
+		except Exception:
+			raise
+	raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
 
 _swig_monkey_patch(SGObject, "get", _internal_get_param)
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -257,8 +257,8 @@ public void readExternal(java.io.ObjectInput in) throws java.io.IOException, jav
         else
             PyErr_SetString(PyExc_TypeError, "type is not a Python type");
     }
-}
 %}
+
 
 %typemap(out) PyObject* __reduce_ex__(int proto)
 {
@@ -481,7 +481,7 @@ namespace shogun
 			pass
 		try:
 			return self.get_real_matrix(name)
-		except RuntimeError
+		except RuntimeError:
 			pass
 		try:
 			return self.get_real_vector(name)
@@ -490,7 +490,7 @@ namespace shogun
 		try:
 			return self.get_int_vector(name)
 		except:
-			raise RuntimeError("There is no parameter called "{}" in {}".format(name, self.get_name()))
+			raise RuntimeError("There is no parameter called '{}' in {}".format(name, self.get_name()))
 	_swig_monkey_patch(SGObject, "get_param", _internal_get_param)
 %}
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -330,7 +330,9 @@ public void readExternal(java.io.ObjectInput in) throws java.io.IOException, jav
 %ignore sg_print_error;
 %ignore sg_cancel_computations;
 
+#ifdef SWIGPYTHON
 %rename(_get) get(const std::string&);
+#endif // SWIGPYTHON
 %rename(SGObject) CSGObject;
 
 %include <shogun/lib/common.h>

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -471,26 +471,48 @@ namespace shogun
 
 %pythoncode %{
 	def _internal_get_param(self, name):
+
+		try:
+			return self.get(name)
+		except SystemError:
+			pass
+		except Exception:
+			raise
+
 		try:
 			return self.get_real(name)
 		except RuntimeError:
 			pass
+		except Exception:
+			raise
+
 		try:
 			return self.get_int(name)
 		except RuntimeError:
 			pass
+		except Exception:
+			raise
+
 		try:
 			return self.get_real_matrix(name)
 		except RuntimeError:
 			pass
+		except Exception:
+			raise
+
 		try:
 			return self.get_real_vector(name)
 		except RuntimeError:
 			pass
+		except Exception:
+			raise
+
 		try:
 			return self.get_int_vector(name)
-		except:
+		except RuntimeError:
 			raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
+		except Exception:
+			raise
 	_swig_monkey_patch(SGObject, "get_param", _internal_get_param)
 %}
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -330,7 +330,7 @@ public void readExternal(java.io.ObjectInput in) throws java.io.IOException, jav
 %ignore sg_print_error;
 %ignore sg_cancel_computations;
 
-
+%rename(_get) get(const std::string&);
 %rename(SGObject) CSGObject;
 
 %include <shogun/lib/common.h>
@@ -470,53 +470,52 @@ namespace shogun
 }
 
 %pythoncode %{
-	def _internal_get_param(self, name):
+def _internal_get_param(self, name):
 
-		try:
-			return self.get(name)
-		except SystemError:
-			pass
-		except Exception:
-			raise
+	try:
+		return self._get(name)
+	except SystemError:
+		pass
+	except Exception:
+		raise
 
-		try:
-			return self.get_real(name)
-		except RuntimeError:
-			pass
-		except Exception:
-			raise
+	try:
+		return self._get_real(name)
+	except RuntimeError:
+		pass
+	except Exception:
+		raise
 
-		try:
-			return self.get_int(name)
-		except RuntimeError:
-			pass
-		except Exception:
-			raise
+	try:
+		return self._get_int(name)
+	except RuntimeError:
+		pass
+	except Exception:
+		raise
 
-		try:
-			return self.get_real_matrix(name)
-		except RuntimeError:
-			pass
-		except Exception:
-			raise
+	try:
+		return self._get_real_matrix(name)
+	except RuntimeError:
+		pass
+	except Exception:
+		raise
 
-		try:
-			return self.get_real_vector(name)
-		except RuntimeError:
-			pass
-		except Exception:
-			raise
+	try:
+		return self._get_real_vector(name)
+	except RuntimeError:
+		pass
+	except Exception:
+		raise
 
-		try:
-			return self.get_int_vector(name)
-		except RuntimeError:
-			raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
-		except Exception:
-			raise
-	_swig_monkey_patch(SGObject, "get_param", _internal_get_param)
-%}
+	try:
+		return self._get_int_vector(name)
+	except RuntimeError:
+		raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
+	except Exception:
+		raise
 
-%pythoncode %{
+_swig_monkey_patch(SGObject, "get", _internal_get_param)
+
 try:
     import copy_reg
 except ImportError:

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -490,7 +490,7 @@ namespace shogun
 		try:
 			return self.get_int_vector(name)
 		except:
-			raise RuntimeError("There is no parameter called '{}' in {}".format(name, self.get_name()))
+			raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
 	_swig_monkey_patch(SGObject, "get_param", _internal_get_param)
 %}
 

--- a/src/interfaces/swig/shogun.i
+++ b/src/interfaces/swig/shogun.i
@@ -229,13 +229,24 @@ namespace shogun
 #else // SWIGJAVA
 %template(put) CSGObject::put_vector_or_matrix_from_double_matrix_dispatcher<SGMatrix<float64_t>, float64_t>;
 #endif // SWIGJAVA
-
+#ifdef SWIGPYTHON
+%template(_get_real) CSGObject::get<float64_t, void>;
+%template(_get_int) CSGObject::get<int32_t, void>;
+%template(_get_real_matrix) CSGObject::get<SGMatrix<float64_t>, void>;
+#else // SWIGPYTHON
 %template(get_real) CSGObject::get<float64_t, void>;
 %template(get_int) CSGObject::get<int32_t, void>;
 %template(get_real_matrix) CSGObject::get<SGMatrix<float64_t>, void>;
+#endif // SWIGPYTHON
+
 #ifndef SWIGJAVA
+#ifdef SWIGPYTHON
+%template(_get_real_vector) CSGObject::get<SGVector<float64_t>, void>;
+%template(_get_int_vector) CSGObject::get<SGVector<int32_t>, void>;
+#else // SWIGPYTHON
 %template(get_real_vector) CSGObject::get<SGVector<float64_t>, void>;
 %template(get_int_vector) CSGObject::get<SGVector<int32_t>, void>;
+#endif // SWIGPYTHON
 #else // SWIGJAVA
 %template(get_real_vector) CSGObject::get_vector_as_matrix_dispatcher<SGMatrix<float64_t>, float64_t>;
 %template(get_int_vector) CSGObject::get_vector_as_matrix_dispatcher<SGMatrix<int32_t>, int32_t>;


### PR DESCRIPTION
Found this [thread](https://github.com/swig/swig/issues/723) where they discuss how to add a Python method (written in python) dynamically even when using swig's -builtins. The python code then checks which CSGObject getter works and returns the one that works. If the parameter does not exist it returns the same `RuntimeError` as we would get with the other getters.

I tested this with Python 3.6, but it should work fine with any other Python 3 version, and should work with Python 2.7.