### PR TITLE
fix library path for google benchmark

### DIFF
--- a/src/shogun/CMakeLists.txt
+++ b/src/shogun/CMakeLists.txt
@@ -566,16 +566,16 @@ IF (BUILD_BENCHMARKS)
   enable_testing()
   add_library(shogun_benchmark_main ${CMAKE_CURRENT_SOURCE_DIR}/util/benchmark_main.cc)
   if (APPLE)
-    target_link_libraries(shogun_benchmark_main benchmark shogun-static)
+    target_link_libraries(shogun_benchmark_main benchmark::benchmark shogun-static)
   elseif(MSVC)
     target_link_libraries(shogun_benchmark_main
-      benchmark
+      benchmark::benchmark
       Shlwapi.lib
       shogun-static
     )
   else()
     target_link_libraries(shogun_benchmark_main
-      benchmark
+      benchmark::benchmark
       pthread
       shogun-static
     )


### PR DESCRIPTION
alternative fix for one of the issues described in #4452.