### PR TITLE
Python API change RuntimeError to SystemError

### DIFF
--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1289,7 +1289,7 @@ TYPEMAP_SPARSEFEATURES_OUT(PyObject,      NPY_OBJECT)
 
 %typemap(throws) shogun::ShogunException
 {
-    PyErr_SetString(PyExc_RuntimeError, $1.what());
+    PyErr_SetString(PyExc_SystemError, $1.what());
     SWIG_fail;
 }
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -483,7 +483,7 @@ def _internal_get_param(self, name):
 			):
 		try:
 			return f(name)
-		except (SystemError, RuntimeError):
+		except SystemError:
 			pass
 		except Exception:
 			raise


### PR DESCRIPTION
SystemError seems to be the default error in the rest of the SWIG files so makes sense to switch it here. (See also https://github.com/shogun-toolbox/shogun/pull/4441#discussion_r247320333)