### PR TITLE
Fix observe() method when called for SGVector/SGMatrix.

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <shogun/lib/type_case.h>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -30,7 +30,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <shogun/lib/type_case.h>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <shogun/lib/type_case.h>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace
@@ -1011,7 +1012,16 @@ protected:
 	 * @param step step
 	 * @param name tag's name
 	 */
-	template <class T>
+	template<class T,
+			typename std::enable_if_t<
+				!type_internal::is_sg_vector<T>::value &&
+				!type_internal::is_sg_matrix<T>::value>* = nullptr>
+	void observe(const int64_t step, const std::string& name) const;
+
+	template<class T,
+			typename std::enable_if_t<
+					type_internal::is_sg_vector<T>::value ||
+					type_internal::is_sg_matrix<T>::value>* = nullptr>
 	void observe(const int64_t step, const std::string& name) const;
 
 	/**
@@ -1313,7 +1323,10 @@ void CSGObject::observe(
 	this->observe(obs);
 }
 
-template <class T>
+	template<class T,
+			typename std::enable_if_t<
+					!type_internal::is_sg_vector<T>::value &&
+					!type_internal::is_sg_matrix<T>::value>* = nullptr>
 void CSGObject::observe(const int64_t step, const std::string& name) const
 {
 	auto param = this->get_parameter(BaseTag(name));
@@ -1321,5 +1334,19 @@ void CSGObject::observe(const int64_t step, const std::string& name) const
 		step, name, any_cast<T>(param.get_value()), param.get_properties());
 	this->observe(obs);
 }
+
+template<class T,
+		typename std::enable_if_t<
+				type_internal::is_sg_vector<T>::value ||
+				type_internal::is_sg_matrix<T>::value>* = nullptr>
+void CSGObject::observe(const int64_t step, const std::string& name) const
+{
+	auto param = this->get_parameter(BaseTag(name));
+	auto obs = some<ObservedValueTemplated<T>>(
+			step, name, any_cast<T>(param.get_value()).clone(), param.get_properties());
+	this->observe(obs);
+}
+
+
 }
 #endif // __SGOBJECT_H__

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -30,7 +30,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <shogun/lib/type_case.h>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace
@@ -1014,14 +1013,14 @@ protected:
 	 */
 	template<class T,
 			typename std::enable_if_t<
-				!type_internal::is_sg_vector<T>::value &&
-				!type_internal::is_sg_matrix<T>::value>* = nullptr>
+				!is_sg_vector<T>::value &&
+				!is_sg_matrix<T>::value>* = nullptr>
 	void observe(const int64_t step, const std::string& name) const;
 
 	template<class T,
 			typename std::enable_if_t<
-					type_internal::is_sg_vector<T>::value ||
-					type_internal::is_sg_matrix<T>::value>* = nullptr>
+					is_sg_vector<T>::value ||
+					is_sg_matrix<T>::value>* = nullptr>
 	void observe(const int64_t step, const std::string& name) const;
 
 	/**
@@ -1323,10 +1322,10 @@ void CSGObject::observe(
 	this->observe(obs);
 }
 
-	template<class T,
-			typename std::enable_if_t<
-					!type_internal::is_sg_vector<T>::value &&
-					!type_internal::is_sg_matrix<T>::value>* = nullptr>
+template<class T,
+		typename std::enable_if_t<
+				!is_sg_vector<T>::value &&
+				!is_sg_matrix<T>::value>*>
 void CSGObject::observe(const int64_t step, const std::string& name) const
 {
 	auto param = this->get_parameter(BaseTag(name));
@@ -1337,8 +1336,8 @@ void CSGObject::observe(const int64_t step, const std::string& name) const
 
 template<class T,
 		typename std::enable_if_t<
-				type_internal::is_sg_vector<T>::value ||
-				type_internal::is_sg_matrix<T>::value>* = nullptr>
+				is_sg_vector<T>::value ||
+				is_sg_matrix<T>::value>*>
 void CSGObject::observe(const int64_t step, const std::string& name) const
 {
 	auto param = this->get_parameter(BaseTag(name));

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <shogun/util/clone.h>
 
 /** \namespace shogun
  * @brief all of classes and functions are contained in the shogun namespace
@@ -1011,16 +1012,7 @@ protected:
 	 * @param step step
 	 * @param name tag's name
 	 */
