### PR TITLE
Suggest class names if class name not found

### DIFF
--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1300,6 +1300,7 @@ TYPEMAP_SPARSEFEATURES_OUT(PyObject,      NPY_OBJECT)
 %ignore create;
 %ignore delete_object;
 %ignore create_object;
+%rename(_available_objects) available_objects;
 %include <shogun/base/class_list.h>
 %rename(_kernel) kernel;
 
@@ -1339,7 +1340,7 @@ def _internal_autocorrect(func):
                 raise
             groups = match.groups()
             wrong_class_name = groups[0]
-            all_objects = _shogun.available_objects()
+            all_objects = _shogun._available_objects()
             dists = [_internal_iterative_levenshtein(wrong_class_name, x) for x in all_objects]
             did_you_mean_class_name = all_objects[dists.index(min(dists))]
             raise SystemError("{} Did you mean {}?".format(match.group(), did_you_mean_class_name))


### PR DESCRIPTION
I found that it can be a bit annoying finding the correct spelling of a class name using factories. This PR adds an exception that suggests alternatives when using the Python API.

Example:
```python
In [1]: import shogun as sg

In [2]: sg.kernel("GaussianKernels", log_width=1)
---------------------------------------------------------------------------
SystemError                               Traceback (most recent call last)
~/shogun/build/src/interfaces/python/shogun.py in wrapper(*args, **kwargs)
    151         try:
--> 152             return func(*args, **kwargs)
    153         except SystemError as e:

~/shogun/build/src/interfaces/python/shogun.py in _internal_factory(name, **kwargs)
    174     def _internal_factory(name, **kwargs):
--> 175         new_obj = _obj(name)
    176         for k,v in kwargs.items():

SystemError: [ERROR] In file /home/gil/shogun/src/shogun/base/class_list.h line 51: Class GaussianKernels with primitive type SGOBJECT does not exist.


During handling of the above exception, another exception occurred:

SystemError                               Traceback (most recent call last)
<ipython-input-2-dd78094495dc> in <module>()
----> 1 sg.kernel("GaussianKernels", log_width=1)

~/shogun/build/src/interfaces/python/shogun.py in wrapper(*args, **kwargs)
    160             dists = [_internal_iterative_levenshtein(wrong_class_name, x) for x in all_objects]
    161             did_you_mean_class_name = all_objects[dists.index(min(dists))]
--> 162             raise SystemError("{} Did you mean {}?".format(match.group(), did_you_mean_class_name))
    163     return wrapper
    164 

SystemError: Class GaussianKernels with primitive type SGOBJECT does not exist. Did you mean GaussianKernel?
```
This increases the size of the SWIG source file, but in the long term could implement something like this in C++, and then have it available in all languages? Just need to implement Levenshtein in C++.