### PR TITLE
mapped labels

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -692,6 +692,24 @@ public:
 			demangled_type<T>().c_str());
 		return nullptr;
 	}
+
+	/** Specializes the object to the specified type.
+	 * Throws exception if the object cannot be specialized.
+	 *
+	 * @return The requested type
+	 */
+	template<class T> const T* as() const
+	{
+		auto c = dynamic_cast<const T*>(this);
+		if (c)
+			return c;
+
+		SG_SERROR(
+			"Object of type %s cannot be converted to type %s.\n",
+			this->get_name(),
+			demangled_type<T>().c_str());
+		return nullptr;
+	}
 #ifndef SWIG
 	/**
 	  * Get parameters observable

--- a/src/shogun/classifier/AveragedPerceptron.cpp
+++ b/src/shogun/classifier/AveragedPerceptron.cpp
@@ -48,7 +48,7 @@ void CAveragedPerceptron::init_model(CFeatures* data)
 	}
 	ASSERT(features)
 
-	SGVector<int32_t> train_labels = binary_labels(m_labels)->get_int_labels();
+	SGVector<int32_t> train_labels = m_labels->as<CBinaryLabels>()->get_int_labels();
 	int32_t num_feat = features->get_dim_feature_space();
 	int32_t num_vec = features->get_num_vectors();
 	ASSERT(num_vec == train_labels.vlen)
@@ -68,7 +68,7 @@ void CAveragedPerceptron::iteration()
 	bool converged = true;
 	
 	SGVector<float64_t> w = get_w();
-	auto labels = binary_labels(m_labels)->get_int_labels();
+	auto labels = m_labels->as<CBinaryLabels>()->get_int_labels();
 	auto iter_train_labels = labels.begin();
 	
 	int32_t num_vec = features->get_num_vectors();

--- a/src/shogun/classifier/LDA.cpp
+++ b/src/shogun/classifier/LDA.cpp
@@ -14,6 +14,7 @@
 #include <shogun/preprocessor/FisherLDA.h>
 #include <shogun/solver/LDACanVarSolver.h>
 #include <shogun/solver/LDASolver.h>
+#include <shogun/labels/MappedMulticlassLabels.h>
 #include <vector>
 
 using namespace Eigen;
@@ -66,7 +67,6 @@ bool CLDA::train_machine_templated(CDenseFeatures<ST>* data)
 {
 	index_t num_feat = data->get_num_features();
 	index_t num_vec = data->get_num_vectors();
-	;
 
 	bool lda_more_efficient = (m_method == AUTO_LDA && num_vec <= num_feat);
 
@@ -79,7 +79,8 @@ bool CLDA::train_machine_templated(CDenseFeatures<ST>* data)
 template <typename ST>
 bool CLDA::solver_svd(CDenseFeatures<ST>* data)
 {
-	auto labels = multiclass_labels(m_labels);
+	auto labels = some<CMappedMulticlassLabels>(m_labels);
+
 	REQUIRE(
 	    labels->get_num_classes() == 2, "Number of classes (%d) must be 2\n",
 	    labels->get_num_classes())
@@ -113,7 +114,8 @@ bool CLDA::solver_svd(CDenseFeatures<ST>* data)
 template <typename ST>
 bool CLDA::solver_classic(CDenseFeatures<ST>* data)
 {
-	auto labels = multiclass_labels(m_labels);
+	auto labels = Some<CMulticlassLabels>::from_raw(MappedLabels<CMulticlassLabels>::wrap_if_necessary<CMappedMulticlassLabels>(m_labels));
+
 	REQUIRE(
 	    labels->get_num_classes() == 2, "Number of classes (%d) must be 2\n",
 	    labels->get_num_classes())

--- a/src/shogun/classifier/Perceptron.cpp
+++ b/src/shogun/classifier/Perceptron.cpp
@@ -60,7 +60,7 @@ void CPerceptron::iteration()
 	bool converged = true;
 	SGVector<float64_t> w = get_w();
 
-	auto labels = binary_labels(m_labels)->get_int_labels();
+	auto labels = m_labels->as<CBinaryLabels>()->get_int_labels();
 	auto iter_train_labels = labels.begin();
 
 	for (const auto& v : DotIterator(features))

--- a/src/shogun/classifier/svm/LibLinear.cpp
+++ b/src/shogun/classifier/svm/LibLinear.cpp
@@ -139,10 +139,10 @@ bool CLibLinear::train_machine(CFeatures* data)
 	double Cp = get_C1();
 	double Cn = get_C2();
 
-	auto labels = binary_labels(m_labels);
+	auto labels = m_labels->as<CBinaryLabels>();
 	for (int32_t i = 0; i < prob.l; i++)
 	{
-		prob.y[i] = labels->get_int_label(i);
+		prob.y[i] = labels->get_label(i);
 		if (prob.y[i] == +1)
 			Cs[i] = get_C1();
 		else if (prob.y[i] == -1)

--- a/src/shogun/classifier/svm/LibSVM.cpp
+++ b/src/shogun/classifier/svm/LibSVM.cpp
@@ -50,7 +50,8 @@ bool CLibSVM::train_machine(CFeatures* data)
 
 	struct svm_node* x_space;
 
-	ASSERT(m_labels && m_labels->get_num_labels())
+	REQUIRE(m_labels && m_labels->get_num_labels(), "No labels provided.\n")
+	REQUIRE(kernel, "No kernel provided.\n")
 
 	if (data)
 	{
@@ -94,7 +95,7 @@ bool CLibSVM::train_machine(CFeatures* data)
 
 	x_space=SG_MALLOC(struct svm_node, 2*problem.l);
 
-	auto labels = binary_labels(m_labels);
+	auto labels = m_labels->as<CBinaryLabels>();
 	for (int32_t i=0; i<problem.l; i++)
 	{
 		problem.y[i] = labels->get_label(i);

--- a/src/shogun/classifier/svm/MPDSVM.cpp
+++ b/src/shogun/classifier/svm/MPDSVM.cpp
@@ -30,7 +30,7 @@ CMPDSVM::~CMPDSVM()
 
 bool CMPDSVM::train_machine(CFeatures* data)
 {
-	auto labels = binary_labels(m_labels);
+	auto labels = m_labels->as<CBinaryLabels>();
 
 	ASSERT(kernel)
 

--- a/src/shogun/classifier/svm/NewtonSVM.cpp
+++ b/src/shogun/classifier/svm/NewtonSVM.cpp
@@ -57,7 +57,7 @@ void CNewtonSVM::init_model(CFeatures* data)
 
 	ASSERT(features)
 
-	SGVector<float64_t> train_labels = binary_labels(m_labels)->get_labels();
+	SGVector<float64_t> train_labels = m_labels->as<CBinaryLabels>()->get_labels();
 	int32_t num_feat=features->get_dim_feature_space();
 	int32_t num_vec=features->get_num_vectors();
 
@@ -144,7 +144,7 @@ void CNewtonSVM::iteration()
 
 void CNewtonSVM::line_search_linear(const SGVector<float64_t> d)
 {
-	SGVector<float64_t> Y = binary_labels(m_labels)->get_labels();
+	SGVector<float64_t> Y = m_labels->as<CBinaryLabels>()->get_labels();
 	SGVector<float64_t> outz(x_n);
 	SGVector<float64_t> temp1(x_n);
 	SGVector<float64_t> temp1forout(x_n);
@@ -215,7 +215,7 @@ void CNewtonSVM::line_search_linear(const SGVector<float64_t> d)
 void CNewtonSVM::obj_fun_linear()
 {
 	SGVector<float64_t> weights = get_w();
-	SGVector<float64_t> v = binary_labels(m_labels)->get_labels();
+	SGVector<float64_t> v = m_labels->as<CBinaryLabels>()->get_labels();
 
 	for (int32_t i=0; i<x_n; i++)
 	{

--- a/src/shogun/classifier/svm/SVMLight.cpp
+++ b/src/shogun/classifier/svm/SVMLight.cpp
@@ -310,7 +310,7 @@ void CSVMLight::svm_learn()
 	int32_t trainpos=0, trainneg=0 ;
 	ASSERT(m_labels)
 
-	SGVector<int32_t> lab = binary_labels(m_labels)->get_int_labels();
+	SGVector<int32_t> lab = m_labels->as<CBinaryLabels>()->get_int_labels();
 	int32_t totdoc=lab.vlen;
 	ASSERT(lab.vector && lab.vlen)
 	int32_t* label=SGVector<int32_t>::clone_vector(lab.vector, lab.vlen);

--- a/src/shogun/evaluation/ClusteringEvaluation.cpp
+++ b/src/shogun/evaluation/ClusteringEvaluation.cpp
@@ -39,8 +39,8 @@ void CClusteringEvaluation::best_map(CLabels* predicted, CLabels* ground_truth)
 	ASSERT(predicted->get_label_type() == LT_MULTICLASS)
 	ASSERT(ground_truth->get_label_type() == LT_MULTICLASS)
 
-	SGVector<float64_t> label_p=((CMulticlassLabels*) predicted)->get_unique_labels();
-	SGVector<float64_t> label_g=((CMulticlassLabels*) ground_truth)->get_unique_labels();
+	SGVector<float64_t> label_p=((CMulticlassLabels*) predicted)->get_labels().unique();
+	SGVector<float64_t> label_g=((CMulticlassLabels*) ground_truth)->get_labels().unique();
 
 	SGVector<int32_t> predicted_ilabels=((CMulticlassLabels*) predicted)->get_int_labels();
 	SGVector<int32_t> groundtruth_ilabels=((CMulticlassLabels*) ground_truth)->get_int_labels();

--- a/src/shogun/evaluation/ClusteringMutualInformation.cpp
+++ b/src/shogun/evaluation/ClusteringMutualInformation.cpp
@@ -15,8 +15,8 @@ float64_t CClusteringMutualInformation::evaluate(CLabels* predicted, CLabels* gr
 	ASSERT(predicted && ground_truth)
 	ASSERT(predicted->get_label_type() == LT_MULTICLASS)
 	ASSERT(ground_truth->get_label_type() == LT_MULTICLASS)
-	SGVector<float64_t> label_p=((CMulticlassLabels*) predicted)->get_unique_labels();
-	SGVector<float64_t> label_g=((CMulticlassLabels*) ground_truth)->get_unique_labels();
+	SGVector<float64_t> label_p=((CMulticlassLabels*) predicted)->get_labels().unique();
+	SGVector<float64_t> label_g=((CMulticlassLabels*) ground_truth)->get_labels().unique();
 
 	if (label_p.vlen != label_g.vlen)
 		SG_ERROR("Number of classes are different\n")

--- a/src/shogun/evaluation/ContingencyTableEvaluation.cpp
+++ b/src/shogun/evaluation/ContingencyTableEvaluation.cpp
@@ -19,11 +19,11 @@ float64_t CContingencyTableEvaluation::evaluate(CLabels* predicted, CLabels* gro
 	    get_name(), predicted->get_num_labels(),
 	    ground_truth->get_num_labels());
 
-	auto predicted_binary = binary_labels(predicted);
-	auto ground_truth_binary = binary_labels(ground_truth);
+	auto predicted_binary = predicted->as<CBinaryLabels>();
+	auto ground_truth_binary = ground_truth->as<CBinaryLabels>();
 
 	ground_truth->ensure_valid();
-	compute_scores(predicted_binary.get(), ground_truth_binary.get());
+	compute_scores(predicted_binary, ground_truth_binary);
 	switch (m_type)
 	{
 		case ACCURACY:

--- a/src/shogun/evaluation/MulticlassAccuracy.cpp
+++ b/src/shogun/evaluation/MulticlassAccuracy.cpp
@@ -16,8 +16,8 @@ float64_t CMulticlassAccuracy::evaluate(CLabels* predicted, CLabels* ground_trut
 	ASSERT(predicted && ground_truth)
 	ASSERT(predicted->get_num_labels() == ground_truth->get_num_labels())
 	int32_t length = predicted->get_num_labels();
-	auto predicted_mc = multiclass_labels(predicted);
-	auto ground_truth_mc = multiclass_labels(ground_truth);
+	auto predicted_mc = predicted->as<CMulticlassLabels>();
+	auto ground_truth_mc = ground_truth->as<CMulticlassLabels>();
 	int32_t correct = 0;
 	if (m_ignore_rejects)
 	{

--- a/src/shogun/labels/BinaryLabels.cpp
+++ b/src/shogun/labels/BinaryLabels.cpp
@@ -8,6 +8,7 @@
 
 #include <shogun/base/range.h>
 #include <shogun/labels/BinaryLabels.h>
+#include <shogun/labels/MulticlassLabels.h>
 #include <shogun/labels/DenseLabels.h>
 #include <shogun/lib/SGVector.h>
 #include <shogun/mathematics/Statistics.h>
@@ -63,14 +64,13 @@ CBinaryLabels::CBinaryLabels(CFile * loader) : CDenseLabels(loader)
 
 bool CBinaryLabels::is_valid() const
 {
-	if (!CDenseLabels::is_valid())
-		return false;
+//	if (!CDenseLabels::is_valid())
+//		return false;
 
-	int32_t subset_size = get_num_labels();
-	for (int32_t i = 0; i < subset_size; i++)
+	for (auto i : range(get_num_labels()))
 	{
-		int32_t real_i = m_subset_stack->subset_idx_conversion(i);
-		if (m_labels[real_i] != +1.0 && m_labels[real_i] != -1.0)
+		auto val = get_label(i);
+		if (val != +1.0 && val != -1.0)
 			return false;
 	}
 	return true;
@@ -138,29 +138,3 @@ CLabels* CBinaryLabels::duplicate() const
 {
 	return new CBinaryLabels(*this);
 }
-
-namespace shogun
-{
-	Some<CBinaryLabels> binary_labels(CLabels* orig)
-	{
-		REQUIRE(orig, "No labels provided.\n");
-		try
-		{
-			switch (orig->get_label_type())
-			{
-			case LT_BINARY:
-				return Some<CBinaryLabels>::from_raw((CBinaryLabels*)orig);
-			default:
-				SG_SNOTIMPLEMENTED
-			}
-		}
-		catch (const ShogunException& e)
-		{
-			SG_SERROR(
-			    "Cannot convert %s to binary labels: %s\n", orig->get_name(),
-			    e.what());
-		}
-
-		return Some<CBinaryLabels>::from_raw(nullptr);
-	}
-} // namespace shogun

--- a/src/shogun/labels/BinaryLabels.h
+++ b/src/shogun/labels/BinaryLabels.h
@@ -13,7 +13,6 @@
 
 #include <shogun/labels/DenseLabels.h>
 #include <shogun/labels/LabelTypes.h>
-#include <shogun/labels/MulticlassLabels.h>
 #include <shogun/lib/common.h>
 
 namespace shogun
@@ -129,8 +128,5 @@ public:
 #endif
 };
 
-#ifndef SWIG
-Some<CBinaryLabels> binary_labels(CLabels* orig);
-#endif // SWIG
 }
 #endif

--- a/src/shogun/labels/DenseLabels.cpp
+++ b/src/shogun/labels/DenseLabels.cpp
@@ -197,11 +197,12 @@ float64_t CDenseLabels::get_label(int32_t idx) const
 int32_t CDenseLabels::get_int_label(int32_t idx)
 {
 	int32_t real_num=m_subset_stack->subset_idx_conversion(idx);
-	ASSERT(m_labels.vector && idx<get_num_labels())
-	if (m_labels.vector[real_num] != float64_t((int32_t(m_labels.vector[real_num]))))
-		SG_ERROR("label[%d]=%g is not an integer\n", m_labels.vector[real_num])
+	ASSERT(idx<get_num_labels())
+	auto label = get_label(real_num);
+	if (label != float64_t((int32_t(label))))
+		SG_ERROR("label[%d]=%g is not an integer\n", label)
 
-	return int32_t(m_labels.vector[real_num]);
+	return int32_t(label);
 }
 
 int32_t CDenseLabels::get_num_labels() const

--- a/src/shogun/labels/DenseLabels.h
+++ b/src/shogun/labels/DenseLabels.h
@@ -108,7 +108,7 @@ namespace shogun
 		 *
 		 * @return labels, a copy if a subset is set
 		 */
