### PR TITLE
Cleanup broken links and fix some issues on Shogun's webpages.

### DIFF
--- a/doc/cookbook/source/references.bib
+++ b/doc/cookbook/source/references.bib
@@ -35,9 +35,8 @@
 @book{Rasmussen2005GPM,
   author = {Rasmussen, C. E. and Williams, C. K. I.},
   title = {Gaussian Processes for Machine Learning},
-  year = {2005},
   publisher = {The MIT Press},
-  year={2008},
+  year={2006},
 }
 
 @article{gretton2012kernel,

--- a/doc/cookbook/source/static/mathconf.js
+++ b/doc/cookbook/source/static/mathconf.js
@@ -1,0 +1,8 @@
+MathJax.Hub.Config({
+  TeX: {
+    Macros: {
+      argmax: ["\\mathop{\\rm arg\\,max}\\limits"],
+      argmin: ["\\mathop{\\rm arg\\,min}\\limits"]
+    }
+  }
+});

--- a/doc/cookbook/source/static/mathconf.js
+++ b/doc/cookbook/source/static/mathconf.js
@@ -1,8 +1,0 @@
-MathJax.Hub.Config({
-  TeX: {
-    Macros: {
-      argmax: ["\\mathop{\\rm arg\\,max}\\limits"],
-      argmin: ["\\mathop{\\rm arg\\,min}\\limits"]
-    }
-  }
-});

--- a/doc/cookbook/source/static/mathconf.js
+++ b/doc/cookbook/source/static/mathconf.js
@@ -1,8 +1,8 @@
-MathJax.Hub.Config({
+window.MathJax = {
   TeX: {
     Macros: {
       argmax: ["\\mathop{\\rm arg\\,max}\\limits"],
       argmin: ["\\mathop{\\rm arg\\,min}\\limits"]
     }
   }
-});
+};

--- a/doc/cookbook/source/static/shogun-style.css
+++ b/doc/cookbook/source/static/shogun-style.css
@@ -57,3 +57,8 @@ div.toctree-wrapper > p.caption {
     font-weight: 300;
     margin-bottom: 0.5em;
 }
+
+.citation td.label {
+    display: block;
+}
+

--- a/doc/cookbook/source/templates/layout.html
+++ b/doc/cookbook/source/templates/layout.html
@@ -1,10 +1,5 @@
 {% extends "!layout.html" %}
 
-{% set bootswatch_css_custom = ['_static/shogun-style.css'] %}
-{#
-    bootswatch_css_custom is removed in sphinx-bootstrap-theme v0.5.0
-    css_files should be used instead
-#}
 {% set css_files = (css_files or []) + ['_static/shogun-style.css'] %}
 
 {% block rootrellink %}

--- a/doc/cookbook/source/templates/layout.html
+++ b/doc/cookbook/source/templates/layout.html
@@ -1,5 +1,4 @@
 {% extends "!layout.html" %}
-{% set script_files = script_files + ["_static/mathconf.js"] %}
 
 {% set bootswatch_css_custom = ['_static/shogun-style.css'] %}
 {#

--- a/doc/cookbook/source/templates/layout.html
+++ b/doc/cookbook/source/templates/layout.html
@@ -1,4 +1,5 @@
 {% extends "!layout.html" %}
+{% set script_files = script_files + ["_static/mathconf.js"] %}
 
 {% set css_files = (css_files or []) + ['_static/shogun-style.css'] %}
 

--- a/doc/cookbook/source/templates/page.html
+++ b/doc/cookbook/source/templates/page.html
@@ -23,6 +23,17 @@ jQuery(document).ready(function ($) {
 });
 </script>
 
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    TeX: {
+      Macros: {
+        argmax: ["\\mathop{\\rm arg\\,max}\\limits"],
+        argmin: ["\\mathop{\\rm arg\\,min}\\limits"]
+      }
+    }
+  });
+</script>
+
 {% else %}
 {{ body }}
 {% endif %}

--- a/doc/cookbook/source/templates/page.html
+++ b/doc/cookbook/source/templates/page.html
@@ -23,17 +23,6 @@ jQuery(document).ready(function ($) {
 });
 </script>
 
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    TeX: {
-      Macros: {
-        argmax: ["\\mathop{\\rm arg\\,max}\\limits"],
-        argmin: ["\\mathop{\\rm arg\\,min}\\limits"]
-      }
-    }
-  });
-</script>
-
 {% else %}
 {{ body }}
 {% endif %}

