### PR TITLE
Exception fix

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -1086,15 +1086,19 @@ CSGObject* CSGObject::get(const std::string& name, std::nothrow_t) const
 
 CSGObject* CSGObject::get(const std::string& name) const noexcept(false)
 {
-	auto* result = get(name, std::nothrow);
-	if (!result && has(name))
+	if (!has(name))
 	{
-		SG_ERROR(
+		SG_ERROR("Parameter %s::%s does not exist.\n", get_name(), name.c_str())
+	}
+	if (auto* result = get(name, std::nothrow))
+	{
+		return result;
+	}
+	SG_ERROR(
 			"Cannot get parameter %s::%s of type %s as object.\n",
 			get_name(), name.c_str(),
 			self->map[BaseTag(name)].get_value().type().c_str());
-	}
-	return result;
+	return nullptr;
 }
 
 std::string CSGObject::string_enum_reverse_lookup(

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -342,7 +342,7 @@ public:
 	 * @return true if the parameter exists with the input name and type
 	 */
 	template <typename T, typename U = void>
-	bool has(const std::string& name) const throw(ShogunException)
+	bool has(const std::string& name) const noexcept(true)
 	{
 		BaseTag tag(name);
 		if (!has_parameter(tag))
@@ -1112,8 +1112,6 @@ template<class T>
 CSGObject* get_by_tag(const CSGObject* obj, const std::string& name,
 		T&& how)
 {
-	REQUIRE(obj->has(name), "Parameter %s::%s does not exist.\n",
-			obj->get_name(), name.c_str());
 	return get_dispatch_all_base_types(obj, name, how);
 }
 }

--- a/src/shogun/io/SGIO.h
+++ b/src/shogun/io/SGIO.h
@@ -600,6 +600,8 @@ void SGIO::message(EMessageType prio, Args&&... args) const
 template <typename ExceptionType, typename... Args>
 void SGIO::error(EMessageType prio, Args&&... args) const
 {
+	static_assert(std::is_nothrow_copy_constructible<ExceptionType>::value,
+			  "ExceptionType must be nothrow copy constructible");
 	const auto& msg = format(prio, std::forward<Args>(args)...);
 	print(prio, msg);
 	throw ExceptionType(msg);

--- a/src/shogun/lib/exception/ShogunException.cpp
+++ b/src/shogun/lib/exception/ShogunException.cpp
@@ -23,16 +23,7 @@ ShogunException::ShogunException(const char* what_arg)
 {
 }
 
-ShogunException::ShogunException(const ShogunException& orig)
-{
-	msg = orig.msg;
-}
-
-ShogunException::~ShogunException()
-{
-}
-
 const char* ShogunException::what() const noexcept
 {
-	return msg.c_str();
+	return msg.what();
 }

--- a/src/shogun/lib/exception/ShogunException.cpp
+++ b/src/shogun/lib/exception/ShogunException.cpp
@@ -14,16 +14,11 @@
 using namespace shogun;
 
 ShogunException::ShogunException(const std::string& what_arg)
-    : std::exception(), msg(what_arg)
+    : std::runtime_error(what_arg)
 {
 }
 
 ShogunException::ShogunException(const char* what_arg)
-    : std::exception(), msg(what_arg)
+	: std::runtime_error(what_arg)
 {
-}
-
-const char* ShogunException::what() const noexcept
-{
-	return msg.what();
 }

--- a/src/shogun/lib/exception/ShogunException.h
+++ b/src/shogun/lib/exception/ShogunException.h
@@ -9,14 +9,13 @@
 
 #include <shogun/lib/config.h>
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace shogun
 {
 	/** @brief Class ShogunException defines an exception which is thrown
-	 * whenever an
-	 * error inside of shogun occurs.
+	 * whenever an error inside of shogun occurs.
 	 */
 	class ShogunException : public std::exception
 	{
@@ -33,21 +32,11 @@ namespace shogun
 		 */
 		explicit ShogunException(const char* what_arg);
 
-		/** copy constructor
-		 *
-		 * @param orig source object
-		 */
-		ShogunException(const ShogunException& orig);
-
-		/** destructor
-		 */
-		virtual ~ShogunException();
-
-		virtual const char* what() const noexcept override;
+		const char* what() const noexcept override;
 
 	private:
-		/** exception string */
-		std::string msg;
+		/** exception object */
+		std::runtime_error msg;
 	};
-}
+} // namespace shogun
 #endif // _SHOGUN_EXCEPTION_H_

--- a/src/shogun/lib/exception/ShogunException.h
+++ b/src/shogun/lib/exception/ShogunException.h
@@ -17,7 +17,7 @@ namespace shogun
 	/** @brief Class ShogunException defines an exception which is thrown
 	 * whenever an error inside of shogun occurs.
 	 */
-	class ShogunException : public std::exception
+	class ShogunException : public std::runtime_error
 	{
 	public:
 		/** constructor
@@ -31,12 +31,6 @@ namespace shogun
 		 * @param str exception string
 		 */
 		explicit ShogunException(const char* what_arg);
-
-		const char* what() const noexcept override;
-
-	private:
-		/** exception object */
-		std::runtime_error msg;
 	};
 } // namespace shogun
 #endif // _SHOGUN_EXCEPTION_H_


### PR DESCRIPTION
Fixes two things:
 - SGObject::get noexcept version calling a function that throws an error 
 - ShogunException c++11 compliance (which requires exceptions to be nothrow copy constructible)
see https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible