### PR TITLE
[WIP] first draft of sg_add method

### DIFF
--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -202,7 +202,12 @@ namespace shogun
 			return m_properties;
 		}
 
-		const std::shared_ptr<params::AutoInit>& get_init_function() const
+		void set_init_function(std::shared_ptr<params::AutoInit> func)
+		{
+			m_init_function = func;
+		}
+
+		std::shared_ptr<params::AutoInit> get_init_function() const
 		{
 			return m_init_function;
 		}

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -207,6 +207,11 @@ namespace shogun
 			m_init_function = std::move(func);
 		}
 
+		void set_constrain_function(std::function<std::string(Any)>&& func)
+		{
+			m_constrain_function = std::move(func);
+		}
+
 		std::shared_ptr<params::AutoInit> get_init_function() const
 		{
 			return m_init_function;

--- a/src/shogun/base/AnyParameter.h
+++ b/src/shogun/base/AnyParameter.h
@@ -204,7 +204,7 @@ namespace shogun
 
 		void set_init_function(std::shared_ptr<params::AutoInit> func)
 		{
-			m_init_function = func;
+			m_init_function = std::move(func);
 		}
 
 		std::shared_ptr<params::AutoInit> get_init_function() const

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -790,7 +790,7 @@ protected:
 	}
 
 	template <ParameterProperties PPVal, typename ...Args, std::enable_if_t<static_cast<bool>(PPVal&ParameterProperties::AUTO)>* = nullptr>
