### PR TITLE
Make kernel normalizer functions const

### DIFF
--- a/src/shogun/kernel/normalizer/AvgDiagKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/AvgDiagKernelNormalizer.h
@@ -80,7 +80,7 @@ class CAvgDiagKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			return value/scale;
 		}
@@ -89,7 +89,7 @@ class CAvgDiagKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			return value/sqrt(scale);
 		}
@@ -98,7 +98,7 @@ class CAvgDiagKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			return value/sqrt(scale);
 		}

--- a/src/shogun/kernel/normalizer/DiceKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/DiceKernelNormalizer.h
@@ -85,7 +85,7 @@ class CDiceKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			float64_t diag_sum=diag_lhs[idx_lhs]*diag_rhs[idx_rhs];
 			return 2*value/diag_sum;
@@ -95,7 +95,7 @@ class CDiceKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			SG_ERROR("linadd not supported with Dice normalization.\n")
 			return 0;
@@ -105,7 +105,7 @@ class CDiceKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			SG_ERROR("linadd not supported with Dice normalization.\n")
 			return 0;
@@ -119,12 +119,12 @@ class CDiceKernelNormalizer : public CKernelNormalizer
 		virtual const char* get_name() const {
 			return "DiceKernelNormalizer"; }
 
-    public:
+    protected:
 		/**
 		 * alloc and compute the vector containing the square root of the
 		 * diagonal elements of this kernel.
 		 */
-		bool alloc_and_compute_diag(CKernel* k, float64_t* &v, int32_t num)
+		bool alloc_and_compute_diag(CKernel* k, float64_t* &v, int32_t num) const
 		{
 			SG_FREE(v);
 			v=SG_MALLOC(float64_t, num);
@@ -148,7 +148,6 @@ class CDiceKernelNormalizer : public CKernelNormalizer
 			return (v!=NULL);
 		}
 
-    protected:
 		/** diagonal left-hand side */
 		float64_t* diag_lhs;
 		/** num diag lhs */

--- a/src/shogun/kernel/normalizer/FirstElementKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/FirstElementKernelNormalizer.h
@@ -62,7 +62,7 @@ class CFirstElementKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			return value/scale;
 		}
@@ -71,7 +71,7 @@ class CFirstElementKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			return value/sqrt(scale);
 		}
@@ -80,7 +80,7 @@ class CFirstElementKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			return value/sqrt(scale);
 		}

--- a/src/shogun/kernel/normalizer/IdentityKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/IdentityKernelNormalizer.h
@@ -40,7 +40,7 @@ class CIdentityKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-				float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+				float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			return value;
 		}
@@ -49,7 +49,7 @@ class CIdentityKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			return value;
 		}
@@ -58,7 +58,7 @@ class CIdentityKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			return value;
 		}

--- a/src/shogun/kernel/normalizer/KernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/KernelNormalizer.h
@@ -71,20 +71,28 @@ class CKernelNormalizer : public CSGObject
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)=0;
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const=0;
 
 		/** normalize only the left hand side vector
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)=0;
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const=0;
 
 		/** normalize only the right hand side vector
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)=0;
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const=0;
 
+		/** getter for normalizer type
+		 */
+		ENormalizerType get_normalizer_type() const noexcept
+		{
+			return m_type;
+		}
+
+	protected:
 		/** register the parameters
 		 */
 		virtual void register_params()
@@ -92,13 +100,6 @@ class CKernelNormalizer : public CSGObject
 			SG_ADD_OPTIONS(
 			    (machine_int_t*)&m_type, "m_type", "Normalizer type.",
 			    ParameterProperties::NONE, SG_OPTIONS(N_REGULAR, N_MULTITASK));
-		}
-
-		/** getter for normalizer type
-		 */
-		ENormalizerType get_normalizer_type()
-		{
-			return m_type;
 		}
 
 		/** setter for normalizer type
@@ -109,7 +110,6 @@ class CKernelNormalizer : public CSGObject
 			m_type = type;
 		}
 
-	protected:
 		/** normalizer type */
 		ENormalizerType m_type;
 };

--- a/src/shogun/kernel/normalizer/RidgeKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/RidgeKernelNormalizer.h
@@ -101,7 +101,7 @@ class CRidgeKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			if (idx_lhs==idx_rhs)
 				return value+ridge;
@@ -113,7 +113,7 @@ class CRidgeKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			SG_ERROR("linadd not supported with Ridge normalization.\n")
 			return 0;
@@ -123,7 +123,7 @@ class CRidgeKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			SG_ERROR("linadd not supported with Ridge normalization.\n")
 			return 0;

--- a/src/shogun/kernel/normalizer/ScatterKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/ScatterKernelNormalizer.h
@@ -77,7 +77,7 @@ public:
 	 *
 	 * @return testing class (-1 disabled, 0...class otherwise)
 	 */
-	int32_t get_testing_class()
+	int32_t get_testing_class() const noexcept
 	{
 		return m_testing_class;
 	}
@@ -97,7 +97,7 @@ public:
 	 * @param idx_rhs index of right hand side vector
 	 */
 	virtual float64_t normalize(float64_t value, int32_t idx_lhs,
-			int32_t idx_rhs)
+			int32_t idx_rhs) const
 	{
 		value=m_normalizer->normalize(value, idx_lhs, idx_rhs);
 		float64_t c=m_const_offdiag;
@@ -120,7 +120,7 @@ public:
 	 * @param value value of a component of the left hand side feature vector
 	 * @param idx_lhs index of left hand side vector
 	 */
-	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 	{
 		SG_ERROR("normalize_lhs not implemented")
 		return 0;
@@ -130,7 +130,7 @@ public:
 	 * @param value value of a component of the right hand side feature vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 	{
 		SG_ERROR("normalize_rhs not implemented")
 		return 0;

--- a/src/shogun/kernel/normalizer/SqrtDiagKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/SqrtDiagKernelNormalizer.h
@@ -89,7 +89,7 @@ class CSqrtDiagKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			float64_t sqrt_both=sqrtdiag_lhs[idx_lhs]*sqrtdiag_rhs[idx_rhs];
 			return value/sqrt_both;
@@ -99,7 +99,7 @@ class CSqrtDiagKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			return value/sqrtdiag_lhs[idx_lhs];
 		}
@@ -108,17 +108,20 @@ class CSqrtDiagKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			return value/sqrtdiag_rhs[idx_rhs];
 		}
 
-    public:
+		/** @return object name */
+		virtual const char* get_name() const { return "SqrtDiagKernelNormalizer"; }
+
+    protected:
 		/**
 		 * alloc and compute the vector containing the square root of the
 		 * diagonal elements of this kernel.
 		 */
-		bool alloc_and_compute_diag(CKernel* k, float64_t* &v, int32_t num)
+		bool alloc_and_compute_diag(CKernel* k, float64_t* &v, int32_t num) const
 		{
 			SG_FREE(v);
 			v=SG_MALLOC(float64_t, num);
@@ -142,10 +145,6 @@ class CSqrtDiagKernelNormalizer : public CKernelNormalizer
 			return (v!=NULL);
 		}
 
-		/** @return object name */
-		virtual const char* get_name() const { return "SqrtDiagKernelNormalizer"; }
-
-    protected:
 		/** sqrt diagonal left-hand side */
 		float64_t* sqrtdiag_lhs;
 

--- a/src/shogun/kernel/normalizer/TanimotoKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/TanimotoKernelNormalizer.h
@@ -74,7 +74,7 @@ class CTanimotoKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			float64_t diag_sum=diag_lhs[idx_lhs]*diag_rhs[idx_rhs];
 			return value/(diag_sum-value);
@@ -84,7 +84,7 @@ class CTanimotoKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			SG_ERROR("linadd not supported with Tanimoto normalization.\n")
 			return 0;
@@ -94,7 +94,7 @@ class CTanimotoKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			SG_ERROR("linadd not supported with Tanimoto normalization.\n")
 			return 0;
@@ -108,12 +108,12 @@ class CTanimotoKernelNormalizer : public CKernelNormalizer
 		virtual const char* get_name() const {
 			return "TanimotoKernelNormalizer"; }
 
-    public:
+    protected:
 		/**
 		 * alloc and compute the vector containing the square root of the
 		 * diagonal elements of this kernel.
 		 */
-		bool alloc_and_compute_diag(CKernel* k, float64_t* &v, int32_t num)
+		bool alloc_and_compute_diag(CKernel* k, float64_t* &v, int32_t num) const
 		{
 			SG_FREE(v);
 			v=SG_MALLOC(float64_t, num);
@@ -137,7 +137,6 @@ class CTanimotoKernelNormalizer : public CKernelNormalizer
 			return (v!=NULL);
 		}
 
-    protected:
 		/** diagonal left-hand side */
 		float64_t* diag_lhs;
 		/** diagonal right-hand side */

--- a/src/shogun/kernel/normalizer/VarianceKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/VarianceKernelNormalizer.h
@@ -80,7 +80,7 @@ class CVarianceKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-			float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+			float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			return value*meandiff;
 		}
@@ -89,7 +89,7 @@ class CVarianceKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			return value*sqrt_meandiff;
 		}
@@ -98,7 +98,7 @@ class CVarianceKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			return value*sqrt_meandiff;
 		}

--- a/src/shogun/kernel/normalizer/ZeroMeanCenterKernelNormalizer.h
+++ b/src/shogun/kernel/normalizer/ZeroMeanCenterKernelNormalizer.h
@@ -103,7 +103,7 @@ class CZeroMeanCenterKernelNormalizer : public CKernelNormalizer
 		 * @param idx_rhs index of right hand side vector
 		 */
 		virtual float64_t normalize(
-				float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+				float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 		{
 			value += (-ktrain_row_means[idx_lhs] - ktest_row_means[idx_rhs] + ktrain_mean);
 			return value;
@@ -113,7 +113,7 @@ class CZeroMeanCenterKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the left hand side feature vector
 		 * @param idx_lhs index of left hand side vector
 		 */
-		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+		virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 		{
 			SG_ERROR("normalize_lhs not implemented")
 			return 0;
@@ -123,7 +123,7 @@ class CZeroMeanCenterKernelNormalizer : public CKernelNormalizer
 		 * @param value value of a component of the right hand side feature vector
 		 * @param idx_rhs index of right hand side vector
 		 */
-		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+		virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 		{
 			SG_ERROR("normalize_rhs not implemented")
 			return 0;
@@ -133,7 +133,7 @@ class CZeroMeanCenterKernelNormalizer : public CKernelNormalizer
 		 * alloc and compute the vector containing the row margins of all rows
 		 * for a kernel matrix.
 		 */
-		bool alloc_and_compute_row_means(CKernel* k, float64_t* &v, int32_t num_lhs, int32_t num_rhs)
+		bool alloc_and_compute_row_means(CKernel* k, float64_t* &v, int32_t num_lhs, int32_t num_rhs) const
 		{
 			SG_FREE(v);
 			v=SG_MALLOC(float64_t, num_rhs);

--- a/src/shogun/transfer/multitask/MultitaskKernelMaskNormalizer.h
+++ b/src/shogun/transfer/multitask/MultitaskKernelMaskNormalizer.h
@@ -110,7 +110,7 @@ public:
 	 * @param idx_lhs index of left hand side vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize(float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+	virtual float64_t normalize(float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 	{
 
 		//lookup tasks
@@ -132,7 +132,7 @@ public:
 	 * @param value value of a component of the left hand side feature vector
 	 * @param idx_lhs index of left hand side vector
 	 */
-	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 	{
 		SG_ERROR("normalize_lhs not implemented")
 		return 0;
@@ -142,7 +142,7 @@ public:
 	 * @param value value of a component of the right hand side feature vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 	{
 		SG_ERROR("normalize_rhs not implemented")
 		return 0;
@@ -202,7 +202,7 @@ public:
 	 * @param task_rhs task_id on right hand side
 	 * @return similarity between tasks
 	 */
-	float64_t get_similarity(int32_t task_lhs, int32_t task_rhs)
+	float64_t get_similarity(int32_t task_lhs, int32_t task_rhs) const noexcept
 	{
 
 		const bool lhs_is_in = active_tasks.find(task_lhs) != active_tasks.end();
@@ -222,7 +222,7 @@ public:
 	/**
 	 * @return list of active task ids
 	 */
-	std::vector<int32_t> get_active_tasks()
+	std::vector<int32_t> get_active_tasks() const
 	{
 
 		std::vector<int32_t> active_tasks_vec;

--- a/src/shogun/transfer/multitask/MultitaskKernelMaskPairNormalizer.h
+++ b/src/shogun/transfer/multitask/MultitaskKernelMaskPairNormalizer.h
@@ -96,7 +96,7 @@ public:
 	 * @param idx_lhs index of left hand side vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize(float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+	virtual float64_t normalize(float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 	{
 
 		//lookup tasks
@@ -118,7 +118,7 @@ public:
 	 * @param value value of a component of the left hand side feature vector
 	 * @param idx_lhs index of left hand side vector
 	 */
-	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 	{
 		SG_ERROR("normalize_lhs not implemented")
 		return 0;
@@ -128,7 +128,7 @@ public:
 	 * @param value value of a component of the right hand side feature vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 	{
 		SG_ERROR("normalize_rhs not implemented")
 		return 0;
@@ -188,7 +188,7 @@ public:
 	 * @param task_rhs task_id on right hand side
 	 * @return similarity between tasks
 	 */
-	float64_t get_similarity(int32_t task_lhs, int32_t task_rhs)
+	float64_t get_similarity(int32_t task_lhs, int32_t task_rhs) const noexcept
 	{
 
 		float64_t similarity = 0.0;

--- a/src/shogun/transfer/multitask/MultitaskKernelMklNormalizer.h
+++ b/src/shogun/transfer/multitask/MultitaskKernelMklNormalizer.h
@@ -73,7 +73,7 @@ public:
 	 * @param value value of a component of the left hand side feature vector
 	 * @param idx_lhs index of left hand side vector
 	 */
-	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 	{
 		SG_ERROR("normalize_lhs not implemented")
 		return 0;
@@ -83,7 +83,7 @@ public:
 	 * @param value value of a component of the right hand side feature vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 	{
 		SG_ERROR("normalize_rhs not implemented")
 		return 0;
@@ -95,7 +95,7 @@ public:
 	/**
 	 *  @param idx index of MKL weight to get
 	 */
-	virtual float64_t get_beta(int32_t idx) = 0;
+	virtual float64_t get_beta(int32_t idx) const = 0;
 
 	/**
 	 *  @param idx index of MKL weight to set
@@ -107,7 +107,7 @@ public:
 	/**
 	 * @return number of sub-kernel weights for MKL
 	 */
-	virtual int32_t get_num_betas() = 0;
+	virtual int32_t get_num_betas() const noexcept = 0;
 
 
 	/** @return object name */

--- a/src/shogun/transfer/multitask/MultitaskKernelNormalizer.h
+++ b/src/shogun/transfer/multitask/MultitaskKernelNormalizer.h
@@ -99,7 +99,7 @@ public:
 	 * @param vec vector with containing task_id for each example
 	 * @return number of unique task ids
 	 */
-	int32_t get_num_unique_tasks(std::vector<int32_t> vec) {
+	int32_t get_num_unique_tasks(std::vector<int32_t> vec) const noexcept {
 
 		//sort
 		std::sort(vec.begin(), vec.end());
@@ -120,7 +120,7 @@ public:
 	 * @param idx_rhs index of right hand side vector
 	 */
 	virtual float64_t normalize(float64_t value, int32_t idx_lhs,
-			int32_t idx_rhs)
+			int32_t idx_rhs) const
 	{
 
 		//lookup tasks
@@ -143,7 +143,7 @@ public:
 	 * @param value value of a component of the left hand side feature vector
 	 * @param idx_lhs index of left hand side vector
 	 */
-	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 	{
 		SG_ERROR("normalize_lhs not implemented")
 		return 0;
@@ -153,7 +153,7 @@ public:
 	 * @param value value of a component of the right hand side feature vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 	{
 		SG_ERROR("normalize_rhs not implemented")
 		return 0;
@@ -197,7 +197,7 @@ public:
 	 * @param task_rhs task_id on right hand side
 	 * @return similarity between tasks
 	 */
-	float64_t get_task_similarity(int32_t task_lhs, int32_t task_rhs)
+	float64_t get_task_similarity(int32_t task_lhs, int32_t task_rhs) const
 	{
 
 		ASSERT(task_lhs < num_tasks && task_lhs >= 0)

--- a/src/shogun/transfer/multitask/MultitaskKernelPlifNormalizer.h
+++ b/src/shogun/transfer/multitask/MultitaskKernelPlifNormalizer.h
@@ -70,7 +70,7 @@ public:
 	 * @param idx_rhs index of right hand side vector
 	 */
 	virtual float64_t normalize(float64_t value, int32_t idx_lhs,
-			int32_t idx_rhs)
+			int32_t idx_rhs) const
 	{
 
 		//lookup tasks
@@ -94,7 +94,7 @@ public:
 	 * @param vec vector with containing task_id for each example
 	 * @return number of unique task ids
 	 */
-	int32_t get_num_unique_tasks(std::vector<int32_t> vec) {
+	int32_t get_num_unique_tasks(std::vector<int32_t> vec) const noexcept {
 
 		//sort
 		std::sort(vec.begin(), vec.end());
@@ -136,7 +136,7 @@ public:
 
 
 	/** derive similarity from distance with plif */
-	float64_t compute_task_similarity(int32_t task_a, int32_t task_b)
+	float64_t compute_task_similarity(int32_t task_a, int32_t task_b) const
 	{
 
 		float64_t distance = get_task_distance(task_a, task_b);
@@ -216,7 +216,7 @@ public:
 	 * @param task_rhs task_id on right hand side
 	 * @return distance between tasks
 	 */
-	float64_t get_task_distance(int32_t task_lhs, int32_t task_rhs)
+	float64_t get_task_distance(int32_t task_lhs, int32_t task_rhs) const
 	{
 
 		ASSERT(task_lhs < num_tasks && task_lhs >= 0)
@@ -247,7 +247,7 @@ public:
 	 * @param task_rhs task_id on right hand side
 	 * @return similarity between tasks
 	 */
-	float64_t get_task_similarity(int32_t task_lhs, int32_t task_rhs)
+	float64_t get_task_similarity(int32_t task_lhs, int32_t task_rhs) const
 	{
 
 		ASSERT(task_lhs < num_tasks && task_lhs >= 0)
@@ -276,7 +276,7 @@ public:
 	/**
 	 *  @param idx index of MKL weight to get
 	 */
-	float64_t get_beta(int32_t idx)
+	float64_t get_beta(int32_t idx) const
 	{
 
 		return betas[idx];
@@ -299,7 +299,7 @@ public:
 	/**
 	 *  @return number of kernel weights (support points)
 	 */
-	int32_t get_num_betas()
+	int32_t get_num_betas() const noexcept
 	{
 
 		return num_betas;

--- a/src/shogun/transfer/multitask/MultitaskKernelTreeNormalizer.h
+++ b/src/shogun/transfer/multitask/MultitaskKernelTreeNormalizer.h
@@ -102,7 +102,7 @@ public:
     }
 
     /** @return boolean indicating, whether this node is a leaf */
-    bool is_leaf()
+    bool is_leaf() const noexcept
 	{
 		return children.empty();
 
@@ -170,7 +170,7 @@ public:
 	 *  @param task_id task identifier
 	 *  @return node with id task_id
 	 */
-	CNode* get_node(int32_t task_id) {
+	CNode* get_node(int32_t task_id) const{
 		return nodes[task_id];
 	}
 
@@ -226,7 +226,7 @@ public:
 	 *  @param node_rhs node of right hand side
 	 *  @return intersection of the two sets of ancestors
 	 */
-	std::set<CNode*> intersect_root_path(CNode* node_lhs, CNode* node_rhs)
+	std::set<CNode*> intersect_root_path(CNode* node_lhs, CNode* node_rhs) const
 	{
 
 		std::set<CNode*> root_path_lhs = node_lhs->get_path_root();
@@ -247,7 +247,7 @@ public:
 	 * @param task_rhs task_id on right hand side
 	 * @return similarity between tasks
 	 */
-	float64_t compute_node_similarity(int32_t task_lhs, int32_t task_rhs)
+	float64_t compute_node_similarity(int32_t task_lhs, int32_t task_rhs) const
 	{
 
 		CNode* node_lhs = get_node(task_lhs);
@@ -297,13 +297,13 @@ public:
 	}
 
 	/** @return number of nodes */
-	int32_t get_num_nodes()
+	int32_t get_num_nodes() const noexcept
 	{
 		return (int32_t)(nodes.size());
 	}
 
 	/** @return number of leaves */
-	int32_t get_num_leaves()
+	int32_t get_num_leaves() const
 	{
 		int32_t num_leaves = 0;
 
@@ -319,7 +319,7 @@ public:
 	}
 
 	/** @return weight of node with identifier idx */
-	float64_t get_node_weight(int32_t idx)
+	float64_t get_node_weight(int32_t idx) const
 	{
 		CNode* node = get_node(idx);
 		return node->beta;
@@ -342,7 +342,7 @@ public:
 	}
 
 	/** @return mapping from name to id */
-	std::map<std::string, int32_t> get_name2id() {
+	std::map<std::string, int32_t> get_name2id() const noexcept {
 		return name2id;
 	}
 
@@ -438,7 +438,7 @@ public:
 	 * @param idx_lhs index of left hand side vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize(float64_t value, int32_t idx_lhs, int32_t idx_rhs)
+	virtual float64_t normalize(float64_t value, int32_t idx_lhs, int32_t idx_rhs) const
 	{
 		//lookup tasks
 		int32_t task_idx_lhs = task_vector_lhs[idx_lhs];
@@ -459,7 +459,7 @@ public:
 	 * @param value value of a component of the left hand side feature vector
 	 * @param idx_lhs index of left hand side vector
 	 */
-	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs)
+	virtual float64_t normalize_lhs(float64_t value, int32_t idx_lhs) const
 	{
 		SG_ERROR("normalize_lhs not implemented")
 		return 0;
@@ -469,7 +469,7 @@ public:
 	 * @param value value of a component of the right hand side feature vector
 	 * @param idx_rhs index of right hand side vector
 	 */
-	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs)
+	virtual float64_t normalize_rhs(float64_t value, int32_t idx_rhs) const
 	{
 		SG_ERROR("normalize_rhs not implemented")
 		return 0;
@@ -513,7 +513,7 @@ public:
 	}
 
 	/** @return number of parameters/weights */
-	int32_t get_num_betas()
+	int32_t get_num_betas() const noexcept
 	{
 
 		return taxonomy.get_num_nodes();
@@ -523,7 +523,7 @@ public:
 	/**
 	 * @param idx id of weight
 	 * @return weight of node with given id */
-	float64_t get_beta(int32_t idx)
+	float64_t get_beta(int32_t idx) const
 	{
 
 		return taxonomy.get_node_weight(idx);
@@ -548,7 +548,7 @@ public:
 	 * @param node_rhs node_id on right hand side
 	 * @return similarity between nodes
 	 */
-	float64_t get_node_similarity(int32_t node_lhs, int32_t node_rhs)
+	float64_t get_node_similarity(int32_t node_lhs, int32_t node_rhs) const
 	{
 
 		ASSERT(node_lhs < num_nodes && node_lhs >= 0)


### PR DESCRIPTION
This makes the kernel normalizer interface constant, which will be useful when attempting to make the kernel interface stateless. It also changes accessibility of `alloc_and_compute_diag` in some normalizers from public to protected, since it's only a helper function used in initialization.