### PR TITLE
Add string lists to integration testing

### DIFF
--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -76,7 +76,8 @@ def getBasicTypesToStore():
 
 def getSGTypesToStore():
     """ Returns all SG* types which will be serialized """
-    return ("RealVector","RealMatrix","FloatVector","FloatMatrix")
+    return ("RealVector","RealMatrix","FloatVector","FloatMatrix",
+            "StringCharList")
 
 def getSGTypeToStoreMethodName(sgType):
     """ Translates given SG* type into meta language type """
@@ -90,6 +91,8 @@ def getSGTypeToStoreMethodName(sgType):
         return "real_matrix"
     elif sgType=="FloatMatrix":
         return "float_matrix"
+    elif sgType=="StringCharList":
+        return "string_char_list"
 
     else:
         raise RuntimeError("Given Shogun type \"%s\" cannot be translated to meta type", sgType)

--- a/src/interfaces/csharp/swig_typemaps.i
+++ b/src/interfaces/csharp/swig_typemaps.i
@@ -319,8 +319,11 @@ TYPEMAP_STRINGFEATURES(float64_t, double, double)
 	sprintf(res[0], "%d", size);
 
 	for (i = 0; i < size; i++) {
-		res[i + 1] = SG_MALLOC(char, str[i].slen);
+		res[i + 1] = SG_MALLOC(char, str[i].slen + 1);
 		sg_memcpy(res[i + 1], str[i].string, str[i].slen * sizeof(char));
+		
+		// null terminate string as C#'s Marshal.PtrToStringAnsi expects that
+		res[i+1][str[i].slen] = '\0';
 	}
 	$result = res;
 }

--- a/src/interfaces/swig/Library.i
+++ b/src/interfaces/swig/Library.i
@@ -403,6 +403,12 @@ namespace shogun
     {
         $self->append_element(v, name);
     }
+
+    template <typename T, typename X = typename std::enable_if_t<std::is_same<SGStringList<typename extract_value_type<T>::value_type>, T>::value>>
+    void append_element_string_list(T v, const char* name="")
+    {
+        $self->append_element(v, name);
+    }
 }
 
     /* Specialize DynamicObjectArray::append_element function */
@@ -430,6 +436,7 @@ namespace shogun
 #ifdef USE_INT32
     %template(append_element_int) CDynamicObjectArray::append_element<int32_t, int32_t>;
 #endif
+	%template(append_element_string_char_list) CDynamicObjectArray::append_element_string_list<SGStringList<char>, SGStringList<char>>;
 }
 %include <shogun/lib/IndexBlock.h>
 %include <shogun/lib/IndexBlockRelation.h>

--- a/src/shogun/io/Serializable.h
+++ b/src/shogun/io/Serializable.h
@@ -36,6 +36,7 @@
 #define SHOGUN_SERIALIZABLE_H__
 
 #include <shogun/base/SGObject.h>
+#include <shogun/lib/SGStringList.h>
 
 namespace shogun
 {
@@ -55,8 +56,8 @@ struct extract_value_type<X<T, Args...>>
 #endif
 
 /** @brief A trait that makes a none SGObject SG-serializable
- * This only works with classes derived of SGReferencedData (SGVector, SGMatrix etc)
- * and fundamental types (std::is_arithmetic)
+ * This only works with classes derived of SGReferencedData (SGVector, SGMatrix,
+ * SGStringList, etc) and fundamental types.
  */
 template<class T> class CSerializable: public CSGObject
 {
@@ -123,6 +124,33 @@ public:
 
 	/** @return name of the CSGObject, without C prefix */
 	virtual const char* get_name() const { return "MatrixSerializable"; }
+};
+
+// FIXME: there is no SG_ADD for SGStringList so need to do that manually.
+// can be dropped once SG_ADD works with SGStringList
+// Note: cannot inherit from CSerializable as need to overload/change init()
+template<class T> class CStringListSerializable: public CSGObject
+{
+public:
+	CStringListSerializable() : CSGObject() { init(); }
+	CStringListSerializable(SGStringList<T> value, const char* value_name="") : CSGObject()
+	{
+		init();
+		m_value = value;
+	}
+	virtual ~CStringListSerializable() {}
+	virtual const char* get_name() const { return "StringListSerializable"; }
+
+protected:
+	virtual void init()
+	{
+		set_generic<T>();
+		m_value = SGStringList<T>();
+		m_parameters->add_vector(&m_value.strings, &m_value.num_strings, "value",
+				"Serialized value");
+	}
+
+	SGStringList<T> m_value;
 };
 };
 #endif // SHOGUN_SERIALIZABLE_H_

--- a/src/shogun/lib/DynamicObjectArray.h
+++ b/src/shogun/lib/DynamicObjectArray.h
@@ -298,6 +298,13 @@ class CDynamicObjectArray : public CSGObject
 			return append_element(serialized_element);
 		}
 
+		template <typename T>
+		inline bool append_element(SGStringList<T> e, const char* name="")
+		{
+			auto serialized_element = new CStringListSerializable<T>(e, name);
+			return append_element(serialized_element);
+		}
+
 		/** append array element to the end of array
 		 *
 		 * @param e element to append


### PR DESCRIPTION
Implicitly tests all in/out typemaps for string lists via the string_char meta example