### PR TITLE
Centralise type definitions

### DIFF
--- a/src/shogun/features/FeatureTypes.h
+++ b/src/shogun/features/FeatureTypes.h
@@ -8,6 +8,7 @@
 #define _FEATURE_TYPES__H__
 
 #include <shogun/lib/config.h>
+#include <shogun/lib/sg_types.h>
 
 namespace shogun
 {
@@ -15,20 +16,20 @@ namespace shogun
 	/// shogun feature type
 	enum EFeatureType
 	{
-		F_UNKNOWN = 0,
-		F_BOOL = 5,
-		F_CHAR = 10,
-		F_BYTE = 20,
-		F_SHORT = 30,
-		F_WORD = 40,
-		F_INT = 50,
-		F_UINT = 60,
-		F_LONG = 70,
-		F_ULONG = 80,
-		F_SHORTREAL = 90,
-		F_DREAL = 100,
-		F_LONGREAL = 110,
-		F_ANY = 1000
+		F_UNKNOWN,
+		F_BOOL,
+		F_CHAR,
+		F_BYTE,
+		F_SHORT,
+		F_WORD,
+		F_INT,
+		F_UINT,
+		F_LONG,
+		F_ULONG,
+		F_SHORTREAL,
+		F_DREAL,
+		F_LONGREAL,
+		F_ANY
 	};
 
 	/// shogun feature class

--- a/src/shogun/features/FeatureTypes.h
+++ b/src/shogun/features/FeatureTypes.h
@@ -8,7 +8,6 @@
 #define _FEATURE_TYPES__H__
 
 #include <shogun/lib/config.h>
-#include <shogun/lib/sg_types.h>
 
 namespace shogun
 {

--- a/src/shogun/io/TBOutputFormat.cpp
+++ b/src/shogun/io/TBOutputFormat.cpp
@@ -84,11 +84,11 @@ tensorflow::Event TBOutputFormat::convert_scalar(
 	summaryValue->set_tag(value.first.get_name());
 	summaryValue->set_node_name(node_name);
 
-	auto write_summary = [&summaryValue=summaryValue](auto value) {
-		summaryValue->set_simple_value(value);
+	auto write_summary = [&summaryValue=summaryValue](auto val) {
+		summaryValue->set_simple_value(val);
 	};
 
-	sg_any_dispatch(value.first.get_value(), sg_all_types, write_summary);
+	sg_any_dispatch(value.first.get_value(), sg_all_typemap, write_summary);
 
 	return e;
 }

--- a/src/shogun/lib/sg_types.h
+++ b/src/shogun/lib/sg_types.h
@@ -1,0 +1,110 @@
+#include <type_traits>
+#include <shogun/lib/common.h>
+
+// ENUMS
+enum class EFeatureType
+{
+    F_UNKNOWN,
+    F_BOOL,
+    F_CHAR,
+    F_BYTE,
+    F_SHORT,
+    F_WORD,
+    F_INT,
+    F_UINT,
+    F_LONG,
+    F_ULONG,
+    F_SHORTREAL,
+    F_DREAL,
+    F_LONGREAL,
+};
+
+enum class EFeatureClass
+{
+    C_UNKNOWN = 1,
+    C_DENSE = 2,
+    C_SPARSE = 20,
+    C_STRING = 30,
+    C_COMBINED = 40,
+    C_COMBINED_DOT = 60,
+    C_WD = 70,
+    C_SPEC = 80,
+    C_WEIGHTEDSPEC = 90,
+    C_POLY = 100,
+    C_STREAMING_DENSE = 110,
+    C_STREAMING_SPARSE = 120,
+    C_STREAMING_STRING = 130,
+    C_STREAMING_VW = 140,
+    C_BINNED_DOT = 150,
+    C_DIRECTOR_DOT = 160,
+    C_LATENT = 170,
+    C_MATRIX = 180,
+    C_FACTOR_GRAPH = 190,
+    C_INDEX = 200,
+    C_SUB_SAMPLES_DENSE=300,
+    C_ANY = 1000
+};
+
+enum class EFeatureProperty
+{
+    FP_NONE = 0,
+    FP_DOT = 1,
+    FP_STREAMING_DOT = 2
+};
+
+// utility structs
+struct Unknown {};
+struct None {};
+
+// struct to store types
+template <typename... Args>
+struct Types
+{
+    typedef None Head;
+    static constexpr int size = 0;
+};
+
+template <typename T1, typename... Args>
+struct Types<T1, Args...> : Types<Args...>
+{
+    typedef Types<Args...> Tail;
+    typedef T1 Head;
+    static constexpr int size = sizeof...(Args);
+};
+
+// Type definitions
+typedef	Types <long double, double, float, unsigned long, long,
+        unsigned int, int, unsigned short, short, uint8_t,
+        char, bool, Unknown> feature_types;
+
+typedef Types<
+        int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
+        float64_t, floatmax_t, char>
+        all_primitive_types;
+
+template<typename T1, int index, bool>
+struct getTypeIndex_impl
+{
+};
+
+template<typename T1, int index>
+struct getTypeIndex_impl<T1, index, false>
+{
+    using type = None;
+};
+
+template<typename T1, int index>
+struct getTypeIndex_impl<T1, index, true>
+{
+    using type = std::conditional_t<(T1::size == index),
+            typename T1::Head,
+            typename getTypeIndex_impl<typename T1::Tail, index, (T1::size > 0)>::type>;
+};
+
+template<typename T1, int index>
+struct getTypeIndex
+{
+    using type = std::conditional_t<index >= 0,
+            typename getTypeIndex_impl<T1, index, true>::type,
+            None>;
+};

--- a/src/shogun/lib/sg_types.h
+++ b/src/shogun/lib/sg_types.h
@@ -26,81 +26,82 @@ namespace shogun
 	template <typename... Args>
 	struct Types
 	{
-		typedef None Head;
+		using Head = None;
 		static constexpr int size = 0;
 	};
 
 	template <typename T1, typename... Args>
 	struct Types<T1, Args...> : Types<Args...>
 	{
-		typedef Types<Args...> Tail;
-		typedef T1 Head;
+		using Tail = Types<Args...>;
+		using Head = T1;
 		static constexpr int size = sizeof...(Args) + 1;
 	};
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-	// Type definitions
-	typedef Types<
-	    Any, floatmax_t, float64_t, float32_t, uint64_t, int64_t, uint32_t,
-	    int32_t, uint16_t, int16_t, uint8_t, char, bool, Unknown>
-	    sg_feature_types;
+	using sg_feature_types = Types<
+	    Unknown, bool, char, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+	    int64_t, uint64_t, float32_t, float64_t, floatmax_t, Any>;
 
-	typedef Types<
+	using sg_all_primitive_types = Types<
 	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
-	    float32_t, float64_t, floatmax_t, complex128_t, char, bool>
-	    sg_all_primitive_types;
+	    float32_t, float64_t, floatmax_t, complex128_t, char, bool>;
 
-	typedef Types<
+	using sg_non_complex_types = Types<
 	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
-	    float32_t, float64_t, floatmax_t>
-	    sg_non_complex_types;
+	    float32_t, float64_t, floatmax_t>;
 
-	typedef Types<float32_t, float64_t, floatmax_t> sg_real_types;
+	using sg_real_types = Types<float32_t, float64_t, floatmax_t>;
 
-	typedef Types<float32_t, float64_t, floatmax_t, complex128_t> sg_non_integer_types;
+	using sg_non_integer_types =
+	    Types<float32_t, float64_t, floatmax_t, complex128_t>;
 
-    typedef Types<int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
-    float32_t, float64_t, floatmax_t, complex128_t> sg_numeric_types;
-
-    typedef Types<uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-            uint64_t, float32_t, float64_t, floatmax_t, char> sg_tb_types;
+	using sg_numeric_types = Types<
+	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+	    float32_t, float64_t, floatmax_t, complex128_t>;
 
 	namespace types_detail
 	{
-        template <typename T1, int index, bool>
-        struct getTypeFromIndex_impl;
+		template <typename T1, int index, bool>
+		struct getTypeFromIndexImpl;
 
-        template <typename T1, int index>
-        struct getTypeFromIndex_impl<T1, index, false>
-        {
-            using type = None;
-        };
+		template <typename T1, int index>
+		struct getTypeFromIndexImpl<T1, index, false>
+		{
+			using type = None;
+		};
 
-        template <typename T1, int index>
-        struct getTypeFromIndex_impl<T1, index, true>
-        {
-            using type = std::conditional_t<
-                    (T1::size == index),
-                    typename T1::Head,
-                    typename getTypeFromIndex_impl<typename T1::Tail, index, (T1::size > 1)>::type>;
-        };
+		template <typename T1, int index>
+		struct getTypeFromIndexImpl<T1, index, true>
+		{
+			using type = std::conditional_t<
+			    (T1::size == index), typename T1::Head,
+			    typename getTypeFromIndexImpl<
+			        typename T1::Tail, index, (T1::size > 1)>::type>;
+		};
 
-		template <typename TypesT, typename T>      
-		struct appendToTypes_impl;
+		template <typename TypesT, typename T>
+		struct appendToTypesImpl;
 
-		template <template<typename...> class TypesT, typename T, typename... Args>              
-		struct appendToTypes_impl <TypesT<Args...>, T >
-		{                                                                               
-		    using type = TypesT<T, Args...>;                                                  
+		template <
+		    template <typename...> class TypesT, typename T, typename... Args>
+		struct appendToTypesImpl<TypesT<Args...>, T>
+		{
+			using type = TypesT<T, Args...>;
 		};
 
 		template <typename TypesT1, typename TypesT2>
-		struct appendTypes_impl;
+		struct appendTypesImpl;
 
-		template <template<typename...> class TypesT1, template<typename...> class TypesT2, typename... Args1, typename... Args2>
-		struct appendTypes_impl<TypesT1<Args1...>, TypesT2<Args2...>>
+		template <
+		    template <typename...> class TypesT1,
+		    template <typename...> class TypesT2, typename... Args1,
+		    typename... Args2>
+		struct appendTypesImpl<TypesT1<Args1...>, TypesT2<Args2...>>
 		{
-			static_assert(std::is_same<TypesT1<>, TypesT2<>>::value, "Expected types to be the same");
+			static_assert(
+			    std::is_same<TypesT1<>, TypesT2<>>::value,
+			    "Expected types to be the same");
 			using type = TypesT1<Args2..., Args1...>;
 		};
 	} // namespace types_detail
@@ -108,121 +109,139 @@ namespace shogun
 	template <typename TypesT, int index>
 	struct getTypeFromIndex
 	{
-		static_assert(index >= 0, "Index must be greater or equal than zero");
+		static_assert(
+		    index >= 0, "Index must be greater than or equal to zero");
 		static_assert(index < TypesT::size, "Index is out of bounds");
-		using type = typename types_detail::getTypeFromIndex_impl<TypesT, TypesT::size-index, true>::type;
+		using type = typename types_detail::getTypeFromIndexImpl<
+		    TypesT, TypesT::size - index, true>::type;
 	};
 
 	template <typename TypesT, typename T1>
 	struct appendToTypes
 	{
-		using type = typename types_detail::appendToTypes_impl<TypesT, T1>::type;
+		using type = typename types_detail::appendToTypesImpl<TypesT, T1>::type;
 	};
 
 	template <typename TypesT1, typename TypesT2>
 	struct appendTypes
 	{
-		using type = typename types_detail::appendTypes_impl<TypesT1, TypesT2>::type;
-	};	
+		using type =
+		    typename types_detail::appendTypesImpl<TypesT1, TypesT2>::type;
+	};
 
-	namespace types_detail {
+	namespace types_detail
+	{
 
 		template <typename TypesT1, typename TypesT2, bool>
-		struct reverseTypes_impl;
+		struct reverseTypesImpl;
 
 		template <typename TypesT1, typename TypesT2>
-		struct reverseTypes_impl<TypesT1, TypesT2, false>
+		struct reverseTypesImpl<TypesT1, TypesT2, false>
 		{
 			using type = None;
 		};
 
 		template <typename TypesT1, typename TypesT2>
-		struct reverseTypes_impl <TypesT1, TypesT2, true>
+		struct reverseTypesImpl<TypesT1, TypesT2, true>
 		{
 			using type = std::conditional_t<
-				(TypesT2::size == 1),
-				typename appendToTypes<TypesT1, typename TypesT2::Head>::type,
-				typename reverseTypes_impl<
-					typename appendToTypes<
-						TypesT1, typename TypesT2::Head>::type, 
-					typename TypesT2::Tail, (TypesT2::size > 1)>::type>;
+			    (TypesT2::size == 1),
+			    typename appendToTypes<TypesT1, typename TypesT2::Head>::type,
+			    typename reverseTypesImpl<
+			        typename appendToTypes<
+			            TypesT1, typename TypesT2::Head>::type,
+			        typename TypesT2::Tail, (TypesT2::size > 1)>::type>;
 		};
 
 	} // namespace types_detail
 
-	template<typename TypesT>
+	template <typename TypesT>
 	struct reverseTypes
 	{
-		using type = typename types_detail::reverseTypes_impl<Types<>, TypesT, true>::type;
+		using type = typename types_detail::reverseTypesImpl<
+		    Types<>, TypesT, true>::type;
 	};
 
-	namespace types_detail {
+	namespace types_detail
+	{
 
 		template <typename TypesTHead, typename TypesTTail, typename, bool>
-		struct popTypes_impl_type_;
+		struct popTypesImplType_;
 
 		template <typename TypesTHead, typename TypesTTail, typename T1>
-		struct popTypes_impl_type_<TypesTHead, TypesTTail, T1, false>
+		struct popTypesImplType_<TypesTHead, TypesTTail, T1, false>
 		{
 			using type = typename TypesTTail::Tail;
 		};
 
 		template <typename TypesTHead, typename TypesTTail, typename T1>
-		struct popTypes_impl_type_<TypesTHead, TypesTTail, T1, true>
+		struct popTypesImplType_<TypesTHead, TypesTTail, T1, true>
 		{
-			using type = typename appendTypes<typename TypesTTail::Tail, typename reverseTypes<TypesTHead>::type>::type;
+			using type = typename appendTypes<
+			    typename TypesTTail::Tail,
+			    typename reverseTypes<TypesTHead>::type>::type;
 		};
 
 		template <typename TypesTHead, typename TypesTTail, typename T, bool>
-		struct popTypes_impl_type;
+		struct popTypesImplType;
 
 		template <typename TypesTHead, typename TypesTTail, typename T>
-		struct popTypes_impl_type<TypesTHead, TypesTTail, T, false>
+		struct popTypesImplType<TypesTHead, TypesTTail, T, false>
 		{
 			using type = None;
 		};
 
 		template <typename TypesTHead, typename TypesTTail, typename T>
-		struct popTypes_impl_type<TypesTHead, TypesTTail, T, true>
+		struct popTypesImplType<TypesTHead, TypesTTail, T, true>
 		{
 			using type = std::conditional_t<
-				std::is_same<typename TypesTTail::Head, T>::value,
-				typename popTypes_impl_type_<TypesTHead, TypesTTail, T, (TypesTHead::size > 0)>::type,
-				typename popTypes_impl_type<typename appendToTypes<TypesTHead, typename TypesTTail::Head>::type, typename TypesTTail::Tail, T, (TypesTTail::size > 1)>::type>;
+			    std::is_same<typename TypesTTail::Head, T>::value,
+			    typename popTypesImplType_<
+			        TypesTHead, TypesTTail, T, (TypesTHead::size > 0)>::type,
+			    typename popTypesImplType<
+			        typename appendToTypes<
+			            TypesTHead, typename TypesTTail::Head>::type,
+			        typename TypesTTail::Tail, T,
+			        (TypesTTail::size > 1)>::type>;
 		};
 	} // namespace types_detail
 
-	template<typename TypesT, typename T1>
+	template <typename TypesT, typename T1>
 	struct popTypesByType
 	{
-		using type = typename types_detail::popTypes_impl_type<Types<>, TypesT, T1, true>::type;
+		using type = typename types_detail::popTypesImplType<
+		    Types<>, TypesT, T1, true>::type;
 	};
 
-	namespace types_detail {
+	namespace types_detail
+	{
 
 		template <typename TypesT, typename T1, bool>
-		struct popTypes_impl_types;
+		struct popTypesImplTypes;
 
 		template <typename TypesT, typename T1>
-		struct popTypes_impl_types<TypesT, T1, false>
+		struct popTypesImplTypes<TypesT, T1, false>
 		{
 			using type = None;
 		};
 
 		template <typename TypesT, typename T1>
-		struct popTypes_impl_types<TypesT, T1, true>
+		struct popTypesImplTypes<TypesT, T1, true>
 		{
 			using type = std::conditional_t<
-				(T1::size == 1), 
-				typename popTypesByType<TypesT, typename T1::Head>::type,
-				typename popTypes_impl_types<typename popTypesByType<TypesT, typename T1::Head>::type, typename T1::Tail, (T1::size > 1)>::type>;
+			    (T1::size == 1),
+			    typename popTypesByType<TypesT, typename T1::Head>::type,
+			    typename popTypesImplTypes<
+			        typename popTypesByType<TypesT, typename T1::Head>::type,
+			        typename T1::Tail, (T1::size > 1)>::type>;
 		};
 	} // namespace types_detail
 
-	template<typename TypesT, typename TypesT1>
+	template <typename TypesT, typename TypesT1>
 	struct popTypesByTypes
 	{
-		using type = typename types_detail::popTypes_impl_types<TypesT, TypesT1, true>::type;
+		using type = typename types_detail::popTypesImplTypes<
+		    TypesT, TypesT1, true>::type;
 	};
 } // namespace shogun
 

--- a/src/shogun/lib/sg_types.h
+++ b/src/shogun/lib/sg_types.h
@@ -1,110 +1,126 @@
+#include <shogun/lib/any.h>
 #include <type_traits>
-#include <shogun/lib/common.h>
 
-// ENUMS
-enum class EFeatureType
+using namespace shogun;
+
+namespace shogun
 {
-    F_UNKNOWN,
-    F_BOOL,
-    F_CHAR,
-    F_BYTE,
-    F_SHORT,
-    F_WORD,
-    F_INT,
-    F_UINT,
-    F_LONG,
-    F_ULONG,
-    F_SHORTREAL,
-    F_DREAL,
-    F_LONGREAL,
-};
+	// ENUMS
+	enum class EFeatureType
+	{
+		F_UNKNOWN,
+		F_BOOL,
+		F_CHAR,
+		F_BYTE,
+		F_SHORT,
+		F_WORD,
+		F_INT,
+		F_UINT,
+		F_LONG,
+		F_ULONG,
+		F_SHORTREAL,
+		F_DREAL,
+		F_LONGREAL,
+		F_ANY
+	};
 
-enum class EFeatureClass
-{
-    C_UNKNOWN = 1,
-    C_DENSE = 2,
-    C_SPARSE = 20,
-    C_STRING = 30,
-    C_COMBINED = 40,
-    C_COMBINED_DOT = 60,
-    C_WD = 70,
-    C_SPEC = 80,
-    C_WEIGHTEDSPEC = 90,
-    C_POLY = 100,
-    C_STREAMING_DENSE = 110,
-    C_STREAMING_SPARSE = 120,
-    C_STREAMING_STRING = 130,
-    C_STREAMING_VW = 140,
-    C_BINNED_DOT = 150,
-    C_DIRECTOR_DOT = 160,
-    C_LATENT = 170,
-    C_MATRIX = 180,
-    C_FACTOR_GRAPH = 190,
-    C_INDEX = 200,
-    C_SUB_SAMPLES_DENSE=300,
-    C_ANY = 1000
-};
+	enum class EFeatureClass
+	{
+		C_UNKNOWN = 1,
+		C_DENSE = 2,
+		C_SPARSE = 20,
+		C_STRING = 30,
+		C_COMBINED = 40,
+		C_COMBINED_DOT = 60,
+		C_WD = 70,
+		C_SPEC = 80,
+		C_WEIGHTEDSPEC = 90,
+		C_POLY = 100,
+		C_STREAMING_DENSE = 110,
+		C_STREAMING_SPARSE = 120,
+		C_STREAMING_STRING = 130,
+		C_STREAMING_VW = 140,
+		C_BINNED_DOT = 150,
+		C_DIRECTOR_DOT = 160,
+		C_LATENT = 170,
+		C_MATRIX = 180,
+		C_FACTOR_GRAPH = 190,
+		C_INDEX = 200,
+		C_SUB_SAMPLES_DENSE = 300,
+		C_ANY = 1000
+	};
 
-enum class EFeatureProperty
-{
-    FP_NONE = 0,
-    FP_DOT = 1,
-    FP_STREAMING_DOT = 2
-};
+	enum class EFeatureProperty
+	{
+		FP_NONE = 0,
+		FP_DOT = 1,
+		FP_STREAMING_DOT = 2
+	};
 
-// utility structs
-struct Unknown {};
-struct None {};
+	// utility structs
+	struct Unknown
+	{
+	};
+	struct None
+	{
+	};
 
-// struct to store types
-template <typename... Args>
-struct Types
-{
-    typedef None Head;
-    static constexpr int size = 0;
-};
+	// struct to store types
+	template <typename... Args>
+	struct Types
+	{
+		typedef None Head;
+		static constexpr int size = 0;
+	};
 
-template <typename T1, typename... Args>
-struct Types<T1, Args...> : Types<Args...>
-{
-    typedef Types<Args...> Tail;
-    typedef T1 Head;
-    static constexpr int size = sizeof...(Args);
-};
+	template <typename T1, typename... Args>
+	struct Types<T1, Args...> : Types<Args...>
+	{
+		typedef Types<Args...> Tail;
+		typedef T1 Head;
+		static constexpr int size = sizeof...(Args);
+	};
 
-// Type definitions
-typedef	Types <long double, double, float, unsigned long, long,
-        unsigned int, int, unsigned short, short, uint8_t,
-        char, bool, Unknown> feature_types;
+	// Type definitions
+	typedef Types<
+	    Any, long double, double, float, unsigned long, long, unsigned int, int,
+	    unsigned short, short, uint8_t, char, bool, Unknown>
+	    feature_types;
 
-typedef Types<
-        int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
-        float64_t, floatmax_t, char>
-        all_primitive_types;
+	typedef Types<
+	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+	    float32_t, float64_t, floatmax_t, char>
+	    all_primitive_types;
 
-template<typename T1, int index, bool>
-struct getTypeIndex_impl
-{
-};
+	namespace types_detail
+	{
+		template <typename T1, int index, bool>
+		struct getTypeIndex_impl
+		{
+		};
 
-template<typename T1, int index>
-struct getTypeIndex_impl<T1, index, false>
-{
-    using type = None;
-};
+		template <typename T1, int index>
+		struct getTypeIndex_impl<T1, index, false>
+		{
+			using type = None;
+		};
 
-template<typename T1, int index>
-struct getTypeIndex_impl<T1, index, true>
-{
-    using type = std::conditional_t<(T1::size == index),
-            typename T1::Head,
-            typename getTypeIndex_impl<typename T1::Tail, index, (T1::size > 0)>::type>;
-};
+		template <typename T1, int index>
+		struct getTypeIndex_impl<T1, index, true>
+		{
+			using type = std::conditional_t<
+			    (T1::size == index), typename T1::Head,
+			    typename getTypeIndex_impl<
+			        typename T1::Tail, index, (T1::size > 0)>::type>;
+		};
+	} // namespace types_detail
 
-template<typename T1, int index>
-struct getTypeIndex
-{
-    using type = std::conditional_t<index >= 0,
-            typename getTypeIndex_impl<T1, index, true>::type,
-            None>;
-};
+	template <typename T1, int index>
+	struct getTypeIndex
+	{
+		using type = std::conditional_t<
+		    index >= 0,
+		    typename types_detail::getTypeIndex_impl<T1, index, true>::type,
+		    None>;
+	};
+} // namespace shogun

--- a/src/shogun/lib/sg_types.h
+++ b/src/shogun/lib/sg_types.h
@@ -40,19 +40,14 @@ namespace shogun
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 	// Type definitions
-	// NOTE: order of Types is reverse of enum as it uses last in first out
-	// approach.
 	typedef Types<
 	    Any, floatmax_t, float64_t, float32_t, uint64_t, int64_t, uint32_t,
 	    int32_t, uint16_t, int16_t, uint8_t, char, bool, Unknown>
 	    sg_feature_types;
 
-	// TODO: add bool and complex128_t types
-	// TODO: in C++17 can use constexpr if (...) to check types in tests
-	// 		 to skip types that we don't write tests for
 	typedef Types<
 	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
-	    float32_t, float64_t, floatmax_t, char>
+	    float32_t, float64_t, floatmax_t, complex128_t, char, bool>
 	    sg_all_primitive_types;
 
 	typedef Types<
@@ -62,40 +57,172 @@ namespace shogun
 
 	typedef Types<float32_t, float64_t, floatmax_t> sg_real_types;
 
-	// TODO: add complex128_t type
-	typedef Types<float32_t, float64_t, floatmax_t> sg_non_integer_types;
+	typedef Types<float32_t, float64_t, floatmax_t, complex128_t> sg_non_integer_types;
+
+    typedef Types<int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+    float32_t, float64_t, floatmax_t, complex128_t> sg_numeric_types;
+
+    typedef Types<uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
+            uint64_t, float32_t, float64_t, floatmax_t, char> sg_tb_types;
 
 	namespace types_detail
 	{
-		template <typename T1, int index, bool>
-		struct getTypeFromIndex_impl
-		{
+        template <typename T1, int index, bool>
+        struct getTypeFromIndex_impl;
+
+        template <typename T1, int index>
+        struct getTypeFromIndex_impl<T1, index, false>
+        {
+            using type = None;
+        };
+
+        template <typename T1, int index>
+        struct getTypeFromIndex_impl<T1, index, true>
+        {
+            using type = std::conditional_t<
+                    (T1::size == index),
+                    typename T1::Head,
+                    typename getTypeFromIndex_impl<typename T1::Tail, index, (T1::size > 1)>::type>;
+        };
+
+		template <typename TypesT, typename T>      
+		struct appendToTypes_impl;
+
+		template <template<typename...> class TypesT, typename T, typename... Args>              
+		struct appendToTypes_impl <TypesT<Args...>, T >
+		{                                                                               
+		    using type = TypesT<T, Args...>;                                                  
 		};
 
-		template <typename T1, int index>
-		struct getTypeFromIndex_impl<T1, index, false>
+		template <typename TypesT1, typename TypesT2>
+		struct appendTypes_impl;
+
+		template <template<typename...> class TypesT1, template<typename...> class TypesT2, typename... Args1, typename... Args2>
+		struct appendTypes_impl<TypesT1<Args1...>, TypesT2<Args2...>>
+		{
+			static_assert(std::is_same<TypesT1<>, TypesT2<>>::value, "Expected types to be the same");
+			using type = TypesT1<Args2..., Args1...>;
+		};
+	} // namespace types_detail
+
+	template <typename TypesT, int index>
+	struct getTypeFromIndex
+	{
+		static_assert(index >= 0, "Index must be greater or equal than zero");
+		static_assert(index < TypesT::size, "Index is out of bounds");
+		using type = typename types_detail::getTypeFromIndex_impl<TypesT, TypesT::size-index, true>::type;
+	};
+
+	template <typename TypesT, typename T1>
+	struct appendToTypes
+	{
+		using type = typename types_detail::appendToTypes_impl<TypesT, T1>::type;
+	};
+
+	template <typename TypesT1, typename TypesT2>
+	struct appendTypes
+	{
+		using type = typename types_detail::appendTypes_impl<TypesT1, TypesT2>::type;
+	};	
+
+	namespace types_detail {
+
+		template <typename TypesT1, typename TypesT2, bool>
+		struct reverseTypes_impl;
+
+		template <typename TypesT1, typename TypesT2>
+		struct reverseTypes_impl<TypesT1, TypesT2, false>
 		{
 			using type = None;
 		};
 
-		template <typename T1, int index>
-		struct getTypeFromIndex_impl<T1, index, true>
+		template <typename TypesT1, typename TypesT2>
+		struct reverseTypes_impl <TypesT1, TypesT2, true>
 		{
 			using type = std::conditional_t<
-			    (T1::size == index),
-			    typename T1::Head,
-			    typename getTypeFromIndex_impl<
-			        typename T1::Tail, index, (T1::size > 1)>::type>;
+				(TypesT2::size == 1),
+				typename appendToTypes<TypesT1, typename TypesT2::Head>::type,
+				typename reverseTypes_impl<
+					typename appendToTypes<
+						TypesT1, typename TypesT2::Head>::type, 
+					typename TypesT2::Tail, (TypesT2::size > 1)>::type>;
+		};
+
+	} // namespace types_detail
+
+	template<typename TypesT>
+	struct reverseTypes
+	{
+		using type = typename types_detail::reverseTypes_impl<Types<>, TypesT, true>::type;
+	};
+
+	namespace types_detail {
+
+		template <typename TypesTHead, typename TypesTTail, typename, bool>
+		struct popTypes_impl_type_;
+
+		template <typename TypesTHead, typename TypesTTail, typename T1>
+		struct popTypes_impl_type_<TypesTHead, TypesTTail, T1, false>
+		{
+			using type = typename TypesTTail::Tail;
+		};
+
+		template <typename TypesTHead, typename TypesTTail, typename T1>
+		struct popTypes_impl_type_<TypesTHead, TypesTTail, T1, true>
+		{
+			using type = typename appendTypes<typename TypesTTail::Tail, typename reverseTypes<TypesTHead>::type>::type;
+		};
+
+		template <typename TypesTHead, typename TypesTTail, typename T, bool>
+		struct popTypes_impl_type;
+
+		template <typename TypesTHead, typename TypesTTail, typename T>
+		struct popTypes_impl_type<TypesTHead, TypesTTail, T, false>
+		{
+			using type = None;
+		};
+
+		template <typename TypesTHead, typename TypesTTail, typename T>
+		struct popTypes_impl_type<TypesTHead, TypesTTail, T, true>
+		{
+			using type = std::conditional_t<
+				std::is_same<typename TypesTTail::Head, T>::value,
+				typename popTypes_impl_type_<TypesTHead, TypesTTail, T, (TypesTHead::size > 0)>::type,
+				typename popTypes_impl_type<typename appendToTypes<TypesTHead, typename TypesTTail::Head>::type, typename TypesTTail::Tail, T, (TypesTTail::size > 1)>::type>;
 		};
 	} // namespace types_detail
 
-	template <typename T1, int index>
-	struct getTypeFromIndex
+	template<typename TypesT, typename T1>
+	struct popTypesByType
 	{
-		using type = std::conditional_t<
-		    (index >= 0) && (index < T1::size),
-		    typename types_detail::getTypeFromIndex_impl<T1, index+1, true>::type,
-		    None>;
+		using type = typename types_detail::popTypes_impl_type<Types<>, TypesT, T1, true>::type;
+	};
+
+	namespace types_detail {
+
+		template <typename TypesT, typename T1, bool>
+		struct popTypes_impl_types;
+
+		template <typename TypesT, typename T1>
+		struct popTypes_impl_types<TypesT, T1, false>
+		{
+			using type = None;
+		};
+
+		template <typename TypesT, typename T1>
+		struct popTypes_impl_types<TypesT, T1, true>
+		{
+			using type = std::conditional_t<
+				(T1::size == 1), 
+				typename popTypesByType<TypesT, typename T1::Head>::type,
+				typename popTypes_impl_types<typename popTypesByType<TypesT, typename T1::Head>::type, typename T1::Tail, (T1::size > 1)>::type>;
+		};
+	} // namespace types_detail
+
+	template<typename TypesT, typename TypesT1>
+	struct popTypesByTypes
+	{
+		using type = typename types_detail::popTypes_impl_types<TypesT, TypesT1, true>::type;
 	};
 } // namespace shogun
 

--- a/src/shogun/lib/sg_types.h
+++ b/src/shogun/lib/sg_types.h
@@ -1,62 +1,18 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_TYPE_H
+#define SHOGUN_TYPE_H
+
 #include <shogun/lib/any.h>
-#include <type_traits>
 
 using namespace shogun;
 
 namespace shogun
 {
-	// ENUMS
-	enum class EFeatureType
-	{
-		F_UNKNOWN,
-		F_BOOL,
-		F_CHAR,
-		F_BYTE,
-		F_SHORT,
-		F_WORD,
-		F_INT,
-		F_UINT,
-		F_LONG,
-		F_ULONG,
-		F_SHORTREAL,
-		F_DREAL,
-		F_LONGREAL,
-		F_ANY
-	};
-
-	enum class EFeatureClass
-	{
-		C_UNKNOWN = 1,
-		C_DENSE = 2,
-		C_SPARSE = 20,
-		C_STRING = 30,
-		C_COMBINED = 40,
-		C_COMBINED_DOT = 60,
-		C_WD = 70,
-		C_SPEC = 80,
-		C_WEIGHTEDSPEC = 90,
-		C_POLY = 100,
-		C_STREAMING_DENSE = 110,
-		C_STREAMING_SPARSE = 120,
-		C_STREAMING_STRING = 130,
-		C_STREAMING_VW = 140,
-		C_BINNED_DOT = 150,
-		C_DIRECTOR_DOT = 160,
-		C_LATENT = 170,
-		C_MATRIX = 180,
-		C_FACTOR_GRAPH = 190,
-		C_INDEX = 200,
-		C_SUB_SAMPLES_DENSE = 300,
-		C_ANY = 1000
-	};
-
-	enum class EFeatureProperty
-	{
-		FP_NONE = 0,
-		FP_DOT = 1,
-		FP_STREAMING_DOT = 2
-	};
-
 	// utility structs
 	struct Unknown
 	{
@@ -65,6 +21,7 @@ namespace shogun
 	{
 	};
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 	// struct to store types
 	template <typename... Args>
 	struct Types
@@ -78,49 +35,68 @@ namespace shogun
 	{
 		typedef Types<Args...> Tail;
 		typedef T1 Head;
-		static constexpr int size = sizeof...(Args);
+		static constexpr int size = sizeof...(Args) + 1;
 	};
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 	// Type definitions
+	// NOTE: order of Types is reverse of enum as it uses last in first out
+	// approach.
 	typedef Types<
-	    Any, long double, double, float, unsigned long, long, unsigned int, int,
-	    unsigned short, short, uint8_t, char, bool, Unknown>
-	    feature_types;
+	    Any, floatmax_t, float64_t, float32_t, uint64_t, int64_t, uint32_t,
+	    int32_t, uint16_t, int16_t, uint8_t, char, bool, Unknown>
+	    sg_feature_types;
 
+	// TODO: add bool and complex128_t types
+	// TODO: in C++17 can use constexpr if (...) to check types in tests
+	// 		 to skip types that we don't write tests for
 	typedef Types<
 	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
 	    float32_t, float64_t, floatmax_t, char>
-	    all_primitive_types;
+	    sg_all_primitive_types;
+
+	typedef Types<
+	    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+	    float32_t, float64_t, floatmax_t>
+	    sg_non_complex_types;
+
+	typedef Types<float32_t, float64_t, floatmax_t> sg_real_types;
+
+	// TODO: add complex128_t type
+	typedef Types<float32_t, float64_t, floatmax_t> sg_non_integer_types;
 
 	namespace types_detail
 	{
 		template <typename T1, int index, bool>
-		struct getTypeIndex_impl
+		struct getTypeFromIndex_impl
 		{
 		};
 
 		template <typename T1, int index>
-		struct getTypeIndex_impl<T1, index, false>
+		struct getTypeFromIndex_impl<T1, index, false>
 		{
 			using type = None;
 		};
 
 		template <typename T1, int index>
-		struct getTypeIndex_impl<T1, index, true>
+		struct getTypeFromIndex_impl<T1, index, true>
 		{
 			using type = std::conditional_t<
-			    (T1::size == index), typename T1::Head,
-			    typename getTypeIndex_impl<
-			        typename T1::Tail, index, (T1::size > 0)>::type>;
+			    (T1::size == index),
+			    typename T1::Head,
+			    typename getTypeFromIndex_impl<
+			        typename T1::Tail, index, (T1::size > 1)>::type>;
 		};
 	} // namespace types_detail
 
 	template <typename T1, int index>
-	struct getTypeIndex
+	struct getTypeFromIndex
 	{
 		using type = std::conditional_t<
-		    index >= 0,
-		    typename types_detail::getTypeIndex_impl<T1, index, true>::type,
+		    (index >= 0) && (index < T1::size),
+		    typename types_detail::getTypeFromIndex_impl<T1, index+1, true>::type,
 		    None>;
 	};
 } // namespace shogun
+
+#endif // SHOGUN_TYPE_H

--- a/src/shogun/lib/type_case.h
+++ b/src/shogun/lib/type_case.h
@@ -13,30 +13,12 @@
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/any.h>
+#include <shogun/lib/sg_types.h>
 
 using namespace shogun;
 
 namespace shogun
 {
-	struct None
-	{
-	};
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
-	template <typename... Args>
-	struct Types
-	{
-		typedef None Head;
-	};
-
-	template <typename T1, typename... Args>
-	struct Types<T1, Args...> : Types<Args...>
-	{
-		typedef Types<Args...> Tail;
-		typedef T1 Head;
-	};
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 	typedef Types<
 		bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
 		int64_t, uint64_t, float32_t, float64_t, floatmax_t, SGVector<int32_t>,
@@ -416,7 +398,7 @@ namespace shogun
 
 #define ADD_TYPE_TO_MAP(TYPENAME, TYPE_ENUM)                                   \
 	{std::type_index(typeid(TYPENAME)), TYPE_ENUM},
-static const typemap sg_all_types = {
+static const typemap sg_all_typemap = {
 		ADD_TYPE_TO_MAP(bool, TYPE::T_BOOL)
 		ADD_TYPE_TO_MAP(char, TYPE::T_CHAR)
 		ADD_TYPE_TO_MAP(int8_t, TYPE::T_INT8)
@@ -442,21 +424,21 @@ static const typemap sg_all_types = {
 		ADD_TYPE_TO_MAP(SGMatrix<int32_t>, TYPE::T_SGMATRIX_INT32)
 		ADD_TYPE_TO_MAP(SGMatrix<int64_t>, TYPE::T_SGMATRIX_INT64)
 };
-static const typemap sg_vector_types = {
+static const typemap sg_vector_typemap = {
 		ADD_TYPE_TO_MAP(SGVector<float32_t>, TYPE::T_SGVECTOR_FLOAT32)
 		ADD_TYPE_TO_MAP(SGVector<float64_t>, TYPE::T_SGVECTOR_FLOAT64)
 		ADD_TYPE_TO_MAP(SGVector<floatmax_t>, TYPE::T_SGVECTOR_FLOATMAX)
 		ADD_TYPE_TO_MAP(SGVector<int32_t>, TYPE::T_SGVECTOR_INT32)
 		ADD_TYPE_TO_MAP(SGVector<int64_t>, TYPE::T_SGVECTOR_INT64)
 };
-static const typemap sg_matrix_types = {
+static const typemap sg_matrix_typemap = {
 		ADD_TYPE_TO_MAP(SGMatrix<float32_t>, TYPE::T_SGMATRIX_FLOAT32)
 		ADD_TYPE_TO_MAP(SGMatrix<float64_t>, TYPE::T_SGMATRIX_FLOAT64)
 		ADD_TYPE_TO_MAP(SGMatrix<floatmax_t>, TYPE::T_SGMATRIX_FLOATMAX)
 		ADD_TYPE_TO_MAP(SGMatrix<int32_t>, TYPE::T_SGMATRIX_INT32)
 		ADD_TYPE_TO_MAP(SGMatrix<int64_t>, TYPE::T_SGMATRIX_INT64)
 };
-static const typemap sg_non_complex_types = {
+static const typemap sg_non_complex_typemap = {
 		ADD_TYPE_TO_MAP(bool, TYPE::T_BOOL)
 		ADD_TYPE_TO_MAP(char, TYPE::T_CHAR)
 		ADD_TYPE_TO_MAP(int8_t, TYPE::T_INT8)
@@ -471,12 +453,12 @@ static const typemap sg_non_complex_types = {
 		ADD_TYPE_TO_MAP(float64_t , TYPE::T_FLOAT64)
 		ADD_TYPE_TO_MAP(floatmax_t , TYPE::T_FLOATMAX)
 };
-static const typemap sg_real_types = {
+static const typemap sg_real_typemap = {
 		ADD_TYPE_TO_MAP(float32_t , TYPE::T_FLOAT32)
 		ADD_TYPE_TO_MAP(float64_t , TYPE::T_FLOAT64)
 		ADD_TYPE_TO_MAP(floatmax_t , TYPE::T_FLOATMAX)
 };
-static const typemap sg_non_integer_types = {
+static const typemap sg_non_integer_typemap = {
 		ADD_TYPE_TO_MAP(float32_t , TYPE::T_FLOAT32)
 		ADD_TYPE_TO_MAP(float64_t , TYPE::T_FLOAT64)
 		ADD_TYPE_TO_MAP(floatmax_t , TYPE::T_FLOATMAX)

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -4,7 +4,6 @@
  * Authors: Heiko Strathmann, Thoralf Klein, Wu Lin
  */
 
-#include <gtest/gtest.h>
 #include "sg_gtest_utilities.h"
 
 #include "MockObject.h"

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -5,6 +5,8 @@
  */
 
 #include <gtest/gtest.h>
+#include "sg_gtest_utilities.h"
+
 #include "MockObject.h"
 #include <shogun/base/class_list.h>
 #include <shogun/base/some.h>
@@ -38,14 +40,8 @@ class SGObjectClone : public ::testing::Test
 {
 };
 
-// types that go into SGVector<> and co
-// TODO: SGString doesn't support complex128_t, so omitted here
-typedef ::testing::Types<bool, char, int8_t, int16_t, int32_t, int64_t,
-                         float32_t, float64_t, floatmax_t>
-    SGBasicTypes;
-
-TYPED_TEST_CASE(SGObjectEquals, SGBasicTypes);
-TYPED_TEST_CASE(SGObjectClone, SGBasicTypes);
+SG_TYPED_TEST_CASE(SGObjectEquals, sg_all_primitive_types, complex128_t);
+SG_TYPED_TEST_CASE(SGObjectClone, sg_all_primitive_types, complex128_t);
 
 TYPED_TEST(SGObjectEquals, mock_allocate_delete)
 {

--- a/tests/unit/io/TBOutputFormat_unittest.cc
+++ b/tests/unit/io/TBOutputFormat_unittest.cc
@@ -35,7 +35,8 @@
 #include <shogun/lib/config.h>
 #ifdef HAVE_TFLOGGER
 
-#include <gtest/gtest.h>
+#include "sg_gtest_utilities.h"
+
 #include <shogun/io/TBOutputFormat.h>
 #include <shogun/lib/any.h>
 #include <shogun/lib/tfhistogram/histogram.h>
@@ -44,7 +45,6 @@
 #include <utility>
 #include <vector>
 
-#include "sg_gtest_utilities.h"
 
 using namespace shogun;
 

--- a/tests/unit/io/TBOutputFormat_unittest.cc
+++ b/tests/unit/io/TBOutputFormat_unittest.cc
@@ -44,6 +44,8 @@
 #include <utility>
 #include <vector>
 
+#include "sg_gtest_utilities.h"
+
 using namespace shogun;
 
 template <class T>
@@ -140,10 +142,7 @@ class TBOutputFormatTest : public ::testing::Test
 {
 };
 
-typedef ::testing::Types<uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                         uint64_t, float32_t, float64_t, floatmax_t, char>
-    TBTypes;
-TYPED_TEST_CASE(TBOutputFormatTest, TBTypes);
+SG_TYPED_TEST_CASE(TBOutputFormatTest, sg_all_primitive_types, bool, complex128_t);
 
 TYPED_TEST(TBOutputFormatTest, convert_all_types_scalar)
 {

--- a/tests/unit/lib/DynamicArray_unittest.cc
+++ b/tests/unit/lib/DynamicArray_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "utils/Utils.h"
 
+#include "sg_gtest_utilities.h"
+
 using namespace shogun;
 
 template <typename T>
@@ -36,10 +38,7 @@ protected:
 	T* m_array;
 };
 
-typedef ::testing::Types<bool, char, int8_t, uint8_t, int16_t, int32_t, int64_t,
-                         float32_t, float64_t>
-    DynamicArrayTypes;
-TYPED_TEST_CASE(CDynamicArrayFixture, DynamicArrayTypes);
+SG_TYPED_TEST_CASE(CDynamicArrayFixture, sg_all_primitive_types, complex128_t);
 
 TYPED_TEST(CDynamicArrayFixture, array_ctor)
 {

--- a/tests/unit/lib/DynamicArray_unittest.cc
+++ b/tests/unit/lib/DynamicArray_unittest.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include "sg_gtest_utilities.h"
+
 #include <shogun/io/SerializableAsciiFile.h>
 #include <shogun/lib/DynamicArray.h>
 #include <shogun/mathematics/Math.h>
 
 #include "utils/Utils.h"
 
-#include "sg_gtest_utilities.h"
 
 using namespace shogun;
 

--- a/tests/unit/lib/SGSparseVector_unittest.cc
+++ b/tests/unit/lib/SGSparseVector_unittest.cc
@@ -5,13 +5,12 @@
  *          Viktor Gal
  */
 
-#include <gtest/gtest.h>
+#include "sg_gtest_utilities.h"
+
 #include <shogun/lib/common.h>
 #include <shogun/lib/sg_types.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGSparseVector.h>
-
-#include "sg_gtest_utilities.h"
 
 #include <vector>
 

--- a/tests/unit/lib/SGSparseVector_unittest.cc
+++ b/tests/unit/lib/SGSparseVector_unittest.cc
@@ -7,8 +7,11 @@
 
 #include <gtest/gtest.h>
 #include <shogun/lib/common.h>
+#include <shogun/lib/sg_types.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/SGSparseVector.h>
+
+#include "sg_gtest_utilities.h"
 
 #include <vector>
 
@@ -513,10 +516,8 @@ public:
 	SGSparseVector<T> v1_;
 	SGSparseVector<T> v2_;
 };
-typedef ::testing::Types<int16_t, int32_t, int64_t, float32_t, float64_t,
-                         floatmax_t, complex128_t>
-    SGSparseVectorEqualsTypes;
-TYPED_TEST_CASE(SGSparseVectorEquals, SGSparseVectorEqualsTypes);
+
+SG_TYPED_TEST_CASE(SGSparseVectorEquals, sg_numeric_types);
 
 TYPED_TEST(SGSparseVectorEquals, equals_same_dim)
 {

--- a/tests/unit/lib/SGTypes_unittest.cc
+++ b/tests/unit/lib/SGTypes_unittest.cc
@@ -14,7 +14,7 @@ using testing::StaticAssertTypeEq;
 
 TEST(SGTypes, get_type_from_index)
 {
-    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_UNKNOWN>::type , Unknown>();
+    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_UNKNOWN>::type , shogun::Unknown>();
     StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_BOOL>::type , bool>();
-    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_ANY>::type , Any>();
+    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_ANY>::type , shogun::Any>();
 }

--- a/tests/unit/lib/SGTypes_unittest.cc
+++ b/tests/unit/lib/SGTypes_unittest.cc
@@ -4,27 +4,44 @@
  * Authors: Gil Hoben
  */
 
-#include <gtest/gtest.h>
-
-#include <shogun/features/FeatureTypes.h>
-#include <shogun/lib/sg_types.h>
+#include "sg_gtest_utilities.h"
 
 using namespace shogun;
 using testing::StaticAssertTypeEq;
 
-using testing_types = Types<Any, int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
-        float32_t, float64_t, floatmax_t, complex128_t, char, bool, shogun::Unknown>;
+using testing_types = Types<
+    Any, int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+    float32_t, float64_t, floatmax_t, complex128_t, char, bool,
+    shogun::Unknown>;
 
 TEST(SGTypes, get_type_from_index)
 {
-    StaticAssertTypeEq<getTypeFromIndex<testing_types, 0>::type, shogun::Any>();
-    StaticAssertTypeEq<getTypeFromIndex<testing_types, 1>::type , int8_t >();
-    StaticAssertTypeEq<getTypeFromIndex<testing_types, 14>::type , shogun::Unknown>();
+	StaticAssertTypeEq<getTypeFromIndex<testing_types, 0>::type, shogun::Any>();
+	StaticAssertTypeEq<getTypeFromIndex<testing_types, 1>::type, int8_t>();
+	StaticAssertTypeEq<
+	    getTypeFromIndex<testing_types, 14>::type, shogun::Unknown>();
 }
 
 TEST(SGTypes, pop_by_type)
 {
-    StaticAssertTypeEq<getTypeFromIndex<typename popTypesByTypes<testing_types, Types<shogun::Unknown>>::type, 13>::type , bool>();
-    StaticAssertTypeEq<getTypeFromIndex<typename popTypesByTypes<testing_types, Types<uint64_t>>::type, 6>::type , int64_t>();
-    StaticAssertTypeEq<getTypeFromIndex<typename popTypesByTypes<testing_types, Types<Any>>::type, 0>::type , int8_t >();
+	StaticAssertTypeEq<
+	    getTypeFromIndex<
+	        typename popTypesByTypes<
+	            testing_types, Types<shogun::Unknown>>::type,
+	        13>::type,
+	    bool>();
+	StaticAssertTypeEq<
+	    getTypeFromIndex<
+	        typename popTypesByTypes<testing_types, Types<uint64_t>>::type,
+	        6>::type,
+	    int64_t>();
+	StaticAssertTypeEq<
+	    getTypeFromIndex<
+	        typename popTypesByTypes<testing_types, Types<Any>>::type, 0>::type,
+	    int8_t>();
+	StaticAssertTypeEq<
+	    getTypeFromIndex<
+	        typename popTypesByTypes<testing_types, Types<Any, int8_t>>::type,
+	        0>::type,
+	    int16_t>();
 }

--- a/tests/unit/lib/SGTypes_unittest.cc
+++ b/tests/unit/lib/SGTypes_unittest.cc
@@ -1,0 +1,20 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#include <gtest/gtest.h>
+
+#include <shogun/features/FeatureTypes.h>
+#include <shogun/lib/sg_types.h>
+
+using namespace shogun;
+using testing::StaticAssertTypeEq;
+
+TEST(SGTypes, get_type_from_index)
+{
+    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_UNKNOWN>::type , Unknown>();
+    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_BOOL>::type , bool>();
+    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_ANY>::type , Any>();
+}

--- a/tests/unit/lib/SGTypes_unittest.cc
+++ b/tests/unit/lib/SGTypes_unittest.cc
@@ -12,9 +12,19 @@
 using namespace shogun;
 using testing::StaticAssertTypeEq;
 
+using testing_types = Types<Any, int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t,
+        float32_t, float64_t, floatmax_t, complex128_t, char, bool, shogun::Unknown>;
+
 TEST(SGTypes, get_type_from_index)
 {
-    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_UNKNOWN>::type , shogun::Unknown>();
-    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_BOOL>::type , bool>();
-    StaticAssertTypeEq<getTypeFromIndex<sg_feature_types, F_ANY>::type , shogun::Any>();
+    StaticAssertTypeEq<getTypeFromIndex<testing_types, 0>::type, shogun::Any>();
+    StaticAssertTypeEq<getTypeFromIndex<testing_types, 1>::type , int8_t >();
+    StaticAssertTypeEq<getTypeFromIndex<testing_types, 14>::type , shogun::Unknown>();
+}
+
+TEST(SGTypes, pop_by_type)
+{
+    StaticAssertTypeEq<getTypeFromIndex<typename popTypesByTypes<testing_types, Types<shogun::Unknown>>::type, 13>::type , bool>();
+    StaticAssertTypeEq<getTypeFromIndex<typename popTypesByTypes<testing_types, Types<uint64_t>>::type, 6>::type , int64_t>();
+    StaticAssertTypeEq<getTypeFromIndex<typename popTypesByTypes<testing_types, Types<Any>>::type, 0>::type , int8_t >();
 }

--- a/tests/unit/lib/type_case_unittest.cc
+++ b/tests/unit/lib/type_case_unittest.cc
@@ -74,16 +74,16 @@ TEST(Type_case, positional_lambdas)
 	auto f_vector = [&counter](auto value) { counter++; };
 	auto f_matrix = [&counter](auto value) { counter++; };
 
-	sg_any_dispatch(any_scalar, sg_all_types, f_scalar);
+	sg_any_dispatch(any_scalar, sg_all_typemap, f_scalar);
 	EXPECT_EQ(counter, 1);
 
-	sg_any_dispatch(any_vector, sg_all_types, None{}, f_vector);
+	sg_any_dispatch(any_vector, sg_all_typemap, None{}, f_vector);
 	EXPECT_EQ(counter, 2);
 
-	sg_any_dispatch(any_matrix, sg_all_types, None{}, None{}, f_matrix);
+	sg_any_dispatch(any_matrix, sg_all_typemap, None{}, None{}, f_matrix);
 	EXPECT_EQ(counter, 3);
 
-	sg_any_dispatch(any_scalar, sg_all_types, None{}, f_vector, f_matrix);
+	sg_any_dispatch(any_scalar, sg_all_typemap, None{}, f_vector, f_matrix);
 	EXPECT_EQ(counter, 3);
 }
 
@@ -96,7 +96,7 @@ TEST(Type_case, exception)
 	auto f_scalar = [&counter](auto value) { counter++; };
 
 	EXPECT_THROW(
-		sg_any_dispatch(any_scalar, sg_real_types, f_scalar), ShogunException);
+		sg_any_dispatch(any_scalar, sg_real_typemap, f_scalar), ShogunException);
 	EXPECT_EQ(counter, 0);
 }
 
@@ -117,10 +117,10 @@ TEST(Type_case, modify_struct)
 		a_struct.add_value(value);
 	};
 
-	sg_any_dispatch(any_float, sg_real_types, f_float);
+	sg_any_dispatch(any_float, sg_real_typemap, f_float);
 	EXPECT_EQ(a_struct.get_value(), 84);
 	EXPECT_THROW(
-		sg_any_dispatch(any_int, sg_real_types, f_int), ShogunException);
+		sg_any_dispatch(any_int, sg_real_typemap, f_int), ShogunException);
 	EXPECT_EQ(a_struct.get_value(), 84);
 }
 
@@ -162,13 +162,13 @@ TEST(Type_case, static_asserts)
 	auto f_arity_fail = [](auto a, float b) {};
 #if defined(_MSC_VER) && _MSC_VER < 1920
 	StaticAssertOKEqTestHelper<decltype(
-		sg_any_dispatch(any_float, sg_all_types, f_return_fail)), int>();
+		sg_any_dispatch(any_float, sg_all_typemap, f_return_fail)), int>();
 	StaticAssertOKEqTestHelper<decltype(
-		sg_any_dispatch(any_float, sg_all_types, f_arity_fail)), type_internal::ok>();
+		sg_any_dispatch(any_float, sg_all_typemap, f_arity_fail)), type_internal::ok>();
 #else
 	StaticAssertReturnTypeEqTestHelper<decltype(
-		sg_any_dispatch(any_float, sg_all_types, f_return_fail))>();
+		sg_any_dispatch(any_float, sg_all_typemap, f_return_fail))>();
 	StaticAssertArityEqTestHelper<decltype(
-		sg_any_dispatch(any_float, sg_all_types, f_arity_fail))>();
+		sg_any_dispatch(any_float, sg_all_typemap, f_arity_fail))>();
 #endif
 }

--- a/tests/unit/machine/FeatureDispatchCRTP_unittest.cc
+++ b/tests/unit/machine/FeatureDispatchCRTP_unittest.cc
@@ -1,12 +1,12 @@
+#include "sg_gtest_utilities.h"
+
 #include "utils/Utils.h"
-#include <gtest/gtest.h>
 #include <shogun/base/some.h>
 #include <shogun/features/DenseFeatures.h>
 #include <shogun/features/StringFeatures.h>
 #include <shogun/machine/FeatureDispatchCRTP.h>
 #include <shogun/machine/LinearMachine.h>
 
-#include "sg_gtest_utilities.h"
 
 using namespace shogun;
 

--- a/tests/unit/machine/FeatureDispatchCRTP_unittest.cc
+++ b/tests/unit/machine/FeatureDispatchCRTP_unittest.cc
@@ -6,6 +6,8 @@
 #include <shogun/machine/FeatureDispatchCRTP.h>
 #include <shogun/machine/LinearMachine.h>
 
+#include "sg_gtest_utilities.h"
+
 using namespace shogun;
 
 class CDenseRealMockMachine
@@ -62,14 +64,13 @@ public:
 	EFeatureType m_expected_feature_type;
 };
 
-typedef ::testing::Types<float32_t, float64_t, floatmax_t> SGFloatTypes;
 
 template <typename T>
 class DenseDispatchCRTP : public ::testing::Test
 {
 };
 
-TYPED_TEST_CASE(DenseDispatchCRTP, SGFloatTypes);
+SG_TYPED_TEST_CASE(DenseDispatchCRTP, sg_real_types);
 
 TYPED_TEST(DenseDispatchCRTP, train_with_dense)
 {

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -3,6 +3,7 @@
 #include <shogun/base/range.h>
 #include <shogun/lib/config.h>
 #include <shogun/lib/exception/ShogunException.h>
+#include <shogun/lib/sg_types.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
 #include <shogun/mathematics/linalg/LinalgSpecialPurposes.h>
@@ -10,6 +11,15 @@
 using namespace shogun;
 using namespace linalg;
 using namespace Eigen;
+
+template <typename Types>
+struct TypesGoogleTestWrapper;
+
+template <template<typename...> class TypesT, typename... Args>
+struct TypesGoogleTestWrapper<TypesT<Args...>>
+{
+    typedef ::testing::Types<Args...> type;
+};
 
 // Tolerance values for tests
 template <typename T>
@@ -44,10 +54,7 @@ class LinalgBackendEigenNonIntegerTypesTest : public ::testing::Test
 // Definition of the 4 groups of Shogun types
 // (shogun/mathematics/linalg/LinalgBackendBase.h)
 // TODO: add bool and complex128_t types
-typedef ::testing::Types<
-    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
-    float64_t, floatmax_t, char>
-    AllTypes;
+
 typedef ::testing::Types<
     int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
     float64_t, floatmax_t>
@@ -56,7 +63,7 @@ typedef ::testing::Types<float32_t, float64_t, floatmax_t> RealTypes;
 // TODO: add complex128_t type
 typedef ::testing::Types<float32_t, float64_t, floatmax_t> NonIntegerTypes;
 
-TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, AllTypes);
+TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, TypesGoogleTestWrapper<all_primitive_types>::type);
 TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, NonComplexTypes);
 TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, RealTypes);
 TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, NonIntegerTypes);

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -1,9 +1,8 @@
-#include <gtest/gtest.h>
+#include "sg_gtest_utilities.h"
 
 #include <shogun/base/range.h>
 #include <shogun/lib/config.h>
 #include <shogun/lib/exception/ShogunException.h>
-#include "sg_gtest_utilities.h"
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
 #include <shogun/mathematics/linalg/LinalgSpecialPurposes.h>
@@ -14,12 +13,12 @@ using namespace Eigen;
 
 // Tolerance values for tests
 template <typename T>
-T get_epsilon()
+constexpr T get_epsilon()
 {
 	return std::numeric_limits<T>::epsilon() * 100;
 }
 template <>
-floatmax_t get_epsilon()
+constexpr floatmax_t get_epsilon()
 {
 	return 1e-13;
 }
@@ -40,9 +39,6 @@ template <typename T>
 class LinalgBackendEigenNonIntegerTypesTest : public ::testing::Test
 {
 };
-
-//typedef typename  temp_all_test_types;
-//typedef typename PopTypesGoogleTestWrapper<sg_non_integer_types, complex128_t>::type temp_non_int_test_types;
 
 SG_TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, sg_all_primitive_types, bool, complex128_t);
 SG_TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, sg_non_complex_types);

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -3,7 +3,7 @@
 #include <shogun/base/range.h>
 #include <shogun/lib/config.h>
 #include <shogun/lib/exception/ShogunException.h>
