### PR TITLE
Translator doesn't find method calls within method calls

### DIFF
--- a/examples/meta/generator/translate.py
+++ b/examples/meta/generator/translate.py
@@ -19,7 +19,7 @@ def find(key, dictionary):
     for k, v in dictionary.items():
         if k == key:
             yield v
-        elif isinstance(v, dict):
+        if isinstance(v, dict):
             for result in find(key, v):
                 yield result
         elif isinstance(v, list):

--- a/examples/meta/src/evaluation/cross_validation_multiple_kernel_learning_weights_storage.sg
+++ b/examples/meta/src/evaluation/cross_validation_multiple_kernel_learning_weights_storage.sg
@@ -21,8 +21,8 @@ combined_kernel.add("kernel_array", k_3)
 #![create_kernels]
 
 #![create_classifier]
-SVM libsvm = as_svm(machine("LibSVM"))
-Machine svm = machine("MKLClassification", kernel=combined_kernel, interleaved_optimization=False, svm=libsvm)
+Machine libsvm = machine("LibSVM")
+Machine svm = machine("MKLClassification", kernel=combined_kernel, interleaved_optimization=False, svm=as_svm(libsvm))
 #![create_classifier]
 
 #![create_cross_validation]


### PR DESCRIPTION
There seems to be an issue with the recursive lookup of keywords in the program dictionary during translation. The lookup stops when it finds a keyword, but should instead continue as there may be more nested keywords of interest.
Example:
```
Machine svm = machine("...", svm=as_svm(libsvm))
```
Old behaviour ignores the `as_svm` globalCall, which causes it not to add `as_svm` import.