-	void sg_add_auto_func(AnyParameter& any_pprop, Args&&... args)
+	void declare_auto_func(AnyParameter& any_pprop, Args&&... args)
 	{
 		static_assert(sg_is_any_base_of<params::AutoInit, Args...>::value,
 				"Expected a params::AutoInit function when passing param with"
@@ -800,11 +800,12 @@ protected:
 	}
 
 	template <ParameterProperties pprop, typename T, typename ...Args>
-	void sg_add(T* value, const std::string& name, const std::string& description, Args&& ...args)
+	void declare(T* value, const std::string& name, const std::string& description, Args&& ...args)
 	{
 		auto any_pprop = AnyParameterProperties(description, pprop);
 		auto anyp = AnyParameter(make_any_ref(value), any_pprop);
-		sg_add_auto_func<pprop>(anyp, args...);
+		if constexpr (static_cast<bool>(pprop&ParameterProperties::AUTO))
+            declare_auto_func<pprop>(anyp, args...);
 
 		BaseTag tag(name);
 		create_parameter(tag, anyp);

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -784,31 +784,27 @@ public:
 	}
 
 protected:
-	void sg_add_auto_func(AnyParameter& any_pprop, std::shared_ptr<params::AutoInit> func)
+	template <ParameterProperties PPVal, typename ...Args, std::enable_if_t<!static_cast<bool>(PPVal&ParameterProperties::AUTO)>* = nullptr>
+	void sg_add_auto_func(AnyParameter& any_pprop, Args&&... args)
 	{
-		any_pprop.set_init_function(std::move(func));
 	}
 
-	template <typename ...Args>
+	template <ParameterProperties PPVal, typename ...Args, std::enable_if_t<static_cast<bool>(PPVal&ParameterProperties::AUTO)>* = nullptr>
 	void sg_add_auto_func(AnyParameter& any_pprop, Args&&... args)
 	{
 		static_assert(sg_is_any_base_of<params::AutoInit, Args...>::value,
 				"Expected a params::AutoInit function when passing param with"
 				" ParameterProperty::AUTO!");
 		constexpr size_t idx = get_idx_from_pack<params::AutoInit, Args...>::idx;
-		any_pprop.set_init_function(std::get<idx>(std::forward_as_tuple(args...)));
+		any_pprop.set_init_function(std::move(std::get<idx>(std::forward_as_tuple(args...))));
 	}
 
-	template <typename T, typename ...Args>
-	void sg_add(T* value, const std::string& name, const std::string& description,
-			ParameterProperties pprop, Args&& ...args)
+	template <ParameterProperties pprop, typename T, typename ...Args>
+	void sg_add(T* value, const std::string& name, const std::string& description, Args&& ...args)
 	{
 		auto any_pprop = AnyParameterProperties(description, pprop);
 		auto anyp = AnyParameter(make_any_ref(value), any_pprop);
-		if (any_pprop.has_property(ParameterProperties::AUTO))
-		{
-			sg_add_auto_func(anyp, args...);
-		}
+		sg_add_auto_func<pprop>(anyp, args...);
 
 		BaseTag tag(name);
 		create_parameter(tag, anyp);

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -824,12 +824,13 @@ protected:
 		any_pprop.set_constrain_function(std::move(func));
 	}
 
-	template <ParameterProperties pprop, typename T, typename... Args>
+	template <ParameterProperties pprop = ParameterProperties::NONE, typename T, typename... Args>
 	void declare(
 			T* value, const std::string& name, const std::string& description,
 			Args&&... args)
 	{
-		auto any_pprop = AnyParameterProperties(description, pprop);
+	    auto mask = pprop | m_default_mask;
+		auto any_pprop = AnyParameterProperties(description, mask);
 		auto anyp = AnyParameter(make_any_ref(value), any_pprop);
 		if constexpr (static_cast<bool>(pprop & ParameterProperties::AUTO))
 			declare_auto_func<pprop>(anyp, std::forward<Args&&>(args)...);

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -784,6 +784,36 @@ public:
 	}
 
 protected:
+	void sg_add_auto_func(AnyParameter& any_pprop, std::shared_ptr<params::AutoInit> func)
+	{
+		any_pprop.set_init_function(std::move(func));
+	}
+
+	template <typename ...Args>
+	void sg_add_auto_func(AnyParameter& any_pprop, Args&&... args)
+	{
+		static_assert(sg_is_any_base_of<params::AutoInit, Args...>::value,
+				"Expected a params::AutoInit function when passing param with"
+				" ParameterProperty::AUTO!");
+		constexpr size_t idx = get_idx_from_pack<params::AutoInit, Args...>::idx;
+		any_pprop.set_init_function(std::get<idx>(std::forward_as_tuple(args...)));
+	}
+
+	template <typename T, typename ...Args>
+	void sg_add(T* value, const std::string& name, const std::string& description,
+			ParameterProperties pprop, Args&& ...args)
+	{
+		auto any_pprop = AnyParameterProperties(description, pprop);
+		auto anyp = AnyParameter(make_any_ref(value), any_pprop);
+		if (any_pprop.has_property(ParameterProperties::AUTO))
+		{
+			sg_add_auto_func(anyp, args...);
+		}
+
+		BaseTag tag(name);
+		create_parameter(tag, anyp);
+	}
+
 	/** Registers a class parameter which is identified by a tag.
 	 * This enables the parameter to be modified by put() and retrieved by
 	 * get().

--- a/src/shogun/base/constraint.h
+++ b/src/shogun/base/constraint.h
@@ -177,13 +177,15 @@ namespace shogun
 		}
 	};
 
+	class ConstraintBase {};
+
 	/**
 	 * Constraint helper class that invokes apply using class member functions
 	 * m_funcs. If any of the functions returns false then it retrieves
 	 * the error and passes it to the buffer.
 	 */
 	template <typename... Args>
-	class Constraint
+	class Constraint: ConstraintBase
 	{
 	public:
 		Constraint(std::tuple<Args...>&& funcs) : m_funcs(std::move(funcs))

--- a/src/shogun/base/sg_type_traits.h
+++ b/src/shogun/base/sg_type_traits.h
@@ -1,0 +1,80 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_TYPE_TRAITS_H
+#define SHOGUN_TYPE_TRAITS_H
+
+namespace shogun
+{
+	template <typename T>
+	struct get_container_underlying
+	{
+		using type = T;
+	};
+
+	template <template <typename> class Container, typename T>
+	struct get_container_underlying<Container<T>>
+	{
+		using type = T;
+	};
+
+	template <typename T>
+	using get_container_underlying_t = typename get_container_underlying<typename std::remove_reference<T>::type>::type;
+
+	template <typename T, typename... Rest>
+	struct sg_is_any_base_of : std::false_type
+	{
+	};
+
+	template <typename T, typename First>
+	struct sg_is_any_base_of<T, First> : std::is_base_of<T, get_container_underlying_t<First>>
+	{
+	};
+
+	template <typename T, typename First, typename... Rest>
+	struct sg_is_any_base_of<T, First, Rest...>
+	    : std::integral_constant<
+	          bool, std::is_base_of<T, get_container_underlying_t<First>>::value ||
+	                    sg_is_any_base_of<T, Rest...>::value>
+	{
+	};
+
+	template <typename T, bool, size_t size, typename... Rest>
+	struct get_idx_from_pack_helper
+	{
+		constexpr static size_t idx = size;
+	};
+
+	template <typename T, size_t size, typename First>
+	struct get_idx_from_pack_helper<T, false, size, First>
+	{
+		static_assert(std::is_base_of<T, get_container_underlying_t<First>>::value, "Could not find type in pack!\n");
+		constexpr static size_t idx = size;
+	};
+
+	template <typename T, size_t size, typename First, typename... Rest>
+	struct get_idx_from_pack_helper<T, true, size, First, Rest...>
+	{
+		constexpr static size_t idx = size - sizeof...(Rest) - 1;
+	};
+
+	template <typename T, size_t size, typename First, typename... Rest>
+	struct get_idx_from_pack_helper<T, false, size, First, Rest...>
+	{
+		constexpr static size_t idx = get_idx_from_pack_helper<
+				T, std::is_base_of<T, get_container_underlying_t<First>>::value, size, Rest...>::idx;
+	};
+
+	template <typename T, typename First, typename... Rest>
+	struct get_idx_from_pack
+	{
+		constexpr static size_t idx = get_idx_from_pack_helper<
+				T, std::is_base_of<T, get_container_underlying_t<First>>::value, sizeof...(Rest), Rest...>::idx;
+	};
+
+} // namespace shogun
+
+#endif // SHOGUN_TYPE_TRAITS_H

--- a/src/shogun/clustering/KMeansBase.cpp
+++ b/src/shogun/clustering/KMeansBase.cpp
@@ -307,10 +307,8 @@ void KMeansBase::init()
 	SG_ADD(
 	    &max_iter, "max_iter", "Maximum number of iterations",
 	    ParameterProperties::HYPER);
-	SG_ADD(
-	    &k, "k", "k, the number of clusters",
-	    ParameterProperties::HYPER | ParameterProperties::CONSTRAIN,
-	    SG_CONSTRAINT(positive<>()));
+	declare<ParameterProperties::HYPER | ParameterProperties::CONSTRAIN>(
+	    &k, "k", "k, the number of clusters", SG_CONSTRAINT(positive<>()));
 	SG_ADD(
 	    &dimensions, "dimensions", "Dimensions of data",
 	    ParameterProperties::READONLY);

--- a/src/shogun/clustering/KMeansBase.cpp
+++ b/src/shogun/clustering/KMeansBase.cpp
@@ -307,8 +307,10 @@ void KMeansBase::init()
 	SG_ADD(
 	    &max_iter, "max_iter", "Maximum number of iterations",
 	    ParameterProperties::HYPER);
-	declare<ParameterProperties::HYPER | ParameterProperties::CONSTRAIN>(
-	    &k, "k", "k, the number of clusters", SG_CONSTRAINT(positive<>()));
+	SG_ADD(
+	    &k, "k", "k, the number of clusters", 
+	    ParameterProperties::HYPER | ParameterProperties::CONSTRAIN,
+	    SG_CONSTRAINT(positive<>()));
 	SG_ADD(
 	    &dimensions, "dimensions", "Dimensions of data",
 	    ParameterProperties::READONLY);

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -595,9 +595,9 @@ template<class ST> void DenseFeatures<ST>::init()
 	set_generic<ST>();
 
 	/* not store number of vectors in subset */
-	SG_ADD(&num_vectors, "num_vectors", "Number of vectors.");
-	SG_ADD(&num_features, "num_features", "Number of features.");
-	SG_ADD(&feature_matrix, "feature_matrix",
+	declare(&num_vectors, "num_vectors", "Number of vectors.");
+    declare(&num_features, "num_features", "Number of features.");
+    declare(&feature_matrix, "feature_matrix",
 			"Matrix of feature vectors / 1 vector per column.");
 }
 

--- a/src/shogun/features/Features.cpp
+++ b/src/shogun/features/Features.cpp
@@ -51,12 +51,12 @@ void Features::init()
 {
 	set_default_mask(ParameterProperties::READONLY);
 
-	SG_ADD(&properties, "properties", "Feature properties");
-	SG_ADD(&cache_size, "cache_size", "Size of cache in MB");
+	declare(&properties, "properties", "Feature properties");
+	declare(&cache_size, "cache_size", "Size of cache in MB");
 
-	SG_ADD(&preproc, "preproc", "Array of preprocessors.");
+	declare(&preproc, "preproc", "Array of preprocessors.");
 
-	SG_ADD((std::shared_ptr<SGObject>*)&m_subset_stack, "subset_stack", "Stack of subsets");
+	declare((std::shared_ptr<SGObject>*)&m_subset_stack, "subset_stack", "Stack of subsets");
 
 	m_subset_stack=std::make_shared<SubsetStack>();
 

--- a/src/shogun/kernel/SigmoidKernel.cpp
+++ b/src/shogun/kernel/SigmoidKernel.cpp
@@ -57,8 +57,8 @@ void SigmoidKernel::init()
 	gamma = 0.0;
 	coef0 = 0.0;
 
-	sg_add<ParameterProperties::HYPER | ParameterProperties::AUTO>(
+	declare<ParameterProperties::HYPER | ParameterProperties::AUTO>(
 	    &gamma, "gamma", "Scaler for the dot product.",
 	    std::make_shared<params::GammaFeatureNumberInit>(this));
-	sg_add<ParameterProperties::HYPER>(&coef0, "coef0", "Coefficient 0.");
+    declare<ParameterProperties::HYPER>(&coef0, "coef0", "Coefficient 0.");
 }

--- a/src/shogun/kernel/SigmoidKernel.cpp
+++ b/src/shogun/kernel/SigmoidKernel.cpp
@@ -57,13 +57,8 @@ void SigmoidKernel::init()
 	gamma = 0.0;
 	coef0 = 0.0;
 
-	sg_add(&gamma, "gamma", "Scaler for the dot product.",
-		   ParameterProperties::HYPER | ParameterProperties::AUTO,
-		   std::make_shared<params::GammaFeatureNumberInit>(this));
-
-//	SG_ADD(
-//	    &gamma, "gamma", "Scaler for the dot product.",
-//	    ParameterProperties::HYPER | ParameterProperties::AUTO,
-//	    std::make_shared<params::GammaFeatureNumberInit>(this));
-	SG_ADD(&coef0, "coef0", "Coefficient 0.", ParameterProperties::HYPER);
+	sg_add<ParameterProperties::HYPER | ParameterProperties::AUTO>(
+	    &gamma, "gamma", "Scaler for the dot product.",
+	    std::make_shared<params::GammaFeatureNumberInit>(this));
+	sg_add<ParameterProperties::HYPER>(&coef0, "coef0", "Coefficient 0.");
 }

--- a/src/shogun/kernel/SigmoidKernel.cpp
+++ b/src/shogun/kernel/SigmoidKernel.cpp
@@ -57,9 +57,13 @@ void SigmoidKernel::init()
 	gamma = 0.0;
 	coef0 = 0.0;
 
-	SG_ADD(
-	    &gamma, "gamma", "Scaler for the dot product.",
-	    ParameterProperties::HYPER | ParameterProperties::AUTO,
-	    std::make_shared<params::GammaFeatureNumberInit>(this));
+	sg_add(&gamma, "gamma", "Scaler for the dot product.",
+		   ParameterProperties::HYPER | ParameterProperties::AUTO,
+		   std::make_shared<params::GammaFeatureNumberInit>(this));
+
+//	SG_ADD(
+//	    &gamma, "gamma", "Scaler for the dot product.",
+//	    ParameterProperties::HYPER | ParameterProperties::AUTO,
+//	    std::make_shared<params::GammaFeatureNumberInit>(this));
 	SG_ADD(&coef0, "coef0", "Coefficient 0.", ParameterProperties::HYPER);
 }

--- a/tests/unit/base/MockObject.h
+++ b/tests/unit/base/MockObject.h
@@ -276,9 +276,10 @@ namespace shogun
 
 			watch_param(
 			    "watched_object", &m_object, AnyParameterProperties("Object"));
-			SG_ADD(
-			    &m_constrained_parameter, "constrained_parameter", "Mock parameter to test constraints.",
-                ParameterProperties::CONSTRAIN, SG_CONSTRAINT(positive<>(), less_than(10)));
+			declare<ParameterProperties::CONSTRAIN>(
+			    &m_constrained_parameter, "constrained_parameter",
+			    "Mock parameter to test constraints.",
+			    SG_CONSTRAINT(positive<>(), less_than(10)));
 
 			watch_method("some_method", &MockObject::some_method);
 		}


### PR DESCRIPTION
Here is a simple first draft of how the SG_ADD macros could be replaced with methods. I try to make the variadic argument pack somewhat type safe by adding some checks. This could probably be done inside a macro, but this way we can remove all the macro "overloads" of SG_ADD which are annoying to deal with and borderline portable imo because the preprocessor behaviour is not specified in the standard...

The variadic pack is required because a parameter could require both a constraint function #4647 and an automatic initialiser:
```cpp
sg_add(&k, "k", "k, the number of clusters", 
ParameterProperties::HYPER | ParameterProperties::AUTO | ParameterProperties::CONSTRAIN,
std::make_shared<my_kmeans_heuristic>(this), positive<>);
``` 

This also brings into question whether ParameterProperties::AUTO and ParameterProperties::CONSTRAIN have to be explicitly passed to the method