### PR TITLE
Constrain parameter values

### DIFF
--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -37,7 +37,8 @@ namespace shogun
 	        {ParameterProperties::MODEL, "MODEL"},
 	        {ParameterProperties::AUTO, "AUTO"},
 	        {ParameterProperties::READONLY, "READONLY"},
-	        {ParameterProperties::RUNFUNCTION, "RUNFUNCTION"}};
+	        {ParameterProperties::RUNFUNCTION, "RUNFUNCTION"},
+	        {ParameterProperties::CONSTRAIN, "CONSTRAIN"}};
 
 	enableEnumClassBitmask(ParameterProperties);
 
@@ -87,11 +88,11 @@ namespace shogun
 		{
 			return static_cast<bool>(m_attribute_mask & other);
 		}
-		bool compare_mask(const ParameterProperties other) const
+		bool compare_mask(ParameterProperties other) const
 		{
 			return m_attribute_mask == other;
 		}
-		void remove_property(const ParameterProperties other)
+		void remove_property(ParameterProperties other)
 		{
 			m_attribute_mask &= ~other;
 		}
@@ -139,9 +140,9 @@ namespace shogun
 		{
 		}
 		AnyParameter(
-		    const Any& value, AnyParameterProperties properties,
-		    std::function<bool(Any)> constrain_function)
-		    : m_value(value), m_properties(properties),
+		    Any&& value, const AnyParameterProperties& properties,
+		    std::function<std::string(Any)> constrain_function)
+		    : m_value(std::move(value)), m_properties(properties),
 		      m_constrain_function(std::move(constrain_function))
 		{
 		}
@@ -172,12 +173,13 @@ namespace shogun
 			return m_properties;
 		}
 
-		std::shared_ptr<params::AutoInit> get_init_function() const
+		const std::shared_ptr<params::AutoInit>& get_init_function() const
 		{
 			return m_init_function;
 		}
 
-		const std::function<bool(Any)>& get_constrain_function() const noexcept
+		const std::function<std::string(Any)>& get_constrain_function() const
+		    noexcept
 		{
 			return m_constrain_function;
 		}
@@ -199,7 +201,7 @@ namespace shogun
 		Any m_value;
 		AnyParameterProperties m_properties;
 		std::shared_ptr<params::AutoInit> m_init_function;
-		std::function<bool(Any)> m_constrain_function;
+		std::function<std::string(Any)> m_constrain_function;
 	};
 } // namespace shogun
 

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -25,7 +25,8 @@ namespace shogun
 		MODEL = 1u << 2,
 		AUTO = 1u << 10,
 		READONLY = 1u << 11,
-		RUNFUNCTION = 1u << 12
+		RUNFUNCTION = 1u << 12,
+		CONSTRAIN = 1u << 13
 	};
 
 	static const std::list<std::pair<ParameterProperties, std::string>>
@@ -137,9 +138,17 @@ namespace shogun
 		      m_init_function(std::move(auto_init))
 		{
 		}
+		AnyParameter(
+		    const Any& value, AnyParameterProperties properties,
+		    std::function<bool(Any)> constrain_function)
+		    : m_value(value), m_properties(properties),
+		      m_constrain_function(std::move(constrain_function))
+		{
+		}
 		AnyParameter(const AnyParameter& other)
 		    : m_value(other.m_value), m_properties(other.m_properties),
-		      m_init_function(other.m_init_function)
+		      m_init_function(other.m_init_function),
+		      m_constrain_function(other.m_constrain_function)
 		{
 		}
 
@@ -168,6 +177,11 @@ namespace shogun
 			return m_init_function;
 		}
 
+		const std::function<bool(Any)>& get_constrain_function() const noexcept
+		{
+			return m_constrain_function;
+		}
+
 		/** Equality operator which compares value but not properties.
 		 * @return true if value of other parameter equals own */
 		inline bool operator==(const AnyParameter& other) const
@@ -185,6 +199,7 @@ namespace shogun
 		Any m_value;
 		AnyParameterProperties m_properties;
 		std::shared_ptr<params::AutoInit> m_init_function;
+		std::function<bool(Any)> m_constrain_function;
 	};
 } // namespace shogun
 

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -650,18 +650,20 @@ void CSGObject::create_parameter(
 
 void CSGObject::update_parameter(const BaseTag& _tag, const Any& value)
 {
-	auto any_param = self->map[_tag];
-	auto pprop = any_param.get_properties();
+	auto& pprop = self->map[_tag].get_properties();
 	if (pprop.has_property(ParameterProperties::READONLY))
 		SG_ERROR(
 		    "%s::%s is marked as read-only and cannot be modified!\n",
 		    get_name(), _tag.name().c_str());
 	if (pprop.has_property(ParameterProperties::CONSTRAIN))
 	{
-		if (!any_param.get_constrain_function()(value))
+		auto msg = self->map[_tag].get_constrain_function()(value);
+		if (!msg.empty())
+		{
 			SG_ERROR(
-			    "%s::%s cannot be updated because of its constraint!\n",
-			    get_name(), _tag.name().c_str())
+					"%s::%s cannot be updated because it must be: %s!\n",
+					get_name(), _tag.name().c_str(), msg.c_str())
+		}
 	}
 	self->update(_tag, value);
 	pprop.remove_property(ParameterProperties::AUTO);

--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -650,25 +650,33 @@ void CSGObject::create_parameter(
 
 void CSGObject::update_parameter(const BaseTag& _tag, const Any& value)
 {
-	if (!self->map[_tag].get_properties().has_property(
-	        ParameterProperties::READONLY))
-		self->update(_tag, value);
-	else
-	{
+	auto any_param = self->map[_tag];
+	auto pprop = any_param.get_properties();
+	if (pprop.has_property(ParameterProperties::READONLY))
 		SG_ERROR(
-		    "%s::%s is marked as read-only and cannot be modified", get_name(),
-		    _tag.name().c_str());
+		    "%s::%s is marked as read-only and cannot be modified!\n",
+		    get_name(), _tag.name().c_str());
+	if (pprop.has_property(ParameterProperties::CONSTRAIN))
+	{
+		if (!any_param.get_constrain_function()(value))
+			SG_ERROR(
+			    "%s::%s cannot be updated because of its constraint!\n",
+			    get_name(), _tag.name().c_str())
 	}
-	self->map[_tag].get_properties().remove_property(ParameterProperties::AUTO);
+	self->update(_tag, value);
+	pprop.remove_property(ParameterProperties::AUTO);
 }
 
 AnyParameter CSGObject::get_parameter(const BaseTag& _tag) const
 {
 	const auto& parameter = self->get(_tag);
-	if (parameter.get_properties().has_property(ParameterProperties::RUNFUNCTION))
+	if (parameter.get_properties().has_property(
+	        ParameterProperties::RUNFUNCTION))
 	{
-		SG_ERROR("The parameter %s::%s is registered as a function, "
-		   "use the run method instead", get_name(), _tag.name().c_str())
+		SG_ERROR(
+		    "The parameter %s::%s is registered as a function, "
+		    "use the .run() method instead!\n",
+		    get_name(), _tag.name().c_str())
 	}
 	if (parameter.get_value().empty())
 	{
@@ -682,16 +690,19 @@ AnyParameter CSGObject::get_parameter(const BaseTag& _tag) const
 AnyParameter CSGObject::get_function(const BaseTag& _tag) const
 {
 	const auto& parameter = self->get(_tag);
-	if (!parameter.get_properties().has_property(ParameterProperties::RUNFUNCTION))
+	if (!parameter.get_properties().has_property(
+	        ParameterProperties::RUNFUNCTION))
 	{
-		SG_ERROR("The parameter %s::%s is not registered as a function, "
-				 "use the get method instead", get_name(), _tag.name().c_str())
+		SG_ERROR(
+		    "The parameter %s::%s is not registered as a function, "
+		    "use the .get() method instead",
+		    get_name(), _tag.name().c_str())
 	}
 	if (parameter.get_value().empty())
 	{
 		SG_ERROR(
-				"There is no parameter called \"%s\" in %s\n", _tag.name().c_str(),
-				get_name());
+		    "There is no parameter called \"%s\" in %s\n", _tag.name().c_str(),
+		    get_name());
 	}
 	return parameter;
 }

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -861,6 +861,8 @@ protected:
 				AnyParameter(
 						make_any_ref(value), properties, std::move(auto_init)));
 	}
+
+#ifndef SWIG
 	/** Puts a pointer to some parameter into the parameter map.
 	 * The parameter is the constrained to the rules from the
 	 * Composer.
@@ -872,10 +874,10 @@ protected:
 	 * @param properties properties of the parameter (e.g. if model
 	 * selection is supported)
 	 */
-	template <typename T1, typename T2>
+	template <typename T1, typename ...Args>
 	void watch_param(
 			const std::string& name, T1* value,
-			Constraint<T2>&& constrain_function,
+			Constraint<Args...>&& constrain_function,
 			AnyParameterProperties properties)
 	{
 		REQUIRE(
@@ -892,6 +894,7 @@ protected:
 							return result;
 						}));
 	}