-#include <shogun/lib/sg_types.h>
+#include "sg_gtest_utilities.h"
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
 #include <shogun/mathematics/linalg/LinalgSpecialPurposes.h>
@@ -11,15 +11,6 @@
 using namespace shogun;
 using namespace linalg;
 using namespace Eigen;
-
-template <typename Types>
-struct TypesGoogleTestWrapper;
-
-template <template<typename...> class TypesT, typename... Args>
-struct TypesGoogleTestWrapper<TypesT<Args...>>
-{
-    typedef ::testing::Types<Args...> type;
-};
 
 // Tolerance values for tests
 template <typename T>
@@ -50,10 +41,13 @@ class LinalgBackendEigenNonIntegerTypesTest : public ::testing::Test
 {
 };
 
-TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, TypesGoogleTestWrapper<sg_all_primitive_types>::type);
-TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, TypesGoogleTestWrapper<sg_non_complex_types>::type);
-TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, TypesGoogleTestWrapper<sg_real_types>::type);
-TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, TypesGoogleTestWrapper<sg_non_integer_types>::type);
+//typedef typename  temp_all_test_types;
+//typedef typename PopTypesGoogleTestWrapper<sg_non_integer_types, complex128_t>::type temp_non_int_test_types;
+
+SG_TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, sg_all_primitive_types, bool, complex128_t);
+SG_TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, sg_non_complex_types);
+SG_TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, sg_real_types);
+SG_TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, sg_non_integer_types, complex128_t);
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
 {

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -50,23 +50,10 @@ class LinalgBackendEigenNonIntegerTypesTest : public ::testing::Test
 {
 };
 
-// TODO: make global definitions
-// Definition of the 4 groups of Shogun types
-// (shogun/mathematics/linalg/LinalgBackendBase.h)
-// TODO: add bool and complex128_t types
-
-typedef ::testing::Types<
-    int8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float32_t,
-    float64_t, floatmax_t>
-    NonComplexTypes;
-typedef ::testing::Types<float32_t, float64_t, floatmax_t> RealTypes;
-// TODO: add complex128_t type
-typedef ::testing::Types<float32_t, float64_t, floatmax_t> NonIntegerTypes;
-
-TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, TypesGoogleTestWrapper<all_primitive_types>::type);
-TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, NonComplexTypes);
-TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, RealTypes);
-TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, NonIntegerTypes);
+TYPED_TEST_CASE(LinalgBackendEigenAllTypesTest, TypesGoogleTestWrapper<sg_all_primitive_types>::type);
+TYPED_TEST_CASE(LinalgBackendEigenNonComplexTypesTest, TypesGoogleTestWrapper<sg_non_complex_types>::type);
+TYPED_TEST_CASE(LinalgBackendEigenRealTypesTest, TypesGoogleTestWrapper<sg_real_types>::type);
+TYPED_TEST_CASE(LinalgBackendEigenNonIntegerTypesTest, TypesGoogleTestWrapper<sg_non_integer_types>::type);
 
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGVector_add)
 {

--- a/tests/unit/sg_gtest_utilities.h
+++ b/tests/unit/sg_gtest_utilities.h
@@ -39,8 +39,8 @@ struct PopTypesGoogleTestWrapper<TypesT<Args...>, Args1...>
 };
 
 #define RANDOM_NAME(a, b) RANDOM_NAME_I(a, b)
