### PR TITLE
remove LibLinear from SWIG

### DIFF
--- a/examples/meta/src/binary/linear_support_vector_machine.sg
+++ b/examples/meta/src/binary/linear_support_vector_machine.sg
@@ -16,7 +16,7 @@ real epsilon = 0.001
 #![set_parameters]
 
 #![create_instance]
-Machine svm = machine("LibLinear", C1=C, C2=C, labels=labels_train, epsilon=epsilon, liblinear_solver_type=enum LIBLINEAR_SOLVER_TYPE.L2R_L2LOSS_SVC, use_bias=True)
+Machine svm = machine("LibLinear", C1=C, C2=C, labels=labels_train, epsilon=epsilon, liblinear_solver_type="L2R_L2LOSS_SVC", use_bias=True)
 #![create_instance]
 
 #![train_and_apply]

--- a/examples/meta/src/evaluation/cross_validation.sg
+++ b/examples/meta/src/evaluation/cross_validation.sg
@@ -17,7 +17,7 @@ real epsilon = 0.001
 #![set_parameters]
 
 #![create_instance]
-Machine svm = machine("LibLinear", labels=labels_train, epsilon=epsilon, C1=C, C2=C, liblinear_solver_type=enum LIBLINEAR_SOLVER_TYPE.L2R_L2LOSS_SVC)
+Machine svm = machine("LibLinear", labels=labels_train, epsilon=epsilon, C1=C, C2=C, liblinear_solver_type="L2R_L2LOSS_SVC")
 #![create_instance]
 
 #![create_cross_validation]

--- a/examples/meta/src/evaluation/cross_validation_support_vector_machine.sg
+++ b/examples/meta/src/evaluation/cross_validation_support_vector_machine.sg
@@ -4,7 +4,7 @@ File f_labels = csv_file("../../data/label_train_twoclass.dat")
 Features feats = features(f_feats)
 Labels labs = labels(f_labels)
 
-Machine svm = machine("LibLinear", liblinear_solver_type=enum LIBLINEAR_SOLVER_TYPE.L2R_L2LOSS_SVC)
+Machine svm = machine("LibLinear", liblinear_solver_type="L2R_L2LOSS_SVC")
 
 SplittingStrategy strategy = splitting_strategy("StratifiedCrossValidationSplitting", labels=labs, num_subsets=5)
 Evaluation evaluation_criterion = evaluation("AccuracyMeasure")

--- a/examples/meta/src/meta_api/enums.sg
+++ b/examples/meta/src/meta_api/enums.sg
@@ -1,2 +1,7 @@
-Machine m = machine("LibLinear", liblinear_solver_type=enum LIBLINEAR_SOLVER_TYPE.L2R_LR)
-m.put("liblinear_solver_type", enum LIBLINEAR_SOLVER_TYPE.L2R_L2LOSS_SVC_DUAL)
+# enums visible to the interfaces
+File f = csv_file("../../data/classifier_binary_2d_linear_features_train.dat")
+Features feats = features(f, enum EPrimitiveType.PT_FLOAT64)
+
+# internal class C++ enums are not visible to the interfaces but can be passed
+# as simple strings
+Machine m = machine("LibLinear", liblinear_solver_type="L2R_L2LOSS_SVC")

--- a/examples/undocumented/python/classifier_multiclass_ecoc.py
+++ b/examples/undocumented/python/classifier_multiclass_ecoc.py
@@ -13,7 +13,7 @@ parameter_list = [[traindat,testdat,label_traindat,label_testdat,2.1,1,1e-5]]
 def classifier_multiclass_ecoc (fm_train_real=traindat,fm_test_real=testdat,label_train_multiclass=label_traindat,label_test_multiclass=label_testdat,lawidth=2.1,C=1,epsilon=1e-5):
 
 	import shogun
-	from shogun import ECOCStrategy, L2R_L2LOSS_SVC, LinearMulticlassMachine
+	from shogun import ECOCStrategy, LinearMulticlassMachine
 	from shogun import MulticlassAccuracy
 	from shogun import RealFeatures, MulticlassLabels
 	import shogun as sg
