### PR TITLE
Remove m_gradient_parameters WIP

### DIFF
--- a/examples/undocumented/libshogun/exact_inference_method.cpp
+++ b/examples/undocumented/libshogun/exact_inference_method.cpp
@@ -1,0 +1,104 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Eleftherios Avramidis
+ */
+
+#include <shogun/base/init.h>
+#include <shogun/labels/MulticlassLabels.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/clustering/KMeans.h>
+#include <shogun/distance/EuclideanDistance.h>
+#include <shogun/mathematics/Math.h>
+
+#include <shogun/labels/RegressionLabels.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/kernel/GaussianKernel.h>
+#include <shogun/machine/gp/ExactInferenceMethod.h>
+#include <shogun/machine/gp/ZeroMean.h>
+#include <shogun/machine/gp/GaussianLikelihood.h>
+#include <shogun/mathematics/Math.h>
+#include <shogun/machine/gp/ConstMean.h>
+#include <iostream>
+
+#include <shogun/lib/any.h>
+
+using namespace shogun;
+
+int main(int argc, char **argv)
+{
+	init_shogun_with_defaults();
+
+    // create some easy regression data: 1d noisy sine wave
+    index_t ntr=5;
+
+    SGMatrix<float64_t> feat_train(1, ntr);
+    SGVector<float64_t> lab_train(ntr);
+
+    feat_train[0]=1.25107;
+    feat_train[1]=2.16097;
+    feat_train[2]=0.00034;
+    feat_train[3]=0.90699;
+    feat_train[4]=0.44026;
+
+    lab_train[0]=0.39635;
+    lab_train[1]=0.00358;
+    lab_train[2]=-1.18139;
+    lab_train[3]=1.35533;
+    lab_train[4]=-0.08232;
+
+    // shogun representation of features and labels
+    CDenseFeatures<float64_t>* features_train=new CDenseFeatures<float64_t>(feat_train);
+    CRegressionLabels* labels_train=new CRegressionLabels(lab_train);
+
+    float64_t ell=0.1;
+
+    // choose Gaussian kernel with width = 2 * ell^2 = 0.02 and zero mean function
+    CGaussianKernel* kernel=new CGaussianKernel(10, 2*ell*ell);
+
+
+    CZeroMean* mean=new CZeroMean();
+
+    // Gaussian likelihood with sigma = 0.25
+    CGaussianLikelihood* lik=new CGaussianLikelihood(0.25);
+
+    // specify GP regression with exact inference
+    CExactInferenceMethod* inf=new CExactInferenceMethod(kernel, features_train,
+                                                         mean, labels_train, lik);
+    // build parameter dictionary
+    CMap<AnyParameter*, CSGObject*>* parameter_dictionary=new CMap<AnyParameter*, CSGObject*>();
+    inf->build_gradient_parameter_dictionary(parameter_dictionary);
+
+
+//    // compute derivatives wrt parameters
+//    CMap<TParameter*, SGVector<float64_t> >* gradient=
+//            inf->get_negative_log_marginal_likelihood_derivatives(parameter_dictionary);
+
+//    // get parameters to compute derivatives
+//    TParameter* width_param=kernel->m_gradient_parameters->get_parameter("log_width");
+//    TParameter* scale_param=inf->m_gradient_parameters->get_parameter("log_scale");
+//    TParameter* sigma_param=lik->m_gradient_parameters->get_parameter("log_sigma");
+//
+//    float64_t dnlZ_ell=(gradient->get_element(width_param))[0];
+//    float64_t dnlZ_sf2=(gradient->get_element(scale_param))[0];
+//    float64_t dnlZ_lik=(gradient->get_element(sigma_param))[0];
+
+    // comparison of partial derivatives of negative marginal likelihood with
+    // result from GPML package:
+    // lik =  0.10638
+    // cov =
+    // -0.015133
+    // 1.699483
+//    EXPECT_NEAR(dnlZ_lik, 0.10638, 1E-5);
+//    EXPECT_NEAR(dnlZ_ell, -0.015133, 1E-6);
+//    EXPECT_NEAR(dnlZ_sf2, 1.699483, 1E-6);
+
+//    SG_UNREF(gradient);
+    SG_UNREF(parameter_dictionary);
+    SG_UNREF(inf);
+
+	exit_shogun();
+
+	return 0;
+}
+

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -51,13 +51,15 @@ namespace shogun
 		/** Default constructor where all parameter properties are false
 		 */
 		AnyParameterProperties()
-		    : m_description("No description given"),
+		    : m_name("No name given"),
+		      m_description("No description given"),
 			  m_model_selection(MS_NOT_AVAILABLE),
 			  m_gradient(GRADIENT_NOT_AVAILABLE),
 		      m_attribute_mask(ParameterProperties::NONE)
 		{
 		}
 		/** Constructor
+		 * @param name parameter name
 		 * @param description parameter description
 		 * @param hyperparameter set to true for parameters that determine
 		 * how training is performed, e.g. regularisation parameters
@@ -67,11 +69,13 @@ namespace shogun
 		 * weights and bias
 		 * */
 		AnyParameterProperties(
+            std::string name,
 		    std::string description,
 		    EModelSelectionAvailability hyperparameter = MS_NOT_AVAILABLE,
 		    EGradientAvailability gradient = GRADIENT_NOT_AVAILABLE,
 		    bool model = false)
-		    : m_description(description), m_model_selection(hyperparameter),
+		    : m_name(name), m_description(description),
+		      m_model_selection(hyperparameter),
 		      m_gradient(gradient)
 		{
 			m_attribute_mask = ParameterProperties::NONE;
@@ -83,23 +87,30 @@ namespace shogun
 				m_attribute_mask |= ParameterProperties::MODEL;
 		}
 		/** Mask constructor
+		 * @param name parameter name
 		 * @param description parameter description
 		 * @param attribute_mask mask encoding parameter properties
 		 * */
 		AnyParameterProperties(
-		    std::string description, ParameterProperties attribute_mask)
-		    : m_description(description)
+            std::string name, std::string description,
+            ParameterProperties attribute_mask)
+		    : m_name(name), m_description(description)
 		{
 			m_attribute_mask = attribute_mask;
 		}
-		/** Copy contructor */
+		/** Copy constructor */
 		AnyParameterProperties(const AnyParameterProperties& other)
-		    : m_description(other.m_description),
+		    : m_name(other.m_name),
+		      m_description(other.m_description),
 		      m_model_selection(other.m_model_selection),
 		      m_gradient(other.m_gradient),
 		      m_attribute_mask(other.m_attribute_mask)
 		{
 		}
+        const std::string& get_name() const
+        {
+            return m_name;
+        }
 		const std::string& get_description() const
 		{
 			return m_description;
@@ -131,6 +142,7 @@ namespace shogun
 		}
 
 	private:
+		std::string m_name;
 		std::string m_description;
 		EModelSelectionAvailability m_model_selection;
 		EGradientAvailability m_gradient;

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -80,22 +80,22 @@ template <class T> class SGStringList;
 #define VARARG_IMPL(base, count, ...) VARARG_IMPL2(base, count, __VA_ARGS__)
 #define VARARG(base, ...) VARARG_IMPL(base, VA_NARGS(__VA_ARGS__), __VA_ARGS__)
 
