### PR TITLE
Fix issue with an incorrect data coping in SGVector class #4497

### DIFF
--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -18,9 +18,10 @@
 #include <shogun/util/iterators.h>
 #include <shogun/mathematics/linalg/GPUMemoryBase.h>
 
-#include <memory>
+#include <algorithm>
 #include <atomic>
 #include <initializer_list>
+#include <memory>
 
 namespace Eigen
 {
@@ -129,7 +130,7 @@ template<class T> class SGVector : public SGReferencedData
 		SGVector<X> as() const
 		{
 			SGVector<X> v(vlen);
-			std::copy(v.begin(), v.end(), vector);
+			std::copy_n(vector, vlen, v.begin());
 			return v;
 		}
 #endif // SWIG

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -445,19 +445,26 @@ TEST(SGVectorTest, unique_method)
 
 TEST(SGVectorTest, as)
 {
-	SGVector<float64_t> vec{4, 3, 2.1};
+	std::vector<float64_t> data{4, 3, 2, 1};
+	SGVector<float64_t> vec{data.begin(), data.end()};
 
 	SGVector<float32_t> vec_float = vec.as<float32_t>();
 	ASSERT_NE(vec_float.data(), nullptr);
 	EXPECT_NE((void*)vec_float.data(), (void*)vec.data());
 	ASSERT_EQ(vec_float.size(), vec.size());
 	for (auto i : range(vec.size()))
+	{
 		EXPECT_NEAR((float32_t)vec[i], vec_float[i], 1e-7);
+		EXPECT_NEAR((float32_t)data[i], vec_float[i], 1e-7);
+	}
 
 	SGVector<int32_t> vec_int = vec.as<int32_t>();
 	ASSERT_NE(vec_int.data(), nullptr);
 	EXPECT_NE((void*)vec_int.data(), (void*)vec.data());
 	ASSERT_EQ(vec_int.size(), vec.size());
 	for (auto i : range(vec.size()))
+	{
 		EXPECT_EQ((int32_t)vec[i], vec_int[i]);
+		EXPECT_EQ((int32_t)data[i], vec_int[i]);
+	}
 }


### PR DESCRIPTION
There is an incorrect call of std::copy algorithm in SGVector.h:132 file. The code on specified line clears original data and return wrong result.

To solve this problem the  correct call to coping algorithm is added.
Unit test for SGVector::as function updated to check error case.