--- a/doc/readme/INSTALL.md
+++ b/doc/readme/INSTALL.md
@@ -142,7 +142,7 @@ You need at least 1GB free disk space. If you compile any interface, roughly 4 G
 
 ## Basics <a name="manual-basics"></a>
 Shogun uses [CMake](https://cmake.org/) for its build. The general workflow is now explained.
-For further details on testing etc, see [DEVELOPING.md](https://github.com/shogun-toolbox/shogun/blob/develop/doc/readme/DEVELOPING.md).
+For further details on testing etc, see [DEVELOPING.md](docs/DEVELOPING.md).
 
 Download the latest [stable release source code](https://github.com/shogun-toolbox/shogun/releases/latest), or (as demonstrated here) clone the latest develop code.
 Potentially update submodules

--- a/doc/readme/INSTALL.md
+++ b/doc/readme/INSTALL.md
@@ -82,17 +82,17 @@ Install as
 
 
 ### MacOS <a name="mac"></a>
-Shogun is part of [homebrew-science](https://github.com/Homebrew/homebrew-science).
+Shogun is part of [Homebrew](https://formulae.brew.sh/formula/shogun).
 Install the latest stable version as
 
-    brew install homebrew/science/shogun
+    brew install shogun
 
 ### Windows <a name="windows"></a>
 Shogun natively compiles under Windows using MSVC, see the [AppVeyor CI build](https://ci.appveyor.com/project/vigsterkr/shogun) and the [Windows section](#manual-windows). We currently only support binary packages via conda.
 If you are interested in packaging, documenting, or contributing otherwise, please contact us.
 
 ## Docker images <a name="docker"></a>
-You can run Shogun in [our own cloud](cloud.shogun.ml) or set up your own using our
+You can set up Shogun using our
 [Docker images](https://hub.docker.com/r/shogun/shogun/) as:
 
     sudo docker pull shogun/shogun:master
@@ -142,7 +142,7 @@ You need at least 1GB free disk space. If you compile any interface, roughly 4 G
 
 ## Basics <a name="manual-basics"></a>
 Shogun uses [CMake](https://cmake.org/) for its build. The general workflow is now explained.
-For further details on testing etc, see [DEVELOPING.md](DEVELOPING.md).
+For further details on testing etc, see [DEVELOPING.md](https://github.com/shogun-toolbox/shogun/blob/develop/doc/readme/DEVELOPING.md).
 
 Download the latest [stable release source code](https://github.com/shogun-toolbox/shogun/releases/latest), or (as demonstrated here) clone the latest develop code.
 Potentially update submodules

--- a/doc/readme/INTERFACES.md
+++ b/doc/readme/INTERFACES.md
@@ -1,7 +1,7 @@
 Running Shogun from the interfaces
 ==================================
 
-We assume that installation (including the interfaces) was successful and all dependencies are installed. See [INSTALL.md](INSTALL.md) and our website.
+We assume that installation (including the interfaces) was successful and all dependencies are installed. See [our installation page][installation-page].
 
 Note that setting some of the environmental variables should not be necessary in case you installed Shogun to the default folder or installed it from a binary package.
 
@@ -111,7 +111,7 @@ Running it again requires the above class path and some more options
     java -Xmx1024m -cp /path/to/jblas.jar:/path/to/shogun.jar:path/to/java_example.java -Djava.library.path=/path/to/shogun.jar java_example
 
 ### Provided Examples
-Stand-alone, executable code for all interface examples on our website (and more) can be generated locally, see [INSTALL.md](INSTALL.md).
+Stand-alone, executable code for all interface examples on our website (and more) can be generated locally, [see our installation page][installation-page].
 As the examples load data files, they requires the `shogun-data` submodule to be checked out.
 
 All examples should be run in the respective folder they are located in, for example (assuming that all described variables are set)
@@ -123,3 +123,5 @@ Or, for a compiled language with a manually compiled, not yet installed Shogun, 
 
     cd /path/to/shogun-source/build/examples/meta/csharp/regression/
     mono linear_ridge_regression.cs
+
+[installation-page]: http://shogun.ml/install

--- a/doc/readme/INTERFACES.md
+++ b/doc/readme/INTERFACES.md
@@ -1,7 +1,7 @@
 Running Shogun from the interfaces
 ==================================
 
-We assume that installation (including the interfaces) was successful and all dependencies are installed. See [our installation page][installation-page].
+We assume that installation (including the interfaces) was successful and all dependencies are installed. See [INSTALL.md][installation-page].
 
 Note that setting some of the environmental variables should not be necessary in case you installed Shogun to the default folder or installed it from a binary package.
 
@@ -111,7 +111,7 @@ Running it again requires the above class path and some more options
     java -Xmx1024m -cp /path/to/jblas.jar:/path/to/shogun.jar:path/to/java_example.java -Djava.library.path=/path/to/shogun.jar java_example
 
 ### Provided Examples
-Stand-alone, executable code for all interface examples on our website (and more) can be generated locally, [see our installation page][installation-page].
+Stand-alone, executable code for all interface examples on our website (and more) can be generated locally, [see INSTALL.md][installation-page].
 As the examples load data files, they requires the `shogun-data` submodule to be checked out.
 
 All examples should be run in the respective folder they are located in, for example (assuming that all described variables are set)
@@ -124,4 +124,4 @@ Or, for a compiled language with a manually compiled, not yet installed Shogun, 
     cd /path/to/shogun-source/build/examples/meta/csharp/regression/
     mono linear_ridge_regression.cs
 
-[installation-page]: http://shogun.ml/install
+[installation-page]: docs/INSTALL.md

--- a/doc/readme/MISSION.md
+++ b/doc/readme/MISSION.md
@@ -68,6 +68,6 @@ The original focus was on large-scale kernel methods and bioinformatics.
 Since then, Shogun has continuously been used for scientific research (a list of papers citing Shogun can be found [here](http://scholar.google.com/scholar?hl=en&q=shogun+toolbox&btnG=&as_sdt=1%2C33&as_sdtp=)) and massively expanded.
 Shogun joined [NumFocus](https://www.numfocus.org/) in early 2017.
 
-Currently, Shogun is developed by a diverse team of students, scientists and professionals, see the [website](http://shogun-toolbox.org/page/about/ourteam) and Shogun's [AUTHORS](https://github.com/shogun-toolbox/shogun/wiki/AUTHORS). 
+Currently, Shogun is developed by a diverse team of students, scientists and professionals, see Shogun's [AUTHORS](https://github.com/shogun-toolbox/shogun/wiki/AUTHORS). 
 None of their work would have been possible without the patches and bug reports by various contributors. 
 


### PR DESCRIPTION
These commits address issues reported in #4512.

Apart from updating links, one notable change is the style of the reference section in the example pages. Please see the effect below.
<img width="749" alt="image" src="https://user-images.githubusercontent.com/1214890/52415413-30707880-2ae7-11e9-897b-cf7d9a8dc7e4.png">

