### PR TITLE
Revert "constexpr version"

### DIFF
--- a/src/shogun/base/Version.cpp
+++ b/src/shogun/base/Version.cpp
@@ -16,17 +16,15 @@ using namespace shogun;
 
 namespace shogun
 {
-// TODO: in C++17 inline all of this in header file and remove it from here
-constexpr int64_t Version::version_revision;
-constexpr int32_t Version::version_year;
-constexpr int32_t Version::version_month;
-constexpr int32_t Version::version_day;
-constexpr int32_t Version::version_hour;
-constexpr int32_t Version::version_minute;
-constexpr int32_t Version::version_parameter;
-constexpr const char Version::version_extra[128];
-constexpr const char Version::version_release[128];
-constexpr const char Version::version_main[32];
+const int64_t Version::version_revision = VERSION_REVISION;
+const int32_t Version::version_year = VERSION_YEAR;
+const int32_t Version::version_month = VERSION_MONTH;
+const int32_t Version::version_day = VERSION_DAY;
+const int32_t Version::version_hour = VERSION_HOUR;
+const int32_t Version::version_minute = VERSION_MINUTE;
+const int32_t Version::version_parameter=VERSION_PARAMETER;
+const char Version::version_extra[128] = VERSION_EXTRA;
+const char Version::version_release[128] = VERSION_RELEASE;
 }
 
 Version::Version()
@@ -42,7 +40,7 @@ Version::~Version()
 
 void Version::print_version()
 {
-	SG_SPRINT("libshogun (%s/%s%" PRId64 ")\n\n", MACHINE, Version::get_version_release(), Version::get_version_revision())
+	SG_SPRINT("libshogun (%s/%s%" PRId64 ")\n\n", MACHINE, VERSION_RELEASE, version_revision)
 	SG_SPRINT("Copyright (C) 1999-2009 Fraunhofer Institute FIRST\n")
 	SG_SPRINT("Copyright (C) 1999-2011 Max Planck Society\n")
 	SG_SPRINT("Copyright (C) 2009-2011 Berlin Institute of Technology\n")
@@ -52,6 +50,56 @@ void Version::print_version()
 	SG_SPRINT("This is free software; see the source for copying conditions.  There is NO\n")
 	SG_SPRINT("warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n")
 #endif
+}
+
+const char* Version::get_version_extra()
+{
+	return version_extra;
+}
+
+const char* Version::get_version_release()
+{
+	return version_release;
+}
+
+int64_t Version::get_version_revision()
+{
+	return version_revision;
+}
+
+int32_t Version::get_version_year()
+{
+	return version_year;
+}
+
+int32_t Version::get_version_month()
+{
+	return version_month;
+}
+
+int32_t Version::get_version_day()
+{
+	return version_day;
+}
+
+int32_t Version::get_version_hour()
+{
+	return version_hour;
+}
+
+int32_t Version::get_version_minute()
+{
+	return version_year;
+}
+
+int32_t Version::get_version_parameter()
+{
+	return version_parameter;
+}
+
+int64_t Version::get_version_in_minutes()
+{
+	return ((((version_year)*12 + version_month)*30 + version_day)* 24 + version_hour)*60 + version_minute;
 }
 
 int32_t Version::ref()

--- a/src/shogun/base/Version.cpp
+++ b/src/shogun/base/Version.cpp
@@ -1,7 +1,7 @@
 /*
  * This software is distributed under BSD 3-clause license (see LICENSE file).
  *
- * Authors: Soeren Sonnenburg, Viktor Gal, Heiko Strathmann, Thoralf Klein, 
+ * Authors: Soeren Sonnenburg, Viktor Gal, Heiko Strathmann, Thoralf Klein,
  *          Evan Shelhamer, Bjoern Esser, Evangelos Anagnostopoulos
  */
 
@@ -23,6 +23,7 @@ const int32_t Version::version_day = VERSION_DAY;
 const int32_t Version::version_hour = VERSION_HOUR;
 const int32_t Version::version_minute = VERSION_MINUTE;
 const int32_t Version::version_parameter=VERSION_PARAMETER;
+const char Version::version_main[32] = MAINVERSION;
 const char Version::version_extra[128] = VERSION_EXTRA;
 const char Version::version_release[128] = VERSION_RELEASE;
 }
@@ -50,6 +51,11 @@ void Version::print_version()
 	SG_SPRINT("This is free software; see the source for copying conditions.  There is NO\n")
 	SG_SPRINT("warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n")
 #endif
+}
+
+const char* Version::get_version_main()
+{
+	return version_main;
 }
 
 const char* Version::get_version_extra()

