### PR TITLE
Drop HAVE_CXX11 macro, fix for #4284

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ if (MSVC)
 	endif()
 endif()
 
-### FIXME: remove these flags when the codebase
-# is cleared up
-set(HAVE_CXX11 ON)
-
 ############# minimum library versions ###################
 SET(VIENNACL_VERSION_MINIMUM 1.5.0)
 

--- a/src/shogun/lib/GPUMatrix.cpp
+++ b/src/shogun/lib/GPUMatrix.cpp
@@ -34,7 +34,6 @@
 #include <shogun/lib/config.h>
 
 #ifdef HAVE_VIENNACL
-#ifdef HAVE_CXX11
 
 #include <shogun/lib/GPUMatrix.h>
 #include <viennacl/matrix.hpp>
@@ -206,5 +205,4 @@ template class CGPUMatrix<float32_t>;
 template class CGPUMatrix<float64_t>;
 }
 
-#endif // HAVE_CXX11
 #endif // HAVE_VIENNACL

--- a/src/shogun/lib/GPUMatrix.h
+++ b/src/shogun/lib/GPUMatrix.h
@@ -37,7 +37,6 @@
 #include <shogun/lib/config.h>
 
 #ifdef HAVE_VIENNACL
-#ifdef HAVE_CXX11
 
 #include <shogun/lib/common.h>
 #include <memory>
@@ -214,6 +213,5 @@ public:
 }
 #endif // SWIG
 
-#endif // HAVE_CXX11
 #endif // HAVE_VIENNACL
 #endif // __GPUMATRIX_H__

--- a/src/shogun/lib/config.h.in
+++ b/src/shogun/lib/config.h.in
@@ -95,8 +95,6 @@
 #cmakedefine HAVE_ALIGNED_MALLOC 1
 #cmakedefine HAVE_POSIX_MEMALIGN 1
 
-#cmakedefine HAVE_CXX11 1
-
 #cmakedefine HAVE_STD_VARIANT 1
 
 /* does the compiler support abi::__cxa_demangle */

--- a/tests/unit/base/Some_unittest.cc
+++ b/tests/unit/base/Some_unittest.cc
@@ -4,7 +4,6 @@
 #include <shogun/classifier/AveragedPerceptron.h>
 #include <shogun/kernel/GaussianKernel.h>
 
-#ifdef HAVE_CXX11
 using namespace shogun;
 
 TEST(Some,basic)
@@ -87,4 +86,3 @@ TEST(Some, constructor_new_type_wrong_casting)
 	EXPECT_TRUE(kernel.get() != nullptr);
 }
 
-#endif  // HAVE_CXX11

--- a/tests/unit/kernel/ShiftInvariantKernel_unittest.cc
+++ b/tests/unit/kernel/ShiftInvariantKernel_unittest.cc
@@ -31,8 +31,6 @@
 #include <gtest/gtest.h>
 #include <shogun/lib/config.h>
 
-#ifdef HAVE_CXX11
-
 #include <shogun/base/some.h>
 #include <shogun/kernel/Kernel.h>
 #include <shogun/kernel/ShiftInvariantKernel.h>
@@ -125,4 +123,3 @@ TEST(ShiftInvariantKernel, precompute_distance_symmetric)
 			EXPECT_NEAR(kernel_1->get_distance(i, j), kernel_2->get_distance(i, j), 1E-6);
 	}
 }
-#endif // HAVE_CXX11

--- a/tests/unit/lib/GPUMatrix_unittest.cc
+++ b/tests/unit/lib/GPUMatrix_unittest.cc
@@ -35,7 +35,6 @@
 #include <shogun/lib/config.h>
 
 #ifdef HAVE_VIENNACL
-#ifdef HAVE_CXX11
 
 #include <shogun/lib/GPUMatrix.h>
 #include <viennacl/matrix.hpp>
@@ -199,5 +198,4 @@ TEST(GPUMatrix, from_eigen3)
 		EXPECT_EQ(eigen_mat(i), gpu_mat[i]);
 }
 
-#endif // HAVE_CXX11
 #endif // HAVE_VIENNACL

--- a/tests/unit/mathematics/linalg/DenseMatrixOperator_unittest.cc
+++ b/tests/unit/mathematics/linalg/DenseMatrixOperator_unittest.cc
@@ -91,11 +91,7 @@ TEST(DenseMatrixOperator, shift_apply)
 	SGVector<complex128_t> diag=op.get_diagonal();
 	for (index_t i=0; i<diag.vlen; ++i)
 	{
-#if defined(HAVE_CXX11) || defined(_LIBCPP_VERSION)
 		diag[i].imag(diag[i].imag()-0.75);
-#else
-		diag[i].imag()-=0.75;
-#endif
 	}
 	op.set_diagonal(diag);
 
@@ -106,11 +102,7 @@ TEST(DenseMatrixOperator, shift_apply)
 	m.set_const(complex128_t(0.5, 0.0));
 	for (index_t i=0; i<size; ++i)
 	{
-#if defined(HAVE_CXX11) || defined(_LIBCPP_VERSION)
 		m(i,i).imag(m(i,i).imag()-0.75);
-#else
-		m(i,i).imag()-=0.75;
-#endif
 	}
 
 	SGVector<complex128_t> r2=op.apply(b);

--- a/tests/unit/regression/lars_unittest.cc
+++ b/tests/unit/regression/lars_unittest.cc
@@ -41,7 +41,6 @@
 using namespace Eigen;
 using namespace shogun;
 
-#ifdef HAVE_CXX11
 //Generate the Data that N is greater than D
 void generate_data_n_greater_d(SGMatrix<float64_t> &data, SGVector<float64_t> &lab)
 {
@@ -496,4 +495,3 @@ TEST(LeastAngleRegression, early_stop_l1_norm)
 	SG_UNREF(features);
 	SG_UNREF(labels);
 }
-#endif


### PR DESCRIPTION
Drop HAVE_CXX11 macro. Some fix for #4284 on gpl submodule has been submitted [there](https://github.com/shogun-toolbox/shogun-gpl/pull/9).