-		SGVector<float64_t> get_labels() const;
+		virtual SGVector<float64_t> get_labels() const;
 
 		/** get label
 		 *
@@ -117,7 +117,7 @@ namespace shogun
 		 * @param idx index of label to get
 		 * @return value of label
 		 */
-		float64_t get_label(int32_t idx) const;
+		virtual float64_t get_label(int32_t idx) const;
 
 		/** get label
 		 *

--- a/src/shogun/labels/MappedBinaryLabels.cpp
+++ b/src/shogun/labels/MappedBinaryLabels.cpp
@@ -1,0 +1,43 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann
+ */
+
+#include <shogun/labels/MappedBinaryLabels.h>
+#include <shogun/labels/MulticlassLabels.h>
+
+
+using namespace shogun;
+
+std::pair<LabelMap, LabelMap>  CMappedBinaryLabels::create_mapping(const CLabels* orig) const
+{
+	LabelMap to_internal;
+	LabelMap from_internal;
+
+	switch (orig->get_label_type())
+	{
+		case LT_BINARY:
+			break;
+		case LT_MULTICLASS:
+		case LT_REGRESSION:
+		{
+			auto dense = static_cast<const CDenseLabels*>(orig);
+			auto unique = dense->get_labels().unique();
+			REQUIRE(unique.size()<=2, "Cannot use %d label values as binary labels.\n", unique.size());
+			to_internal[unique[0]] = -1;
+			from_internal[-1] = unique[0];
+
+			if (unique.size()==2)
+			{
+				to_internal[unique[1]] = 1;
+				from_internal[+1] = unique[1];
+			}
+			break;
+		}
+		default:
+			SG_ERROR("Cannot use %s as %s.", orig->get_name(), orig->get_name());
+	}
+
+	return std::make_pair(to_internal, from_internal);
+}