-#define SG_ADD3(param, name, description)                                      \
-	{                                                                          \
-		this->m_parameters->add(param, name, description);                     \
-		this->watch_param(name, param, AnyParameterProperties(description));   \
+#define SG_ADD3(param, name, description)                                      		\
+	{                                                                          		\
+		this->m_parameters->add(param, name, description);                     		\
+		this->watch_param(name, param, AnyParameterProperties(name, description));  \
 	}
 
-#define SG_ADD4(param, name, description, param_properties)                    \
-	{                                                                          \
-		AnyParameterProperties pprop =                                         \
-		    AnyParameterProperties(description, param_properties);             \
-		this->m_parameters->add(param, name, description);                     \
-		this->watch_param(name, param, pprop);                                 \
-		if (pprop.get_model_selection())                                       \
-			this->m_model_selection_parameters->add(param, name, description); \
-		if (pprop.get_gradient())                                              \
-			this->m_gradient_parameters->add(param, name, description);        \
+#define SG_ADD4(param, name, description, param_properties)                    		\
+	{                                                                          		\
+		AnyParameterProperties pprop =                                         		\
+		    AnyParameterProperties(name, description, param_properties);            \
+		this->m_parameters->add(param, name, description);                     		\
+		this->watch_param(name, param, pprop);                                 		\
+		if (pprop.get_model_selection())                                       		\
+			this->m_model_selection_parameters->add(param, name, description); 		\
+		if (pprop.get_gradient())                                              		\
+			this->m_gradient_parameters->add(param, name, description);        		\
 	}
 
 #define SG_ADD(...) VARARG(SG_ADD, __VA_ARGS__)
@@ -294,13 +294,29 @@ public:
 	 */
 	index_t get_modsel_param_index(const char* param_name);
 
-	/** Builds a dictionary of all parameters in SGObject as well of those
+
+	/** Returns a vector with pairs of the name of the parameter and
+	 * its properties
+	 *
+	 * @param property parameter property
+	 * @return vector with pairs of the name and parameter properties
+	 */
+	std::vector<std::pair<std::string, AnyParameter>>  get_parameters_by_property(ParameterProperties property);
+
+    /** Returns a AnyParameter pointer of the requested parameter
+     *
+     * @param name parameter name
+     * @return AnyParameter pointer
+     */
+	AnyParameter* get_parameter_by_name(std::string name);
+
+    /** Builds a dictionary of all parameters in SGObject as well of those
 	 *  of SGObjects that are parameters of this object. Dictionary maps
 	 *  parameters to the objects that own them.
 	 *
 	 * @param dict dictionary of parameters to be built.
 	 */
-	void build_gradient_parameter_dictionary(CMap<TParameter*, CSGObject*>* dict);
+	void build_gradient_parameter_dictionary(CMap<AnyParameter*, CSGObject*>* dict);
 
 	/** Checks if object has a class parameter identified by a name.
 	 *
@@ -739,6 +755,7 @@ protected:
 	{
 		BaseTag tag(name);
 		AnyParameterProperties properties(
+            name,
 			"Dynamic parameter",
 			ParameterProperties::HYPER |
 			ParameterProperties::GRADIENT |

--- a/src/shogun/base/base_types.h
+++ b/src/shogun/base/base_types.h
@@ -28,6 +28,7 @@ namespace shogun
 	class CMeanFunction;
 	class CDifferentiableFunction;
 	class CInference;
+	class CKernelNormalizer;
 
 	// type trait to enable certain methods only for shogun base types
 	template <class T>
@@ -48,7 +49,8 @@ namespace shogun
 	                    std::is_same<CDifferentiableFunction, T>::value ||
 	                    std::is_same<CInference, T>::value ||
 	                    std::is_same<CLikelihoodModel, T>::value ||
-	                    std::is_same<CMeanFunction, T>::value>
+	                    std::is_same<CMeanFunction, T>::value ||
+	                    std::is_same<CKernelNormalizer, T>::value>
 	{
 	};
 }

--- a/src/shogun/distance/CustomDistance.cpp
+++ b/src/shogun/distance/CustomDistance.cpp
@@ -125,7 +125,7 @@ void CCustomDistance::init()
 	m_parameters->add_matrix(&dmatrix, &num_rows, &num_cols, "dmatrix", "Distance Matrix");
 	watch_param(
 	    "dmatrix", &dmatrix, &num_rows, &num_cols,
-	    AnyParameterProperties("Distance Matrix"));
+	    AnyParameterProperties("dmatrix", "Distance Matrix"));
 
 	SG_ADD(
 	    &upper_diagonal, "upper_diagonal", "Upper diagonal");

--- a/src/shogun/evaluation/DifferentiableFunction.h
+++ b/src/shogun/evaluation/DifferentiableFunction.h
@@ -34,8 +34,8 @@ public:
 	 * @return map of gradient. Keys are names of parameters, values are values
 	 * of derivative with respect to that parameter.
 	 */
-	virtual CMap<TParameter*, SGVector<float64_t> >* get_gradient(
-			CMap<TParameter*, CSGObject*>* parameters)=0;
+	virtual CMap<AnyParameter*, SGVector<float64_t> >* get_gradient(
+			CMap<AnyParameter*, CSGObject*>* parameters)=0;
 
 	/** get the function value
 	 *

--- a/src/shogun/evaluation/GradientEvaluation.cpp
+++ b/src/shogun/evaluation/GradientEvaluation.cpp
@@ -43,7 +43,7 @@ void CGradientEvaluation::update_parameter_dictionary()
 {
 	SG_UNREF(m_parameter_dictionary);
 
-	m_parameter_dictionary=new CMap<TParameter*, CSGObject*>();
+	m_parameter_dictionary=new CMap<AnyParameter*, CSGObject*>();
 	m_diff->build_gradient_parameter_dictionary(m_parameter_dictionary);
 	SG_REF(m_parameter_dictionary);
 }
@@ -60,7 +60,7 @@ CEvaluationResult* CGradientEvaluation::evaluate_impl()
 	// set function value
 	result->set_value(m_diff->get_value());
 
-	CMap<TParameter*, SGVector<float64_t> >* gradient=m_diff->get_gradient(
+	CMap<AnyParameter*, SGVector<float64_t> >* gradient=m_diff->get_gradient(
 			m_parameter_dictionary);
 
 	// set gradient and parameter dictionary

--- a/src/shogun/evaluation/GradientEvaluation.h
+++ b/src/shogun/evaluation/GradientEvaluation.h
@@ -67,7 +67,7 @@ public:
 	}
 
 private:
-	/** initialses and registers parameters */
+	/** initialises and registers parameters */
 	void init();
 
 	/** evaluates differentiable function for value and derivative.
@@ -84,7 +84,7 @@ private:
 	CDifferentiableFunction* m_diff;
 
 	/** parameter dictionary of differentiable function */
-	CMap<TParameter*, CSGObject*>*  m_parameter_dictionary;
+	CMap<AnyParameter*, CSGObject*>*  m_parameter_dictionary;
 };
 }
 #endif /* CGRADIENTEVALUATION_H_ */

