### PR TITLE
MKL fixes

### DIFF
--- a/src/shogun/converter/ica/SOBI.cpp
+++ b/src/shogun/converter/ica/SOBI.cpp
@@ -66,8 +66,11 @@ void CSOBI::fit_dense(CDenseFeatures<float64_t>* features)
 	MatrixXd M0 = cor(EX,int(m_tau[0]));
 	EigenSolver<MatrixXd> eig;
 	eig.compute(M0);
-	MatrixXd SPH = (eig.pseudoEigenvectors() * eig.pseudoEigenvalueMatrix().cwiseSqrt() * eig.pseudoEigenvectors ().transpose()).inverse();
-	MatrixXd spx = SPH*EX;
+	MatrixXd EVMsqrt = eig.pseudoEigenvalueMatrix().cwiseSqrt();
+	MatrixXd SPH = (eig.pseudoEigenvectors() * EVMsqrt *
+	                eig.pseudoEigenvectors().transpose())
+	                   .inverse();
+	MatrixXd spx = SPH * EX;
 
 	// Compute Correlation Matrices
 	index_t * M_dims = SG_MALLOC(index_t, 3);

--- a/src/shogun/machine/gp/LogitVGPiecewiseBoundLikelihood.cpp
+++ b/src/shogun/machine/gp/LogitVGPiecewiseBoundLikelihood.cpp
@@ -502,11 +502,12 @@ void CLogitVGPiecewiseBoundLikelihood::precompute()
 
 	float64_t h_bak = eigen_h(eigen_h.size()-1);
 	eigen_h(eigen_h.size()-1) = 0;
-
 	//bsxfun(@plus, l.^2, v)
-	eigen_l2_plus_s2 = (eigen_s2.replicate(1,eigen_l.rows()).array().transpose().colwise() + eigen_l.array().pow(2)).matrix();
+	VectorXd epl_pow = eigen_l.array().pow(2);
+	VectorXd eph_pow = eigen_h.array().pow(2);
+	eigen_l2_plus_s2 = (eigen_s2.replicate(1,eigen_l.rows()).array().transpose().colwise() + epl_pow.array()).matrix();
 	//bsxfun(@plus, h.^2, v)
-	eigen_h2_plus_s2 = (eigen_s2.replicate(1,eigen_h.rows()).array().transpose().colwise() + eigen_h.array().pow(2)).matrix();
+	eigen_h2_plus_s2 = (eigen_s2.replicate(1,eigen_h.rows()).array().transpose().colwise() + eph_pow.array()).matrix();
 	//pl.*l - ph.*h
 	eigen_weighted_pdf_diff = (eigen_pl.array().colwise() * eigen_l.array() - eigen_ph.array().colwise() * eigen_h.array()).matrix();
 


### PR DESCRIPTION
I am not sure what causes this issue, but somehow separating evaluation of unary functions from the main expression fixes the issue.

I did some debugging and it seems like for example the square root operation of a matrix (`.cwiseSqrt()`) makes its rows and cols attributes be 0, which then causes an assertion error when this matrix is used in another operation.

This only happens with MKL backend and is first reported in #3992