### PR TITLE
Shogun version python

### DIFF
--- a/src/interfaces/python/swig_typemaps.i
+++ b/src/interfaces/python/swig_typemaps.i
@@ -1422,6 +1422,8 @@ def _internal_get_param(self, name):
         raise KeyError("There is no parameter called '{}' in {}".format(name, self.get_name()))
 
 _swig_monkey_patch(SGObject, "get", _internal_get_param)
+
+__version__ = _shogun.Version_get_version_main()
 %}
 
 #endif /* HAVE_PYTHON */

--- a/src/shogun/base/Version.cpp
+++ b/src/shogun/base/Version.cpp
@@ -16,15 +16,17 @@ using namespace shogun;
 
 namespace shogun
 {
-const int64_t Version::version_revision = VERSION_REVISION;
-const int32_t Version::version_year = VERSION_YEAR;
-const int32_t Version::version_month = VERSION_MONTH;
-const int32_t Version::version_day = VERSION_DAY;
-const int32_t Version::version_hour = VERSION_HOUR;
-const int32_t Version::version_minute = VERSION_MINUTE;
-const int32_t Version::version_parameter=VERSION_PARAMETER;
-const char Version::version_extra[128] = VERSION_EXTRA;
-const char Version::version_release[128] = VERSION_RELEASE;
+// TODO: in C++17 inline all of this in header file and remove it from here
+constexpr int64_t Version::version_revision;
+constexpr int32_t Version::version_year;
+constexpr int32_t Version::version_month;
+constexpr int32_t Version::version_day;
+constexpr int32_t Version::version_hour;
+constexpr int32_t Version::version_minute;
+constexpr int32_t Version::version_parameter;
+constexpr const char Version::version_extra[128];
+constexpr const char Version::version_release[128];
+constexpr const char Version::version_main[32];
 }
 
 Version::Version()
@@ -40,7 +42,7 @@ Version::~Version()
 
 void Version::print_version()
 {
-	SG_SPRINT("libshogun (%s/%s%" PRId64 ")\n\n", MACHINE, VERSION_RELEASE, version_revision)
+	SG_SPRINT("libshogun (%s/%s%" PRId64 ")\n\n", MACHINE, Version::get_version_release(), Version::get_version_revision())
 	SG_SPRINT("Copyright (C) 1999-2009 Fraunhofer Institute FIRST\n")
 	SG_SPRINT("Copyright (C) 1999-2011 Max Planck Society\n")
 	SG_SPRINT("Copyright (C) 2009-2011 Berlin Institute of Technology\n")
@@ -50,56 +52,6 @@ void Version::print_version()
 	SG_SPRINT("This is free software; see the source for copying conditions.  There is NO\n")
 	SG_SPRINT("warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n")
 #endif
-}
-
-const char* Version::get_version_extra()
-{
-	return version_extra;
-}
-
-const char* Version::get_version_release()
-{
-	return version_release;
-}
-
-int64_t Version::get_version_revision()
-{
-	return version_revision;
-}
-
-int32_t Version::get_version_year()
-{
-	return version_year;
-}
-
-int32_t Version::get_version_month()
-{
-	return version_month;
-}
-
-int32_t Version::get_version_day()
-{
-	return version_day;
-}
-
-int32_t Version::get_version_hour()
-{
-	return version_hour;
-}
-
-int32_t Version::get_version_minute()
-{
-	return version_year;
-}
-
-int32_t Version::get_version_parameter()
-{
-	return version_parameter;
-}
-
-int64_t Version::get_version_in_minutes()
-{
-	return ((((version_year)*12 + version_month)*30 + version_day)* 24 + version_hour)*60 + version_minute;
 }
 
 int32_t Version::ref()

--- a/src/shogun/base/Version.h
+++ b/src/shogun/base/Version.h
@@ -12,6 +12,7 @@
 #define VERSION_H__
 
 #include <shogun/lib/config.h>
+#include <shogun/lib/versionstring.h>
 
 namespace shogun
 {
@@ -34,35 +35,60 @@ public:
 	/** print version */
 	static void print_version();
 
+	/** get main version */
+    static constexpr const char* get_version_main() {
+        return version_main;
+    }
+
 	/** get version extra */
-	static const char* get_version_extra();
+	static constexpr const char* get_version_extra() {
+	    return version_extra;
+	}
 
 	/** get version release */
-	static const char* get_version_release();
+	static constexpr const char* get_version_release() {
+	    return version_release;
+	}
 
 	/** get version revision */
-	static int64_t get_version_revision();
+    static constexpr int64_t get_version_revision() {
+        return version_revision;
+    }
 
 	/** get version year */
-	static int32_t get_version_year();
+    static constexpr int32_t get_version_year() {
+        return version_year;
+    }
 
 	/** get version month */
-	static int32_t get_version_month();
+    static constexpr int32_t get_version_month() {
+        return version_month;
+    }
 
 	/** get version day */
-	static int32_t get_version_day();
+    static constexpr int32_t get_version_day() {
+        return version_day;
+    }
 
 	/** get version hour */
-	static int32_t get_version_hour();
+    static constexpr int32_t get_version_hour() {
+        return version_hour;
+    }
 
 	/** get version minute */
-	static int32_t get_version_minute();
+    static constexpr int32_t get_version_minute() {
+        return version_minute;
+    }
 
 	/** get parameter serialization version */
-	static int32_t get_version_parameter();
+    static constexpr int32_t get_version_parameter() {
+        return version_parameter;
+    }
 
 	/** get version in minutes */
-	static int64_t get_version_in_minutes();
+    static constexpr int64_t get_version_in_minutes() {
+        return version_minute;
+    }
 
 	/** ref object
 	 * @return ref count
@@ -81,24 +107,26 @@ public:
 
 protected:
 	/** version release */
-	static const char version_release[128];
+	static constexpr char version_release[128] = VERSION_RELEASE;
 	/** version extra */
-	static const char version_extra[128];
+	static constexpr char version_extra[128] = VERSION_EXTRA;
 
 	/** version revision */
-	static const int64_t version_revision;
+	static constexpr int64_t version_revision = VERSION_REVISION;
 	/** version year */
-	static const int32_t version_year;
+	static constexpr int32_t version_year = VERSION_YEAR;
 	/** version month */
-	static const int32_t version_month;
+	static constexpr int32_t version_month = VERSION_MONTH;
 	/** version day */
-	static const int32_t version_day;
+	static constexpr int32_t version_day = VERSION_DAY;
 	/** version hour */
-	static const int32_t version_hour;
+	static constexpr int32_t version_hour = VERSION_HOUR;
 	/** version minute */
-	static const int32_t version_minute;
+	static constexpr int32_t version_minute = VERSION_MINUTE;
 	/** version parameter */
-	static const int32_t version_parameter;
+	static constexpr int32_t version_parameter = VERSION_PARAMETER;
+    /** version main */
+	static constexpr char version_main[32] = MAINVERSION;
 
 private:
 	RefCount* m_refcount;


### PR DESCRIPTION
Also made stuff in Version constexpr, because nothing stops it from being constexpr I think? 
@vigsterkr in your C++17 branch can you check if you can remove the cpp definition of the constexpr members, i.e. `constexpr int64_t Version::version_revision` and so on? In C++17 constexpr implies inline and variables can be inline :D
And then can now get shogun version from python, which is useful for openml.
```python
import shogun as sg
sg.__version__
```