--- a/src/shogun/labels/MappedBinaryLabels.h
+++ b/src/shogun/labels/MappedBinaryLabels.h
@@ -1,0 +1,28 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann
+ */
+
+#ifndef MAPPED_BINARY_LABELS_H
+#define MAPPED_BINARY_LABELS_H
+
+#include <shogun/labels/MappedLabels.h>
+#include <shogun/labels/BinaryLabels.h>
+
+namespace shogun
+{
+
+class CMappedBinaryLabels : public MappedLabels<CBinaryLabels>
+{
+public:
+	CMappedBinaryLabels() {} // for class_list.h
+	CMappedBinaryLabels(CLabels* l) : MappedLabels(l) {}
+	virtual const char* get_name() const { return "MappedBinaryLabels"; }
+protected:
+	virtual std::pair<LabelMap, LabelMap> create_mapping(const CLabels* orig) const;
+};
+
+} // namespace shogun
+
+#endif // MAPPED_BINARY_LABELS_H

--- a/src/shogun/labels/MappedLabels.h
+++ b/src/shogun/labels/MappedLabels.h
@@ -1,0 +1,150 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann
+ */
+
+#ifndef MAPPED_LABELS_H
+#define MAPPED_LABELS_H
+
+#ifndef SWIG
+#include <shogun/lib/config.h>
+
+#include <shogun/lib/common.h>
+
+#include <shogun/labels/DenseLabels.h>
+#include <shogun/base/class_list.h>
+#include <shogun/base/range.h>
+
+
+namespace shogun
+{
+
+typedef std::map<float64_t, float64_t> LabelMap;
+
+template <typename T,
+	      std::enable_if_t<
+	          std::is_base_of<
+	              CDenseLabels, typename std::remove_pointer<T>::type>::value,
+	          T>* = nullptr>
+class MappedLabels : public T
+{
+public:
+	MappedLabels() : T() { init(); }
+	MappedLabels(CLabels* orig) : T()
+	{
+		init();
+
+		auto dense = orig->as<CDenseLabels>();
+		ASSERT(dense);
+		m_orig = dense;
+		SG_REF(m_orig);
+	}
+
+	virtual ~MappedLabels()
+	{
+		SG_UNREF(m_orig);
+	}
+
+	virtual SGVector<float64_t> get_labels() const
+	{
+		if (m_to_internal.empty())
+			return m_orig->get_labels();
+
+		auto num_labels = m_orig->get_num_labels();
+		SGVector<float64_t> converted(num_labels);
+		for (auto i : range(num_labels))
+			converted[i] = m_to_internal.at(m_orig->get_label(i));
+
+		return converted;
+	}
+
+	virtual float64_t get_label(index_t i) const
+	{
+		auto orig = m_orig->get_label(i);
+		return m_to_internal.size() ? m_to_internal.at(orig) : orig;
+	}
+
+	virtual int32_t get_num_labels() const { return m_orig->get_num_labels(); }
+
+	CDenseLabels* invert(const CLabels* labels) const
+	{
+		auto dense = labels->as<CDenseLabels>();
+		ASSERT(dense); // internal error
+
+		auto orig = dense->get_labels();
+		auto inverted = SGVector<float64_t>(orig.size());
+		std::transform(orig.begin(), orig.end(), inverted.begin(),
+				[this](float64_t l) {
+					return this->m_from_internal.at(l);
+				});
+
+		auto result = create_object<CDenseLabels>(m_orig->get_name());
+		SG_REF(result);
+		result->set_labels(inverted);
+		return result;
+	}
+	template<class MAPPED_CLASS, std::enable_if_t<std::is_base_of<T, MAPPED_CLASS>::value, MAPPED_CLASS>* = nullptr>
+	static T* wrap_if_necessary(CLabels* orig)
+	{
+		auto casted = dynamic_cast<T*>(orig);
+		if (casted && casted->is_valid())
+		{
+			SG_SDEBUG("Not necessary to map %s as %s, using original.\n", orig->get_name(), demangled_type<MAPPED_CLASS>().c_str());
+			return casted;
+
+		}
+
+		SG_SDEBUG("Mapping %s as %s.\n", orig->get_name(), demangled_type<MAPPED_CLASS>().c_str());
+		MAPPED_CLASS* result = new MAPPED_CLASS(orig);
+
+		// cast is safe since this is a mixin
+		auto mapping = std::move((static_cast<MappedLabels<T>*>(result))->create_mapping(orig));
+
+		result->m_to_internal = std::move(mapping.first);
+		result->m_from_internal = std::move(mapping.second);
+
+		SG_SDEBUG("to internal mapping:\n");
+		for (const auto& it : result->m_to_internal)
+			SG_SDEBUG("\t%f->%f\n", it.first, it.second)
+
+		SG_SDEBUG("from internal mapping:\n");
+		for (const auto& it : result->m_from_internal)
+			SG_SDEBUG("\t%f->%f\n", it.first, it.second)
+
+		return result;
+	}
+
+private:
+	void init()
+	{
+		m_orig = nullptr;
+		SG_ADD(&m_orig, "orig", "Original labels that are mapped via this object");
+		this->watch_param("to_internal", &m_to_internal, AnyParameterProperties("Map from provided into internal representation"));
+		this->watch_param("from_internal", &m_from_internal, AnyParameterProperties("Map from internal back into originally provided representation"));
+	}
+
+protected:
+
+	virtual std::pair<LabelMap, LabelMap> create_mapping(const CLabels* orig) const = 0;
+
+	CDenseLabels* m_orig;
+	LabelMap m_to_internal;
+	LabelMap m_from_internal;
+};
+
+template <class MAPPED_CLASS>
+CLabels* invert_labels_if_possible(CLabels* inverter, CLabels* result)
+{
+	CLabels* potentially_inverted = result;
+	if (auto casted = dynamic_cast<MAPPED_CLASS*>(inverter))
+	{
+		potentially_inverted = casted->invert(result);
+		SG_UNREF(result);
+	}
+	return potentially_inverted;
+}
+
+} // namespace shogun
+#endif // SWIG
+#endif // MAPPED_LABELS_H