-#define RANDOM_NAME_I(a, b) RANDOM_NAME_II(~, a##b)
-#define RANDOM_NAME_II(p, res) res
+#define RANDOM_NAME_I(a, b) RANDOM_NAME_II(a##b)
+#define RANDOM_NAME_II(res) res
 
 #define SG_TYPED_TEST_CASE(class_name, types, ...)                             \
 	using RANDOM_NAME(class_name, __LINE__) =                                  \

--- a/tests/unit/sg_gtest_utilities.h
+++ b/tests/unit/sg_gtest_utilities.h
@@ -1,0 +1,50 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_SG_GTEST_UTILITIES_H
+#define SHOGUN_SG_GTEST_UTILITIES_H
+
+#include <gtest/gtest.h>
+#include <shogun/lib/sg_types.h>
+
+template <typename Types>
+struct TypesGoogleTestWrapper;
+
+template <template <typename...> class TypesT, typename... Args>
+struct TypesGoogleTestWrapper<TypesT<Args...>>
+{
+	using type = ::testing::Types<Args...>;
+};
+
+template <typename T1, typename... Args>
+struct PopTypesGoogleTestWrapper
+{
+};
+
+template <template <typename...> class TypesT, typename... Args>
+struct PopTypesGoogleTestWrapper<TypesT<Args...>>
+{
+	using type = typename TypesGoogleTestWrapper<Types<Args...>>::type;
+};
+
+template <
+    template <typename...> class TypesT, typename... Args, typename... Args1>
+struct PopTypesGoogleTestWrapper<TypesT<Args...>, Args1...>
+{
+	using type = typename TypesGoogleTestWrapper<
+	    typename popTypesByTypes<Types<Args...>, Types<Args1...>>::type>::type;
+};
+
+#define RANDOM_NAME(a, b) RANDOM_NAME_I(a, b)
+#define RANDOM_NAME_I(a, b) RANDOM_NAME_II(~, a##b)
+#define RANDOM_NAME_II(p, res) res
+
+#define SG_TYPED_TEST_CASE(class_name, types, ...)                             \
+	using RANDOM_NAME(class_name, __LINE__) =                                  \
+	    typename PopTypesGoogleTestWrapper<types, ##__VA_ARGS__>::type;        \
+	TYPED_TEST_CASE(class_name, RANDOM_NAME(class_name, __LINE__))
+
+#endif // SHOGUN_SG_GTEST_UTILITIES_H


### PR DESCRIPTION
In shogun we redefine types so many it makes sense to start centralising definitions of types. An example is the Google typed tests where we redefine what types to test against. 

I also replaced all the current TYPED_TEST_CASE with a SG_TYPED_TEST_CASE macro that does the conversions from shogun to gtest.