### PR TITLE
Check if parameter is sg base

### DIFF
--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -411,6 +411,18 @@ namespace shogun
             }
         }
 
+        bool parameter_is_sg_base(const std::string& name) const {
+            auto params = $self->get_params();
+            if (params.find(name) != params.end()) {
+                if ($self->get(name, std::nothrow) != nullptr)
+                    return true;
+                else
+                    return false;
+            }
+            else
+                SG_SERROR("There is no parameter called '%s' in %s", name.c_str(), $self->get_name());
+        }
+
 #ifdef SWIGPYTHON
         std::string __str__() const
         {

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -1059,7 +1059,8 @@ CSGObject* CSGObject::create_empty() const
 	return object;
 }
 
-CSGObject* CSGObject::get(const std::string& name, std::nothrow_t) const noexcept
+CSGObject* CSGObject::get(const std::string& name, std::nothrow_t) const
+    noexcept
 {
 	if (auto* result = get_sgobject_type_dispatcher<CDistance>(name))
 		return result;
@@ -1075,16 +1076,22 @@ CSGObject* CSGObject::get(const std::string& name, std::nothrow_t) const noexcep
 CSGObject* CSGObject::get(const std::string& name) const noexcept(false)
 {
 	auto* result = get(name, std::nothrow);
-	if (result == nullptr) {
-		if (self->map.find(BaseTag(name)) != self->map.end()) {
+	if (result == nullptr)
+	{
+		if (self->map.find(BaseTag(name)) != self->map.end())
+		{
 			SG_ERROR(
-					"Cannot get parameter %s::%s of type %s as object, not a shogun "
-					"object base type.\n",
-					get_name(), name.c_str(),
-					self->map[BaseTag(name)].get_value().type().c_str());
-		} else {
+			    "Cannot get parameter %s::%s of type %s as object, not a "
+			    "shogun "
+			    "object base type.\n",
+			    get_name(), name.c_str(),
+			    self->map[BaseTag(name)].get_value().type().c_str());
+		}
+		else
+		{
 			SG_ERROR(
-					"There is no parameter '%s' in %s.\n", name.c_str(), get_name());
+			    "There is no parameter '%s' in %s.\n", name.c_str(),
+			    get_name());
 		}
 	}
 	return result;

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -1059,7 +1059,7 @@ CSGObject* CSGObject::create_empty() const
 	return object;
 }
 
-CSGObject* CSGObject::get(const std::string& name)
+CSGObject* CSGObject::get(const std::string& name, std::nothrow_t) const noexcept
 {
 	if (auto* result = get_sgobject_type_dispatcher<CDistance>(name))
 		return result;
@@ -1069,21 +1069,25 @@ CSGObject* CSGObject::get(const std::string& name)
 		return result;
 	if (auto* result = get_sgobject_type_dispatcher<CLabels>(name))
 		return result;
-
-	if (self->map.find(BaseTag(name)) != self->map.end())
-	{
-		SG_ERROR(
-		    "Cannot get parameter %s::%s of type %s as object, not a shogun "
-		    "object base type.\n",
-		    get_name(), name.c_str(),
-		    self->map[BaseTag(name)].get_value().type().c_str());
-	}
-	else
-	{
-		SG_ERROR(
-		    "There is no parameter '%s' in %s.\n", name.c_str(), get_name());
-	}
 	return nullptr;
+}
+
+CSGObject* CSGObject::get(const std::string& name) const noexcept(false)
+{
+	auto* result = get(name, std::nothrow);
+	if (result == nullptr) {
+		if (self->map.find(BaseTag(name)) != self->map.end()) {
+			SG_ERROR(
+					"Cannot get parameter %s::%s of type %s as object, not a shogun "
+					"object base type.\n",
+					get_name(), name.c_str(),
+					self->map[BaseTag(name)].get_value().type().c_str());
+		} else {
+			SG_ERROR(
+					"There is no parameter '%s' in %s.\n", name.c_str(), get_name());
+		}
+	}
+	return result;
 }
 
 void CSGObject::push_back(CDynamicObjectArray* array, CSGObject* value)

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -444,7 +444,8 @@ public:
 	 * @param name name of the parameter
 	 * @return object parameter
 	 */
-	CSGObject* get(const std::string& name);
+	CSGObject* get(const std::string& name, std::nothrow_t) const noexcept;
+	CSGObject* get(const std::string& name) const noexcept(false);
 
 #ifndef SWIG
 	/** Typed setter for an object class parameter of a Shogun base class type,
@@ -588,7 +589,7 @@ public:
 
 protected:
 	template <typename T>
-	CSGObject* get_sgobject_type_dispatcher(const std::string& name)
+	CSGObject* get_sgobject_type_dispatcher(const std::string& name) const
 	{
 		if (has<T*>(name))
 		{

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -440,12 +440,21 @@ public:
 
 	/** Untyped getter for an object class parameter, identified by a name.
 	 * Will attempt to get specified object of appropriate internal type.
+	 * If this is not possible it will raise a ShogunException.
+	 *
+	 * @param name name of the parameter
+	 * @return object parameter
+	 */
+	CSGObject* get(const std::string& name) const noexcept(false);
+
+	/** Untyped getter for an object class parameter, identified by a name.
+	 * Does not throw an error if class parameter object cannot be casted
+	 * to appropriate internal type.
 	 *
 	 * @param name name of the parameter
 	 * @return object parameter
 	 */
 	CSGObject* get(const std::string& name, std::nothrow_t) const noexcept;
-	CSGObject* get(const std::string& name) const noexcept(false);
 
 #ifndef SWIG
 	/** Typed setter for an object class parameter of a Shogun base class type,


### PR DESCRIPTION
Added a no throw overload of SGObject::get(const std::string&) to use in swig. Catching errors in C++ code in swig can cause issues because of the error printing.
The interface method is needed for openml to check if a model parameter is an sgobject, i.e. CKernel or CDistance, and if so it needs to be serialised properly.