--- a/src/shogun/labels/MappedMulticlassLabels.cpp
+++ b/src/shogun/labels/MappedMulticlassLabels.cpp
@@ -1,0 +1,53 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann
+ */
+
+#include <shogun/labels/MappedMulticlassLabels.h>
+#include <shogun/labels/MulticlassLabels.h>
+#include <shogun/base/range.h>
+#include <shogun/util/converters.h>
+#include <set>
+
+using namespace shogun;
+
+int32_t CMappedMulticlassLabels::get_num_classes()
+{
+	std::set<float64_t> s;
+	for (auto i : range(get_num_labels()))
+		s.insert(get_label(i));
+	return utils::safe_convert<int32_t>(s.size());
+}
+
+CLabels* CMappedMulticlassLabels::shallow_subset_copy()
+{
+	return nullptr;
+}
+
+std::pair<LabelMap, LabelMap> CMappedMulticlassLabels::create_mapping(const CLabels* orig) const
+{
+	LabelMap to_internal;
+	LabelMap from_internal;
+
+	switch (orig->get_label_type())
+	{
+		case LT_BINARY:
+		case LT_MULTICLASS:
+		case LT_REGRESSION:
+		{
+			auto dense = static_cast<const CDenseLabels*>(orig);
+			auto unique = dense->get_labels().unique();
+			for (auto i : range(unique.size()))
+			{
+				to_internal[unique[i]] = i;
+				from_internal[i] = unique[i];
+			}
+			break;
+		}
+		default:
+			SG_ERROR("Cannot use %s as %s.", orig->get_name(), get_name());
+	}
+
+	return std::make_pair(to_internal, from_internal);
+}