--- a/src/shogun/evaluation/GradientResult.h
+++ b/src/shogun/evaluation/GradientResult.h
@@ -92,20 +92,20 @@ public:
 
 		for (index_t i=0; i<m_gradient->get_num_elements(); i++)
 		{
-			CMapNode<TParameter*, SGVector<float64_t> >* param_node=
+			CMapNode<AnyParameter*, SGVector<float64_t> >* param_node=
 				m_gradient->get_node_ptr(i);
 
 			// get parameter name
-			const char* param_name=param_node->key->m_name;
+			const char* param_name=param_node->key->get_properties().get_name().c_str();
 
 			// get object name
-			const char* object_name=
-				m_parameter_dictionary->get_element(param_node->key)->get_name();
+//			const char* object_name=
+//				m_parameter_dictionary->get_element(param_node->key)->get_name();
 
 			// get gradient wrt parameter
 			SGVector<float64_t> param_gradient=param_node->data;
 
-			SG_PRINT("%s.%s: ", object_name, param_name)
+//			SG_PRINT("%s.%s: ", object_name, param_name)
 
 			for (index_t j=0; j<param_gradient.vlen-1; j++)
 				SG_SPRINT("%f, ", param_gradient[j])
@@ -156,7 +156,7 @@ public:
 	 *
 	 * @param gradient gradient map to set
 	 */
-	virtual void set_gradient(CMap<TParameter*, SGVector<float64_t> >* gradient)
+	virtual void set_gradient(CMap<AnyParameter*, SGVector<float64_t> >* gradient)
 	{
 		REQUIRE(gradient, "Gradient map should not be NULL\n")
 
@@ -168,7 +168,7 @@ public:
 
 		for (index_t i=0; i<gradient->get_num_elements(); i++)
 		{
-			CMapNode<TParameter*, SGVector<float64_t> >* node=
+			CMapNode<AnyParameter*, SGVector<float64_t> >* node=
 				m_gradient->get_node_ptr(i);
 			m_total_variables+=node->data.vlen;
 		}
@@ -178,7 +178,7 @@ public:
 	 *
 	 * @return gradient map
 	 */
-	virtual CMap<TParameter*, SGVector<float64_t> >* get_gradient()
+	virtual CMap<AnyParameter*, SGVector<float64_t> >* get_gradient()
 	{
 		SG_REF(m_gradient);
 		return m_gradient;
@@ -189,7 +189,7 @@ public:
 	 * @param parameter_dictionary parameter dictionary
 	 */
 	virtual void set_paramter_dictionary(
-			CMap<TParameter*, CSGObject*>* parameter_dictionary)
+			CMap<AnyParameter*, CSGObject*>* parameter_dictionary)
 	{
 		SG_REF(parameter_dictionary);
 		SG_UNREF(m_parameter_dictionary);
@@ -200,7 +200,7 @@ public:
 	 *
 	 * @return parameter dictionary
 	 */
-	virtual CMap<TParameter*, CSGObject*>* get_paramter_dictionary()
+	virtual CMap<AnyParameter*, CSGObject*>* get_paramter_dictionary()
 	{
 		SG_REF(m_parameter_dictionary);
 		return m_parameter_dictionary;
@@ -211,10 +211,10 @@ private:
 	SGVector<float64_t> m_value;
 
 	/** function gradient */
-	CMap<TParameter*, SGVector<float64_t> >* m_gradient;
+	CMap<AnyParameter*, SGVector<float64_t> >* m_gradient;
 
 	/** which objects do the gradient parameters belong to? */
-	CMap<TParameter*, CSGObject*>*  m_parameter_dictionary;
+	CMap<AnyParameter*, CSGObject*>*  m_parameter_dictionary;
 
 	/** total number of variables represented by the gradient */
 	uint32_t m_total_variables;

--- a/src/shogun/kernel/CombinedKernel.cpp
+++ b/src/shogun/kernel/CombinedKernel.cpp
@@ -783,11 +783,11 @@ void CCombinedKernel::enable_subkernel_weight_learning()
 }
 
 SGMatrix<float64_t> CCombinedKernel::get_parameter_gradient(
-		const TParameter* param, index_t index)
+		const AnyParameter* param, index_t index)
 {
 	SGMatrix<float64_t> result;
 
-	if (!strcmp(param->m_name, "combined_kernel_weight"))
+	if (!param->get_properties().get_name().compare("combined_kernel_weight"))
 	{
 		if (append_subkernel_weights)
 		{
@@ -817,7 +817,7 @@ SGMatrix<float64_t> CCombinedKernel::get_parameter_gradient(
 	}
 	else
 	{
-		if (!strcmp(param->m_name, "subkernel_log_weights"))
+		if (!param->get_properties().get_name().compare("subkernel_log_weights"))
 		{
 			if(enable_subkernel_weight_opt)
 			{

--- a/src/shogun/kernel/CombinedKernel.h
+++ b/src/shogun/kernel/CombinedKernel.h
@@ -402,7 +402,7 @@ class CCombinedKernel : public CKernel
 		 *
 		 * @return gradient with respect to parameter
 		 */
-		SGMatrix<float64_t> get_parameter_gradient(const TParameter* param,
+		SGMatrix<float64_t> get_parameter_gradient(const AnyParameter* param,
 				index_t index=-1);
 
 		/** Get the Kernel array

--- a/src/shogun/kernel/GaussianARDKernel.cpp
+++ b/src/shogun/kernel/GaussianARDKernel.cpp
@@ -198,7 +198,7 @@ float64_t CGaussianARDKernel::compute_gradient_helper(SGVector<float64_t> avec,
 
 
 SGVector<float64_t> CGaussianARDKernel::get_parameter_gradient_diagonal(
-		const TParameter* param, index_t index)
+		const AnyParameter* param, index_t index)
 {
 	REQUIRE(param, "Param not set\n");
 	REQUIRE(lhs , "Left features not set!\n");
@@ -206,7 +206,7 @@ SGVector<float64_t> CGaussianARDKernel::get_parameter_gradient_diagonal(
 
 	if (lhs==rhs)
 	{
-		if (!strcmp(param->m_name, "log_weights"))
+		if (!param->get_properties().get_name().compare("log_weights"))
 		{
 			SGVector<float64_t> derivative(num_lhs);
 			derivative.zero();
@@ -220,7 +220,7 @@ SGVector<float64_t> CGaussianARDKernel::get_parameter_gradient_diagonal(
 		check_weight_gradient_index(index);
 		for (index_t j=0; j<length; j++)
 		{
-			if (!strcmp(param->m_name, "log_weights") )
+			if (!param->get_properties().get_name().compare("log_weights") )
 			{
 				if (m_ARD_type==KT_SCALAR)
 				{
@@ -239,18 +239,18 @@ SGVector<float64_t> CGaussianARDKernel::get_parameter_gradient_diagonal(
 		return derivative;
 	}
 
-	SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name);
+	SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name());
 	return SGVector<float64_t>();
 }
 
 
 float64_t CGaussianARDKernel::get_parameter_gradient_helper(
-	const TParameter* param, index_t index, int32_t idx_a,
+	const AnyParameter* param, index_t index, int32_t idx_a,
 	int32_t idx_b, SGVector<float64_t> avec, SGVector<float64_t> bvec)
 {
 	REQUIRE(param, "Param not set\n");
 
-	if (!strcmp(param->m_name, "log_weights"))
+	if (!param->get_properties().get_name().compare("log_weights"))
 	{
 		bvec=linalg::add(avec, bvec, 1.0, -1.0);
 		float64_t scale=-kernel(idx_a,idx_b)/2.0;
@@ -258,19 +258,19 @@ float64_t CGaussianARDKernel::get_parameter_gradient_helper(
 	}
 	else
 	{
-		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name);
+		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name());
 		return 0.0;
 	}
 }
 
 SGMatrix<float64_t> CGaussianARDKernel::get_parameter_gradient(
-		const TParameter* param, index_t index)
+		const AnyParameter* param, index_t index)
 {
 	REQUIRE(param, "Param not set\n");
 	REQUIRE(lhs , "Left features not set!\n");
 	REQUIRE(rhs, "Right features not set!\n");
 
-	if (!strcmp(param->m_name, "log_weights"))
+	if (!param->get_properties().get_name().compare("log_weights"))
 	{
 		SGMatrix<float64_t> derivative(num_lhs, num_rhs);
 		check_weight_gradient_index(index);
@@ -295,7 +295,7 @@ SGMatrix<float64_t> CGaussianARDKernel::get_parameter_gradient(
 	}
 	else
 	{
-		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name);
+		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name());
 		return SGMatrix<float64_t>();
 	}
 }

--- a/src/shogun/kernel/GaussianARDKernel.h
+++ b/src/shogun/kernel/GaussianARDKernel.h
@@ -129,7 +129,7 @@ public:
 	 *
 	 * @return gradient with respect to parameter
 	 */
-	virtual SGMatrix<float64_t> get_parameter_gradient(const TParameter* param,
+	virtual SGMatrix<float64_t> get_parameter_gradient(const AnyParameter* param,
 			index_t index=-1);
 
 	/** return diagonal part of derivative with respect to specified parameter
@@ -140,7 +140,7 @@ public:
 	 * @return diagonal part of gradient with respect to parameter
 	 */
 	virtual SGVector<float64_t> get_parameter_gradient_diagonal(
-		const TParameter* param, index_t index=-1);
+		const AnyParameter* param, index_t index=-1);
 
 protected:
 	/** helper function to compute quadratic terms in
@@ -196,7 +196,7 @@ protected:
 	 *
 	 * @return gradient at row idx_a and column idx_b with respect to parameter
 	 */
-	virtual float64_t get_parameter_gradient_helper(const TParameter* param,
+	virtual float64_t get_parameter_gradient_helper(const AnyParameter* param,
 		index_t index, int32_t idx_a, int32_t idx_b,
 		SGVector<float64_t> avec, SGVector<float64_t> bvec);
 };

--- a/src/shogun/kernel/Kernel.h
+++ b/src/shogun/kernel/Kernel.h
@@ -847,9 +847,9 @@ class CKernel : public CSGObject
 		 * @return gradient with respect to parameter
 		 */
 		virtual SGMatrix<float64_t> get_parameter_gradient(
-				const TParameter* param, index_t index=-1)
+				const AnyParameter* param, index_t index=-1)
 		{
-			SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name)
+			SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name())
 			return SGMatrix<float64_t>();
 		}
 
@@ -861,7 +861,7 @@ class CKernel : public CSGObject
 		 * @return diagonal part of gradient with respect to parameter
 		 */
 		virtual SGVector<float64_t> get_parameter_gradient_diagonal(
-				const TParameter* param, index_t index=-1)
+				const AnyParameter* param, index_t index=-1)
 		{
 			return get_parameter_gradient(param,index).get_diagonal_vector();
 		}

--- a/src/shogun/kernel/ProductKernel.cpp
+++ b/src/shogun/kernel/ProductKernel.cpp
@@ -234,7 +234,7 @@ void CProductKernel::init()
 }
 
 SGMatrix<float64_t> CProductKernel::get_parameter_gradient(
-		const TParameter* param, index_t index)
+		const AnyParameter* param, index_t index)
 {
 	CKernel* k=get_kernel(0);
 	SGMatrix<float64_t> temp_kernel=k->get_kernel_matrix();

--- a/src/shogun/kernel/ProductKernel.h
+++ b/src/shogun/kernel/ProductKernel.h
@@ -184,7 +184,7 @@ class CProductKernel : public CKernel
 		 *
 		 * @return gradient with respect to parameter
 		 */
-		SGMatrix<float64_t> get_parameter_gradient(const TParameter* param,
+		SGMatrix<float64_t> get_parameter_gradient(const AnyParameter* param,
 				index_t index=-1);
 
 		/** Get the Kernel array

--- a/src/shogun/lib/type_case.h
+++ b/src/shogun/lib/type_case.h
@@ -24,7 +24,7 @@ namespace shogun
 		int64_t, uint64_t, float32_t, float64_t, floatmax_t, SGVector<int32_t>,
 		SGVector<int64_t>, SGVector<float32_t>, SGVector<float64_t>,
 		SGVector<floatmax_t>, SGMatrix<int32_t>, SGMatrix<int64_t>,
-		SGMatrix<float32_t>, SGMatrix<float64_t>, SGMatrix<floatmax_t>>
+		SGMatrix<float32_t>, SGMatrix<float64_t>, SGMatrix<floatmax_t>, CSGObject*, CKernel*, CLikelihoodModel*, CMeanFunction*>
 		SG_TYPES;
 
 	enum class TYPE
@@ -54,7 +54,10 @@ namespace shogun
 		T_SGMATRIX_FLOATMAX = 23,
 		T_SGMATRIX_INT32 = 24,
 		T_SGMATRIX_INT64 = 25,
-		T_UNDEFINED = 26
+		T_UNDEFINED = 26,
+        T_CKERNEL = 27,
+        T_CLIKELIHOOD_MODEL = 28,
+        T_CMEANFUNCTION = 29
 	};
 
 	typedef std::unordered_map<std::type_index, TYPE> typemap;
@@ -115,6 +118,10 @@ namespace shogun
 	{                                                                          \
 	};
 
+        SG_ADD_PRIMITIVE_TYPE(CSGObject*, TYPE::T_SGOBJECT)
+        SG_ADD_PRIMITIVE_TYPE(CKernel*, TYPE::T_CKERNEL)
+        SG_ADD_PRIMITIVE_TYPE(CLikelihoodModel*, TYPE::T_CLIKELIHOOD_MODEL)
+        SG_ADD_PRIMITIVE_TYPE(CMeanFunction*, TYPE::T_CMEANFUNCTION)
 		SG_ADD_PRIMITIVE_TYPE(bool, TYPE::T_BOOL)
 		SG_ADD_PRIMITIVE_TYPE(char, TYPE::T_CHAR)
 		SG_ADD_PRIMITIVE_TYPE(int8_t, TYPE::T_INT8)
@@ -463,6 +470,12 @@ static const typemap sg_non_integer_typemap = {
 		ADD_TYPE_TO_MAP(float64_t , TYPE::T_FLOAT64)
 		ADD_TYPE_TO_MAP(floatmax_t , TYPE::T_FLOATMAX)
 		ADD_TYPE_TO_MAP(complex128_t, TYPE::T_COMPLEX128)
+};
+static const typemap sg_object_typemap = {
+        ADD_TYPE_TO_MAP(CSGObject* , TYPE::T_SGOBJECT)
+        ADD_TYPE_TO_MAP(CKernel* , TYPE::T_CKERNEL)
+        ADD_TYPE_TO_MAP(CLikelihoodModel*, TYPE::T_CLIKELIHOOD_MODEL)
+        ADD_TYPE_TO_MAP(CMeanFunction*, TYPE::T_CMEANFUNCTION)
 };
 #undef ADD_TYPE_TO_MAP
 

--- a/src/shogun/machine/gp/DualVariationalGaussianLikelihood.cpp
+++ b/src/shogun/machine/gp/DualVariationalGaussianLikelihood.cpp
@@ -74,7 +74,7 @@ void CDualVariationalGaussianLikelihood::set_noise_factor(float64_t noise_factor
 	var_lik->set_noise_factor(noise_factor);
 }
 
-SGVector<float64_t> CDualVariationalGaussianLikelihood::get_variational_first_derivative(const TParameter* param) const
+SGVector<float64_t> CDualVariationalGaussianLikelihood::get_variational_first_derivative(const AnyParameter* param) const
 {
 	CVariationalLikelihood * var_lik=get_variational_likelihood();
 	return var_lik->get_variational_first_derivative(param);
@@ -86,7 +86,7 @@ bool CDualVariationalGaussianLikelihood::supports_derivative_wrt_hyperparameter(
 	return var_lik->supports_derivative_wrt_hyperparameter();
 }
 
-SGVector<float64_t> CDualVariationalGaussianLikelihood::get_first_derivative_wrt_hyperparameter(const TParameter* param) const
+SGVector<float64_t> CDualVariationalGaussianLikelihood::get_first_derivative_wrt_hyperparameter(const AnyParameter* param) const
 {
 	CVariationalLikelihood * var_lik=get_variational_likelihood();
 	return var_lik->get_first_derivative_wrt_hyperparameter(param);

--- a/src/shogun/machine/gp/DualVariationalGaussianLikelihood.h
+++ b/src/shogun/machine/gp/DualVariationalGaussianLikelihood.h
@@ -87,7 +87,7 @@ public:
 	 *
 	 * @return derivative
 	 */
-	virtual SGVector<float64_t> get_variational_first_derivative(const TParameter* param) const;
+	virtual SGVector<float64_t> get_variational_first_derivative(const AnyParameter* param) const;
 
 	/** return whether likelihood function supports
 	 * computing the derivative wrt hyperparameter
@@ -105,7 +105,7 @@ public:
 	 *
 	 * @return derivative
 	 */
-	virtual SGVector<float64_t> get_first_derivative_wrt_hyperparameter(const TParameter* param) const;
+	virtual SGVector<float64_t> get_first_derivative_wrt_hyperparameter(const AnyParameter* param) const;
 
 	/** set the variational distribution given data and parameters
 	 *
@@ -196,7 +196,7 @@ public:
 	 * @return the value of of the derivative
 	 *
 	 */
-	virtual SGVector<float64_t> get_dual_first_derivative(const TParameter* param) const=0;
+	virtual SGVector<float64_t> get_dual_first_derivative(const AnyParameter* param) const=0;
 
 	/** set the m_strict_scale
 	 *

--- a/src/shogun/machine/gp/EPInferenceMethod.h
+++ b/src/shogun/machine/gp/EPInferenceMethod.h
@@ -291,7 +291,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -301,7 +301,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -311,7 +311,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -321,7 +321,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 private:
 	void init();

--- a/src/shogun/machine/gp/ExactInferenceMethod.h
+++ b/src/shogun/machine/gp/ExactInferenceMethod.h
@@ -65,6 +65,8 @@ namespace shogun
  */
 class CExactInferenceMethod: public CInference
 {
+	friend class CLikelihoodModel;
+
 public:
 	/** default constructor */
 	CExactInferenceMethod();
@@ -221,7 +223,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -231,7 +233,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -241,7 +243,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -251,7 +253,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** update gradients */
 	virtual void compute_gradient();

--- a/src/shogun/machine/gp/FITCInferenceMethod.cpp
+++ b/src/shogun/machine/gp/FITCInferenceMethod.cpp
@@ -401,12 +401,12 @@ SGMatrix<float64_t> CFITCInferenceMethod::get_posterior_covariance()
 }
 
 SGVector<float64_t> CFITCInferenceMethod::get_derivative_wrt_likelihood_model(
-		const TParameter* param)
+        const AnyParameter *param)
 {
 	//time complexity O(m*n)
-	REQUIRE(!strcmp(param->m_name, "log_sigma"), "Can't compute derivative of "
+	REQUIRE(!param->get_properties().get_name().compare("log_sigma"), "Can't compute derivative of "
 			"the nagative log marginal likelihood wrt %s.%s parameter\n",
-			m_model->get_name(), param->m_name)
+			m_model->get_name(), param->get_properties().get_name())
 
 	// create eigen representation of dg, al, w, W and B
 	Map<VectorXd> eigen_t(m_t.vector, m_t.vlen);

--- a/src/shogun/machine/gp/FITCInferenceMethod.h
+++ b/src/shogun/machine/gp/FITCInferenceMethod.h
@@ -182,7 +182,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** update gradients */
 	virtual void compute_gradient();

--- a/src/shogun/machine/gp/GaussianARDSparseKernel.cpp
+++ b/src/shogun/machine/gp/GaussianARDSparseKernel.cpp
@@ -74,20 +74,20 @@ CGaussianARDSparseKernel* CGaussianARDSparseKernel::obtain_from_generic(CKernel*
 }
 
 SGVector<float64_t> CGaussianARDSparseKernel::get_parameter_gradient_diagonal(
-		const TParameter* param, index_t index)
+		const AnyParameter* param, index_t index)
 {
 	REQUIRE(param, "Param not set\n");
-	if (!strcmp(param->m_name, "inducing_features"))
+	if (!param->get_properties().get_name().compare("inducing_features"))
 		return CKernel::get_parameter_gradient_diagonal(param, index);
 	else
 		return CGaussianARDKernel::get_parameter_gradient_diagonal(param, index);
 }
 
 SGMatrix<float64_t> CGaussianARDSparseKernel::get_parameter_gradient(
-		const TParameter* param, index_t index)
+		const AnyParameter* param, index_t index)
 {
 	REQUIRE(param, "Param not set\n");
-	if (!strcmp(param->m_name, "inducing_features"))
+	if (!param->get_properties().get_name().compare("inducing_features"))
 	{
 		REQUIRE(lhs, "Left features not set!\n");
 		REQUIRE(rhs, "Right features not set!\n");

--- a/src/shogun/machine/gp/GaussianARDSparseKernel.h
+++ b/src/shogun/machine/gp/GaussianARDSparseKernel.h
@@ -102,7 +102,7 @@ public:
 	 *
 	 * @return gradient with respect to parameter
 	 */
-	virtual SGMatrix<float64_t> get_parameter_gradient(const TParameter* param,
+	virtual SGMatrix<float64_t> get_parameter_gradient(const AnyParameter* param,
 		index_t index=-1);
 
 	/** return diagonal part of derivative with respect to specified parameter
@@ -113,7 +113,7 @@ public:
 	 * @return diagonal part of gradient with respect to parameter
 	 */
 	virtual SGVector<float64_t> get_parameter_gradient_diagonal(
-		const TParameter* param, index_t index=-1);
+		const AnyParameter* param, index_t index=-1);
 };
 }
 

--- a/src/shogun/machine/gp/Inference.cpp
+++ b/src/shogun/machine/gp/Inference.cpp
@@ -181,8 +181,8 @@ float64_t CInference::get_marginal_likelihood_estimate(
 	return CMath::log_mean_exp(sum);
 }
 
-CMap<TParameter*, SGVector<float64_t> >* CInference::
-get_negative_log_marginal_likelihood_derivatives(CMap<TParameter*, CSGObject*>* params)
+CMap<AnyParameter*, SGVector<float64_t> >* CInference::
+get_negative_log_marginal_likelihood_derivatives(CMap<AnyParameter*, CSGObject*>* params)
 {
 	REQUIRE(params->get_num_elements(), "Number of parameters should be greater "
 			"than zero\n")
@@ -193,15 +193,15 @@ get_negative_log_marginal_likelihood_derivatives(CMap<TParameter*, CSGObject*>* 
 	const index_t num_deriv=params->get_num_elements();
 
 	// create map of derivatives
-	CMap<TParameter*, SGVector<float64_t> >* result=
-		new CMap<TParameter*, SGVector<float64_t> >(num_deriv, num_deriv);
+	CMap<AnyParameter*, SGVector<float64_t> >* result=
+		new CMap<AnyParameter*, SGVector<float64_t> >(num_deriv, num_deriv);
 
 	SG_REF(result);
 
 	#pragma omp parallel for
 	for (index_t i=0; i<num_deriv; i++)
 	{
-        CMapNode<TParameter*, CSGObject*>* node=params->get_node_ptr(i);
+        CMapNode<AnyParameter*, CSGObject*>* node=params->get_node_ptr(i);
         SGVector<float64_t> gradient;
 
 		if(node->data == this)
@@ -227,7 +227,7 @@ get_negative_log_marginal_likelihood_derivatives(CMap<TParameter*, CSGObject*>* 
 		else
 		{
 			SG_SERROR("Can't compute derivative of negative log marginal "
-					"likelihood wrt %s.%s", node->data->get_name(), node->key->m_name);
+					"likelihood wrt %s.%s", node->data->get_name(), node->key->get_properties().get_name());
 		}
 
 		#pragma omp critical

--- a/src/shogun/machine/gp/Inference.h
+++ b/src/shogun/machine/gp/Inference.h
@@ -168,8 +168,8 @@ public:
 	 * where \f$y\f$ are the labels, \f$X\f$ are the features, and \f$\theta\f$
 	 * represent hyperparameters.
 	 */
-	virtual CMap<TParameter*, SGVector<float64_t> >*
-	get_negative_log_marginal_likelihood_derivatives(CMap<TParameter*,
+	virtual CMap<AnyParameter*, SGVector<float64_t> >*
+	get_negative_log_marginal_likelihood_derivatives(CMap<AnyParameter*,
 			CSGObject*>* parameters);
 
 	/** get alpha vector
@@ -242,8 +242,8 @@ public:
 	 * @return map of gradient. Keys are names of parameters, values are values
 	 * of derivative with respect to that parameter.
 	 */
-	virtual CMap<TParameter*, SGVector<float64_t> >* get_gradient(
-			CMap<TParameter*, CSGObject*>* parameters)
+	virtual CMap<AnyParameter*, SGVector<float64_t> >* get_gradient(
+			CMap<AnyParameter*, CSGObject*>* parameters)
 	{
         return get_negative_log_marginal_likelihood_derivatives(parameters);
 	}
@@ -418,7 +418,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param)=0;
+            const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -428,7 +428,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param)=0;
+            const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -438,7 +438,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param)=0;
+            const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -448,7 +448,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param)=0;
+            const AnyParameter *param)=0;
 
 	/** update gradients */
 	virtual void compute_gradient();

--- a/src/shogun/machine/gp/KLCholeskyInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLCholeskyInferenceMethod.cpp
@@ -153,12 +153,10 @@ void CKLCholeskyInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<fl
 
 	CVariationalGaussianLikelihood * lik=get_variational_likelihood();
 	//[a,df,dV] = a_related2(mu,s2,y,lik);
-	TParameter* s2_param=lik->m_parameters->get_parameter("sigma2");
-	SGVector<float64_t> dv=lik->get_variational_first_derivative(s2_param);
+	SGVector<float64_t> dv=lik->get_variational_first_derivative(get_parameter_by_name("sigma2"));
 	Map<VectorXd> eigen_dv(dv.vector, dv.vlen);
 
-	TParameter* mu_param=lik->m_parameters->get_parameter("mu");
-	SGVector<float64_t> df=lik->get_variational_first_derivative(mu_param);
+	SGVector<float64_t> df=lik->get_variational_first_derivative(get_parameter_by_name("mu"));
 	Map<VectorXd> eigen_df(df.vector, df.vlen);
 
 	Map<VectorXd> eigen_dnlz_alpha(gradient.vector, len);

--- a/src/shogun/machine/gp/KLCovarianceInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLCovarianceInferenceMethod.cpp
@@ -185,12 +185,10 @@ void CKLCovarianceInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<
 	lik->set_variational_distribution(m_mu, m_s2, m_labels);
 
 	//[a,df,dV] = a_related2(mu,s2,y,lik);
-	TParameter* s2_param=lik->m_parameters->get_parameter("sigma2");
-	m_dv=lik->get_variational_first_derivative(s2_param);
+	m_dv=lik->get_variational_first_derivative(get_parameter_by_name("sigma2"));
 	Map<VectorXd> eigen_dv(m_dv.vector, m_dv.vlen);
 
-	TParameter* mu_param=lik->m_parameters->get_parameter("mu");
-	m_df=lik->get_variational_first_derivative(mu_param);
+	m_df=lik->get_variational_first_derivative(get_parameter_by_name("mu"));
 	Map<VectorXd> eigen_df(m_df.vector, m_df.vlen);
 	//U=inv(L')*diag(sW)
 	MatrixXd eigen_U=eigen_L.triangularView<Upper>().adjoint().solve(MatrixXd(eigen_sW.asDiagonal()));

--- a/src/shogun/machine/gp/KLDiagonalInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDiagonalInferenceMethod.cpp
@@ -144,12 +144,10 @@ void CKLDiagonalInferenceMethod::get_gradient_of_nlml_wrt_parameters(SGVector<fl
 
 	CVariationalGaussianLikelihood * lik=get_variational_likelihood();
 	//[a,df,dV] = a_related2(mu,s2,y,lik);
-	TParameter* s2_param=lik->m_parameters->get_parameter("sigma2");
-	SGVector<float64_t> dv=lik->get_variational_first_derivative(s2_param);
+	SGVector<float64_t> dv=lik->get_variational_first_derivative(get_parameter_by_name("sigma2"));
 	Map<VectorXd> eigen_dv(dv.vector, dv.vlen);
 
-	TParameter* mu_param=lik->m_parameters->get_parameter("mu");
-	SGVector<float64_t> df=lik->get_variational_first_derivative(mu_param);
+	SGVector<float64_t> df=lik->get_variational_first_derivative(get_parameter_by_name("mu"));
 	Map<VectorXd> eigen_df(df.vector, df.vlen);
 
 	Map<VectorXd> eigen_dnlz_alpha(gradient.vector, len);

--- a/src/shogun/machine/gp/KLDualInferenceMethod.cpp
+++ b/src/shogun/machine/gp/KLDualInferenceMethod.cpp
@@ -371,8 +371,7 @@ void CKLDualInferenceMethod::get_gradient_of_dual_objective_wrt_parameters(SGVec
 
 	CDualVariationalGaussianLikelihood *lik= get_dual_variational_likelihood();
 
-	TParameter* lambda_param=lik->m_parameters->get_parameter("lambda");
-	SGVector<float64_t>d_lambda=lik->get_dual_first_derivative(lambda_param);
+	SGVector<float64_t>d_lambda=lik->get_dual_first_derivative(get_parameter_by_name("lambda"));
 	Map<VectorXd> eigen_d_lambda(d_lambda.vector, d_lambda.vlen);
 
 	Map<VectorXd> eigen_mu(m_mu.vector, m_mu.vlen);
@@ -532,10 +531,8 @@ void CKLDualInferenceMethod::update_alpha()
 
 	nlml_new=optimization();
 	lik->set_variational_distribution(m_mu, m_s2, m_labels);
-	TParameter* s2_param=lik->m_parameters->get_parameter("sigma2");
-	m_dv=lik->get_variational_first_derivative(s2_param);
-	TParameter* mu_param=lik->m_parameters->get_parameter("mu");
-	m_df=lik->get_variational_first_derivative(mu_param);
+	m_dv=lik->get_variational_first_derivative(get_parameter_by_name("sigma2"));
+	m_df=lik->get_variational_first_derivative(get_parameter_by_name("mu"));
 }
 
 float64_t CKLDualInferenceMethod::optimization()

--- a/src/shogun/machine/gp/KLInference.cpp
+++ b/src/shogun/machine/gp/KLInference.cpp
@@ -36,7 +36,7 @@
 #include <shogun/mathematics/Math.h>
 #include <shogun/optimization/FirstOrderCostFunction.h>
 #include <shogun/optimization/lbfgs/LBFGSMinimizer.h>
-
+#include <shogun/lib/type_case.h>
 
 using namespace Eigen;
 
@@ -287,7 +287,7 @@ float64_t CKLInference::get_negative_log_marginal_likelihood()
 	return get_negative_log_marginal_likelihood_helper();
 }
 
-SGVector<float64_t> CKLInference::get_derivative_wrt_likelihood_model(const TParameter* param)
+SGVector<float64_t> CKLInference::get_derivative_wrt_likelihood_model(const AnyParameter *param)
 {
 	CVariationalLikelihood * lik=get_variational_likelihood();
 	if (!lik->supports_derivative_wrt_hyperparameter())
@@ -303,15 +303,21 @@ SGVector<float64_t> CKLInference::get_derivative_wrt_likelihood_model(const TPar
 	return result;
 }
 
-SGVector<float64_t> CKLInference::get_derivative_wrt_mean(const TParameter* param)
+SGVector<float64_t> CKLInference::get_derivative_wrt_mean(const AnyParameter *param)
 {
 	// create eigen representation of K, Z, dfhat and alpha
 	Map<VectorXd> eigen_alpha(m_alpha.vector, m_alpha.vlen/2);
 
 	REQUIRE(param, "Param not set\n");
-	SGVector<float64_t> result;
-	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
-	result=SGVector<float64_t>(len);
+
+    SGVector<float64_t> result;
+    auto param_value = param->get_value();
+    int64_t len;
+    auto f_scalar = [&len](auto value) { len=1;};
+    auto f_vector = [&len, &param_value](auto value) { len=param_value.as<SGVector<float64_t>>().vlen; };
+    auto f_matrix = [&len, &param_value](auto value) { len=param_value.as<SGMatrix<float64_t>>().num_rows*param_value.as<SGMatrix<float64_t>>().num_cols; };
+    sg_any_dispatch(param->get_value(), sg_all_typemap, f_scalar, f_vector, f_matrix);
+    result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{
@@ -362,11 +368,11 @@ void CKLInference::register_minimizer(Minimizer* minimizer)
 }
 
 
-SGVector<float64_t> CKLInference::get_derivative_wrt_inference_method(const TParameter* param)
+SGVector<float64_t> CKLInference::get_derivative_wrt_inference_method(const AnyParameter *param)
 {
-	REQUIRE(!strcmp(param->m_name, "log_scale"), "Can't compute derivative of "
+	REQUIRE(!param->get_properties().get_name().compare("log_scale"), "Can't compute derivative of "
 			"the nagative log marginal likelihood wrt %s.%s parameter\n",
-			get_name(), param->m_name)
+			get_name(), param->get_properties().get_name())
 
 	Map<MatrixXd> eigen_K(m_ktrtr.matrix, m_ktrtr.num_rows, m_ktrtr.num_cols);
 
@@ -378,12 +384,18 @@ SGVector<float64_t> CKLInference::get_derivative_wrt_inference_method(const TPar
 	return result;
 }
 
-SGVector<float64_t> CKLInference::get_derivative_wrt_kernel(const TParameter* param)
+SGVector<float64_t> CKLInference::get_derivative_wrt_kernel(const AnyParameter *param)
 {
 	REQUIRE(param, "Param not set\n");
-	SGVector<float64_t> result;
-	int64_t len=const_cast<TParameter *>(param)->m_datatype.get_num_elements();
-	result=SGVector<float64_t>(len);
+
+    SGVector<float64_t> result;
+    auto param_value = param->get_value();
+    int64_t len;
+    auto f_scalar = [&len](auto value) { len=1;};
+    auto f_vector = [&len, &param_value](auto value) { len=param_value.as<SGVector<float64_t>>().vlen; };
+    auto f_matrix = [&len, &param_value](auto value) { len=param_value.as<SGMatrix<float64_t>>().num_rows*param_value.as<SGMatrix<float64_t>>().num_cols; };
+    sg_any_dispatch(param->get_value(), sg_all_typemap, f_scalar, f_vector, f_matrix);
+    result=SGVector<float64_t>(len);
 
 	for (index_t i=0; i<result.vlen; i++)
 	{

--- a/src/shogun/machine/gp/KLInference.h
+++ b/src/shogun/machine/gp/KLInference.h
@@ -298,7 +298,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -308,7 +308,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -318,7 +318,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -328,7 +328,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** the helper function to compute
 	 * the negative log marginal likelihood

--- a/src/shogun/machine/gp/LikelihoodModel.h
+++ b/src/shogun/machine/gp/LikelihoodModel.h
@@ -190,9 +190,9 @@ public:
 	 * @return derivative
 	 */
 	virtual SGVector<float64_t> get_first_derivative(const CLabels* lab,
-			SGVector<float64_t> func, const TParameter* param) const
+			SGVector<float64_t> func, const AnyParameter* param) const
 	{
-		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name)
+		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name())
 		return SGVector<float64_t>();
 	}
 
@@ -208,9 +208,9 @@ public:
 	 * @return derivative
 	 */
 	virtual SGVector<float64_t> get_second_derivative(const CLabels* lab,
-			SGVector<float64_t> func, const TParameter* param) const
+			SGVector<float64_t> func, const AnyParameter* param) const
 	{
-		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name)
+		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name())
 		return SGVector<float64_t>();
 	}
 
@@ -225,9 +225,9 @@ public:
 	 * @return derivative
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
-			SGVector<float64_t> func, const TParameter* param) const
+			SGVector<float64_t> func, const AnyParameter* param) const
 	{
-		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name)
+		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name())
 		return SGVector<float64_t>();
 	}
 

