### PR TITLE
Expose AnyParameter map to C++ API and extend in SWIG

### DIFF
--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1417,7 +1417,7 @@ def _internal_get_param(self, name):
         except Exception:
             raise
     if name in self.parameter_names():
-        raise ValueError("The current Python API does not have a getter for '{}'".format(name))
+        raise ValueError("The current Python API does not have a getter for '{}' which has type '{}'".format(name, self.parameter_types()[name]))
     else:
         raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
 

--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1287,24 +1287,6 @@ TYPEMAP_SPARSEFEATURES_OUT(floatmax_t,    NPY_LONGDOUBLE)
 TYPEMAP_SPARSEFEATURES_OUT(PyObject,      NPY_OBJECT)
 #undef TYPEMAP_SPARSEFEATURES_OUT
 
-%typemap(out) shogun::CMap<std::string, std::string>* {
-    $result = PyDict_New();
-    for (int i = 0; i<$1->get_array_size(); ++i) {
-        auto pair = $1->get_node_ptr(i);
-#ifdef PYTHON3
-        int py_result = PyDict_SetItem($result, PyUnicode_FromString((pair->key).c_str()),
-        PyUnicode_FromString((pair->data).c_str()));
-#else
-        int py_result = PyDict_SetItem($result, PyString_FromString((pair->key).c_str()),
-        PyString_FromString((pair->data).c_str()));
-#endif
-        if (py_result == -1) {
-            PyErr_SetString(PyExc_TypeError, "Error whilst creating dictionary");
-            SWIG_fail;
-        }
-    }
-}
-
 %typemap(throws) shogun::ShogunException
 {
     PyErr_SetString(PyExc_SystemError, $1.what());

--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1417,7 +1417,7 @@ def _internal_get_param(self, name):
         except Exception:
             raise
     if name in self.parameter_names():
-        raise ValueError("The current Python API does not have a getter for '{}' of type '{}'".format(name, self.parameter_types()[name]))
+        raise ValueError("The current Python API does not have a getter for '{}' of type '{}'".format(name, self.parameter_type(name)))
     else:
         raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
 

--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1290,8 +1290,8 @@ TYPEMAP_SPARSEFEATURES_OUT(PyObject,      NPY_OBJECT)
 %typemap(out) shogun::CMap<std::string, std::string>* {
     $result = PyDict_New();
     for (int i = 0; i<$1->get_array_size(); ++i) {
-#ifdef PYTHON3
         auto pair = $1->get_node_ptr(i);
+#ifdef PYTHON3
         int py_result = PyDict_SetItem($result, PyUnicode_FromString((pair->key).c_str()),
         PyUnicode_FromString((pair->data).c_str()));
 #else

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -379,12 +379,27 @@ namespace std {
 %include <shogun/base/Parallel.h>
 %include <shogun/lib/StoppableSGObject.h>
 
-#ifdef SWIGPYTHON
 namespace shogun
 {
-
     %extend CSGObject
     {
+        std::vector<std::string> parameter_names() const {
+			std::vector<std::string> result;
+			for (auto const& each: $self->get_parameters()) {
+				result.emplace_back(each.first);
+			}
+			return result;
+        }
+
+        CMap<std::string, std::string>* parameter_types() const {
+            auto result = new CMap<std::string, std::string>;
+            for (auto const& each: $self->get_parameters()) {
+                result->add(each.first, each.second.get().get_value().type());
+            }
+            return result;
+        }
+
+#ifdef SWIGPYTHON
         std::string __str__() const
         {
             return $self->to_string();
@@ -491,33 +506,6 @@ namespace shogun
         }
 
         /*int getbuffer(PyObject *obj, Py_buffer *view, int flags) { return 0; }*/
-
-        std::vector<std::string> parameter_names() const {
-			std::vector<std::string> result;
-			for (auto const& each: self->get_parameters()) {
-				result.emplace_back(each.first);
-			}
-			return result;
-        }
-
-		PyObject* parameter_types() const {
-			PyObject* py_result = PyDict_New();
-			for (auto const& each: self->get_parameters()) {
-#ifdef PYTHON3
-				int result = PyDict_SetItem(py_result, PyUnicode_FromString(each.first.c_str()),
-				PyUnicode_FromString(each.second.get().get_value().type().c_str()));
-#else
-				int result = PyDict_SetItem(py_result, PyString_FromString(each.first.c_str()),
-				PyString_FromString(each.second.get().get_value().type().c_str()));
-#endif
-				if (result == -1) {
-					PyErr_SetString(PyExc_TypeError, "Error whilst creating type dictionary");
-					return NULL;
-				}
-			}
-
-			return py_result;
-		}
     }
 }
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -386,7 +386,7 @@ namespace shogun
         std::vector<std::string> parameter_names() const {
             std::vector<std::string> result;
             for (auto const& each: $self->get_params()) {
-                result.emplace_back(each.first);
+                result.push_back(each.first);
             }
             return result;
         }

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -399,6 +399,14 @@ namespace shogun
             return result;
         }
 
+		CMap<std::string, std::string>* parameter_descriptions() const {
+			auto result = new CMap<std::string, std::string>;
+			for (auto const& each: $self->get_parameters()) {
+				result->add(each.first, each.second.get()->get_properties().get_description());
+			}
+			return result;
+		}
+
 #ifdef SWIGPYTHON
         std::string __str__() const
         {

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -385,14 +385,14 @@ namespace shogun
     {
         std::vector<std::string> parameter_names() const {
             std::vector<std::string> result;
-            for (auto const& each: $self->get_parameters()) {
+            for (auto const& each: $self->get_params()) {
                 result.emplace_back(each.first);
             }
             return result;
         }
 
         std::string parameter_type(std::string name) const {
-            auto params = $self->get_parameters();
+            auto params = $self->get_params();
             if (params.find(name) != params.end()) {
                 return params[name].get()->get_value().type();
             }
@@ -402,7 +402,7 @@ namespace shogun
         }
 
         std::string parameter_description(std::string name) const {
-            auto params = $self->get_parameters();
+            auto params = $self->get_params();
             if (params.find(name) != params.end()) {
                 return params[name].get()->get_properties().get_description();
             }

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -508,6 +508,9 @@ namespace shogun
         /*int getbuffer(PyObject *obj, Py_buffer *view, int flags) { return 0; }*/
 #endif //SWIGPYTHON
     }
+
+%template(StringToStringCMap) CMap<std::string, std::string>;
+
 }
 
 #ifdef SWIGPYTHON

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -391,7 +391,7 @@ namespace shogun
             return result;
         }
 
-        std::string parameter_type(std::string name) const {
+        std::string parameter_type(const std::string& name) const {
             auto params = $self->get_params();
             if (params.find(name) != params.end()) {
                 return params[name].get()->get_value().type();
@@ -401,7 +401,7 @@ namespace shogun
             }
         }
 
-        std::string parameter_description(std::string name) const {
+        std::string parameter_description(const std::string& name) const {
             auto params = $self->get_params();
             if (params.find(name) != params.end()) {
                 return params[name].get()->get_properties().get_description();
@@ -520,9 +520,6 @@ namespace shogun
         /*int getbuffer(PyObject *obj, Py_buffer *view, int flags) { return 0; }*/
 #endif //SWIGPYTHON
     }
-
-%template(StringToStringCMap) CMap<std::string, std::string>;
-
 }
 
 #ifdef SWIGPYTHON

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -506,9 +506,11 @@ namespace shogun
         }
 
         /*int getbuffer(PyObject *obj, Py_buffer *view, int flags) { return 0; }*/
+#endif //SWIGPYTHON
     }
 }
 
+#ifdef SWIGPYTHON
 %pythoncode %{
 try:
     import copy_reg

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -1,3 +1,9 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben, Heiko Strathmann, Sergey Lisitsyn
+ */
+
 /* base includes required by any module */
 %include "stdint.i"
 %include "std_string.i"
@@ -485,6 +491,29 @@ namespace shogun
         }
 
         /*int getbuffer(PyObject *obj, Py_buffer *view, int flags) { return 0; }*/
+
+        std::vector<std::string> parameter_names() const {
+			std::vector<std::string> result;
+			for (auto const& each: self->get_parameters()) {
+				result.emplace_back(each.first);
+			}
+			return result;
+        }
+
+		PyObject* parameter_types() const {
+			PyObject* py_result = PyDict_New();
+			for (auto const& each: self->get_parameters()) {
+				int result = PyDict_SetItem(py_result,
+											PyUnicode_FromString(each.first.c_str()),
+											PyUnicode_FromString(each.second.get().get_value().type().c_str()));
+				if (result == -1) {
+					PyErr_SetString(PyExc_TypeError, "Error whilst creating type dictionary");
+					return NULL;
+				}
+			}
+
+			return py_result;
+		}
     }
 }
 

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -384,11 +384,11 @@ namespace shogun
     %extend CSGObject
     {
         std::vector<std::string> parameter_names() const {
-			std::vector<std::string> result;
-			for (auto const& each: $self->get_parameters()) {
-				result.emplace_back(each.first);
-			}
-			return result;
+            std::vector<std::string> result;
+            for (auto const& each: $self->get_parameters()) {
+                result.emplace_back(each.first);
+            }
+            return result;
         }
 
         CMap<std::string, std::string>* parameter_types() const {
@@ -399,13 +399,13 @@ namespace shogun
             return result;
         }
 
-		CMap<std::string, std::string>* parameter_descriptions() const {
-			auto result = new CMap<std::string, std::string>;
-			for (auto const& each: $self->get_parameters()) {
-				result->add(each.first, each.second.get()->get_properties().get_description());
-			}
-			return result;
-		}
+        CMap<std::string, std::string>* parameter_descriptions() const {
+            auto result = new CMap<std::string, std::string>;
+            for (auto const& each: $self->get_parameters()) {
+                result->add(each.first, each.second.get()->get_properties().get_description());
+            }
+            return result;
+        }
 
 #ifdef SWIGPYTHON
         std::string __str__() const

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -391,20 +391,24 @@ namespace shogun
             return result;
         }
 
-        CMap<std::string, std::string>* parameter_types() const {
-            auto result = new CMap<std::string, std::string>;
-            for (auto const& each: $self->get_parameters()) {
-                result->add(each.first, each.second.get()->get_value().type());
+        std::string parameter_type(std::string name) const {
+            auto params = $self->get_parameters();
+            if (params.find(name) != params.end()) {
+                return params[name].get()->get_value().type();
             }
-            return result;
+            else {
+                SG_SERROR("There is no parameter called '%s' in %s", name.c_str(), $self->get_name());
+            }
         }
 
-        CMap<std::string, std::string>* parameter_descriptions() const {
-            auto result = new CMap<std::string, std::string>;
-            for (auto const& each: $self->get_parameters()) {
-                result->add(each.first, each.second.get()->get_properties().get_description());
+        std::string parameter_description(std::string name) const {
+            auto params = $self->get_parameters();
+            if (params.find(name) != params.end()) {
+                return params[name].get()->get_properties().get_description();
             }
-            return result;
+            else {
+                SG_SERROR("There is no parameter called '%s' in %s", name.c_str(), $self->get_name());
+            }
         }
 
 #ifdef SWIGPYTHON

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -394,7 +394,7 @@ namespace shogun
         CMap<std::string, std::string>* parameter_types() const {
             auto result = new CMap<std::string, std::string>;
             for (auto const& each: $self->get_parameters()) {
-                result->add(each.first, each.second.get().get_value().type());
+                result->add(each.first, each.second.get()->get_value().type());
             }
             return result;
         }

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -503,9 +503,13 @@ namespace shogun
 		PyObject* parameter_types() const {
 			PyObject* py_result = PyDict_New();
 			for (auto const& each: self->get_parameters()) {
-				int result = PyDict_SetItem(py_result,
-											PyUnicode_FromString(each.first.c_str()),
-											PyUnicode_FromString(each.second.get().get_value().type().c_str()));
+#ifdef PYTHON3
+				int result = PyDict_SetItem(py_result, PyUnicode_FromString(each.first.c_str()),
+				PyUnicode_FromString(each.second.get().get_value().type().c_str()));
+#else
+				int result = PyDict_SetItem(py_result, PyString_FromString(each.first.c_str()),
+				PyString_FromString(each.second.get().get_value().type().c_str()));
+#endif
 				if (result == -1) {
 					PyErr_SetString(PyExc_TypeError, "Error whilst creating type dictionary");
 					return NULL;

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -1073,8 +1073,8 @@ CSGObject* CSGObject::get(const std::string& name)
 	if (self->map.find(BaseTag(name)) != self->map.end())
 	{
 		SG_ERROR(
-		    "Cannot get parameter %s::%s of type %s as object, not object "
-		    "type.\n",
+		    "Cannot get parameter %s::%s of type %s as object, not a shogun "
+		    "object base type.\n",
 		    get_name(), name.c_str(),
 		    self->map[BaseTag(name)].get_value().type().c_str());
 	}

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -975,11 +975,11 @@ std::string CSGObject::to_string() const
 	return ss.str();
 }
 
-std::map<std::string, std::reference_wrapper<const AnyParameter>> CSGObject::get_parameters() const
+std::map<std::string, std::shared_ptr<const AnyParameter>> CSGObject::get_parameters() const
 {
-	std::map<std::string, std::reference_wrapper<const AnyParameter>> result;
+	std::map<std::string, std::shared_ptr<const AnyParameter>> result;
 	for (auto const& each: self->map) {
-		result.emplace(each.first.name(), std::cref(each.second));
+		result.emplace(each.first.name(), std::make_shared<const AnyParameter>(each.second));
 	}
 	return result;
 }

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -975,7 +975,8 @@ std::string CSGObject::to_string() const
 	return ss.str();
 }
 
-std::map<std::string, std::shared_ptr<const AnyParameter>> CSGObject::get_parameters() const
+#ifndef SWIG // SWIG should skip this part
+std::map<std::string, std::shared_ptr<const AnyParameter>> CSGObject::get_params() const
 {
 	std::map<std::string, std::shared_ptr<const AnyParameter>> result;
 	for (auto const& each: self->map) {
@@ -983,6 +984,7 @@ std::map<std::string, std::shared_ptr<const AnyParameter>> CSGObject::get_parame
 	}
 	return result;
 }
+#endif
 
 bool CSGObject::equals(const CSGObject* other) const
 {

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -1068,11 +1068,19 @@ CSGObject* CSGObject::get(const std::string& name)
 	if (auto* result = get_sgobject_type_dispatcher<CLabels>(name))
 		return result;
 
-
-	SG_ERROR(
-	    "Cannot get parameter %s::%s of type %s as object, not object type.\n",
-	    get_name(), name.c_str(),
-	    self->map[BaseTag(name)].get_value().type().c_str());
+	if (self->map.find(BaseTag(name)) != self->map.end())
+	{
+		SG_ERROR(
+		    "Cannot get parameter %s::%s of type %s as object, not object "
+		    "type.\n",
+		    get_name(), name.c_str(),
+		    self->map[BaseTag(name)].get_value().type().c_str());
+	}
+	else
+	{
+		SG_ERROR(
+		    "There is no parameter '%s' in %s.\n", name.c_str(), get_name());
+	}
 	return nullptr;
 }
 

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -975,12 +975,12 @@ std::string CSGObject::to_string() const
 	return ss.str();
 }
 
-std::vector<std::string> CSGObject::parameter_names() const
+std::map<std::string, std::reference_wrapper<const AnyParameter>> CSGObject::get_parameters() const
 {
-	std::vector<std::string> result;
-	std::transform(self->map.cbegin(), self->map.cend(), std::back_inserter(result),
-		// FIXME: const auto& each fails on gcc 4.8.4
-		[](const std::pair<BaseTag, AnyParameter>& each) -> std::string { return each.first.name(); });
+	std::map<std::string, std::reference_wrapper<const AnyParameter>> result;
+	for (auto const& each: self->map) {
+		result.emplace(each.first.name(), std::cref(each.second));
+	}
 	return result;
 }
 

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -80,17 +80,16 @@ template <class T> class SGStringList;
 #define VARARG_IMPL(base, count, ...) VARARG_IMPL2(base, count, __VA_ARGS__)
 #define VARARG(base, ...) VARARG_IMPL(base, VA_NARGS(__VA_ARGS__), __VA_ARGS__)
 
-#define SG_ADD3(param, name, description)    \
+#define SG_ADD3(param, name, description)                                      \
 	{                                                                          \
 		this->m_parameters->add(param, name, description);                     \
-		this->watch_param(                                                     \
-			name, param, AnyParameterProperties(description)); 			       \
+		this->watch_param(name, param, AnyParameterProperties(description));   \
 	}
 
 #define SG_ADD4(param, name, description, param_properties)                    \
 	{                                                                          \
 		AnyParameterProperties pprop =                                         \
-			AnyParameterProperties(description, param_properties);             \
+		    AnyParameterProperties(description, param_properties);             \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(name, param, pprop);                                 \
 		if (pprop.get_model_selection())                                       \

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -533,11 +533,13 @@ public:
 	 */
 	virtual std::string to_string() const;
 
-	/** Returns map of all parameter names and AnyParameter references of the object.
+	/** Returns map of parameter names and AnyParameter pairs
+	 * of the object.
 	 *
 	 */
-	std::map<std::string, std::shared_ptr<const AnyParameter>> get_parameters() const;
-
+#ifndef SWIG // SWIG should skip this part
+	std::map<std::string, std::shared_ptr<const AnyParameter>> get_params() const;
+#endif
 	/** Specializes a provided object to the specified type.
 	 * Throws exception if the object cannot be specialized.
 	 *

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -537,7 +537,7 @@ public:
 	/** Returns map of all parameter names and AnyParameter references of the object.
 	 *
 	 */
-	std::map<std::string, std::reference_wrapper<const AnyParameter>> get_parameters() const;
+	std::map<std::string, std::shared_ptr<const AnyParameter>> get_parameters() const;
 
 	/** Specializes a provided object to the specified type.
 	 * Throws exception if the object cannot be specialized.

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -28,6 +28,7 @@
 
 #include <utility>
 #include <vector>
+#include <map>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace
@@ -533,10 +534,10 @@ public:
 	 */
 	virtual std::string to_string() const;
 
-	/** Returns set of all parameter names of the object.
+	/** Returns map of all parameter names and AnyParameter references of the object.
 	 *
 	 */
-	std::vector<std::string> parameter_names() const;
+	std::map<std::string, std::reference_wrapper<const AnyParameter>> get_parameters() const;
 
 	/** Specializes a provided object to the specified type.
 	 * Throws exception if the object cannot be specialized.

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -84,13 +84,13 @@ template <class T> class SGStringList;
 	{                                                                          \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(                                                     \
-		    name, param, AnyParameterProperties()); 						   \
+			name, param, AnyParameterProperties(description)); 			       \
 	}
 
-#define SG_ADD4(param, name, description, param_properties)                     \
+#define SG_ADD4(param, name, description, param_properties)                    \
 	{                                                                          \
 		AnyParameterProperties pprop =                                         \
-		    AnyParameterProperties(description, param_properties);             \
+			AnyParameterProperties(description, param_properties);             \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(name, param, pprop);                                 \
 		if (pprop.get_model_selection())                                       \

--- a/tests/unit/base/SGObjectAll_unittest.cc
+++ b/tests/unit/base/SGObjectAll_unittest.cc
@@ -296,7 +296,7 @@ TEST(SGObjectAll, DISABLED_tag_coverage)
 
 		std::vector<std::string> tag_names;
 		std::transform(obj->get_parameters().cbegin(), obj->get_parameters().cend(), std::back_inserter(tag_names),
-			[](const std::pair<std::string, std::reference_wrapper<const AnyParameter>>& each) -> std::string {
+			[](const std::pair<std::string, std::shared_ptr<const AnyParameter>>& each) -> std::string {
 			return each.first;
 		});
 

--- a/tests/unit/base/SGObjectAll_unittest.cc
+++ b/tests/unit/base/SGObjectAll_unittest.cc
@@ -293,7 +293,12 @@ TEST(SGObjectAll, DISABLED_tag_coverage)
 		std::vector<std::string> old_names;
 		for (auto i : range(obj->m_parameters->get_num_parameters()))
 			old_names.push_back(obj->m_parameters->get_parameter(i)->m_name);
-		auto tag_names = obj->parameter_names();
+
+		std::vector<std::string> tag_names;
+		std::transform(obj->get_parameters().cbegin(), obj->get_parameters().cend(), std::back_inserter(tag_names),
+			[](const std::pair<std::string, std::reference_wrapper<const AnyParameter>>& each) -> std::string {
+			return each.first;
+		});
 
 		// hack to increase readability of error messages
 		old_names.push_back("_Shogun class: " + class_name);

--- a/tests/unit/base/SGObjectAll_unittest.cc
+++ b/tests/unit/base/SGObjectAll_unittest.cc
@@ -295,7 +295,7 @@ TEST(SGObjectAll, DISABLED_tag_coverage)
 			old_names.push_back(obj->m_parameters->get_parameter(i)->m_name);
 
 		std::vector<std::string> tag_names;
-		std::transform(obj->get_parameters().cbegin(), obj->get_parameters().cend(), std::back_inserter(tag_names),
+		std::transform(obj->get_params().cbegin(), obj->get_params().cend(), std::back_inserter(tag_names),
 			[](const std::pair<std::string, std::shared_ptr<const AnyParameter>>& each) -> std::string {
 			return each.first;
 		});


### PR DESCRIPTION
This PR exposes AnyParameter map to the C++ library, which is hidden in Self in CSGObject. This is done with ~~`std::reference_wrapper<const AnyParameter>`~~ `std::shared_ptr<const AnyParameter>` (which should make it impossible to mess with a model's parameters through the getter?).
It then further extends the Python API to have parameter_name and parameter_type getters. These can be useful to debug from Python.