### PR TITLE
Fix complex/lapack bug

### DIFF
--- a/src/shogun/mathematics/eigen3.h
+++ b/src/shogun/mathematics/eigen3.h
@@ -8,12 +8,18 @@
 #ifndef EIGEN3_H_
 #define EIGEN3_H_
 
+#ifdef __cplusplus
+#include <complex>
+#define lapack_complex_float std::complex<float>
+#define lapack_complex_double std::complex<double>
+#endif
+
 #include <shogun/lib/config.h>
 
-	//#define EIGEN_RUNTIME_NO_MALLOC
-	#include <Eigen/Eigen>
-	#include <Eigen/Dense>
-	#include <Eigen/Sparse>
+//#define EIGEN_RUNTIME_NO_MALLOC
+#include <Eigen/Eigen>
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
 
 #if ((EIGEN_WORLD_VERSION == 3) && (EIGEN_MAJOR_VERSION == 2) && \
 	((EIGEN_MINOR_VERSION == 91) || (EIGEN_MINOR_VERSION == 92)))

--- a/tests/unit/mathematics/Integration_unittest.cc
+++ b/tests/unit/mathematics/Integration_unittest.cc
@@ -33,6 +33,7 @@
 #include <shogun/lib/config.h>
 
 #include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/Statistics.h>
 #include <shogun/mathematics/Function.h>
 #ifdef USE_GPL_SHOGUN
@@ -778,4 +779,11 @@ TEST(Integration, generate_gauher20)
 	abs_tolerance = CMath::get_abs_tolerance(0.000000000000126, rel_tolerance);
 	EXPECT_NEAR(wgh[19],  0.000000000000126,  abs_tolerance);
 }
+
+TEST(Integration, complex_lapacke_conflict)
+{
+	int I = 23;
+	EXPECT_EQ(I, 23);
+}
+
 #endif //USE_GPL_SHOGUN


### PR DESCRIPTION
This PR addresses the issue with complex.h interfering with the codebase. The header is included by lapacke, which is included by eigen3.h.