+#endif
 
 	/** Puts a pointer to some parameter array into the parameter map.
 	 *

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -14,6 +14,7 @@
 #include <shogun/base/AnyParameter.h>
 #include <shogun/base/Version.h>
 #include <shogun/base/base_types.h>
+#include <shogun/base/composition.h>
 #include <shogun/base/macros.h>
 #include <shogun/base/some.h>
 #include <shogun/base/unique.h>
@@ -107,11 +108,8 @@ using stringToEnumMapType = std::unordered_map<std::string, std::unordered_map<s
 			this->m_gradient_parameters->add(param, name, description);        \
 	}
 
-#define SG_ADD5(param, name, description, param_properties, auto_init)         \
+#define SG_ADD5(param, name, description, param_properties, auto_or_constraint)\
 	{                                                                          \
-		static_assert(                                                         \
-		    static_cast<bool>((param_properties)&ParameterProperties::AUTO),   \
-		    "Expected param to have ParameterProperty::AUTO");                 \
 		AnyParameterProperties pprop =                                         \
 		    AnyParameterProperties(description, param_properties);             \
 		this->m_parameters->add(param, name, description);                     \
@@ -119,29 +117,6 @@ using stringToEnumMapType = std::unordered_map<std::string, std::unordered_map<s
 		if (pprop.has_property(ParameterProperties::HYPER))                    \
 			this->m_model_selection_parameters->add(param, name, description); \
 		if (pprop.has_property(ParameterProperties::GRADIENT))                 \
-			this->m_gradient_parameters->add(param, name, description);        \
-	}
-
-#define SG_ADD_CONSTRAINT(param, name, description, param_properties, ...)     \
-	{                                                                          \
-		static_assert(                                                         \
-		    static_cast<bool>(                                                 \
-		        (param_properties)&ParameterProperties::CONSTRAIN),            \
-		    "Expected param to have ParameterProperty::CONSTRAIN");            \
-		AnyParameterProperties pprop =                                         \
-		    AnyParameterProperties(description, param_properties);             \
-		this->m_parameters->add(param, name, description);                     \
-		this->watch_param(                                                     \
-		    name, param,                                                       \
-		    [](auto val) {                                                     \
-			    auto casted_val =                                              \
-			        any_cast<std::remove_pointer<decltype(param)>::type>(val); \
-			    return make_composer(__VA_ARGS__).run(casted_val);             \
-		    },                                                                 \
-		    pprop);                                                            \
-		if (pprop.get_model_selection())                                       \
-			this->m_model_selection_parameters->add(param, name, description); \
-		if (pprop.get_gradient())                                              \
 			this->m_gradient_parameters->add(param, name, description);        \
 	}
 
@@ -877,13 +852,18 @@ protected:
 			std::shared_ptr<params::AutoInit> auto_init,
 			AnyParameterProperties properties)
 	{
+		REQUIRE(
+				properties.has_property(ParameterProperties::AUTO),
+				"Expected param to have ParameterProperty::AUTO");
 		BaseTag tag(name);
-		create_parameter(tag, AnyParameter(make_any_ref(value), properties,
-				std::move(auto_init)));
+		create_parameter(
+				tag,
+				AnyParameter(
+						make_any_ref(value), properties, std::move(auto_init)));
 	}
 	/** Puts a pointer to some parameter into the parameter map.
-	 * The parameter is the constrained to the rules provided to
-	 * make_composer.
+	 * The parameter is the constrained to the rules from the
+	 * Composer.
 	 *
 	 * @param name name of the parameter
 	 * @param value pointer to the parameter value
@@ -892,16 +872,25 @@ protected:
 	 * @param properties properties of the parameter (e.g. if model
 	 * selection is supported)
 	 */
-	template <typename T>
+	template <typename T1, typename T2>
 	void watch_param(
-		const std::string& name, T* value,
-		std::function<bool(Any)>&& constrain_function,
-		AnyParameterProperties properties)
+			const std::string& name, T1* value,
+			Composer<T2>&& constrain_function,
+			AnyParameterProperties properties)
 	{
+		REQUIRE(
+				properties.has_property(ParameterProperties::CONSTRAIN),
+				"Expected param to have ParameterProperty::CONSTRAIN");
 		BaseTag tag(name);
 		create_parameter(
-			tag, AnyParameter(
-					 make_any_ref(value), properties, constrain_function));
+				tag, AnyParameter(
+						make_any_ref(value), properties,
+						[constrain_function](const auto& val) {
+							std::string result;
+							auto casted_val = any_cast<T1>(val);
+							constrain_function.run(casted_val, result);
+							return result;
+						}));
 	}
 
 	/** Puts a pointer to some parameter array into the parameter map.

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -14,7 +14,7 @@
 #include <shogun/base/AnyParameter.h>
 #include <shogun/base/Version.h>
 #include <shogun/base/base_types.h>
-#include <shogun/base/composition.h>
+#include <shogun/base/constraint.h>
 #include <shogun/base/macros.h>
 #include <shogun/base/some.h>
 #include <shogun/base/unique.h>
@@ -113,7 +113,7 @@ using stringToEnumMapType = std::unordered_map<std::string, std::unordered_map<s
 		AnyParameterProperties pprop =                                         \
 		    AnyParameterProperties(description, param_properties);             \
 		this->m_parameters->add(param, name, description);                     \
-		this->watch_param(name, param, auto_init, pprop);                      \
+		this->watch_param(name, param, auto_or_constraint, pprop);             \
 		if (pprop.has_property(ParameterProperties::HYPER))                    \
 			this->m_model_selection_parameters->add(param, name, description); \
 		if (pprop.has_property(ParameterProperties::GRADIENT))                 \
@@ -875,7 +875,7 @@ protected:
 	template <typename T1, typename T2>
 	void watch_param(
 			const std::string& name, T1* value,
-			Composer<T2>&& constrain_function,
+			Constraint<T2>&& constrain_function,
 			AnyParameterProperties properties)
 	{
 		REQUIRE(

--- a/src/shogun/base/composition.h
+++ b/src/shogun/base/composition.h
@@ -7,75 +7,112 @@
 #ifndef __COMPOSITION_H__
 #define __COMPOSITION_H__
 
+#include <string>
 #include <tuple>
 
 namespace shogun
 {
-#ifdef __cpp_fold_expressions
-	template <typename T, typename... Args, std::size_t... Idx>
-	bool apply_helper(
-	    T&& val, std::tuple<Args...> funcs, std::index_sequence<Idx...>)
+	namespace composition_detail
 	{
-		return (std::get<Idx>(funcs)(std::forward<T>(val)) && ...);
-	}
-	/**
-	 * Compile time composition with tuples.
-	 */
-	template <typename T, typename... Args>
-	bool apply(T&& val, std::tuple<Args...> funcs)
-	{
-		return apply_helper(val, funcs, std::index_sequence_for<Args...>{});
-	}
-#else
-	// taken from
-	// https://stackoverflow.com/questions/10626856/how-to-split-a-tuple
-	template <typename T, typename... Ts>
-	auto head(std::tuple<T, Ts...> t)
-	{
-		return std::get<0>(t);
-	}
+#ifdef __cpp_fold_expressions // The C++17 version
+		template <typename T, typename... Args, std::size_t... Idx>
+		bool apply_helper(
+		    T&& val, std::tuple<Args...> funcs, std::index_sequence<Idx...>)
+		{
+			return (std::get<Idx>(funcs)(std::forward<T>(val)) && ...);
+		}
+		/**
+		 * Compile time composition with tuples.
+		 */
+		template <typename T, typename... Args>
+		bool apply(T&& val, std::tuple<Args...> funcs)
+		{
+			return apply_helper(val, funcs, std::index_sequence_for<Args...>{});
+		}
+#else // the C++14 version
 
-	template <std::size_t... Ns, typename... Ts>
-	auto tail_impl(std::index_sequence<Ns...>, std::tuple<Ts...> t)
-	{
-		return std::make_tuple(std::get<Ns + 1u>(t)...);
-	}
+		// taken from
+		// https://stackoverflow.com/questions/10626856/how-to-split-a-tuple
+		template <typename T, typename... Ts>
+		auto head(std::tuple<T, Ts...> t)
+		{
+			return std::get<0>(t);
+		}
 
-	template <typename... Ts>
-	auto tail(std::tuple<Ts...> t)
-	{
-		return tail_impl(std::make_index_sequence<sizeof...(Ts) - 1u>(), t);
-	}
+		template <std::size_t... Ns, typename... Ts>
+		auto tail_impl(std::index_sequence<Ns...>, std::tuple<Ts...> t)
+		{
+			return std::make_tuple(std::get<Ns + 1u>(t)...);
+		}
 
-	template <
-	    size_t N, typename T1, typename T2, std::enable_if_t<N == 1>* = nullptr>
-	bool apply_helper(T1&& val, T2&& func)
-	{
-		return head(func)(val);
-	}
+		template <typename... Ts>
+		auto tail(std::tuple<Ts...> t)
+		{
+			return tail_impl(std::make_index_sequence<sizeof...(Ts) - 1u>(), t);
+		}
 
-	template <
-	    size_t N, typename T1, typename T2,
-	    std::enable_if_t<(N > 1)>* = nullptr>
-	bool apply_helper(T1&& val, T2&& func)
-	{
-		return head(func)(val) &&
-		       apply_helper<std::tuple_size<T2>::value - 1>(val, tail(func));
-	}
+		template <
+		    size_t N, typename T1, typename T2,
+		    std::enable_if_t<N == 1>* = nullptr>
+		bool apply_helper(T1&& val, T2&& func)
+		{
+			return head(func)(val);
+		}
 
-	/**
-	 * Compile time composition with tuples.
-	 */
-	template <typename T, typename... Args>
-	bool apply(T&& val, std::tuple<Args...> funcs)
-	{
-		return apply_helper<std::tuple_size<std::tuple<Args...>>::value>(
-		    val, funcs);
-	}
+		template <
+		    size_t N, typename T1, typename T2,
+		    std::enable_if_t<(N > 1)>* = nullptr>
+		bool apply_helper(T1&& val, T2&& func)
+		{
+			return head(func)(val) &&
+			       apply_helper<std::tuple_size<T2>::value - 1>(
+			           val, tail(func));
+		}
+
+		/**
+		 * Compile time composition with tuples.
+		 */
+		template <typename T, typename... Args>
+		bool apply(T&& val, std::tuple<Args...> funcs)
+		{
+			return apply_helper<std::tuple_size<std::tuple<Args...>>::value>(
+			    val, funcs);
+		}
 #endif
+		template <size_t N, typename T, std::enable_if_t<N == 1>* = nullptr>
+		void get_error_helper(T&& func, std::string& result)
+		{
+			result += head(func).error_msg();
+		}
 
+		template <size_t N, typename T, std::enable_if_t<N == 2>* = nullptr>
+		void get_error_helper(T&& func, std::string& result)
+		{
+			result += head(func).error_msg() + " and ";
+			apply_helper<1>(tail(func), result);
+		}
+
+		template <size_t N, typename T, std::enable_if_t<(N > 2)>* = nullptr>
+		void get_error_helper(T&& func, std::string& result)
+		{
+			result += head(func).error_msg() + ", ";
+			apply_helper<std::tuple_size<T>::value - 1>(tail(func), result);
+		}
+
+		template <typename... Args>
+		std::string get_error(std::tuple<Args...> funcs)
+		{
+			std::string result;
+			get_error_helper<std::tuple_size<std::tuple<Args...>>::value>(
+			    funcs, result);
+			return result;
+		}
+	} // namespace composition_detail
 	/**
-	 *
+	 * The base class of all constraints. The call operator calls the check pure
+	 * virtual class member with a value to be checked. See derived classes for
+	 * examples. In addition there is also a error_msg method to retrieve a
+	 * custom error message.
 	 */
 	template <typename T>
 	struct generic_checker
@@ -87,54 +124,94 @@ namespace shogun
 			return check(val);
 		};
 
+		virtual std::string error_msg() const = 0;
+
 	protected:
 		T m_val;
-		virtual bool check(T val) = 0;
+		virtual bool check(T val) const = 0;
 	};
 
+	/**
+	 * Checks if a value is less than val.
+	 *
+	 * @tparam T the type of val
+	 */
 	template <typename T>
 	struct less_than : generic_checker<T>
 	{
 	public:
 		less_than(T val) : generic_checker<T>(val){};
 
+		std::string error_msg() const override
+		{
+			return "less than " + std::to_string(this->m_val);
+		}
+
 	protected:
-		bool check(T val) override
+		bool check(T val) const override
 		{
 			return val < this->m_val;
 		}
 	};
 
+	/**
+	 * Checks if a value is greater than val.
+	 *
+	 * @tparam T the type of val
+	 */
 	template <typename T>
 	struct greater_than : generic_checker<T>
 	{
 	public:
 		greater_than(T val) : generic_checker<T>(val){};
+		std::string error_msg() const override
+		{
+			return "greater than " + std::to_string(this->m_val);
+		}
 
 	protected:
-		bool check(T val) override
+		bool check(T val) const override
 		{
 			return val > this->m_val;
 		}
 	};
 
+	/**
+	 * Checks if a value is positive.
+	 *
+	 * @tparam T the type of zero
+	 */
 	template <typename T = double>
 	struct positive : greater_than<T>
 	{
 	public:
 		positive() : greater_than<T>(0){};
+		std::string error_msg() const override
+		{
+			return "positive";
+		}
 	};
 
+	/**
+	 * Checks if a value is negative.
+	 *
+	 * @tparam T the type of zero
+	 */
 	template <typename T = double>
 	struct negative : less_than<T>
 	{
 	public:
 		negative() : less_than<T>(0){};
+		std::string error_msg() const override
+		{
+			return "negative";
+		}
 	};
 
 	/**
 	 * Composer helper class that invokes apply using class member functions
-	 * m_funcs.
+	 * m_funcs. If any of the functions returns false then it retrieves
+	 * the error and passes it to the buffer.
 	 */
 	template <typename... Args>
 	class Composer
@@ -145,20 +222,34 @@ namespace shogun
 		}
 
 		template <typename T>
-		bool run(T val)
+		bool run(T val, std::string& buffer) const
 		{
-			return apply(val, m_funcs);
+			if (!composition_detail::apply(val, m_funcs))
+			{
+				buffer = composition_detail::get_error(m_funcs);
+				return false;
+			}
+			return true;
 		}
 
 	private:
 		std::tuple<Args...> m_funcs;
 	};
 
+	/**
+	 * A helper function to make a new Composer instance.
+	 * @tparam Args the types of args
+	 * @param args the constraints
+	 * @return the new Composer instance
+	 */
 	template <typename... Args>
 	Composer<Args...> make_composer(Args... args)
 	{
 		return Composer<Args...>(std::forward_as_tuple(args...));
 	}
+
 } // namespace shogun
+
+#define SG_CONSTRAINT(...) make_composer(__VA_ARGS__)
 
 #endif // __COMPOSITION_H__

--- a/src/shogun/base/composition.h
+++ b/src/shogun/base/composition.h
@@ -1,0 +1,102 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef __COMPOSITION_H__
+#define __COMPOSITION_H__
+
+#include <tuple>
+
+namespace shogun {
+
+	template <typename T, typename ...Args, std::size_t... Idx>
+	bool apply_helper(T&& val, std::tuple<Args...> funcs, std::index_sequence<Idx...>)
+	{
+		return (std::get<Idx>(funcs)(std::forward<T>(val)) && ...);
+	}
+
+	/**
+	 * Compile time composition with tuples.
+	 */
+	template <typename T, typename ...Args>
+	bool apply(T&& val, std::tuple<Args...> funcs)
+	{
+		return apply_helper(val, funcs, std::index_sequence_for<Args...> {});
+	}
+
+	/**
+ 	 *
+ 	 */
+	template <typename T>
+	struct generic_checker
+	{
+	public:
+		generic_checker(T val): m_val(val) {};
+		bool operator()(T val) {return check(val);};
+
+	protected:
+		T m_val;
+		virtual bool check(T val) = 0;
+	};
+
+	template <typename T>
+	struct less_than: generic_checker<T>
+	{
+	public:
+		less_than(T val): generic_checker<T>(val) {};
+	protected:
+		bool check(T val) override {return val < this->m_val;}
+	};
+
+	template <typename T>
+	struct greater_than: generic_checker<T>
+	{
+	public:
+		greater_than(T val): generic_checker<T>(val) {};
+	protected:
+		bool check(T val) override {return val > this->m_val;}
+	};
+
+	template <typename T = double>
+	struct positive: greater_than<T>
+	{
+	public:
+		positive(): greater_than<T>(0) {};
+	};
+
+	template <typename T = double>
+	struct negative: less_than<T>
+	{
+	public:
+		negative(): less_than<T>(0) {};
+	};
+
+	/**
+ 	  * Composer helper class that invokes apply using class member functions m_funcs.
+	  */
+	template <typename ...Args>
+	class Composer
+	{
+	public:
+		Composer(std::tuple<Args...> funcs): m_funcs(funcs) {}
+
+		template <typename T>
+		bool run(T val)
+		{
+			return apply(val, m_funcs);
+		}
+
+	private:
+		std::tuple<Args...> m_funcs;
+	};
+
+	template <typename ...Args>
+	Composer<Args...> make_composer(Args... args)
+	{
+		return Composer<Args...>(std::forward_as_tuple(args...));
+	}
+}
+
+#endif // __COMPOSITION_H__

--- a/src/shogun/base/composition.h
+++ b/src/shogun/base/composition.h
@@ -9,32 +9,83 @@
 
 #include <tuple>
 
-namespace shogun {
-
-	template <typename T, typename ...Args, std::size_t... Idx>
-	bool apply_helper(T&& val, std::tuple<Args...> funcs, std::index_sequence<Idx...>)
+namespace shogun
+{
+#ifdef __cpp_fold_expressions
+	template <typename T, typename... Args, std::size_t... Idx>
+	bool apply_helper(
+	    T&& val, std::tuple<Args...> funcs, std::index_sequence<Idx...>)
 	{
 		return (std::get<Idx>(funcs)(std::forward<T>(val)) && ...);
+	}
+	/**
+	 * Compile time composition with tuples.
+	 */
+	template <typename T, typename... Args>
+	bool apply(T&& val, std::tuple<Args...> funcs)
+	{
+		return apply_helper(val, funcs, std::index_sequence_for<Args...>{});
+	}
+#else
+	// taken from
+	// https://stackoverflow.com/questions/10626856/how-to-split-a-tuple
+	template <typename T, typename... Ts>
+	auto head(std::tuple<T, Ts...> t)
+	{
+		return std::get<0>(t);
+	}
+
+	template <std::size_t... Ns, typename... Ts>
+	auto tail_impl(std::index_sequence<Ns...>, std::tuple<Ts...> t)
+	{
+		return std::make_tuple(std::get<Ns + 1u>(t)...);
+	}
+
+	template <typename... Ts>
+	auto tail(std::tuple<Ts...> t)
+	{
+		return tail_impl(std::make_index_sequence<sizeof...(Ts) - 1u>(), t);
+	}
+
+	template <
+	    size_t N, typename T1, typename T2, std::enable_if_t<N == 1>* = nullptr>
+	bool apply_helper(T1&& val, T2&& func)
+	{
+		return head(func)(val);
+	}
+
+	template <
+	    size_t N, typename T1, typename T2,
+	    std::enable_if_t<(N > 1)>* = nullptr>
+	bool apply_helper(T1&& val, T2&& func)
+	{
+		return head(func)(val) &&
+		       apply_helper<std::tuple_size<T2>::value - 1>(val, tail(func));
 	}
 
 	/**
 	 * Compile time composition with tuples.
 	 */
-	template <typename T, typename ...Args>
+	template <typename T, typename... Args>
 	bool apply(T&& val, std::tuple<Args...> funcs)
 	{
-		return apply_helper(val, funcs, std::index_sequence_for<Args...> {});
+		return apply_helper<std::tuple_size<std::tuple<Args...>>::value>(
+		    val, funcs);
 	}
+#endif
 
 	/**
- 	 *
- 	 */
+	 *
+	 */
 	template <typename T>
 	struct generic_checker
 	{
 	public:
-		generic_checker(T val): m_val(val) {};
-		bool operator()(T val) {return check(val);};
+		generic_checker(T val) : m_val(val){};
+		bool operator()(T val)
+		{
+			return check(val);
+		};
 
 	protected:
 		T m_val;
@@ -42,45 +93,56 @@ namespace shogun {
 	};
 
 	template <typename T>
-	struct less_than: generic_checker<T>
+	struct less_than : generic_checker<T>
 	{
 	public:
-		less_than(T val): generic_checker<T>(val) {};
+		less_than(T val) : generic_checker<T>(val){};
+
 	protected:
-		bool check(T val) override {return val < this->m_val;}
+		bool check(T val) override
+		{
+			return val < this->m_val;
+		}
 	};
 
 	template <typename T>
-	struct greater_than: generic_checker<T>
+	struct greater_than : generic_checker<T>
 	{
 	public:
-		greater_than(T val): generic_checker<T>(val) {};
+		greater_than(T val) : generic_checker<T>(val){};
+
 	protected:
-		bool check(T val) override {return val > this->m_val;}
+		bool check(T val) override
+		{
+			return val > this->m_val;
+		}
 	};
 
 	template <typename T = double>
-	struct positive: greater_than<T>
+	struct positive : greater_than<T>
 	{
 	public:
-		positive(): greater_than<T>(0) {};
+		positive() : greater_than<T>(0){};
 	};
 
 	template <typename T = double>
-	struct negative: less_than<T>
+	struct negative : less_than<T>
 	{
 	public:
-		negative(): less_than<T>(0) {};
+		negative() : less_than<T>(0){};
 	};
 
 	/**
- 	  * Composer helper class that invokes apply using class member functions m_funcs.
-	  */
-	template <typename ...Args>
+	 * Composer helper class that invokes apply using class member functions
+	 * m_funcs.
+	 */
+	template <typename... Args>
 	class Composer
 	{
 	public:
-		Composer(std::tuple<Args...> funcs): m_funcs(funcs) {}
+		Composer(std::tuple<Args...> funcs) : m_funcs(funcs)
+		{
+		}
 
 		template <typename T>
 		bool run(T val)
@@ -92,11 +154,11 @@ namespace shogun {
 		std::tuple<Args...> m_funcs;
 	};
 
-	template <typename ...Args>
+	template <typename... Args>
 	Composer<Args...> make_composer(Args... args)
 	{
 		return Composer<Args...>(std::forward_as_tuple(args...));
 	}
-}
+} // namespace shogun
 
 #endif // __COMPOSITION_H__

--- a/src/shogun/clustering/KMeansBase.cpp
+++ b/src/shogun/clustering/KMeansBase.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <shogun/base/Parallel.h>
-#include <shogun/base/composition.h>
 #include <shogun/clustering/KMeansBase.h>
 #include <shogun/distance/Distance.h>
 #include <shogun/distance/EuclideanDistance.h>
@@ -326,10 +325,10 @@ void CKMeansBase::init()
 	SG_ADD(
 	    &max_iter, "max_iter", "Maximum number of iterations",
 	    ParameterProperties::HYPER);
-	SG_ADD_CONSTRAINT(
+	SG_ADD(
 	    &k, "k", "k, the number of clusters",
 	    ParameterProperties::HYPER | ParameterProperties::CONSTRAIN,
-	    positive<>());
+	    SG_CONSTRAINT(positive<>()));
 	SG_ADD(&dimensions, "dimensions", "Dimensions of data");
 	SG_ADD(&fixed_centers, "fixed_centers", "Use fixed centers");
 	SG_ADD(&R, "radiuses", "Cluster radiuses");

--- a/src/shogun/clustering/KMeansBase.cpp
+++ b/src/shogun/clustering/KMeansBase.cpp
@@ -335,6 +335,7 @@ void CKMeansBase::init()
 	SG_ADD(
 	    &use_kmeanspp, "kmeanspp", "Whether use kmeans++",
 	    ParameterProperties::HYPER);
+	SG_ADD(&mus, "mus", "Cluster centers");
 
 	watch_method("cluster_centers", &CKMeansBase::get_cluster_centers);
 }

--- a/src/shogun/clustering/KMeansBase.cpp
+++ b/src/shogun/clustering/KMeansBase.cpp
@@ -4,13 +4,14 @@
  * Authors: Saurabh Mahindre, Heiko Strathmann, Pan Deng, Viktor Gal
  */
 
+#include <shogun/base/Parallel.h>
+#include <shogun/base/composition.h>
 #include <shogun/clustering/KMeansBase.h>
 #include <shogun/distance/Distance.h>
 #include <shogun/distance/EuclideanDistance.h>
-#include <shogun/labels/Labels.h>
 #include <shogun/features/DenseFeatures.h>
+#include <shogun/labels/Labels.h>
 #include <shogun/mathematics/Math.h>
-#include <shogun/base/Parallel.h>
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/lib/observers/ObservedValueTemplated.h>
 
@@ -317,19 +318,24 @@ SGMatrix<float64_t> CKMeansBase::kmeanspp()
 
 void CKMeansBase::init()
 {
-	max_iter=300;
-	k=8;
-	dimensions=0;
-	fixed_centers=false;
-	use_kmeanspp=false;
-	SG_ADD(&max_iter, "max_iter", "Maximum number of iterations", ParameterProperties::HYPER);
-	SG_ADD(&k, "k", "k, the number of clusters", ParameterProperties::HYPER);
+	max_iter = 300;
+	k = 8;
+	dimensions = 0;
+	fixed_centers = false;
+	use_kmeanspp = false;
+	SG_ADD(
+	    &max_iter, "max_iter", "Maximum number of iterations",
+	    ParameterProperties::HYPER);
+	SG_ADD_CONSTRAINT(
+	    &k, "k", "k, the number of clusters",
+	    ParameterProperties::HYPER | ParameterProperties::CONSTRAIN,
+	    positive<>());
 	SG_ADD(&dimensions, "dimensions", "Dimensions of data");
 	SG_ADD(&fixed_centers, "fixed_centers", "Use fixed centers");
 	SG_ADD(&R, "radiuses", "Cluster radiuses");
-	SG_ADD(&use_kmeanspp, "kmeanspp", "Whether use kmeans++", ParameterProperties::HYPER);
-	SG_ADD(&mus, "mus", "Cluster centers")
+	SG_ADD(
+	    &use_kmeanspp, "kmeanspp", "Whether use kmeans++",
+	    ParameterProperties::HYPER);
 
 	watch_method("cluster_centers", &CKMeansBase::get_cluster_centers);
 }
-

--- a/tests/unit/base/MockObject.h
+++ b/tests/unit/base/MockObject.h
@@ -304,14 +304,13 @@ namespace shogun
 			register_param("float", decimal);
 
 			watch_param(
-			    "watched_int", &m_watched,
-			    AnyParameterProperties(
-			        "Integer"));
+			    "watched_int", &m_watched, AnyParameterProperties("Integer"));
 
 			watch_param(
-			    "watched_object", &m_object,
-			    AnyParameterProperties(
-			        "Object"));
+			    "watched_object", &m_object, AnyParameterProperties("Object"));
+			SG_ADD(
+			    &m_constrained_parameter, "constrained_parameter", "Mock parameter to test constraints.",
+                ParameterProperties::CONSTRAIN, SG_CONSTRAINT(positive<>(), less_than(10)));
 
 			watch_method("some_method", &CMockObject::some_method);
 		}
