### PR TITLE
GaussianKernel set/get_width should be non-virutal

### DIFF
--- a/src/shogun/kernel/GaussianKernel.cpp
+++ b/src/shogun/kernel/GaussianKernel.cpp
@@ -89,11 +89,6 @@ void CGaussianKernel::set_width(float64_t w)
 	m_log_width = std::log(w / 2.0) / 2.0;
 }
 
-float64_t CGaussianKernel::get_width() const
-{
-	return std::exp(m_log_width * 2.0) * 2.0;
-}
-
 SGMatrix<float64_t> CGaussianKernel::get_parameter_gradient(const TParameter* param, index_t index)
 {
 	REQUIRE(lhs, "Left hand side features must be set!\n")
@@ -135,8 +130,7 @@ void CGaussianKernel::load_serializable_post() throw (ShogunException)
 
 float64_t CGaussianKernel::distance(int32_t idx_a, int32_t idx_b) const
 {
-	const float64_t inv_width=1.0/get_width();
-	return CShiftInvariantKernel::distance(idx_a, idx_b)*inv_width;
+	return CShiftInvariantKernel::distance(idx_a, idx_b)/get_width();
 }
 
 void CGaussianKernel::register_params()

--- a/src/shogun/kernel/GaussianKernel.h
+++ b/src/shogun/kernel/GaussianKernel.h
@@ -1,8 +1,8 @@
 /*
  * This software is distributed under BSD 3-clause license (see LICENSE file).
  *
- * Authors: Jacob Walker, Soeren Sonnenburg, Chiyuan Zhang, Wu Lin, 
- *          Sergey Lisitsyn, Roman Votyakov, Heiko Strathmann, Yuyu Zhang, 
+ * Authors: Jacob Walker, Soeren Sonnenburg, Chiyuan Zhang, Wu Lin,
+ *          Sergey Lisitsyn, Roman Votyakov, Heiko Strathmann, Yuyu Zhang,
  *          Tonmoy Saikia, Soumyajit De, Sanuj Sharma
  */
 
@@ -112,13 +112,16 @@ public:
 	 *
 	 * @param w kernel width
 	 */
-	virtual void set_width(float64_t w);
+	void set_width(float64_t w);
 
 	/** return the kernel's width
 	 *
 	 * @return kernel width
 	 */
-	virtual float64_t get_width() const;
+	SG_FORCED_INLINE float64_t get_width() const
+	{
+		return std::exp(m_log_width * 2.0) * 2.0;
+	}
 
 	/** return derivative with respect to specified parameter
 	 *


### PR DESCRIPTION
as none of the children classes overrides it.

here's the difference in number of operations (top with virtual and none inlined bottom non-virtual inlined) when compiled with O3:
https://pastebin.com/1LvR1338