--- a/src/shogun/machine/gp/LogitDVGLikelihood.cpp
+++ b/src/shogun/machine/gp/LogitDVGLikelihood.cpp
@@ -91,15 +91,15 @@ SGVector<float64_t> CLogitDVGLikelihood::get_dual_objective_value()
 }
 
 SGVector<float64_t> CLogitDVGLikelihood::get_dual_first_derivative(
-		const TParameter* param) const
+		const AnyParameter* param) const
 {
 	REQUIRE(param, "Param is required (param should not be NULL)\n");
-	REQUIRE(param->m_name, "Param name is required (param->m_name should not be NULL)\n");
-	REQUIRE(!strcmp(param->m_name, "lambda"),
+	REQUIRE(param->get_properties().get_name().c_str(), "Param name is required (param->m_name should not be NULL)\n");
+	REQUIRE(!param->get_properties().get_name().compare("lambda"),
 		"Can't compute derivative of the variational expection ",
 		"of log LogitLikelihood in dual setting",
 		"wrt %s.%s parameter. The function only accepts lambda as parameter\n",
-		get_name(), param->m_name);
+		get_name(), param->get_properties().get_name());
 
 	SGVector<float64_t> result(m_lambda.vlen);
 

--- a/src/shogun/machine/gp/LogitDVGLikelihood.h
+++ b/src/shogun/machine/gp/LogitDVGLikelihood.h
@@ -97,7 +97,7 @@ public:
 	 * @return the value of of the derivative
 	 *
 	 */
-	virtual SGVector<float64_t> get_dual_first_derivative(const TParameter* param) const;
+	virtual SGVector<float64_t> get_dual_first_derivative(const AnyParameter* param) const;
 
 	/** get the upper bound for dual parameter (lambda)
 	 *

--- a/src/shogun/machine/gp/MeanFunction.h
+++ b/src/shogun/machine/gp/MeanFunction.h
@@ -71,9 +71,9 @@ public:
 	 * @return derivative of mean function with respect to parameter
 	 */
 	virtual SGVector<float64_t> get_parameter_derivative(const CFeatures* features,
-			const TParameter* param, index_t index=-1)
+			const AnyParameter* param, index_t index=-1)
 	{
-		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->m_name)
+		SG_ERROR("Can't compute derivative wrt %s parameter\n", param->get_properties().get_name())
 		return SGVector<float64_t>();
 	}
 };