--- a/src/shogun/labels/MappedMulticlassLabels.h
+++ b/src/shogun/labels/MappedMulticlassLabels.h
@@ -1,0 +1,30 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann
+ */
+
+#ifndef MAPPED_MULTICLASS_LABELS_H
+#define MAPPED_MULTICLASS_LABELS_H
+
+#include <shogun/labels/MappedLabels.h>
+#include <shogun/labels/MulticlassLabels.h>
+
+namespace shogun
+{
+
+class CMappedMulticlassLabels : public MappedLabels<CMulticlassLabels>
+{
+public:
+	CMappedMulticlassLabels() : MappedLabels() {} // for class_list.h
+	CMappedMulticlassLabels(CLabels* l) : MappedLabels(l) {}
+	virtual int32_t get_num_classes();
+	virtual CLabels* shallow_subset_copy();
+	virtual const char* get_name() const { return "MappedMulticlassLabels"; }
+protected:
+	virtual std::pair<LabelMap, LabelMap> create_mapping(const CLabels* orig) const;
+};
+
+} // namespace shogun
+
+#endif // MAPPED_MULTICLASS_LABELS_H

--- a/src/shogun/labels/MulticlassLabels.h
+++ b/src/shogun/labels/MulticlassLabels.h
@@ -94,21 +94,13 @@ class CMulticlassLabels : public CDenseLabels
 		 */
 		CBinaryLabels* get_binary_for_class(int32_t i);
 
-		/** get unique labels (new SGVector)
-		 *
-		 * possible with subset
-		 *
-		 * @return unique labels
-		 */
-		SGVector<float64_t> get_unique_labels();
-
 		/** return number of classes (for multiclass)
 		 *
 		 * possible with subset
 		 *
 		 * @return number of classes
 		 */
-		int32_t get_num_classes();
+		virtual int32_t get_num_classes();
 
 		/** returns multiclass confidences
 		 *
@@ -161,9 +153,5 @@ class CMulticlassLabels : public CDenseLabels
 		/** multiclass confidences */
 		SGMatrix<float64_t> m_multiclass_confidences;
 };
-
-#ifndef SWIG
-Some<CMulticlassLabels> multiclass_labels(CLabels* orig);
-#endif // SWIG
 }
 #endif

--- a/src/shogun/latent/LatentModel.cpp
+++ b/src/shogun/latent/LatentModel.cpp
@@ -64,7 +64,7 @@ void CLatentModel::set_features(CLatentFeatures* feats)
 void CLatentModel::argmax_h(const SGVector<float64_t>& w)
 {
 	int32_t num = get_num_vectors();
-	CBinaryLabels* y = binary_labels(m_labels->get_labels());
+	CBinaryLabels* y = m_labels->as<CBinaryLabels>();
 	ASSERT(num > 0)
 	ASSERT(num == m_labels->get_num_labels())
 

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -17,9 +17,12 @@
 
 #include <algorithm>
 #include <limits>
+#include <set>
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/lapack.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <shogun/util/converters.h>
+
 
 #define COMPLEX128_ERROR_NOARG(function) \
 template <> \
@@ -760,6 +763,21 @@ SGVector<T> SGVector<T>::unique()
 	auto new_size = unique(result.data(), result.size());
 	result.resize_vector(new_size);
 	return result;
+}
+
+template <class T>
+int32_t SGVector<T>::count_unique()
+{
+	std::set<T> s;
+	std::copy(begin(), end(), std::inserter(s, s.end()));
+	return utils::safe_convert<int32_t>(s.size());
+}
+
+template <>
+int32_t SGVector<complex128_t>::count_unique()
+{
+	SG_SNOTIMPLEMENTED
+	return 0;
 }
 
 template <>

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -487,6 +487,9 @@ template<class T> class SGVector : public SGReferencedData
 		/** Returns new vector with sorted unique elements of current */
 		SGVector<T> unique();
 
+		/** Counts the number of unique elements, using ==, in-place */
+		int32_t count_unique();
+
 		// get the values of the vector in a string representation
 		std::string to_string() const;
 

