### PR TITLE
Initialise parameters at runtime 

### DIFF
--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -179,12 +179,17 @@ namespace shogun
 			m_value = value;
 		}
 
-		AnyParameterProperties get_properties() const
+		AnyParameterProperties& get_properties()
 		{
 			return m_properties;
 		}
 
-		std::function<Any()> get_init_function() const
+        const AnyParameterProperties& get_properties() const
+        {
+            return m_properties;
+        }
+
+		const std::function<Any()>& get_init_function() const
 		{
 			return m_init_function;
 		}

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -53,8 +53,8 @@ namespace shogun
 		 */
 		AnyParameterProperties()
 		    : m_description("No description given"),
-			  m_model_selection(MS_NOT_AVAILABLE),
-			  m_gradient(GRADIENT_NOT_AVAILABLE),
+		      m_model_selection(MS_NOT_AVAILABLE),
+		      m_gradient(GRADIENT_NOT_AVAILABLE),
 		      m_attribute_mask(ParameterProperties::NONE)
 		{
 		}
@@ -129,6 +129,10 @@ namespace shogun
 		{
 			return m_attribute_mask == other;
 		}
+		void remove_property(ParameterProperties other)
+		{
+			m_attribute_mask &= ~other;
+		}
 
 	private:
 		std::string m_description;
@@ -145,16 +149,24 @@ namespace shogun
 		}
 		explicit AnyParameter(const Any& value) : m_value(value), m_properties()
 		{
+			m_init_function = [& m_value = m_value]() { return m_value; };
 		}
 		AnyParameter(const Any& value, AnyParameterProperties properties)
 		    : m_value(value), m_properties(properties)
 		{
-			m_init_function = [](){return make_any(42.);};
+			m_init_function = [& m_value = m_value]() { return m_value; };
+		}
+		AnyParameter(
+		    const Any& value, AnyParameterProperties properties,
+		    std::function<Any()> lambda_)
+		    : m_value(value), m_properties(properties),
+		      m_init_function(std::move(lambda_))
+		{
 		}
 		AnyParameter(const AnyParameter& other)
-		    : m_value(other.m_value), m_properties(other.m_properties)
+		    : m_value(other.m_value), m_properties(other.m_properties),
+		      m_init_function(other.m_init_function)
 		{
-			m_init_function = [](){return make_any(42.);};
 		}
 
 		Any get_value() const
@@ -192,8 +204,8 @@ namespace shogun
 
 	private:
 		Any m_value;
-		std::function<Any()> m_init_function;
 		AnyParameterProperties m_properties;
+		std::function<Any()> m_init_function;
 	};
 } // namespace shogun
 

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -35,7 +35,8 @@ namespace shogun
 		NONE = 0,
 		HYPER = 1u << 0,
 		GRADIENT = 1u << 1,
-		MODEL = 1u << 2
+		MODEL = 1u << 2,
+		AUTO = 1u << 10
 	};
 
 	enableEnumClassBitmask(ParameterProperties);
@@ -88,9 +89,8 @@ namespace shogun
 		 * */
 		AnyParameterProperties(
 		    std::string description, ParameterProperties attribute_mask)
-		    : m_description(description)
+		    : m_description(description), m_attribute_mask(attribute_mask)
 		{
-			m_attribute_mask = attribute_mask;
 		}
 		/** Copy contructor */
 		AnyParameterProperties(const AnyParameterProperties& other)
@@ -149,10 +149,12 @@ namespace shogun
 		AnyParameter(const Any& value, AnyParameterProperties properties)
 		    : m_value(value), m_properties(properties)
 		{
+			m_init_function = [](){return make_any(42.);};
 		}
 		AnyParameter(const AnyParameter& other)
 		    : m_value(other.m_value), m_properties(other.m_properties)
 		{
+			m_init_function = [](){return make_any(42.);};
 		}
 
 		Any get_value() const
@@ -170,6 +172,11 @@ namespace shogun
 			return m_properties;
 		}
 
+		std::function<Any()> get_init_function() const
+		{
+			return m_init_function;
+		}
+
 		/** Equality operator which compares value but not properties.
 		 * @return true if value of other parameter equals own */
 		inline bool operator==(const AnyParameter& other) const
@@ -185,6 +192,7 @@ namespace shogun
 
 	private:
 		Any m_value;
+		std::function<Any()> m_init_function;
 		AnyParameterProperties m_properties;
 	};
 } // namespace shogun

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -90,6 +90,18 @@ namespace shogun
 			return map.find(tag) != map.end();
 		}
 