@@ -326,7 +325,8 @@ namespace shogun
 	private:
 		int32_t m_integer = 0;
 		int32_t m_watched = 0;
+		int32_t m_constrained_parameter = 1;
 
 		CMockObject* m_object = nullptr;
 	};
-}
+} // namespace shogun

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -616,3 +616,13 @@ TEST(SGObject, unsubscribe_observer_failure)
 
 	EXPECT_THROW(obj->unsubscribe(param_obs_not_in), ShogunException);
 }
+
+TEST(SGObject, constrained_parameter)
+{
+    auto obj = some<CMockObject>();
+    obj->put("constrained_parameter", 1);
+    EXPECT_EQ(obj->get<int32_t>("constrained_parameter"), 1);
+    EXPECT_THROW(obj->put("constrained_parameter", 0), ShogunException);
+    EXPECT_THROW(obj->put("constrained_parameter", 10), ShogunException);
+    EXPECT_EQ(obj->get<int32_t>("constrained_parameter"), 1);
+}


### PR DESCRIPTION
Here is a design I came up with to constrain parameter values. At compile time we know the constraints so it can all be wrapped into a tuple that is "evaluated" and should be inlined properly at O3. The issue is the casting from any to the respective type, which is expensive, but then we can "ignore" the parameter type and have something like this:
```cpp
SG_ADD(&k, "k", "k, the number of clusters",
        ParameterProperties::HYPER | ParameterProperties::CONSTRAIN,
	SG_CONSTRAINT(positive<>()));
```
and then python
```python
In [1]: import shogun as sg                                                                                                                                                                                 

In [2]: kmeans = sg.machine("KMeans")                                                                                                                                                                       

In [3]: kmeans.put("k", -1)                                                                                                                                                                                 
---------------------------------------------------------------------------
SystemError                               Traceback (most recent call last)
<ipython-input-3-b598556376d3> in <module>
----> 1 kmeans.put("k", -1)

SystemError: [ERROR] In file /Users/ghoben/shogun/src/shogun/base/SGObject.cpp line 753: KMeans::k cannot be updated because of its constraint!
```