### PR TITLE
Remove EMachineType and related functions

### DIFF
--- a/src/shogun/classifier/NearestCentroid.cpp
+++ b/src/shogun/classifier/NearestCentroid.cpp
@@ -8,6 +8,7 @@
 #include <shogun/labels/MulticlassLabels.h>
 #include <shogun/features/Features.h>
 #include <shogun/features/FeatureTypes.h>
+#include <shogun/features/iterators/DotIterator.h>
 
 
 
@@ -43,7 +44,6 @@ namespace shogun{
 		ASSERT(m_labels)
 		ASSERT(m_labels->get_label_type() == LT_MULTICLASS)
 		ASSERT(distance)
-		ASSERT( data->get_feature_class() == C_DENSE)
 		if (data)
 		{
 			if (m_labels->get_num_labels() != data->get_num_vectors())
@@ -54,34 +54,33 @@ namespace shogun{
 		{
 			data = distance->get_lhs();
 		}
-		int32_t num_vectors = data->get_num_vectors();
-		int32_t num_classes = ((CMulticlassLabels*) m_labels)->get_num_classes();
-		int32_t num_feats = ((CDenseFeatures<float64_t>*) data)->get_num_features();
-		SGMatrix<float64_t> centroids(num_feats,num_classes);
+		ASSERT(data->get_feature_class() == C_DENSE)
+
+		auto* multiclass_labels = m_labels->as<CMulticlassLabels>();
+		auto* dense_data = data->as<CDenseFeatures<float64_t>>();
+
+		int32_t num_classes = multiclass_labels->get_num_classes();
+		int32_t num_feats = dense_data->get_num_features();
+
+		SGMatrix<float64_t> centroids(num_feats, num_classes);
 		centroids.zero();
 
-		int64_t* num_per_class = new int64_t[num_classes];
-		for (int32_t i=0 ; i<num_classes ; i++)
-		{
-			num_per_class[i]=0;
-		}
+		SGVector<int64_t> num_per_class(num_classes);
+		num_per_class.zero();
 
-		for (int32_t idx=0 ; idx<num_vectors ; idx++)
+		auto iter_labels = multiclass_labels->get_int_labels().begin();
+		for(const auto& current : DotIterator(dense_data))
 		{
-			int32_t current_len;
-			bool current_free;
-			int32_t current_class = ((CMulticlassLabels*) m_labels)->get_label(idx);
-			float64_t* target = centroids.matrix + num_feats*current_class;
-			float64_t* current = ((CDenseFeatures<float64_t>*)data)->get_feature_vector(idx,current_len,current_free);
-			SGVector<float64_t>::add(target,1.0,target,1.0,current,current_len);
+			const auto current_class = *(iter_labels++);
+			auto target = centroids.get_column_vector(current_class);
+			auto target_vec = SGVector<float64_t>(target, num_feats);
+			current.add(1, target_vec);
 			num_per_class[current_class]++;
-			((CDenseFeatures<float64_t>*)data)->free_feature_vector(current, current_len, current_free);
 		}
-
 
 		for (int32_t i=0 ; i<num_classes ; i++)
 		{
-			float64_t* target = centroids.matrix + num_feats*i;
+			auto* target = centroids.get_column_vector(i);
 			int32_t total = num_per_class[i];
 			float64_t scale = 0;
 			if(total>1)
@@ -96,8 +95,6 @@ namespace shogun{
 
 		m_is_trained=true;
 		distance->init(centroids_feats, distance->get_rhs());
-
-		SG_FREE(num_per_class);
 
 		return true;
 	}


### PR DESCRIPTION
This PR addresses the issue #4482. I must say, this PR seems like a naive implementation of what was wanted, so sorry for potentially wasting reviewers' time.
Basically, EMachineType is never used almost anywhere in a meaningful way (each machine had a machine type getter, and never used), so I just deleted all of the occurrences.
Build fails on CI since the rest of uses are in the `gpl` submodule (getters in SVM classes). Works fine locally.