+		ParametersMap filter(ParameterProperties pprop) const
+		{
+			ParametersMap result;
+			std::copy_if(map.cbegin(), map.cend(),
+					std::inserter(result, result.end()),
+					[&pprop](const std::pair<BaseTag, AnyParameter>& each)
+					{
+						return each.second.get_properties().has_property(pprop);
+					});
+			return result;
+		}
+
 		ParametersMap map;
 	};
 
@@ -1057,6 +1069,14 @@ CSGObject* CSGObject::create_empty() const
 	CSGObject* object = create(this->get_name(), this->m_generic);
 	SG_REF(object);
 	return object;
+}
+
+void CSGObject::initialise_auto_params()
+{
+	auto params = self->filter(ParameterProperties::AUTO);
+	for (const auto& param: params) {
+        self->update(param.first, param.second.get_init_function()());
+	}
 }
 
 CSGObject* CSGObject::get(const std::string& name)

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -738,6 +738,7 @@ void CSGObject::create_parameter(
 void CSGObject::update_parameter(const BaseTag& _tag, const Any& value)
 {
 	self->update(_tag, value);
+	self->map[_tag].get_properties().remove_property(ParameterProperties::AUTO);
 }
 
 AnyParameter CSGObject::get_parameter(const BaseTag& _tag) const
@@ -1075,8 +1076,7 @@ void CSGObject::initialise_auto_params()
 {
 	auto params = self->filter(ParameterProperties::AUTO);
 	for (const auto& param: params) {
-        self->update(param.first, param.second.get_init_function()());
-		param.second.get_properties().remove_property(ParameterProperties::AUTO);
+        update_parameter(param.first, param.second.get_init_function()());
 	}
 }
 

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -1076,6 +1076,7 @@ void CSGObject::initialise_auto_params()
 	auto params = self->filter(ParameterProperties::AUTO);
 	for (const auto& param: params) {
         self->update(param.first, param.second.get_init_function()());
+		param.second.get_properties().remove_property(ParameterProperties::AUTO);
 	}
 }
 

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -777,6 +777,8 @@ protected:
 	 */
 	virtual CSGObject* create_empty() const;
 
+	void initialise_auto_params();
+
 private:
 	void set_global_objects();
 	void unset_global_objects();

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -66,13 +66,13 @@ template <class T> class SGStringList;
 #define VA_NARGS(...)  INTERNAL_EXPAND_ARGS_PRIVATE(INTERNAL_ARGS_AUGMENTER(__VA_ARGS__))
 #define INTERNAL_ARGS_AUGMENTER(...) unused, __VA_ARGS__
 #define INTERNAL_EXPAND(x) x
-#define INTERNAL_EXPAND_ARGS_PRIVATE(...) INTERNAL_EXPAND(INTERNAL_GET_ARG_COUNT_PRIVATE(__VA_ARGS__, 4, 3, 2, 1, 0))
-#define INTERNAL_GET_ARG_COUNT_PRIVATE(_0_, _1_, _2_, _3_, _4_, count, ...) count
+#define INTERNAL_EXPAND_ARGS_PRIVATE(...) INTERNAL_EXPAND(INTERNAL_GET_ARG_COUNT_PRIVATE(__VA_ARGS__, 5, 4, 3, 2, 1, 0))
+#define INTERNAL_GET_ARG_COUNT_PRIVATE(_0_, _1_, _2_, _3_, _4_, _5_, count, ...) count
 
 #else
 
-#define VA_NARGS_IMPL(_1, _2, _3, _4, N, ...) N
-#define VA_NARGS(...) VA_NARGS_IMPL(__VA_ARGS__, 4, 3, 2, 1)
+#define VA_NARGS_IMPL(_1, _2, _3, _4, _5, N, ...) N
+#define VA_NARGS(...) VA_NARGS_IMPL(__VA_ARGS__, 5, 4, 3, 2, 1)
 
 #endif
 