--- a/src/shogun/machine/gp/MultiLaplaceInferenceMethod.h
+++ b/src/shogun/machine/gp/MultiLaplaceInferenceMethod.h
@@ -225,7 +225,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -235,7 +235,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -245,7 +245,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -255,7 +255,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 private:
 
 	void init();

--- a/src/shogun/machine/gp/NumericalVGLikelihood.cpp
+++ b/src/shogun/machine/gp/NumericalVGLikelihood.cpp
@@ -95,11 +95,11 @@ void CNumericalVGLikelihood::set_GHQ_number(index_t n)
 }
 
 SGVector<float64_t> CNumericalVGLikelihood::get_first_derivative_wrt_hyperparameter(
-	const TParameter* param) const
+	const AnyParameter* param) const
 {
 	REQUIRE(param, "Param is required (param should not be NULL)\n");
-	REQUIRE(param->m_name, "Param name is required (param->m_name should not be NULL)\n");
-	if (!(strcmp(param->m_name, "mu") && strcmp(param->m_name, "sigma2")))
+	REQUIRE(param->get_properties().get_name().c_str(), "Param name is required (param->m_name should not be NULL)\n");
+	if (!(param->get_properties().get_name().compare("mu") && param->get_properties().get_name().compare("sigma2")))
 		return SGVector<float64_t> ();
 
 	SGVector<float64_t> res(m_lab.vlen);
@@ -155,19 +155,19 @@ SGVector<float64_t> CNumericalVGLikelihood::get_variational_expection()
 }
 
 SGVector<float64_t> CNumericalVGLikelihood::get_variational_first_derivative(
-		const TParameter* param) const
+		const AnyParameter* param) const
 {
 	//based on the likKL(v, lik, varargin) function in infKL.m
 
 	//compute gradient using numerical integration
 	REQUIRE(param, "Param is required (param should not be NULL)\n");
-	REQUIRE(param->m_name, "Param name is required (param->m_name should not be NULL)\n");
+	REQUIRE(param->get_properties().get_name().c_str(), "Param name is required (param->m_name should not be NULL)\n");
 	//We take the derivative wrt to param. Only mu or sigma2 can be the param
-	REQUIRE(!(strcmp(param->m_name, "mu") && strcmp(param->m_name, "sigma2")),
+	REQUIRE(!(param->get_properties().get_name().compare("mu") && param->get_properties().get_name().compare("sigma2")),
 		"Can't compute derivative of the variational expection ",
 		"of log LogitLikelihood using numerical integration ",
 		"wrt %s.%s parameter. The function only accepts mu and sigma2 as parameter\n",
-		get_name(), param->m_name);
+		get_name(), param->get_properties().get_name());
 
 	SGVector<float64_t> res(m_mu.vlen);
 	res.zero();
@@ -182,7 +182,7 @@ SGVector<float64_t> CNumericalVGLikelihood::get_variational_first_derivative(
 	else if (supports_regression())
 		lab=new CRegressionLabels(m_lab);
 
-	if (strcmp(param->m_name, "mu")==0)
+	if (param->get_properties().get_name().compare("mu")==0)
 	{
 		//Compute the derivative wrt mu
 

--- a/src/shogun/machine/gp/NumericalVGLikelihood.h
+++ b/src/shogun/machine/gp/NumericalVGLikelihood.h
@@ -104,7 +104,7 @@ public:
 	 *
 	 * @return derivative
 	 */
-	virtual SGVector<float64_t> get_variational_first_derivative(const TParameter* param) const;
+	virtual SGVector<float64_t> get_variational_first_derivative(const AnyParameter* param) const;
 
 	/** get derivative of log likelihood \f$log(p(y|f))\f$ with respect to given
 	 * hyperparameter
@@ -114,7 +114,7 @@ public:
 	 *
 	 * @return derivative
 	 */
-	virtual SGVector<float64_t> get_first_derivative_wrt_hyperparameter(const TParameter* param) const;
+	virtual SGVector<float64_t> get_first_derivative_wrt_hyperparameter(const AnyParameter* param) const;
 
 	/** set the number of Gaussian Hermite point used to compute variational expection
 	 *

--- a/src/shogun/machine/gp/SingleFITCInference.h
+++ b/src/shogun/machine/gp/SingleFITCInference.h
@@ -153,7 +153,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inducing_noise(
-		const TParameter* param);
+		const AnyParameter* param);
 
 	/** helper function to compute variables which are required to compute negative log marginal
 	 * likelihood derivatives wrt the diagonal part of cov-like hyperparameter \f$\theta\f$
@@ -180,7 +180,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_related_inducing_features(
-	SGMatrix<float64_t> BdK, const TParameter* param);
+	SGMatrix<float64_t> BdK, const AnyParameter* param);
 
 	/** update alpha vector */
 	virtual void update_alpha()=0;
@@ -201,7 +201,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param)=0;
+            const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -211,7 +211,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt inducing features (input)
 	 * Note that in order to call this method, kernel must support FITC inference,
@@ -222,7 +222,7 @@ protected:
 	 * @param param parameter of given kernel
 	 * @return derivative of negative log marginal likelihood
 	 */
-	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(const TParameter* param);
+	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(const AnyParameter* param);
 
 	/** Note that alpha is NOT post.alpha
 	 * alpha and post.alpha are defined in infFITC.m and infFITC_Laplace.m

--- a/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h
+++ b/src/shogun/machine/gp/SingleFITCLaplaceInferenceMethod.h
@@ -206,7 +206,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -216,7 +216,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -226,7 +226,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -236,7 +236,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** efficiently compute the Cholesky decomposition of inverse of the input matrix
 	 * chol(inv(mtx))
@@ -276,7 +276,7 @@ protected:
 	 * @param param parameter of given kernel
 	 * @return derivative of negative log marginal likelihood
 	 */
-	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(const TParameter* param);
+	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(const AnyParameter* param);
 
 	/** returns derivative of negative log marginal likelihood wrt inducing noise
 	 *
@@ -284,7 +284,7 @@ protected:
 	 *
 	 * @return derivative of negative log marginal likelihood
 	 */
-	virtual SGVector<float64_t> get_derivative_wrt_inducing_noise(const TParameter* param);
+	virtual SGVector<float64_t> get_derivative_wrt_inducing_noise(const AnyParameter* param);
 
 	/** returns derivative of negative log marginal likelihood wrt param
 	 * when W has at least one negative element
@@ -294,7 +294,7 @@ protected:
 	 *
 	 * @return derivative when W has negative element(s)
 	 */
-	virtual SGVector<float64_t> derivative_helper_when_Wneg(SGVector<float64_t> res, const TParameter* param);
+	virtual SGVector<float64_t> derivative_helper_when_Wneg(SGVector<float64_t> res, const AnyParameter* param);
 
 	/** compute variables which are required to compute negative log marginal
 	 * likelihood full derivatives wrt  cov-like hyperparameter \f$\theta\f$

--- a/src/shogun/machine/gp/SingleLaplaceInferenceMethod.h
+++ b/src/shogun/machine/gp/SingleLaplaceInferenceMethod.h
@@ -165,7 +165,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -175,7 +175,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -185,7 +185,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -195,7 +195,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** compute the function value given the current alpha
 	 *

--- a/src/shogun/machine/gp/SingleSparseInference.h
+++ b/src/shogun/machine/gp/SingleSparseInference.h
@@ -153,7 +153,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inducing_noise(
-		const TParameter* param)=0;
+		const AnyParameter* param)=0;
 
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
@@ -164,7 +164,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param);
+            const AnyParameter *param);
 
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
@@ -175,7 +175,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** check the bound constraint is vailid or not
 	 *
@@ -218,7 +218,7 @@ protected:
 	 * @param param parameter of given kernel
 	 * @return derivative of negative log marginal likelihood
 	 */
-	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(const TParameter* param)=0;
+	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(const AnyParameter* param)=0;
 
 	/** whether the kernel supports to get the gradient wrt inducing points or not*/
 	bool m_fully_sparse;

--- a/src/shogun/machine/gp/SparseInference.h
+++ b/src/shogun/machine/gp/SparseInference.h
@@ -242,7 +242,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inference_method(
-			const TParameter* param)=0;
+            const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt parameter of
 	 * likelihood model
@@ -252,7 +252,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param)=0;
+			const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt kernel's
 	 * parameter
@@ -262,7 +262,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_kernel(
-			const TParameter* param)=0;
+			const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -272,7 +272,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param)=0;
+			const AnyParameter *param)=0;
 
 	/** returns derivative of negative log marginal likelihood wrt
 	 * inducing noise (noise from inducing features) parameter

--- a/src/shogun/machine/gp/VarDTCInferenceMethod.h
+++ b/src/shogun/machine/gp/VarDTCInferenceMethod.h
@@ -192,7 +192,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_likelihood_model(
-			const TParameter* param);
+            const AnyParameter *param);
 
 	/** returns derivative of negative log marginal likelihood wrt inducing features (input)
 	 * Note that in order to call this method, kernel must support Sparse inference,
@@ -204,7 +204,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inducing_features(
-		const TParameter* param);
+		const AnyParameter* param);
 
 	/** returns derivative of negative log marginal likelihood wrt inducing noise
 	 *
@@ -213,7 +213,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_inducing_noise(
-		const TParameter* param);
+		const AnyParameter* param);
 
 	/** returns derivative of negative log marginal likelihood wrt mean
 	 * function's parameter
@@ -223,7 +223,7 @@ protected:
 	 * @return derivative of negative log marginal likelihood
 	 */
 	virtual SGVector<float64_t> get_derivative_wrt_mean(
-			const TParameter* param);
+			const AnyParameter *param);
 
 	/** compute variables which are required to compute negative log marginal
 	 * likelihood full derivatives wrt  cov-like hyperparameter \f$\theta\f$

--- a/src/shogun/machine/gp/VariationalLikelihood.cpp
+++ b/src/shogun/machine/gp/VariationalLikelihood.cpp
@@ -85,7 +85,7 @@ SGVector<float64_t> CVariationalLikelihood::get_predictive_variances(
 
 SGVector<float64_t> CVariationalLikelihood::get_first_derivative(
 	const CLabels* lab, SGVector<float64_t> func,
-	const TParameter* param) const
+	const AnyParameter* param) const
 {
 	REQUIRE(m_likelihood != NULL, "The likelihood should be initialized\n");
 	return m_likelihood->get_first_derivative(lab, func, param);
@@ -93,7 +93,7 @@ SGVector<float64_t> CVariationalLikelihood::get_first_derivative(
 
 SGVector<float64_t> CVariationalLikelihood::get_second_derivative(
 	const CLabels* lab, SGVector<float64_t> func,
-	const TParameter* param) const
+	const AnyParameter* param) const
 {
 	REQUIRE(m_likelihood != NULL, "The likelihood should be initialized\n");
 	return m_likelihood->get_second_derivative(lab, func, param);
@@ -101,7 +101,7 @@ SGVector<float64_t> CVariationalLikelihood::get_second_derivative(
 
 SGVector<float64_t> CVariationalLikelihood::get_third_derivative(
 	const CLabels* lab, SGVector<float64_t> func,
-	const TParameter* param) const
+	const AnyParameter* param) const
 {
 	REQUIRE(m_likelihood != NULL, "The likelihood should be initialized\n");
 	return m_likelihood->get_third_derivative(lab, func, param);

--- a/src/shogun/machine/gp/VariationalLikelihood.h
+++ b/src/shogun/machine/gp/VariationalLikelihood.h
@@ -73,7 +73,7 @@ public:
 	 *
 	 * @return derivative
 	 */
