### PR TITLE
Fixed uninitialised attributes in AnyParameterProperties

### DIFF
--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -52,6 +52,8 @@ namespace shogun
 		 */
 		AnyParameterProperties()
 		    : m_description("No description given"),
+			  m_model_selection(MS_NOT_AVAILABLE),
+			  m_gradient(GRADIENT_NOT_AVAILABLE),
 		      m_attribute_mask(ParameterProperties::NONE)
 		{
 		}


### PR DESCRIPTION
This fixes issues with the copy constructor. Bugs probably only occurred when compiling in Debug mode (see #4439).