@@ -88,10 +88,28 @@ template <class T> class SGStringList;
 
 #define SG_ADD4(param, name, description, param_properties)                    \
 	{                                                                          \
+        static_assert(\
+            !static_cast<bool>((param_properties) & ParameterProperties::AUTO), \
+            "Expected a lambda when passing param with ParameterProperty::AUTO");\
 		AnyParameterProperties pprop =                                         \
 		    AnyParameterProperties(description, param_properties);             \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(name, param, pprop);                                 \
+		if (pprop.get_model_selection())                                       \
+			this->m_model_selection_parameters->add(param, name, description); \
+		if (pprop.get_gradient())                                              \
+			this->m_gradient_parameters->add(param, name, description);        \
+	}
+
+#define SG_ADD5(param, name, description, param_properties, lambda_)           \
+	{                                                                          \
+        static_assert(\
+            static_cast<bool>((param_properties) & ParameterProperties::AUTO), \
+            "Expected param to have ParameterProperty::AUTO");\
+		AnyParameterProperties pprop =                                         \
+		    AnyParameterProperties(description, param_properties);             \
+		this->m_parameters->add(param, name, description);                     \
+		this->watch_param(name, param, lambda_, pprop);                                 \
 		if (pprop.get_model_selection())                                       \
 			this->m_model_selection_parameters->add(param, name, description); \
 		if (pprop.get_gradient())                                              \
@@ -678,6 +696,16 @@ protected:
 	{
 		BaseTag tag(name);
 		create_parameter(tag, AnyParameter(make_any_ref(value), properties));
+	}
+
+	template <typename T>
+	void watch_param(
+			const std::string& name, T* value,
+            std::function<Any()> lambda_,
+			AnyParameterProperties properties = AnyParameterProperties())
+	{
+		BaseTag tag(name);
+		create_parameter(tag, AnyParameter(make_any_ref(value), properties, std::move(lambda_)));
 	}
 
 	/** Puts a pointer to some parameter array into the parameter map.

--- a/src/shogun/kernel/PolyKernel.cpp
+++ b/src/shogun/kernel/PolyKernel.cpp
@@ -73,6 +73,8 @@ void CPolyKernel::init()
 	set_normalizer(new CSqrtDiagKernelNormalizer());
 	SG_ADD(&degree, "degree", "Degree of polynomial kernel", ParameterProperties::HYPER);
 	SG_ADD(&m_c, "c", "The kernel is inhomogeneous if the value is higher than 0", ParameterProperties::HYPER);
-	SG_ADD(&m_gamma, "gamma", "Scaler for the dot product", ParameterProperties::HYPER);
+	SG_ADD(&m_gamma, "gamma", "Scaler for the dot product", ParameterProperties::HYPER | ParameterProperties::AUTO);
+
+	initialise_auto_params();
 }
 

--- a/src/shogun/lib/bitmask_operators.h
+++ b/src/shogun/lib/bitmask_operators.h
@@ -52,7 +52,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-    operator|(E lhs, E rhs) {
+    constexpr operator|(E lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         return static_cast<E>(
                 static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
@@ -60,7 +60,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-    operator&(E lhs, E rhs) {
+    constexpr operator&(E lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         return static_cast<E>(
                 static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
@@ -68,7 +68,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-    operator^(E lhs, E rhs) {
+    constexpr operator^(E lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         return static_cast<E>(
                 static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs));
@@ -76,7 +76,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-    operator~(E lhs) {
+    constexpr operator~(E lhs) {
         typedef typename std::underlying_type<E>::type underlying;
         return static_cast<E>(
                 ~static_cast<underlying>(lhs));
@@ -84,7 +84,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E &>::type
-    operator|=(E &lhs, E rhs) {
+    constexpr operator|=(E &lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         lhs = static_cast<E>(
                 static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
@@ -93,7 +93,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E &>::type
-    operator&=(E &lhs, E rhs) {
+    constexpr operator&=(E &lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         lhs = static_cast<E>(
                 static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
@@ -102,7 +102,7 @@ namespace shogun {
 
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, E &>::type
-    operator^=(E &lhs, E rhs) {
+    constexpr operator^=(E &lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         lhs = static_cast<E>(
                 static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs));
@@ -110,7 +110,7 @@ namespace shogun {
     }
     template<typename E>
     typename std::enable_if<enable_bitmask_operators<E>::enable, bool>::type
-    operator==(E lhs, E rhs) {
+    constexpr operator==(E lhs, E rhs) {
         typedef typename std::underlying_type<E>::type underlying;
         return static_cast<underlying>(lhs) == static_cast<underlying>(rhs);
     }

--- a/src/shogun/machine/IterativeMachine.h
+++ b/src/shogun/machine/IterativeMachine.h
@@ -41,11 +41,9 @@ namespace shogun
 			    &m_max_iterations, "max_iterations",
 			    "Maximum number of Iterations", ParameterProperties::HYPER);
 			SG_ADD(
-			    &m_complete, "complete", "Convergence status",
-			    MS_NOT_AVAILABLE);
+			    &m_complete, "complete", "Convergence status");
 			SG_ADD(
-			    &m_continue_features, "continue_features", "Continue Features",
-			    MS_NOT_AVAILABLE);
+			    &m_continue_features, "continue_features", "Continue Features");
 		}
 		virtual ~CIterativeMachine()
 		{


### PR DESCRIPTION
This PR enables initialising parameters at runtime with a lambda. This needs some rework, but shows how it could be done. This could be used to initialise the gamma parameter in PolyKernel depending on the number of features, i.e. gamma = 1/num_features. I think this is what you wanted @vigsterkr?

I also messed with the constness of some getters to make this work which might not be ideal.