--- a/src/shogun/base/Version.h
+++ b/src/shogun/base/Version.h
@@ -12,7 +12,6 @@
 #define VERSION_H__
 
 #include <shogun/lib/config.h>
-#include <shogun/lib/versionstring.h>
 
 namespace shogun
 {
@@ -35,60 +34,35 @@ public:
 	/** print version */
 	static void print_version();
 
-	/** get main version */
-    static constexpr const char* get_version_main() {
-        return version_main;
-    }
-
 	/** get version extra */
-	static constexpr const char* get_version_extra() {
-	    return version_extra;
-	}
+	static const char* get_version_extra();
 
 	/** get version release */
-	static constexpr const char* get_version_release() {
-	    return version_release;
-	}
+	static const char* get_version_release();
 
 	/** get version revision */
-    static constexpr int64_t get_version_revision() {
-        return version_revision;
-    }
+	static int64_t get_version_revision();
 
 	/** get version year */
-    static constexpr int32_t get_version_year() {
-        return version_year;
-    }
+	static int32_t get_version_year();
 
 	/** get version month */
-    static constexpr int32_t get_version_month() {
-        return version_month;
-    }
+	static int32_t get_version_month();
 
 	/** get version day */
-    static constexpr int32_t get_version_day() {
-        return version_day;
-    }
+	static int32_t get_version_day();
 
 	/** get version hour */
-    static constexpr int32_t get_version_hour() {
-        return version_hour;
-    }
+	static int32_t get_version_hour();
 
 	/** get version minute */
-    static constexpr int32_t get_version_minute() {
-        return version_minute;
-    }
+	static int32_t get_version_minute();
 
 	/** get parameter serialization version */
-    static constexpr int32_t get_version_parameter() {
-        return version_parameter;
-    }
+	static int32_t get_version_parameter();
 
 	/** get version in minutes */
-    static constexpr int64_t get_version_in_minutes() {
-        return version_minute;
-    }
+	static int64_t get_version_in_minutes();
 
 	/** ref object
 	 * @return ref count
@@ -107,26 +81,24 @@ public:
 
 protected:
 	/** version release */
-	static constexpr char version_release[128] = VERSION_RELEASE;
+	static const char version_release[128];
 	/** version extra */
-	static constexpr char version_extra[128] = VERSION_EXTRA;
+	static const char version_extra[128];
 
 	/** version revision */
-	static constexpr int64_t version_revision = VERSION_REVISION;
+	static const int64_t version_revision;
 	/** version year */
-	static constexpr int32_t version_year = VERSION_YEAR;
+	static const int32_t version_year;
 	/** version month */
-	static constexpr int32_t version_month = VERSION_MONTH;
+	static const int32_t version_month;
 	/** version day */
-	static constexpr int32_t version_day = VERSION_DAY;
+	static const int32_t version_day;
 	/** version hour */
-	static constexpr int32_t version_hour = VERSION_HOUR;
+	static const int32_t version_hour;
 	/** version minute */
-	static constexpr int32_t version_minute = VERSION_MINUTE;
+	static const int32_t version_minute;
 	/** version parameter */
-	static constexpr int32_t version_parameter = VERSION_PARAMETER;
-    /** version main */
-	static constexpr char version_main[32] = MAINVERSION;
+	static const int32_t version_parameter;
 
 private:
 	RefCount* m_refcount;

--- a/src/shogun/base/Version.h
+++ b/src/shogun/base/Version.h
@@ -1,8 +1,8 @@
 /*
  * This software is distributed under BSD 3-clause license (see LICENSE file).
  *
- * Authors: Soeren Sonnenburg, Heiko Strathmann, Yuyu Zhang, Viktor Gal, 
- *          Thoralf Klein, Evan Shelhamer, Sergey Lisitsyn, 
+ * Authors: Soeren Sonnenburg, Heiko Strathmann, Yuyu Zhang, Viktor Gal,
+ *          Thoralf Klein, Evan Shelhamer, Sergey Lisitsyn,
  *          Evangelos Anagnostopoulos
  */
 
@@ -33,6 +33,9 @@ public:
 
 	/** print version */
 	static void print_version();
+
+	/** get main version */
+	static const char* get_version_main();
 
 	/** get version extra */
 	static const char* get_version_extra();
@@ -82,9 +85,10 @@ public:
 protected:
 	/** version release */
 	static const char version_release[128];
+	/** version main */
+	static const char version_main[32];
 	/** version extra */
 	static const char version_extra[128];
-
 	/** version revision */
 	static const int64_t version_revision;
 	/** version year */


### PR DESCRIPTION
This reverts commit 46f7838f3c0815e821a3bd0b8805e152e26e9da7.

due to constexpr after every commit the Version.h will change and thus
the whole ccache is contaminated as Version.h is included in SGObject.h