### PR TITLE
isfinite for msvc

### DIFF
--- a/src/shogun/util/converters.h
+++ b/src/shogun/util/converters.h
@@ -12,6 +12,15 @@
 
 #include <shogun/lib/common.h>
 
+#ifdef _MSC_VER
+#include <cfloat>
+// TODO: microsoft should really start supporting c++11
+#define IS_FINITE(x) _isfinite(x)
+#else
+#include <cmath>
+#define IS_FINITE(x) std::isfinite(x)
+#endif
+
 namespace shogun
 {
 	namespace utils
@@ -29,7 +38,7 @@ namespace shogun
 		    std::is_signed<I>::value && std::is_signed<J>::value, I>
 		safe_convert(J value)
 		{
-			if (std::isfinite(value) &&
+			if (IS_FINITE(value) &&
 			    (value < std::numeric_limits<I>::lowest() ||
 			     value > std::numeric_limits<I>::max()))
 				throw std::overflow_error(


### PR DESCRIPTION
`std::isfinite` in msvc only accepts floats (otherwise there is an `ambiguous call to overloaded function` compiler error), so need to use `_isfinite` from cfloat to implicitly covert non-floats to floats.