### PR TITLE
Set `BUILD_META_EXAMPLES` OFF as a default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ STRING(REGEX REPLACE "[0-9]*.[0-9]*.([0-9]*)" "\\1" SHOGUN_VERSION_PATCH "${VERS
 
 ################# EXAMPLES ##################
 OPTION(BUILD_EXAMPLES "Build Examples" ON)
-OPTION(BUILD_META_EXAMPLES "Generate API examples from meta-examples" ON)
+OPTION(BUILD_META_EXAMPLES "Generate API examples from meta-examples" OFF)
 # note the examples dir is added below after tests have been defined
 
 ################# DATATYPES #################


### PR DESCRIPTION
If set `BUILD_META_EXAMPLES` `ON` as a default, first-time builders could get error in `cmake` if they don't have `python-ply` and `ctags`.
set that OFF initially, it could be **smoothier** for first-time builders to get **error free** when `cmake`. And, just as `INSTALL.md` said, if you want to build meta examples, you can manually set it on by `-DBUILD_META_EXAMPLES=ON`.