### PR TITLE
Add cumulative moving average function

### DIFF
--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -1507,6 +1507,36 @@ namespace shogun
 			return infer_backend(a)->mean(a);
 		}
 
+		/** Method that updates moving mean vector with new datum point.
+		 *
+		 * @param cma the previous moving mean
+		 * @param datum new datum point
+		 * @param n number of previous data points including the new datum point
+		 */
+		template <typename T>
+		void update_mean(SGVector<T>& cma, const SGVector<T>& datum, int32_t n)
+		{
+			REQUIRE(n > 0, "Number of data points (%d) must be at least 1", n);
+			T alpha = (T)(1.0) / n;
+			T beta = 1 - alpha;
+			add(datum, cma, cma, alpha, beta);
+		}
+
+		/** Method that updates moving mean scalar with new datum point.
+		 *
+		 * @param cma the previous moving mean
+		 * @param datum new datum point
+		 * @param n number of previous data points including the new datum point
+		 */
+		template <typename T>
+		void update_mean(T& cma, const T datum, int32_t n)
+		{
+			REQUIRE(n > 0, "Number of data points (%d) must be at least 1", n);
+			T alpha = (T)(1.0) / n;
+			T beta = 1 - alpha;
+			cma = alpha * datum + beta * cma;
+		}
+
 		/**
 		 * Method that computes the standard deviation of vectors or matrices
 		 * composed of real numbers.

--- a/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
+++ b/tests/unit/mathematics/linalg/operations/Eigen3_operations_unittest.cc
@@ -1382,6 +1382,63 @@ TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_mean)
 	EXPECT_NEAR(result, 4, get_epsilon<TypeParam>());
 }
 
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, Scalar_update_mean)
+{
+	const index_t n = 1e5;
+	const TypeParam scale = 2;
+
+	TypeParam mean_increasing = 0;
+	TypeParam mean_decreasing = 0;
+	for (index_t i = 0; i < n; i++)
+	{
+		TypeParam datum_inc(scale * i);
+		TypeParam datum_dec(scale * (n - 1 - i));
+		update_mean(mean_increasing, datum_inc, i + 1);
+		update_mean(mean_decreasing, datum_dec, i + 1);
+	}
+	TypeParam mean_true((scale * (n - 1)) / 2.0);
+
+	auto epsilon = n * get_epsilon<TypeParam>();
+	EXPECT_NEAR(mean_increasing, mean_true, epsilon);
+	EXPECT_NEAR(mean_decreasing, mean_true, epsilon);
+	EXPECT_THROW(
+	    update_mean(mean_increasing, mean_increasing, 0), ShogunException);
+}
+
+TYPED_TEST(LinalgBackendEigenNonIntegerTypesTest, SGVector_update_mean)
+{
+	const index_t n = 1e5;
+	const index_t length = 3;
+	const TypeParam scale = 2;
+
+	SGVector<TypeParam> mean_increasing(length);
+	SGVector<TypeParam> mean_decreasing(length);
+	SGVector<TypeParam>::fill_vector(mean_increasing, length, 0);
+	SGVector<TypeParam>::fill_vector(mean_decreasing, length, 0);
+
+	SGVector<TypeParam> datum(length);
+	for (int i = 0; i < n; i++)
+	{
+		datum.range_fill(i);
+		datum.scale(scale);
+		update_mean(mean_increasing, datum, i + 1);
+		datum.range_fill(n - 1 - i);
+		datum.scale(scale);
+		update_mean(mean_decreasing, datum, i + 1);
+	}
+
+	auto epsilon = n * get_epsilon<TypeParam>();
+	for (int j = 0; j < length; j++)
+	{
+		EXPECT_NEAR(
+		    mean_increasing[j], ((2 * j + n - 1) * scale) / 2.0, epsilon);
+		EXPECT_NEAR(
+		    mean_decreasing[j], ((2 * j + n - 1) * scale) / 2.0, epsilon);
+	}
+	EXPECT_THROW(
+	    update_mean(mean_increasing, mean_increasing, 0), ShogunException);
+}
+
 TYPED_TEST(LinalgBackendEigenAllTypesTest, SGMatrix_std_deviation_colwise)
 {
 	const index_t nrows = 3, ncols = 3;


### PR DESCRIPTION
Moving average is implemented in the form average_n = (1-alpha)*average_{n-1} + alpha*x. This has an additional multiplication compared to average_n = average_{n-1} + alpha*(x-average_n), but it should has less rounding error when alpha is small (not sure). 