-	virtual SGVector<float64_t> get_variational_first_derivative(const TParameter* param) const=0;
+	virtual SGVector<float64_t> get_variational_first_derivative(const AnyParameter* param) const=0;
 
 	/** returns mean of the predictive marginal \f$p(y_*|X,y,x_*)\f$
 	 *
@@ -223,7 +223,7 @@ public:
 	 * @return derivative
 	 */
 	virtual SGVector<float64_t> get_first_derivative(const CLabels* lab,
-			SGVector<float64_t> func, const TParameter* param) const;
+			SGVector<float64_t> func, const AnyParameter* param) const;
 
 	/** get derivative of the first derivative of log likelihood with respect to
 	 * function location, i.e. \f$\frac{\partial log(p(y|f))}{\partial f}\f$
@@ -236,7 +236,7 @@ public:
 	 * @return derivative
 	 */
 	virtual SGVector<float64_t> get_second_derivative(const CLabels* lab,
-			SGVector<float64_t> func, const TParameter* param) const;
+			SGVector<float64_t> func, const AnyParameter* param) const;
 
 	/** get derivative of the second derivative of log likelihood with respect
 	 * to function location, i.e. \f$\frac{\partial^{2} log(p(y|f))}{\partial
@@ -249,7 +249,7 @@ public:
 	 * @return derivative
 	 */
 	virtual SGVector<float64_t> get_third_derivative(const CLabels* lab,
-			SGVector<float64_t> func, const TParameter* param) const;
+			SGVector<float64_t> func, const AnyParameter* param) const;
 
 	/** return whether likelihood function supports
 	 * computing the derivative wrt hyperparameter
@@ -267,7 +267,7 @@ public:
 	 *
 	 * @return derivative
 	 */
