### PR TITLE
fixes swig 4.0.0 compilation error

### DIFF
--- a/src/interfaces/python/CustomKernel_protocols.i
+++ b/src/interfaces/python/CustomKernel_protocols.i
@@ -332,7 +332,7 @@ fail:
 }
 
 /* used for numpy's style slicing */
-static PyObject* class_name ## _getsubscript(PyObject *self, PyObject *key, bool get_scalar=true)
+static PyObject* class_name ## _getsubscript_helper(PyObject *self, PyObject *key, bool get_scalar=true)
 {
 	// key is tuple, like (PySlice or PyLong, PySlice or PyLong)
 	// or only PySlice/PyLong
@@ -489,6 +489,11 @@ fail:
 	return NULL;
 }
 
+static PyObject* class_name ## _getsubscript(PyObject *self, PyObject *key)
+{
+	return class_name ##  _getsubscript_helper(self, key, true);
+}
+
 /* used for numpy's style slicing */
 static int class_name ## _setsubscript(PyObject *self, PyObject *key, PyObject* v)
 {
@@ -501,7 +506,7 @@ static int class_name ## _setsubscript(PyObject *self, PyObject *key, PyObject* 
 		goto fail;
 	}
 
-	tmp = (PyArrayObject *) class_name ## _getsubscript(self, key, false);
+	tmp = (PyArrayObject *) class_name ## _getsubscript_helper(self, key, false);
 	if(tmp == NULL)
 	{
 		goto fail;

--- a/src/interfaces/python/DenseFeatures_protocols.i
+++ b/src/interfaces/python/DenseFeatures_protocols.i
@@ -326,7 +326,7 @@ fail:
 }
 
 /* used for numpy's style slicing */
-static PyObject* class_name ## _getsubscript(PyObject *self, PyObject *key, bool get_scalar=true)
+static PyObject* class_name ## _getsubscript_helper(PyObject *self, PyObject *key, bool get_scalar=true)
 {
 	// key is tuple, like (PySlice or PyLong, PySlice or PyLong)
 	// or only PySlice or PyLong
@@ -483,6 +483,11 @@ fail:
 	return NULL;
 }
 
+static PyObject* class_name ## _getsubscript(PyObject *self, PyObject *key)
+{
+	return class_name ## _getsubscript_helper(self, key, true);
+}
+
 /* used for numpy's style slicing */
 static int class_name ## _setsubscript(PyObject *self, PyObject *key, PyObject* v)
 {
@@ -495,7 +500,7 @@ static int class_name ## _setsubscript(PyObject *self, PyObject *key, PyObject* 
 		goto fail;
 	}
 
-	tmp = (PyArrayObject *) class_name ## _getsubscript(self, key, false);
+	tmp = (PyArrayObject *) class_name ## _getsubscript_helper(self, key, false);
 	if(tmp == NULL)
 	{
 		goto fail;

--- a/src/interfaces/python/DenseLabels_protocols.i
+++ b/src/interfaces/python/DenseLabels_protocols.i
@@ -145,7 +145,7 @@ static void class_name ## _releasebuffer(PyObject *self, Py_buffer *view)
 }
 
 /* used by PySequence_GetItem */
-static PyObject* class_name ## _getitem(PyObject *self, Py_ssize_t idx, bool get_scalar=true)
+static PyObject* class_name ## _getitem_helper(PyObject *self, Py_ssize_t idx, bool get_scalar=true)
 {
 	class_type* arg1=0; // self in c++ repr
 	void* argp1=0; // pointer to self
@@ -213,6 +213,11 @@ fail:
 	return NULL;
 }
 
+static PyObject* class_name ## _getitem(PyObject *self, Py_ssize_t idx)
+{
+	return class_name ## _getitem_helper(self, idx, true);
+}
+
 /* used by PySequence_SetItem */
 static int class_name ## _setitem(PyObject *self, Py_ssize_t idx, PyObject *v)
 {
@@ -225,7 +230,7 @@ static int class_name ## _setitem(PyObject *self, Py_ssize_t idx, PyObject *v)
 		goto fail;
 	}
 
-	tmp=(PyArrayObject *) class_name ## _getitem(self, idx, false);
+	tmp=(PyArrayObject *) class_name ## _getitem_helper(self, idx, false);
 	if(tmp==NULL)
 	{
 		goto fail;

--- a/src/interfaces/python/SGVector_protocols.i
+++ b/src/interfaces/python/SGVector_protocols.i
@@ -144,7 +144,7 @@ static void class_name ## _releasebuffer(PyObject *self, Py_buffer *view)
 }
 
 /* used by PySequence_GetItem */
-static PyObject* class_name ## _getitem(PyObject *self, Py_ssize_t idx, bool get_scalar=true)
+static PyObject* class_name ## _getitem_helper(PyObject *self, Py_ssize_t idx, bool get_scalar=true)
 {
 	SGVector< type_name >* arg1=(SGVector< type_name >*) 0; // self in c++ repr
 	void* argp1=0; // pointer to self
@@ -212,6 +212,11 @@ fail:
 	return NULL;
 }
 
+static PyObject* class_name ## _getitem(PyObject *self, Py_ssize_t idx)
+{
+	return class_name ## _getitem_helper(self, idx, true);
+}
+
 /* used by PySequence_SetItem */
 static int class_name ## _setitem(PyObject *self, Py_ssize_t idx, PyObject *v)
 {
@@ -224,7 +229,7 @@ static int class_name ## _setitem(PyObject *self, Py_ssize_t idx, PyObject *v)
 		goto fail;
 	}
 
-	tmp=(PyArrayObject *) class_name ## _getitem(self, idx, false);
+	tmp=(PyArrayObject *) class_name ## _getitem_helper(self, idx, false);
 	if(tmp==NULL)
 	{
 		goto fail;


### PR DESCRIPTION
The `PySequenceMethods.sq_item` and `PyMappingMethods.mp_subscript` functions/PyObject* in shogun are not conforming to the format `PyObject*(PyObject *o, Py_ssize_t i)` (they are `PyObject*(PyObject *o, Py_ssize_t I, bool)`). 
This causes a compilation error in SWIG 4.0.0, for example:
```
shogunPYTHON_wrap.cxx:812720:5: error: cannot initialize a member subobject of type 'binaryfunc' (aka '_object *(*)(_object *, _object *)') with an lvalue of type 'PyObject *(PyObject *, PyObject *, bool)' (aka '_object *(_object *, _object *, bool)'): different number of parameters (2 vs 3)
    CustomKernel_getsubscript,                /* mp_subscript */
```
This PR hides the 3 argument implementation from python and exposes a function with 2 args that calls the 3 args version.