--- a/src/shogun/machine/MulticlassMachine.cpp
+++ b/src/shogun/machine/MulticlassMachine.cpp
@@ -248,7 +248,7 @@ bool CMulticlassMachine::train_machine(CFeatures* data)
 	m_machine->set_labels(train_labels);
 
 	m_multiclass_strategy->train_start(
-	    multiclass_labels(m_labels), train_labels);
+	    m_labels->as<CMulticlassLabels>(), train_labels);
 	while (m_multiclass_strategy->train_has_more())
 	{
 		SGVector<index_t> subset=m_multiclass_strategy->train_prepare_next();

--- a/src/shogun/metric/LMNN.cpp
+++ b/src/shogun/metric/LMNN.cpp
@@ -60,7 +60,7 @@ void CLMNN::train(SGMatrix<float64_t> init_transform)
 
 	// cast is safe, check_training_setup ensures features are dense
 	CDenseFeatures<float64_t>* x = static_cast<CDenseFeatures<float64_t>*>(m_features);
-	CMulticlassLabels* y = multiclass_labels(m_labels);
+	CMulticlassLabels* y = m_labels->as<CMulticlassLabels>();
 	SG_DEBUG("%d input vectors with %d dimensions.\n", x->get_num_vectors(), x->get_num_features());
 
 	auto& L = init_transform;

--- a/src/shogun/metric/LMNNImpl.cpp
+++ b/src/shogun/metric/LMNNImpl.cpp
@@ -67,7 +67,7 @@ void CLMNNImpl::check_training_setup(
 
 void CLMNNImpl::check_maximum_k(CLabels* labels, int32_t k)
 {
-	CMulticlassLabels* y = multiclass_labels(labels);
+	CMulticlassLabels* y = labels->as<CMulticlassLabels>();
 	SGVector<int32_t> int_labels = y->get_int_labels();
 
 	// back-up initial values because they will be overwritten by unique
@@ -112,7 +112,7 @@ SGMatrix<index_t> CLMNNImpl::find_target_nn(CDenseFeatures<float64_t>* x,
 	// get the number of features
 	int32_t d = x->get_num_features();
 	SGMatrix<index_t> target_neighbors(k, x->get_num_vectors());
-	SGVector<float64_t> unique_labels = y->get_unique_labels();
+	SGVector<float64_t> unique_labels = y->get_labels().unique();
 	SGVector<index_t> idxsmap(x->get_num_vectors());
 
 	for (index_t i = 0; i < unique_labels.vlen; ++i)
@@ -417,7 +417,7 @@ ImpostorsSetType CLMNNImpl::find_impostors_exact(
 	CDenseFeatures<float64_t>* lx = new CDenseFeatures<float64_t>(LX);
 
 	// get a vector with unique label values
-	SGVector<float64_t> unique = y->get_unique_labels();
+	SGVector<float64_t> unique = y->get_labels().unique();
 
 	// for each label except from the largest one
 	for (index_t i = 0; i < unique.vlen-1; ++i)

--- a/src/shogun/multiclass/GaussianNaiveBayes.cpp
+++ b/src/shogun/multiclass/GaussianNaiveBayes.cpp
@@ -74,7 +74,7 @@ bool CGaussianNaiveBayes::train_machine(CFeatures* data)
 	// get int labels to train_labels and check length equality
 	ASSERT(m_labels)
 	SGVector<int32_t> train_labels =
-	    multiclass_labels(m_labels)->get_int_labels();
+	    m_labels->as<CMulticlassLabels>()->get_int_labels();
 	ASSERT(m_features->get_num_vectors()==train_labels.vlen)
 
 	// find minimal and maximal label

--- a/src/shogun/multiclass/ShareBoost.cpp
+++ b/src/shogun/multiclass/ShareBoost.cpp
@@ -138,7 +138,7 @@ void CShareBoost::compute_pred(const float64_t *W)
 
 void CShareBoost::compute_rho()
 {
-	auto lab = multiclass_labels(m_labels);
+	auto lab = m_labels->as<CMulticlassLabels>();
 
 	for (int32_t i=0; i < m_rho.num_rows; ++i)
 	{ // i loop classes
@@ -163,7 +163,7 @@ void CShareBoost::compute_rho()
 int32_t CShareBoost::choose_feature()
 {
 	SGVector<float64_t> l1norm(m_fea.num_rows);
-	auto lab = multiclass_labels(m_labels);
+	auto lab = m_labels->as<CMulticlassLabels>();
 	for (int32_t j=0; j < m_fea.num_rows; ++j)
 	{
 		if (std::find(&m_activeset[0], &m_activeset[m_activeset.vlen], j) !=

--- a/src/shogun/multiclass/ShareBoostOptimizer.cpp
+++ b/src/shogun/multiclass/ShareBoostOptimizer.cpp
@@ -51,7 +51,7 @@ float64_t ShareBoostOptimizer::lbfgs_evaluate(void *userdata, const float64_t *W
 	int32_t k = optimizer->m_sb->m_multiclass_strategy->get_num_classes();
 
 	SGMatrix<float64_t> fea = optimizer->m_sb->m_fea;
-	auto lab = multiclass_labels(optimizer->m_sb->m_labels);
+	auto lab = optimizer->m_sb->m_labels->as<CMulticlassLabels>();
 
 	// compute gradient
 	for (int32_t i=0; i < m; ++i)

--- a/src/shogun/multiclass/tree/C45ClassifierTree.cpp
+++ b/src/shogun/multiclass/tree/C45ClassifierTree.cpp
@@ -199,7 +199,7 @@ CTreeMachineNode<C45TreeNodeData>* CC45ClassifierTree::C45train(CFeatures* data,
 	}
 
 	// if all samples belong to the same class
-	if (class_labels->get_unique_labels().size()==1)
+	if (class_labels->get_num_classes()==1)
 		return node;
 
 	// if no feature is left
@@ -655,16 +655,17 @@ float64_t CC45ClassifierTree::informational_gain_attribute(int32_t attr_no, CFea
 
 float64_t CC45ClassifierTree::entropy(CMulticlassLabels* labels, SGVector<float64_t> weights)
 {
-	SGVector<float64_t> log_ratios(labels->get_unique_labels().size());
+	auto unique = labels->get_labels().unique();
+	SGVector<float64_t> log_ratios(unique.size());
 	float64_t total_weight=weights.sum(weights.vector,weights.vlen);
 
-	for (int32_t i=0;i<labels->get_unique_labels().size();i++)
+	for (int32_t i=0;i<unique.size();i++)
 	{
 		int32_t count=0;
 		float64_t weight_count=0.;
 		for (int32_t j=0;j<labels->get_num_labels();j++)
 		{
-			if (labels->get_unique_labels()[i]==labels->get_label(j))
+			if (unique[i]==labels->get_label(j))
 			{
 				weight_count+=weights[j];
 				count++;

--- a/src/shogun/multiclass/tree/ID3ClassifierTree.cpp
+++ b/src/shogun/multiclass/tree/ID3ClassifierTree.cpp
@@ -145,7 +145,7 @@ CTreeMachineNode<id3TreeNodeData>* CID3ClassifierTree::id3train(CFeatures* data,
 		best_feature_values[i] = (feats->get_feature_vector(i))[best_feature_index];
 
 	CMulticlassLabels* best_feature_labels = new CMulticlassLabels(best_feature_values);
-	SGVector<float64_t> best_labels_unique = best_feature_labels->get_unique_labels();
+	SGVector<float64_t> best_labels_unique = best_feature_labels->get_labels().unique();
 
 	for (int32_t i=0; i<best_labels_unique.vlen; i++)
 	{
@@ -225,7 +225,7 @@ float64_t CID3ClassifierTree::informational_gain_attribute(int32_t attr_no, CFea
 		attribute_values[i] = (feats->get_feature_vector(i))[attr_no];
 
 	CMulticlassLabels* attribute_labels = new CMulticlassLabels(attribute_values);
-	SGVector<float64_t> attr_val_unique = attribute_labels->get_unique_labels();
+	SGVector<float64_t> attr_val_unique = attribute_labels->get_labels().unique();
 
 	for (int32_t i=0; i<attr_val_unique.vlen; i++)
 	{
@@ -264,16 +264,16 @@ float64_t CID3ClassifierTree::informational_gain_attribute(int32_t attr_no, CFea
 
 float64_t CID3ClassifierTree::entropy(CMulticlassLabels* labels)
 {
-	SGVector<float64_t> log_ratios = SGVector<float64_t>
-			(labels->get_unique_labels().size());
+	auto unique = labels->get_labels().unique();
+	SGVector<float64_t> log_ratios = SGVector<float64_t>(unique.size());
 
-	for (int32_t i=0;i<labels->get_unique_labels().size();i++)
+	for (int32_t i=0;i<unique.size();i++)
 	{
 		int32_t count = 0;
 
 		for (int32_t j=0;j<labels->get_num_labels();j++)
 		{
-			if (labels->get_unique_labels()[i] == labels->get_label(j))
+			if (unique[i] == labels->get_label(j))
 					count++;
 		}
 

--- a/tests/unit/evaluation/SplittingStrategy_unittest.cc
+++ b/tests/unit/evaluation/SplittingStrategy_unittest.cc
@@ -100,7 +100,7 @@ TEST(SplittingStrategy,stratified_subsets_disjoint_cover)
 		for (index_t i=0; i<num_labels; ++i)
 			labels->set_label(i, CMath::random()%num_classes);
 
-		SGVector<float64_t> classes=labels->get_unique_labels();
+		SGVector<float64_t> classes=labels->get_labels().unique();
 
 		/*No. of labels belonging to one class*/
 		SGVector<index_t> class_labels(num_classes);

--- a/tests/unit/labels/BinaryLabels_unittest.cc
+++ b/tests/unit/labels/BinaryLabels_unittest.cc
@@ -98,10 +98,3 @@ TEST_F(BinaryLabels, set_values_labels_from_constructor)
 
 	SG_UNREF(labels);
 }
-
-TEST_F(BinaryLabels, binary_labels_from_binary)
-{
-	auto labels = some<CBinaryLabels>(probabilities, 0.5);
-	auto labels2 = binary_labels(labels);
-	EXPECT_EQ(labels, labels2);
-}

--- a/tests/unit/labels/MappedLabels_unittest.cc
+++ b/tests/unit/labels/MappedLabels_unittest.cc
@@ -1,0 +1,221 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Heiko Strathmann
+ */
+#include <gtest/gtest.h>
+#include <shogun/labels/MappedLabels.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/features/DenseFeatures.h>
+#include <shogun/machine/Machine.h>
+#include <shogun/labels/MappedBinaryLabels.h>
+#include <shogun/labels/MappedMulticlassLabels.h>
+
+
+#include "environments/LinearTestEnvironment.h"
+
+extern LinearTestEnvironment* linear_test_env;
+
+using namespace shogun;
+
+/** Mock class that asserts correct provided internal label type and returns
+ * the same internal label type in train and apply respectively.
+ * E.g. LibSVM expects CBinaryLabels and returns CBinaryLabels.
+ * Ensures that all machines can rely on particular internal labels, depending
+ * on problem type.
+ */
+class MockMachine : public CMachine
+{
+public:
+	MockMachine(EProblemType pt) : CMachine()
+	{
+//		get_global_io()->set_loglevel(MSG_GCDEBUG);
+		m_problem_type = pt;
+	}
+
+	virtual const char* get_name() const override { return "MockMachine"; }
+
+
+protected:
+	virtual bool train_machine(CFeatures*) override
+	{
+		switch (m_problem_type)
+		{
+		case PT_BINARY:
+		{
+			// binary are -1, +1
+			auto casted = m_labels->as<CBinaryLabels>();
+			ASSERT(casted);
+			for (auto l : casted->get_labels())
+				EXPECT_TRUE(l == -1 || l == 1);
+			for (auto i : range(casted->get_num_labels()))
+			{
+				auto l = casted->get_label(i);
+				EXPECT_TRUE(l == -1 || l == 1);
+			}
+			break;
+		}
+
+		case PT_MULTICLASS:
+		{
+			// multiclass are 0,1,2,3, ... (contiguous integers)
+			auto casted = m_labels->as<CMulticlassLabels>();
+			ASSERT(casted);
+			for (auto l : casted->get_labels())
+				EXPECT_TRUE(l >= 0 && l == int64_t(l));
+			auto uniq = casted->get_labels().unique();
+			for (auto i : range(uniq.size()))
+				EXPECT_EQ(uniq[i], i);
+			break;
+		}
+
+		default:
+			EXPECT_TRUE(false);
+		}
+		return true;
+	}
+
+	virtual CBinaryLabels* apply_binary(CFeatures*) override
+	{
+		auto labs = SGVector<float64_t>(10);
+		for (auto i : range(labs.size()))
+			labs[i] = 2*(i%2)-1;
+		auto result = new CBinaryLabels(labs);
+		SG_REF(result);
+		return result;
+	}
+
+	virtual CMulticlassLabels* apply_multiclass(CFeatures*) override
+	{
+		auto labs = SGVector<float64_t>(10);
+		auto num_classes = m_labels->as<CMulticlassLabels>()->get_labels().unique().vlen;
+		ASSERT(num_classes);
+		for (auto i : range(labs.size()))
+			labs[i] = i % num_classes;
+		auto result = new CMulticlassLabels(labs);
+		SG_REF(result);
+		return result;
+	}
+
+	virtual EProblemType get_machine_problem_type() const
+	{
+		return m_problem_type;
+	}
+
+	EProblemType m_problem_type;
+};
+
+class MappedLabelsFixture : public ::testing::Test
+{
+protected:
+	void SetUp()
+	{
+		feats = nullptr;
+		m = nullptr;
+		result = nullptr;
+	}
+
+	void TearDown()
+	{
+		SG_UNREF(feats);
+		SG_UNREF(m);
+		SG_UNREF(result);
+	}
+
+public:
+	CLabels* train_and_apply(CLabels* labs, EProblemType pt)
+	{
+		ASSERT(labs);
+
+		X = SGMatrix<float64_t>(1, labs->get_num_labels());
+		feats = new CDenseFeatures<float64_t>(X);
+		SG_REF(feats);
+
+		m = new MockMachine(pt);
+		SG_REF(m);
+
+		m->set_labels(labs);
+		m->train(feats);
+		result = m->apply();
+		return result;
+	}
+
+	template <class USER_PROVIDED, class MAPPING, class EXPECTED_INTERNAL>
+	void test_mapped_labels(SGVector<float64_t> user_provided, SGVector<float64_t> expected_internal, EProblemType pt)
+	{
+		auto labs = some<USER_PROVIDED>(user_provided);
+		auto applied = train_and_apply(labs, pt);
+
+		// CMachine::apply returns the same class as user provided
+		EXPECT_TRUE(dynamic_cast<USER_PROVIDED*>(applied));
+
+		// internal labels are of appropriate class and mapping works
+		auto internal = m->get_labels();
+		auto casted = dynamic_cast<MAPPING*>(internal);
+		ASSERT_TRUE(casted);
+		EXPECT_TRUE(casted->get_labels().equals(expected_internal));
+
+		// inversion mapping works: mapping of the internal labels gives original
+		auto invert_labels = some<EXPECTED_INTERNAL>(expected_internal);
+		auto inverted = casted->invert(invert_labels);
+		EXPECT_TRUE(inverted->get_labels().equals(labs->get_labels()));
+		SG_UNREF(inverted);
+		SG_UNREF(internal);
+	}
+
+	template <class USER_PROVIDED>
+	void test_mapped_labels(SGVector<float64_t> user_provided, EProblemType pt)
+	{
+		auto labs = some<USER_PROVIDED>(user_provided);
+		auto applied = train_and_apply(labs, pt);
+
+		// CMachine::apply returns the same class as user provided
+		EXPECT_TRUE(dynamic_cast<USER_PROVIDED*>(applied));
+
+		// internal labels are the same instance as user provided
+		auto converted = m->get_labels();
+		EXPECT_TRUE(converted == labs);
+		SG_UNREF(converted);
+	}
+
+	SGMatrix<float64_t> X;
+	CFeatures* feats;
+	CMachine* m;
+	CLabels* result;
+};
+
+TEST_F(MappedLabelsFixture, mc_as_bin)
+{
+	test_mapped_labels<CMulticlassLabels, CMappedBinaryLabels, CBinaryLabels>({0,2,0,2}, {-1,1,-1,1}, PT_BINARY);
+}
+
+TEST_F(MappedLabelsFixture, bin_as_same_bin)
+{
+	test_mapped_labels<CBinaryLabels>({-1,1,-1,1}, PT_BINARY);
+}
+
+TEST_F(MappedLabelsFixture, reg_as_bin)
+{
+	test_mapped_labels<CRegressionLabels, CMappedBinaryLabels, CBinaryLabels>({-2.1,3.2,3.2,-2.1}, {-1,1,1,-1}, PT_BINARY);
+}
+
+TEST_F(MappedLabelsFixture, mc_as_same_mc)
+{
+	test_mapped_labels<CMulticlassLabels>({0,1,2,3}, PT_MULTICLASS);
+}
+
+TEST_F(MappedLabelsFixture, non_contiguous_mc_as_mc)
+{
+	test_mapped_labels<CMulticlassLabels, CMappedMulticlassLabels, CMulticlassLabels>({0,2,4,6}, {0,1,2,3}, PT_MULTICLASS);
+}
+TEST_F(MappedLabelsFixture, bin_as_mc)
+{
+	test_mapped_labels<CBinaryLabels, CMappedMulticlassLabels, CMulticlassLabels>({-1,1,-1,1}, {0,1,0,1}, PT_MULTICLASS);
+}
+
+TEST_F(MappedLabelsFixture, reg_as_mc)
+{
+	test_mapped_labels<CRegressionLabels, CMappedMulticlassLabels, CMulticlassLabels>({-2.1,3.2,3.2,1.7}, {0,2,2,1}, PT_MULTICLASS);
+}
+

--- a/tests/unit/labels/MulticlassLabels_unittest.cc
+++ b/tests/unit/labels/MulticlassLabels_unittest.cc
@@ -72,29 +72,6 @@ TEST_F(MulticlassLabels, confidences)
 	SG_UNREF(labels);
 }
 
-TEST_F(MulticlassLabels, multiclass_labels_from_multiclass)
-{
-	auto labels = some<CMulticlassLabels>(labels_true);
-	auto labels2 = multiclass_labels(labels);
-	EXPECT_EQ(labels.get(), labels2.get());
-}
-
-TEST_F(MulticlassLabels, multiclass_labels_from_binary_not_contiguous)
-{
-	// delete this test once multiclass labels dont need to be contiguous,
-	// i.e. [0,1,2,3,4,...], anymore
-	auto labels = some<CBinaryLabels>(labels_true.size());
-	labels->set_labels({0, 1, 3});
-	auto converted = multiclass_labels(labels);
-	ASSERT_NE(converted.get(), nullptr);
-	EXPECT_TRUE(converted->get_labels().equals({0, 1, 2}));
-
-	labels->set_labels({-1, 1, 1});
-	auto converted2 = multiclass_labels(labels);
-	ASSERT_NE(converted2.get(), nullptr);
-	EXPECT_TRUE(converted2->get_labels().equals({0, 1, 1}));
-}
-
 TEST_F(MulticlassLabels, view)
 {
 	auto labels = some<CMulticlassLabels>(labels_true);

--- a/tests/unit/lib/SGVector_unittest.cc
+++ b/tests/unit/lib/SGVector_unittest.cc
@@ -468,3 +468,12 @@ TEST(SGVectorTest, as)
 		EXPECT_EQ((int32_t)data[i], vec_int[i]);
 	}
 }
+
+TEST(SGVectorTest, count_unique)
+{
+	EXPECT_EQ(SGVector<int32_t>().count_unique(), 0);
+	EXPECT_EQ(SGVector<int32_t>({0,0,0,0}).count_unique(),1);
+	EXPECT_EQ(SGVector<int32_t>({ 0, 0, 1, 2}).count_unique(), 3);
+	EXPECT_EQ(SGVector<float64_t>({ 0, 0, 1, 2}).count_unique(), 3);
+	EXPECT_EQ(SGVector<float64_t>({ 0, 0.001, 1.0, 1.0, 2.1}).count_unique(), 4);
+}


### PR DESCRIPTION
Enables mapping user-provided labels into the required internal algorithm representation.

This roughly resembles what we discussed @lisitsyn @gf712 I created a drop-in replacement for `CBinaryLabels`, which replaces the provided labels inside `CMachine::train`. These perform shared-memory (if possible) on-the-fly mappings to the required internal label space when the usual access functions of `CDenseLabels` are used. The mapping code is self-contained and the drop-in functionality is achieved via adding a mixing to the desired label classes.

The user gets back prediction labels in the same space/class as she provided in `train`.

I am looking for high level feedback for now, will tune this stuff later on.