@@ -39,7 +39,7 @@ def classifier_multiclass_ecoc (fm_train_real=traindat,fm_test_real=testdat,labe
 		gnd_test = MulticlassLabels(label_test_multiclass)
 
 	base_classifier = sg.machine("LibLinear",
-								liblinear_solver_type=L2R_L2LOSS_SVC,
+								liblinear_solver_type="L2R_L2LOSS_SVC",
 								use_bias=True)
 
 	#print('Testing with %d encoders and %d decoders' % (len(encoders), len(decoders)))

--- a/examples/undocumented/python/modelselection_grid_search_liblinear.py
+++ b/examples/undocumented/python/modelselection_grid_search_liblinear.py
@@ -25,7 +25,6 @@ def modelselection_grid_search_liblinear (traindat=traindat, label_traindat=labe
     from shogun import ParameterCombination
     from shogun import BinaryLabels
     from shogun import RealFeatures
-    from shogun import L2R_L2LOSS_SVC
     import shogun as sg
 
     # build parameter tree to select C1 and C2
@@ -43,7 +42,7 @@ def modelselection_grid_search_liblinear (traindat=traindat, label_traindat=labe
     labels=BinaryLabels(label_traindat)
 
     # classifier
-    classifier=sg.machine("LibLinear", liblinear_solver_type=L2R_L2LOSS_SVC)
+    classifier=sg.machine("LibLinear", liblinear_solver_type="L2R_L2LOSS_SVC")
 
     # print all parameter available for modelselection
     # Dont worry if yours is not included but, write to the mailing list

--- a/examples/undocumented/python/modelselection_random_search_liblinear.py
+++ b/examples/undocumented/python/modelselection_random_search_liblinear.py
@@ -25,7 +25,6 @@ def modelselection_random_search_liblinear (traindat=traindat, label_traindat=la
     from shogun import ParameterCombination
     from shogun import BinaryLabels
     from shogun import RealFeatures
-    from shogun import L2R_L2LOSS_SVC
     import shogun as sg
 
     # build parameter tree to select C1 and C2
@@ -43,7 +42,7 @@ def modelselection_random_search_liblinear (traindat=traindat, label_traindat=la
     labels=BinaryLabels(label_traindat)
 
     # classifier
-    classifier=sg.machine("LibLinear", liblinear_solver_type=L2R_L2LOSS_SVC)
+    classifier=sg.machine("LibLinear", liblinear_solver_type="L2R_L2LOSS_SVC")
 
     # print all parameter available for modelselection
     # Dont worry if yours is not included but, write to the mailing list

--- a/src/interfaces/swig/Classifier.i
+++ b/src/interfaces/swig/Classifier.i
@@ -28,7 +28,6 @@
 %rename(GPBTSVM) CGPBTSVM;
 #endif //USE_GPL_SHOGUN
 %rename(LDA) CLDA;
-%rename(LibLinear) CLibLinear; 
 #ifdef USE_SVMLIGHT
 %rename(SVMLight) CSVMLight;
 %rename(SVMLightOneClass) CSVMLightOneClass;
@@ -84,7 +83,6 @@
 %include <shogun/classifier/svm/GPBTSVM.h>
 #endif //USE_GPL_SHOGUN
 %include <shogun/classifier/LDA.h>
-%include <shogun/classifier/svm/LibLinear.h> 
 #ifdef USE_SVMLIGHT
 %ignore VERSION;
 %ignore VERSION_DATE;

--- a/src/interfaces/swig/Classifier_includes.i
+++ b/src/interfaces/swig/Classifier_includes.i
@@ -7,7 +7,6 @@
  #endif //USE_GPL_SHOGUN
  #include <shogun/machine/DistanceMachine.h>
  #include <shogun/classifier/LDA.h>
- #include <shogun/classifier/svm/LibLinear.h> 
 #ifdef USE_SVMLIGHT
  #include <shogun/classifier/svm/SVMLight.h>
  #include <shogun/classifier/svm/SVMLightOneClass.h>


### PR DESCRIPTION
now that @gf712 implemented a nice solutions for enum options in #4537 , we can start removing more classes, such as LibLinear