-	template<class T,
-			typename std::enable_if_t<
-				!is_sg_vector<T>::value &&
-				!is_sg_matrix<T>::value>* = nullptr>
-	void observe(const int64_t step, const std::string& name) const;
-
-	template<class T,
-			typename std::enable_if_t<
-					is_sg_vector<T>::value ||
-					is_sg_matrix<T>::value>* = nullptr>
+	template <class T>
 	void observe(const int64_t step, const std::string& name) const;
 
 	/**
@@ -1322,27 +1314,13 @@ void CSGObject::observe(
 	this->observe(obs);
 }
 
-template<class T,
-		typename std::enable_if_t<
-				!is_sg_vector<T>::value &&
-				!is_sg_matrix<T>::value>*>
+template <class T>
 void CSGObject::observe(const int64_t step, const std::string& name) const
 {
 	auto param = this->get_parameter(BaseTag(name));
+	auto cloned = any_cast<T>(param.get_value());
 	auto obs = some<ObservedValueTemplated<T>>(
-		step, name, any_cast<T>(param.get_value()), param.get_properties());
-	this->observe(obs);
-}
-
-template<class T,
-		typename std::enable_if_t<
-				is_sg_vector<T>::value ||
-				is_sg_matrix<T>::value>*>
-void CSGObject::observe(const int64_t step, const std::string& name) const
-{
-	auto param = this->get_parameter(BaseTag(name));
-	auto obs = some<ObservedValueTemplated<T>>(
-			step, name, any_cast<T>(param.get_value()).clone(), param.get_properties());
+		step, name, static_cast<T>(clone_utils::clone(cloned)), param.get_properties());
 	this->observe(obs);
 }
 

--- a/src/shogun/base/base_types.h
+++ b/src/shogun/base/base_types.h
@@ -68,6 +68,31 @@ namespace shogun
 	                  const char*, typename std::decay<T>::type>::value>
 	{
 	};
+
+	// General type traits to recognize SGMatrix and SGVectors.
+	template <typename T> class SGMatrix;
+	template <typename T> class SGVector;
+
+	template <typename>
+	struct is_sg_vector : std::false_type
+	{
+	};
+
+	template <typename T>
+	struct is_sg_vector<SGVector<T>> : std::true_type
+	{
+	};
+
+	template <typename>
+	struct is_sg_matrix : std::false_type
+	{
+	};
+
+	template <typename T>
+	struct is_sg_matrix<SGMatrix<T>> : std::true_type
+	{
+	};
+
 } // namespace shogun
 
 #endif // BASE_TYPES__H

--- a/src/shogun/base/base_types.h
+++ b/src/shogun/base/base_types.h
@@ -7,6 +7,8 @@
 #ifndef BASE_TYPES_H
 #define BASE_TYPES_H
 
+#include <shogun/lib/common.h>
+
 namespace shogun
 {
 
@@ -68,6 +70,121 @@ namespace shogun
 	                  const char*, typename std::decay<T>::type>::value>
 	{
 	};
+
+	// Primitive types
+	enum class TYPE
+	{
+		T_BOOL = 1,
+		T_CHAR = 2,
+		T_INT8 = 3,
+		T_UINT8 = 4,
+		T_INT16 = 5,
+		T_UINT16 = 6,
+		T_INT32 = 7,
+		T_UINT32 = 8,
+		T_INT64 = 9,
+		T_UINT64 = 10,
+		T_FLOAT32 = 11,
+		T_FLOAT64 = 12,
+		T_FLOATMAX = 13,
+		T_SGOBJECT = 14,
+		T_COMPLEX128 = 15,
+		T_SGVECTOR_FLOAT32 = 16,
+		T_SGVECTOR_FLOAT64 = 17,
+		T_SGVECTOR_FLOATMAX = 18,
+		T_SGVECTOR_INT32 = 19,
+		T_SGVECTOR_INT64 = 20,
+		T_SGMATRIX_FLOAT32 = 21,
+		T_SGMATRIX_FLOAT64 = 22,
+		T_SGMATRIX_FLOATMAX = 23,
+		T_SGMATRIX_INT32 = 24,
+		T_SGMATRIX_INT64 = 25,
+		T_UNDEFINED = 26
+	};
+
+
+	template <class T> class SGVector;
+	template <class T> class SGMatrix;
+
+	namespace type_internal
+	{
+		template <typename T>
+		struct sg_type
+		{
+		};
+
+		template <typename T>
+		struct is_sg_primitive : public std::false_type
+		{
+		};
+
+		template <typename T>
+		struct is_sg_vector : public std::false_type
+		{
+		};
+
+		template <typename T>
+		struct is_sg_matrix : public std::false_type
+		{
+		};
+
+#define SG_ADD_TYPE(T, type_)                                                  \
+	template <>                                                                \
+	struct sg_type<T>                                                          \
+	{                                                                          \
+		static constexpr TYPE ptype = type_;                                   \
+	};
+#define SG_ADD_PRIMITIVE_TYPE(T, type_)                                        \
+	SG_ADD_TYPE(T, type_)                                                      \
+	template <>                                                                \
+	struct is_sg_primitive<T> : public std::true_type                          \
+	{                                                                          \
+	};
+#define SG_ADD_SGVECTOR_TYPE(T, type_)                                         \
+	SG_ADD_TYPE(T, type_)                                                      \
+	template <>                                                                \
+	struct is_sg_vector<T> : public std::true_type                             \
+	{                                                                          \
+	};
+#define SG_ADD_SGMATRIX_TYPE(T, type_)                                         \
+	SG_ADD_TYPE(T, type_)                                                      \
+	template <>                                                                \
+	struct is_sg_matrix<T> : public std::true_type                             \
+	{                                                                          \
+	};
+
+		SG_ADD_PRIMITIVE_TYPE(bool, TYPE::T_BOOL)
+		SG_ADD_PRIMITIVE_TYPE(char, TYPE::T_CHAR)
+		SG_ADD_PRIMITIVE_TYPE(int8_t, TYPE::T_INT8)
+		SG_ADD_PRIMITIVE_TYPE(uint8_t, TYPE::T_UINT8)
+		SG_ADD_PRIMITIVE_TYPE(int16_t, TYPE::T_INT16)
+		SG_ADD_PRIMITIVE_TYPE(uint16_t, TYPE::T_UINT16)
+		SG_ADD_PRIMITIVE_TYPE(int32_t, TYPE::T_INT32)
+		SG_ADD_PRIMITIVE_TYPE(uint32_t, TYPE::T_UINT32)
+		SG_ADD_PRIMITIVE_TYPE(int64_t, TYPE::T_INT64)
+		SG_ADD_PRIMITIVE_TYPE(uint64_t, TYPE::T_UINT64)
+		SG_ADD_PRIMITIVE_TYPE(float32_t, TYPE::T_FLOAT32)
+		SG_ADD_PRIMITIVE_TYPE(float64_t, TYPE::T_FLOAT64)
+		SG_ADD_PRIMITIVE_TYPE(floatmax_t, TYPE::T_FLOATMAX)
+		SG_ADD_PRIMITIVE_TYPE(complex128_t, TYPE::T_COMPLEX128)
+SG_ADD_SGVECTOR_TYPE(SGVector<float32_t>, TYPE::T_SGVECTOR_FLOAT32)
+SG_ADD_SGVECTOR_TYPE(SGVector<float64_t>, TYPE::T_SGVECTOR_FLOAT64)
+SG_ADD_SGVECTOR_TYPE(SGVector<floatmax_t>, TYPE::T_SGVECTOR_FLOATMAX)
+SG_ADD_SGVECTOR_TYPE(SGVector<int32_t>, TYPE::T_SGVECTOR_INT32)
+SG_ADD_SGVECTOR_TYPE(SGVector<int64_t>, TYPE::T_SGVECTOR_INT64)
+SG_ADD_SGMATRIX_TYPE(SGMatrix<float32_t>, TYPE::T_SGMATRIX_FLOAT32)
+SG_ADD_SGMATRIX_TYPE(SGMatrix<float64_t>, TYPE::T_SGMATRIX_FLOAT64)
+SG_ADD_SGMATRIX_TYPE(SGMatrix<floatmax_t>, TYPE::T_SGMATRIX_FLOATMAX)
+SG_ADD_SGMATRIX_TYPE(SGMatrix<int32_t>, TYPE::T_SGMATRIX_INT32)
+SG_ADD_SGMATRIX_TYPE(SGMatrix<int64_t>, TYPE::T_SGMATRIX_INT64)
+
+#undef SG_ADD_TYPE
+#undef SG_ADD_PRIMITIVE_TYPE
+#undef SG_ADD_SGVECTOR_TYPE
+#undef SG_ADD_SGMATRIX_TYPE
+	}
+
+
 } // namespace shogun
 
 #endif // BASE_TYPES__H

--- a/src/shogun/base/base_types.h
+++ b/src/shogun/base/base_types.h
@@ -7,8 +7,6 @@
 #ifndef BASE_TYPES_H
 #define BASE_TYPES_H
 
-#include <shogun/lib/common.h>
-
 namespace shogun
 {
 
@@ -70,121 +68,6 @@ namespace shogun
 	                  const char*, typename std::decay<T>::type>::value>
 	{
 	};
-
-	// Primitive types
-	enum class TYPE
-	{
-		T_BOOL = 1,
-		T_CHAR = 2,
-		T_INT8 = 3,
-		T_UINT8 = 4,
-		T_INT16 = 5,
-		T_UINT16 = 6,
-		T_INT32 = 7,
-		T_UINT32 = 8,
-		T_INT64 = 9,
-		T_UINT64 = 10,
-		T_FLOAT32 = 11,
-		T_FLOAT64 = 12,
-		T_FLOATMAX = 13,
-		T_SGOBJECT = 14,
-		T_COMPLEX128 = 15,
-		T_SGVECTOR_FLOAT32 = 16,
-		T_SGVECTOR_FLOAT64 = 17,
-		T_SGVECTOR_FLOATMAX = 18,
-		T_SGVECTOR_INT32 = 19,
-		T_SGVECTOR_INT64 = 20,
-		T_SGMATRIX_FLOAT32 = 21,
-		T_SGMATRIX_FLOAT64 = 22,
-		T_SGMATRIX_FLOATMAX = 23,
-		T_SGMATRIX_INT32 = 24,
-		T_SGMATRIX_INT64 = 25,
-		T_UNDEFINED = 26
-	};
-
-
-	template <class T> class SGVector;
-	template <class T> class SGMatrix;
-
-	namespace type_internal
-	{
-		template <typename T>
-		struct sg_type
-		{
-		};
-
-		template <typename T>
-		struct is_sg_primitive : public std::false_type
-		{
-		};
-
-		template <typename T>
-		struct is_sg_vector : public std::false_type
-		{
-		};
-
-		template <typename T>
-		struct is_sg_matrix : public std::false_type
-		{
-		};
-
-#define SG_ADD_TYPE(T, type_)                                                  \
-	template <>                                                                \
-	struct sg_type<T>                                                          \
-	{                                                                          \
-		static constexpr TYPE ptype = type_;                                   \
-	};
-#define SG_ADD_PRIMITIVE_TYPE(T, type_)                                        \
-	SG_ADD_TYPE(T, type_)                                                      \
-	template <>                                                                \
-	struct is_sg_primitive<T> : public std::true_type                          \
-	{                                                                          \
-	};
-#define SG_ADD_SGVECTOR_TYPE(T, type_)                                         \
-	SG_ADD_TYPE(T, type_)                                                      \
-	template <>                                                                \
-	struct is_sg_vector<T> : public std::true_type                             \
-	{                                                                          \
-	};
-#define SG_ADD_SGMATRIX_TYPE(T, type_)                                         \
-	SG_ADD_TYPE(T, type_)                                                      \
-	template <>                                                                \
-	struct is_sg_matrix<T> : public std::true_type                             \
-	{                                                                          \
-	};
-
-		SG_ADD_PRIMITIVE_TYPE(bool, TYPE::T_BOOL)
-		SG_ADD_PRIMITIVE_TYPE(char, TYPE::T_CHAR)
-		SG_ADD_PRIMITIVE_TYPE(int8_t, TYPE::T_INT8)
-		SG_ADD_PRIMITIVE_TYPE(uint8_t, TYPE::T_UINT8)
-		SG_ADD_PRIMITIVE_TYPE(int16_t, TYPE::T_INT16)
-		SG_ADD_PRIMITIVE_TYPE(uint16_t, TYPE::T_UINT16)
-		SG_ADD_PRIMITIVE_TYPE(int32_t, TYPE::T_INT32)
-		SG_ADD_PRIMITIVE_TYPE(uint32_t, TYPE::T_UINT32)
-		SG_ADD_PRIMITIVE_TYPE(int64_t, TYPE::T_INT64)
-		SG_ADD_PRIMITIVE_TYPE(uint64_t, TYPE::T_UINT64)
-		SG_ADD_PRIMITIVE_TYPE(float32_t, TYPE::T_FLOAT32)
-		SG_ADD_PRIMITIVE_TYPE(float64_t, TYPE::T_FLOAT64)
-		SG_ADD_PRIMITIVE_TYPE(floatmax_t, TYPE::T_FLOATMAX)
-		SG_ADD_PRIMITIVE_TYPE(complex128_t, TYPE::T_COMPLEX128)
-SG_ADD_SGVECTOR_TYPE(SGVector<float32_t>, TYPE::T_SGVECTOR_FLOAT32)
-SG_ADD_SGVECTOR_TYPE(SGVector<float64_t>, TYPE::T_SGVECTOR_FLOAT64)
-SG_ADD_SGVECTOR_TYPE(SGVector<floatmax_t>, TYPE::T_SGVECTOR_FLOATMAX)
-SG_ADD_SGVECTOR_TYPE(SGVector<int32_t>, TYPE::T_SGVECTOR_INT32)
-SG_ADD_SGVECTOR_TYPE(SGVector<int64_t>, TYPE::T_SGVECTOR_INT64)
-SG_ADD_SGMATRIX_TYPE(SGMatrix<float32_t>, TYPE::T_SGMATRIX_FLOAT32)
-SG_ADD_SGMATRIX_TYPE(SGMatrix<float64_t>, TYPE::T_SGMATRIX_FLOAT64)
-SG_ADD_SGMATRIX_TYPE(SGMatrix<floatmax_t>, TYPE::T_SGMATRIX_FLOATMAX)
-SG_ADD_SGMATRIX_TYPE(SGMatrix<int32_t>, TYPE::T_SGMATRIX_INT32)
-SG_ADD_SGMATRIX_TYPE(SGMatrix<int64_t>, TYPE::T_SGMATRIX_INT64)
-
-#undef SG_ADD_TYPE
-#undef SG_ADD_PRIMITIVE_TYPE
-#undef SG_ADD_SGVECTOR_TYPE
-#undef SG_ADD_SGMATRIX_TYPE
-	}
-
-
 } // namespace shogun
 
 #endif // BASE_TYPES__H

--- a/src/shogun/lib/type_case.h
+++ b/src/shogun/lib/type_case.h
@@ -10,6 +10,7 @@
 #include <typeindex>
 #include <unordered_map>
 
+#include <shogun/base/base_types.h>
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/any.h>
@@ -20,65 +21,17 @@ using namespace shogun;
 namespace shogun
 {
 	typedef Types<
-	    bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-	    int64_t, uint64_t, float32_t, float64_t, floatmax_t, SGVector<int32_t>,
-	    SGVector<int64_t>, SGVector<float32_t>, SGVector<float64_t>,
-	    SGVector<floatmax_t>, SGMatrix<int32_t>, SGMatrix<int64_t>,
-	    SGMatrix<float32_t>, SGMatrix<float64_t>, SGMatrix<floatmax_t>>
-	    SG_TYPES;
+			bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+			int64_t, uint64_t, float32_t, float64_t, floatmax_t, SGVector<int32_t>,
+			SGVector<int64_t>, SGVector<float32_t>, SGVector<float64_t>,
+			SGVector<floatmax_t>, SGMatrix<int32_t>, SGMatrix<int64_t>,
+			SGMatrix<float32_t>, SGMatrix<float64_t>, SGMatrix<floatmax_t>>
+			SG_TYPES;
 
-	enum class TYPE
-	{
-		T_BOOL = 1,
-		T_CHAR = 2,
-		T_INT8 = 3,
-		T_UINT8 = 4,
-		T_INT16 = 5,
-		T_UINT16 = 6,
-		T_INT32 = 7,
-		T_UINT32 = 8,
-		T_INT64 = 9,
-		T_UINT64 = 10,
-		T_FLOAT32 = 11,
-		T_FLOAT64 = 12,
-		T_FLOATMAX = 13,
-		T_SGOBJECT = 14,
-		T_COMPLEX128 = 15,
-		T_SGVECTOR_FLOAT32 = 16,
-		T_SGVECTOR_FLOAT64 = 17,
-		T_SGVECTOR_FLOATMAX = 18,
-		T_SGVECTOR_INT32 = 19,
-		T_SGVECTOR_INT64 = 20,
-		T_SGMATRIX_FLOAT32 = 21,
-		T_SGMATRIX_FLOAT64 = 22,
-		T_SGMATRIX_FLOATMAX = 23,
-		T_SGMATRIX_INT32 = 24,
-		T_SGMATRIX_INT64 = 25,
-		T_UNDEFINED = 26
-	};
 	typedef std::unordered_map<std::type_index, TYPE> typemap;
+
 	namespace type_internal
 	{
-
-		template <typename T>
-		struct sg_type
-		{
-		};
-
-		template <typename T>
-		struct is_sg_primitive : public std::false_type
-		{
-		};
-
-		template <typename T>
-		struct is_sg_vector : public std::false_type
-		{
-		};
-
-		template <typename T>
-		struct is_sg_matrix : public std::false_type
-		{
-		};
 
 		template <typename T>
 		struct is_none : public std::false_type
@@ -88,61 +41,6 @@ namespace shogun
 		struct is_none<None> : public std::true_type
 		{
 		};
-
-#define SG_ADD_TYPE(T, type_)                                                  \
-	template <>                                                                \
-	struct sg_type<T>                                                          \
-	{                                                                          \
-		static constexpr TYPE ptype = type_;                                   \
-	};
-#define SG_ADD_PRIMITIVE_TYPE(T, type_)                                        \
-	SG_ADD_TYPE(T, type_)                                                      \
-	template <>                                                                \
-	struct is_sg_primitive<T> : public std::true_type                          \
-	{                                                                          \
-	};
-#define SG_ADD_SGVECTOR_TYPE(T, type_)                                         \
-	SG_ADD_TYPE(T, type_)                                                      \
-	template <>                                                                \
-	struct is_sg_vector<T> : public std::true_type                             \
-	{                                                                          \
-	};
-#define SG_ADD_SGMATRIX_TYPE(T, type_)                                         \
-	SG_ADD_TYPE(T, type_)                                                      \
-	template <>                                                                \
-	struct is_sg_matrix<T> : public std::true_type                             \
-	{                                                                          \
-	};
-
-		SG_ADD_PRIMITIVE_TYPE(bool, TYPE::T_BOOL)
-		SG_ADD_PRIMITIVE_TYPE(char, TYPE::T_CHAR)
-		SG_ADD_PRIMITIVE_TYPE(int8_t, TYPE::T_INT8)
-		SG_ADD_PRIMITIVE_TYPE(uint8_t, TYPE::T_UINT8)
-		SG_ADD_PRIMITIVE_TYPE(int16_t, TYPE::T_INT16)
-		SG_ADD_PRIMITIVE_TYPE(uint16_t, TYPE::T_UINT16)
-		SG_ADD_PRIMITIVE_TYPE(int32_t, TYPE::T_INT32)
-		SG_ADD_PRIMITIVE_TYPE(uint32_t, TYPE::T_UINT32)
-		SG_ADD_PRIMITIVE_TYPE(int64_t, TYPE::T_INT64)
-		SG_ADD_PRIMITIVE_TYPE(uint64_t, TYPE::T_UINT64)
-		SG_ADD_PRIMITIVE_TYPE(float32_t, TYPE::T_FLOAT32)
-		SG_ADD_PRIMITIVE_TYPE(float64_t, TYPE::T_FLOAT64)
-		SG_ADD_PRIMITIVE_TYPE(floatmax_t, TYPE::T_FLOATMAX)
-		SG_ADD_PRIMITIVE_TYPE(complex128_t, TYPE::T_COMPLEX128)
-		SG_ADD_SGVECTOR_TYPE(SGVector<float32_t>, TYPE::T_SGVECTOR_FLOAT32)
-		SG_ADD_SGVECTOR_TYPE(SGVector<float64_t>, TYPE::T_SGVECTOR_FLOAT64)
-		SG_ADD_SGVECTOR_TYPE(SGVector<floatmax_t>, TYPE::T_SGVECTOR_FLOATMAX)
-		SG_ADD_SGVECTOR_TYPE(SGVector<int32_t>, TYPE::T_SGVECTOR_INT32)
-		SG_ADD_SGVECTOR_TYPE(SGVector<int64_t>, TYPE::T_SGVECTOR_INT64)
-		SG_ADD_SGMATRIX_TYPE(SGMatrix<float32_t>, TYPE::T_SGMATRIX_FLOAT32)
-		SG_ADD_SGMATRIX_TYPE(SGMatrix<float64_t>, TYPE::T_SGMATRIX_FLOAT64)
-		SG_ADD_SGMATRIX_TYPE(SGMatrix<floatmax_t>, TYPE::T_SGMATRIX_FLOATMAX)
-		SG_ADD_SGMATRIX_TYPE(SGMatrix<int32_t>, TYPE::T_SGMATRIX_INT32)
-		SG_ADD_SGMATRIX_TYPE(SGMatrix<int64_t>, TYPE::T_SGMATRIX_INT64)
-
-#undef SG_ADD_TYPE
-#undef SG_ADD_PRIMITIVE_TYPE
-#undef SG_ADD_SGVECTOR_TYPE
-#undef SG_ADD_SGMATRIX_TYPE
 
 		SG_FORCED_INLINE static std::string print_map(const typemap& map)
 		{

--- a/src/shogun/lib/type_case.h
+++ b/src/shogun/lib/type_case.h
@@ -10,7 +10,6 @@
 #include <typeindex>
 #include <unordered_map>
 
-#include <shogun/base/base_types.h>
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/lib/any.h>
@@ -21,17 +20,65 @@ using namespace shogun;
 namespace shogun
 {
 	typedef Types<
-			bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-			int64_t, uint64_t, float32_t, float64_t, floatmax_t, SGVector<int32_t>,
-			SGVector<int64_t>, SGVector<float32_t>, SGVector<float64_t>,
-			SGVector<floatmax_t>, SGMatrix<int32_t>, SGMatrix<int64_t>,
-			SGMatrix<float32_t>, SGMatrix<float64_t>, SGMatrix<floatmax_t>>
-			SG_TYPES;
+	    bool, char, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+	    int64_t, uint64_t, float32_t, float64_t, floatmax_t, SGVector<int32_t>,
+	    SGVector<int64_t>, SGVector<float32_t>, SGVector<float64_t>,
+	    SGVector<floatmax_t>, SGMatrix<int32_t>, SGMatrix<int64_t>,
+	    SGMatrix<float32_t>, SGMatrix<float64_t>, SGMatrix<floatmax_t>>
+	    SG_TYPES;
 
+	enum class TYPE
+	{
+		T_BOOL = 1,
+		T_CHAR = 2,
+		T_INT8 = 3,
+		T_UINT8 = 4,
+		T_INT16 = 5,
+		T_UINT16 = 6,
+		T_INT32 = 7,
+		T_UINT32 = 8,
+		T_INT64 = 9,
+		T_UINT64 = 10,
+		T_FLOAT32 = 11,
+		T_FLOAT64 = 12,
+		T_FLOATMAX = 13,
+		T_SGOBJECT = 14,
+		T_COMPLEX128 = 15,
+		T_SGVECTOR_FLOAT32 = 16,
+		T_SGVECTOR_FLOAT64 = 17,
+		T_SGVECTOR_FLOATMAX = 18,
+		T_SGVECTOR_INT32 = 19,
+		T_SGVECTOR_INT64 = 20,
+		T_SGMATRIX_FLOAT32 = 21,
+		T_SGMATRIX_FLOAT64 = 22,
+		T_SGMATRIX_FLOATMAX = 23,
+		T_SGMATRIX_INT32 = 24,
+		T_SGMATRIX_INT64 = 25,
+		T_UNDEFINED = 26
+	};
 	typedef std::unordered_map<std::type_index, TYPE> typemap;
-
 	namespace type_internal
 	{
+
+		template <typename T>
+		struct sg_type
+		{
+		};
+
+		template <typename T>
+		struct is_sg_primitive : public std::false_type
+		{
+		};
+
+		template <typename T>
+		struct is_sg_vector : public std::false_type
+		{
+		};
+
+		template <typename T>
+		struct is_sg_matrix : public std::false_type
+		{
+		};
 
 		template <typename T>
 		struct is_none : public std::false_type
@@ -41,6 +88,61 @@ namespace shogun
 		struct is_none<None> : public std::true_type
 		{
 		};
+
+#define SG_ADD_TYPE(T, type_)                                                  \
+	template <>                                                                \
+	struct sg_type<T>                                                          \
+	{                                                                          \
+		static constexpr TYPE ptype = type_;                                   \
+	};
+#define SG_ADD_PRIMITIVE_TYPE(T, type_)                                        \
+	SG_ADD_TYPE(T, type_)                                                      \
+	template <>                                                                \
+	struct is_sg_primitive<T> : public std::true_type                          \
+	{                                                                          \
+	};
+#define SG_ADD_SGVECTOR_TYPE(T, type_)                                         \
+	SG_ADD_TYPE(T, type_)                                                      \
+	template <>                                                                \
+	struct is_sg_vector<T> : public std::true_type                             \
+	{                                                                          \
+	};
+#define SG_ADD_SGMATRIX_TYPE(T, type_)                                         \
+	SG_ADD_TYPE(T, type_)                                                      \
+	template <>                                                                \
+	struct is_sg_matrix<T> : public std::true_type                             \
+	{                                                                          \
+	};
+
+		SG_ADD_PRIMITIVE_TYPE(bool, TYPE::T_BOOL)
+		SG_ADD_PRIMITIVE_TYPE(char, TYPE::T_CHAR)
+		SG_ADD_PRIMITIVE_TYPE(int8_t, TYPE::T_INT8)
+		SG_ADD_PRIMITIVE_TYPE(uint8_t, TYPE::T_UINT8)
+		SG_ADD_PRIMITIVE_TYPE(int16_t, TYPE::T_INT16)
+		SG_ADD_PRIMITIVE_TYPE(uint16_t, TYPE::T_UINT16)
+		SG_ADD_PRIMITIVE_TYPE(int32_t, TYPE::T_INT32)
+		SG_ADD_PRIMITIVE_TYPE(uint32_t, TYPE::T_UINT32)
+		SG_ADD_PRIMITIVE_TYPE(int64_t, TYPE::T_INT64)
+		SG_ADD_PRIMITIVE_TYPE(uint64_t, TYPE::T_UINT64)
+		SG_ADD_PRIMITIVE_TYPE(float32_t, TYPE::T_FLOAT32)
+		SG_ADD_PRIMITIVE_TYPE(float64_t, TYPE::T_FLOAT64)
+		SG_ADD_PRIMITIVE_TYPE(floatmax_t, TYPE::T_FLOATMAX)
+		SG_ADD_PRIMITIVE_TYPE(complex128_t, TYPE::T_COMPLEX128)
+		SG_ADD_SGVECTOR_TYPE(SGVector<float32_t>, TYPE::T_SGVECTOR_FLOAT32)
+		SG_ADD_SGVECTOR_TYPE(SGVector<float64_t>, TYPE::T_SGVECTOR_FLOAT64)
+		SG_ADD_SGVECTOR_TYPE(SGVector<floatmax_t>, TYPE::T_SGVECTOR_FLOATMAX)
+		SG_ADD_SGVECTOR_TYPE(SGVector<int32_t>, TYPE::T_SGVECTOR_INT32)
+		SG_ADD_SGVECTOR_TYPE(SGVector<int64_t>, TYPE::T_SGVECTOR_INT64)
+		SG_ADD_SGMATRIX_TYPE(SGMatrix<float32_t>, TYPE::T_SGMATRIX_FLOAT32)
+		SG_ADD_SGMATRIX_TYPE(SGMatrix<float64_t>, TYPE::T_SGMATRIX_FLOAT64)
+		SG_ADD_SGMATRIX_TYPE(SGMatrix<floatmax_t>, TYPE::T_SGMATRIX_FLOATMAX)
+		SG_ADD_SGMATRIX_TYPE(SGMatrix<int32_t>, TYPE::T_SGMATRIX_INT32)
+		SG_ADD_SGMATRIX_TYPE(SGMatrix<int64_t>, TYPE::T_SGMATRIX_INT64)
+
+#undef SG_ADD_TYPE
+#undef SG_ADD_PRIMITIVE_TYPE
+#undef SG_ADD_SGVECTOR_TYPE
+#undef SG_ADD_SGMATRIX_TYPE
 
 		SG_FORCED_INLINE static std::string print_map(const typemap& map)
 		{

--- a/src/shogun/util/clone.h
+++ b/src/shogun/util/clone.h
@@ -1,0 +1,63 @@
+/*
+* Written (W) 2019 Giovanni De Toni
+*/
+
+#include <type_traits>
+
+#ifndef SHOGUN_CLONE_H
+#define SHOGUN_CLONE_H
+
+namespace shogun {
+	namespace clone_utils
+	{
+
+		struct clone_by_cctor
+		{
+		};
+
+		struct clone_from_value : clone_by_cctor
+		{
+		};
+
+		struct clone_from_pointer : clone_from_value
+		{
+		};
+
+		template <class T, std::enable_if_t<std::is_copy_constructible<T>::value>* = nullptr>
+		inline T clone_impl(clone_by_cctor, const T& value)
+		{
+			return T(value);
+		}
+
+		template <class T>
+		inline auto clone_impl(clone_from_value, T& value)
+		-> decltype(value.clone())
+		{
+			return value.clone();
+		}
+
+		template <class T>
+		inline auto clone_impl(clone_from_pointer, T* value)
+		-> decltype(value->clone())
+		{
+			return value->clone();
+		}
+
+		/**
+		 * Clone a Shogun object by calling its clone() method.
+		 * It also works with non-Shogun object by using the copy
+		 * constructor.
+		 * @tparam T type
+		 * @param value value we want to clone
+		 * @return the cloned value
+		 */
+		template <class T>
+		inline auto clone(T& value)
+		-> decltype(clone_impl(clone_from_pointer(), value))
+		{
+			return clone_impl(clone_from_pointer(), value);
+		}
+	}
+}
+
+#endif //SHOGUN_CLONE_H

--- a/tests/unit/base/MockObject.h
+++ b/tests/unit/base/MockObject.h
@@ -316,6 +316,13 @@ namespace shogun
 			watch_method("some_method", &CMockObject::some_method);
 		}
 
+		virtual CSGObject* create_empty() const
+		{
+			auto new_instance = new CMockObject();
+			SG_REF(new_instance)
+			return new_instance;
+		};
+
 	private:
 		int32_t m_integer = 0;
 		int32_t m_watched = 0;


### PR DESCRIPTION
* Fix `observe()` method when called for `SGVector`/`SGMatrix`. The given `SGVector/SGMatrix` was not cloned correctly (since copying them just copy the pointer to the raw data and it does not make a clone of the data itself).

<del>I moved some useful type traits from `type_case.h` to `base_types.h` since I did not want to pollute too much `SGObject.h` with unnecessary headers. </del>

Any comments on this change? @karlnapf @vigsterkr @gf712   