### PR TITLE
Use MKL in windows build

### DIFF
--- a/.ci/windows-steps.yml
+++ b/.ci/windows-steps.yml
@@ -39,7 +39,7 @@ steps:
 - task: CMake@1
   displayName: Setup
   inputs:
-    cmakeArgs: '-G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_PREFIX_PATH=$(CONDA_PREFIX)\Library -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=$(targetPrefix) $(cmakeOptions) -DBLAS_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_core_dll.lib -DLAPACK_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_core_dll.lib -DBLA_VENDOR=Intel ..'
+    cmakeArgs: '-G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_PREFIX_PATH=$(CONDA_PREFIX)\Library -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=$(targetPrefix) $(cmakeOptions) -DBLAS_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_rt.dll -DLAPACK_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_rt.dll -DBLA_VENDOR=Intel ..'
 
 - script: cmake --build . --config $(buildConfiguration) --target INSTALL -- /p:TrackFileAccess=false /p:CLToolExe=clcache.exe /m:2
   displayName: 'Build ($(buildConfiguration) $(buildPlatform))'

--- a/.ci/windows-steps.yml
+++ b/.ci/windows-steps.yml
@@ -39,7 +39,7 @@ steps:
 - task: CMake@1
   displayName: Setup
   inputs:
-    cmakeArgs: '-G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_PREFIX_PATH=$(CONDA_PREFIX)\Library -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=$(targetPrefix) $(cmakeOptions) ..'
+    cmakeArgs: '-G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_PREFIX_PATH=$(CONDA_PREFIX)\Library -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=$(targetPrefix) $(cmakeOptions) -DBLAS_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_core_dll.lib -DLAPACK_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_core_dll.lib -DBLA_VENDOR=Intel ..'
 
 - script: cmake --build . --config $(buildConfiguration) --target INSTALL -- /p:TrackFileAccess=false /p:CLToolExe=clcache.exe /m:2
   displayName: 'Build ($(buildConfiguration) $(buildPlatform))'

--- a/.ci/windows-steps.yml
+++ b/.ci/windows-steps.yml
@@ -39,7 +39,7 @@ steps:
 - task: CMake@1
   displayName: Setup
   inputs:
-    cmakeArgs: '-G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_PREFIX_PATH=$(CONDA_PREFIX)\Library -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=$(targetPrefix) $(cmakeOptions) -DBLAS_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_rt.dll -DLAPACK_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_rt.dll -DBLA_VENDOR=Intel ..'
+    cmakeArgs: '-G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(buildConfiguration) -DCMAKE_PREFIX_PATH=$(CONDA_PREFIX)\Library -DENABLE_TESTING=ON -DCMAKE_INSTALL_PREFIX=$(targetPrefix) $(cmakeOptions) -DBLAS_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_core_dll.lib -DLAPACK_LIBRARIES=$(CONDA_PREFIX)/Library/lib/mkl_core_dll.lib -DBLA_VENDOR=Intel ..'
 
 - script: cmake --build . --config $(buildConfiguration) --target INSTALL -- /p:TrackFileAccess=false /p:CLToolExe=clcache.exe /m:2
   displayName: 'Build ($(buildConfiguration) $(buildPlatform))'

--- a/cmake/ShogunFindLAPACK.cmake
+++ b/cmake/ShogunFindLAPACK.cmake
@@ -84,7 +84,6 @@ IF (LAPACK_FOUND)
     include(CheckLibraryExists)
     # test whether we have cblas.h in the header paths and the detected
     # LAPACK_LIBRARIES contains all the libraries to compile even with cblas_* functions
-    string(REPLACE "\\" "/" LAPACK_LIBRARIES "${LAPACK_LIBRARIES}")
     check_library_exists("${LAPACK_LIBRARIES}" cblas_dgemv "" FOUND_CBLAS_DGEMV)
 
     # detect if the detected Lapack is atlas

--- a/cmake/ShogunFindLAPACK.cmake
+++ b/cmake/ShogunFindLAPACK.cmake
@@ -84,6 +84,7 @@ IF (LAPACK_FOUND)
     include(CheckLibraryExists)
     # test whether we have cblas.h in the header paths and the detected
     # LAPACK_LIBRARIES contains all the libraries to compile even with cblas_* functions
+    string(REPLACE "\\" "/" LAPACK_LIBRARIES "${LAPACK_LIBRARIES}")
     check_library_exists("${LAPACK_LIBRARIES}" cblas_dgemv "" FOUND_CBLAS_DGEMV)
 
     # detect if the detected Lapack is atlas


### PR DESCRIPTION
This fixes the blas header issue in the windows CI. There seems to be an issue with the include directories if not specified. This PR explicitly gives the path to the MKL libraries to Cmake which then can find the blas header file.