-	virtual SGVector<float64_t> get_first_derivative_wrt_hyperparameter(const TParameter* param) const=0;
+	virtual SGVector<float64_t> get_first_derivative_wrt_hyperparameter(const AnyParameter* param) const=0;
 
 protected:
 	/** this method is called to initialize m_likelihood in init()*/

--- a/src/shogun/modelselection/ParameterCombination.cpp
+++ b/src/shogun/modelselection/ParameterCombination.cpp
@@ -760,13 +760,13 @@ void CParameterCombination::apply_to_modsel_parameter(
 }
 
 void CParameterCombination::build_parameter_values_map(
-		CMap<TParameter*, SGVector<float64_t> >* dict)
+		CMap<AnyParameter*, SGVector<float64_t> >* dict)
 {
 	if (m_param)
 	{
 		for (index_t i=0; i<m_param->get_num_parameters(); i++)
 		{
-			TParameter* param=m_param->get_parameter(i);
+			AnyParameter* param=m_param->get_parameter(i);
 			TSGDataType type=param->m_datatype;
 
 			if (type.m_ptype==PT_FLOAT64 || type.m_ptype==PT_FLOAT32 ||

--- a/src/shogun/modelselection/ParameterCombination.h
+++ b/src/shogun/modelselection/ParameterCombination.h
@@ -243,7 +243,7 @@ public:
 	 * @param values_map map, which contains parameters and its values
 	 */
 	virtual void build_parameter_values_map(
-			CMap<TParameter*, SGVector<float64_t> >* values_map);
+			CMap<AnyParameter*, SGVector<float64_t> >* values_map);
 
 	/** builds map, which contains parameters and its parents
 	 *


### PR DESCRIPTION
WIP to remove m_gradient_parameters form SGObject. Because this parameter is of type Parameter it affects a big number of files. I use AnyParameter to pass the parameters to all the affected functions. 

There are a lot of issues that need to be fixed in this PR such as in type_case.h, makes things simpler, etc.
I added some functions in SGObject that such as get_parameter_by_name and get_parameters_by_property. These probably need to change name/location or get rid of them if there is a better solution.

Now I am at the point of changing the model selection classes. After all these are done with this PR we will be able to remove the Parameter class, the m_parameters and  m_model_selection_parameters variables.