### PR TITLE
Fixes doxygen issue

### DIFF
--- a/src/shogun/lib/type_case.h
+++ b/src/shogun/lib/type_case.h
@@ -22,6 +22,7 @@ namespace shogun
 	{
 	};
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 	template <typename... Args>
 	struct Types
 	{
@@ -34,6 +35,7 @@ namespace shogun
 		typedef Types<Args...> Tail;
 		typedef T1 Head;
 	};
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 	typedef Types<
 		bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
@@ -213,6 +215,7 @@ namespace shogun
 					"have the signature 'void f(auto value)'");
 			}
 		};
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 #if defined(_MSC_VER) && _MSC_VER < 1920
 		template <typename FunctorTraits>
 		using check_lambda_return = ok;
@@ -254,6 +257,7 @@ namespace shogun
 		{
 		};
 #endif
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 		template <typename T, typename FunctorT>
 		auto final_function_execute(const Any& any, FunctorT func)


### PR DESCRIPTION
Doxygen doesn't seem to like arguments packs and variadic templates and gives an error in these lines of shogun_doxygen.i:
```
// File: structshogun_1_1type__internal_1_1function__traits_3_01Ret_07F_1_1_5_08_07Args_8_8_8_08_01const_01_4.xml
%feature("docstring") shogun::type_internal::function_traits<
Ret(F::*)(Args...) const > " "; --> ***this line causes an issue****
```
and
```
%feature("docstring") shogun::Types< T1, Args... > " ";
```
This PR tells doxygen to ignore the corresponding C++ code.