### PR TITLE
Fix MKL macOS bug

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -133,6 +133,11 @@ jobs:
     ccacheArtifactName: 'ccache-macos'
     ccacheArchive: '$(Build.ArtifactStagingDirectory)/ccache-$(Build.BuildId).tar'
     commonMacOSCMakeFlags: '-DBUILD_EXAMPLES=OFF -DBUNDLE_JSON=OFF -DBUNDLE_NLOPT=OFF -DENABLE_TESTING=ON -DENABLE_COVERAGE=OFF -DBUILD_META_EXAMPLES=OFF'
+    openMPMacOSCMakeFlags:
+      '-DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp"
+      -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp"
+      -DOpenMP_CXX_LIB_NAMES="omp" -DOpenMP_C_LIB_NAMES="omp"
+      -DOpenMP_omp_LIBRARY="/usr/local/opt/libomp/lib/libomp.dylib"'
 
   pool:
     vmImage: xcode9-macos10.13
@@ -148,7 +153,7 @@ jobs:
         cmakeOptions: '$(commonMacOSCMakeFlags)'
       MKL:
         use_mkl: true
-        cmakeOptions: '$(commonMacOSCMakeFlags) -DBLAS_LIBRARIES=$(CONDA)/lib/libmkl_core.dylib -DLAPACK_LIBRARIES=$(CONDA)/lib/libmkl_core.dylib -DBLA_VENDOR=Intel'
+        cmakeOptions: '$(commonMacOSCMakeFlags) $(openMPMacOSCMakeFlags) -DBLAS_LIBRARIES=$(CONDA)/lib/libmkl_core.dylib -DLAPACK_LIBRARIES=$(CONDA)/lib/libmkl_core.dylib -DBLA_VENDOR=Intel'
 
 - job: windows_libshogun
   displayName: Windows

--- a/.ci/macos-steps.yml
+++ b/.ci/macos-steps.yml
@@ -17,7 +17,7 @@ steps:
 
 - bash: |
     brew update
-    brew install ccache pkg-config arpack eigen glpk hdf5 json-c lapack lzo nlopt snappy xz
+    brew install ccache pkg-config arpack eigen glpk hdf5 json-c lapack lzo nlopt snappy xz libomp
   displayName: Install dependencies
 
 - script: sudo $(CONDA)/bin/conda install mkl-devel -y -q

--- a/src/shogun/CMakeLists.txt
+++ b/src/shogun/CMakeLists.txt
@@ -200,6 +200,8 @@ if (OPENMP_FOUND)
   SHOGUN_COMPILE_OPTS(${OpenMP_CXX_FLAGS})
   if (CMAKE_COMPILER_IS_GNUCC)
     SHOGUN_LINK_LIBS(gomp)
+  else ()
+    SHOGUN_LINK_LIBS(OpenMP::OpenMP_CXX)
   endif()
 endif()
 


### PR DESCRIPTION
The problem is that mkl tries to run in parallel mode without proper openmp available. I found that these options solve the problem:
1. Install openmp and link to it (which is what I did here)
2. Tell mkl programatically to run in sequential mode if openmp is not available (not the best solution, since it wasn't designed to solve linking problems. `mkl_rt` should solve those).
3. Don't use the dynamic signle library `mkl_rt` and link to each single library needed (`mkl_core`, etc.), and use the sequential library `mkl_sequential`.