### PR TITLE
Use SGVector instead of raw pointers in dense_dot

### DIFF
--- a/src/shogun/classifier/svm/LibLinear.cpp
+++ b/src/shogun/classifier/svm/LibLinear.cpp
@@ -344,7 +344,7 @@ void CLibLinear::solve_l2r_l1l2_svc(
 			i = index[s];
 			int32_t yi = y[i];
 
-			G = prob->x->dense_dot(i, w.vector, n);
+			G = prob->x->dot(i, w.slice(0, n));
 			if (prob->use_bias)
 				G += w.vector[n];
 
@@ -1272,7 +1272,7 @@ void CLibLinear::solve_l2r_lr_dual(
 			double C = upper_bound[GETI(i)];
 			double ywTx = 0, xisq = xTx[i];
 
-			ywTx = prob->x->dense_dot(i, w.vector, w_size);
+			ywTx = prob->x->dot(i, w.slice(0, w_size));
 			if (prob->use_bias)
 				ywTx += w.vector[w_size];
 

--- a/src/shogun/classifier/svm/NewtonSVM.cpp
+++ b/src/shogun/classifier/svm/NewtonSVM.cpp
@@ -153,7 +153,7 @@ void CNewtonSVM::line_search_linear(const SGVector<float64_t> d)
 	SGVector<float64_t> Xd(x_n);
 	SGVector<float64_t> weights = get_w();
 	for (int32_t i=0; i<x_n; i++)
-		Xd[i] = features->dense_dot(i, d.data(), x_d);
+		Xd[i] = features->dot(i, d.slice(0, x_d));
 
 	linalg::add_scalar(Xd, d[x_d]);
 

--- a/src/shogun/classifier/svm/SGDQN.cpp
+++ b/src/shogun/classifier/svm/SGDQN.cpp
@@ -141,7 +141,7 @@ bool CSGDQN::train(CFeatures* data)
 			ASSERT(w.vlen==v.vlen)
 			float64_t eta = 1.0/t;
 			float64_t y = ((CBinaryLabels*) m_labels)->get_label(i);
-			float64_t z = y * features->dense_dot(i, w.vector, w.vlen);
+			float64_t z = y * features->dot(i, w);
 			if(updateB==true)
 			{
 				if (z < 1 || is_log_loss)
@@ -150,7 +150,7 @@ bool CSGDQN::train(CFeatures* data)
 					float64_t loss_1=-loss->first_derivative(z,1);
 					SGVector<float64_t>::vector_multiply(result,Bc,v.vector,w.vlen);
 					SGVector<float64_t>::add(w.vector,eta*loss_1*y,result,1.0,w.vector,w.vlen);
-					float64_t z2 = y * features->dense_dot(i, w.vector, w.vlen);
+					float64_t z2 = y * features->dot(i, w);
 					float64_t diffloss = -loss->first_derivative(z2,1) - loss_1;
 					if(diffloss)
 					{

--- a/src/shogun/features/BinnedDotFeatures.cpp
+++ b/src/shogun/features/BinnedDotFeatures.cpp
@@ -115,7 +115,8 @@ float64_t CBinnedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t ve
 
 }
 
-float64_t CBinnedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CBinnedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	assert_shape(vec2.vlen);
 

--- a/src/shogun/features/BinnedDotFeatures.cpp
+++ b/src/shogun/features/BinnedDotFeatures.cpp
@@ -115,9 +115,9 @@ float64_t CBinnedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t ve
 
 }
 
-float64_t CBinnedDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CBinnedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	assert_shape(vec2_len);
+	assert_shape(vec2.vlen);
 
 	float64_t result=0;
 	double sum=0;

--- a/src/shogun/features/BinnedDotFeatures.cpp
+++ b/src/shogun/features/BinnedDotFeatures.cpp
@@ -118,7 +118,7 @@ float64_t CBinnedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t ve
 float64_t
 CBinnedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	assert_shape(vec2.vlen);
+	assert_shape(vec2.size());
 
 	float64_t result=0;
 	double sum=0;

--- a/src/shogun/features/BinnedDotFeatures.cpp
+++ b/src/shogun/features/BinnedDotFeatures.cpp
@@ -116,7 +116,7 @@ float64_t CBinnedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t ve
 }
 
 float64_t
-CBinnedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CBinnedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	assert_shape(vec2.size());
 

--- a/src/shogun/features/BinnedDotFeatures.h
+++ b/src/shogun/features/BinnedDotFeatures.h
@@ -83,7 +83,8 @@ class CBinnedDotFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/BinnedDotFeatures.h
+++ b/src/shogun/features/BinnedDotFeatures.h
@@ -84,7 +84,7 @@ class CBinnedDotFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/BinnedDotFeatures.h
+++ b/src/shogun/features/BinnedDotFeatures.h
@@ -81,10 +81,9 @@ class CBinnedDotFeatures : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/CombinedDotFeatures.cpp
+++ b/src/shogun/features/CombinedDotFeatures.cpp
@@ -115,7 +115,7 @@ float64_t CCombinedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t 
 }
 
 float64_t CCombinedDotFeatures::dot(
-    int32_t vec_idx1, const SGVector<float64_t> vec2) const
+    int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	float64_t result=0;
 

--- a/src/shogun/features/CombinedDotFeatures.cpp
+++ b/src/shogun/features/CombinedDotFeatures.cpp
@@ -125,8 +125,8 @@ float64_t CCombinedDotFeatures::dot(
 	{
 		CDotFeatures* f = get_feature_obj(f_idx);
 		int32_t dim = f->get_dim_feature_space();
-		result += f->dense_dot(vec_idx1, &vec2[offs], dim) *
-		          f->get_combined_feature_weight();
+		result += f->dot(vec_idx1, vec2.slice(offs, offs+dim)) *
+		          get_subfeature_weight(f_idx);
 		offs += dim;
 
 		SG_UNREF(f);

--- a/src/shogun/features/CombinedDotFeatures.cpp
+++ b/src/shogun/features/CombinedDotFeatures.cpp
@@ -114,7 +114,8 @@ float64_t CCombinedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t 
 	return result;
 }
 
-float64_t CCombinedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CCombinedDotFeatures::dot(
+    int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	float64_t result=0;
 
@@ -124,7 +125,8 @@ float64_t CCombinedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> 
 	{
 		CDotFeatures* f = get_feature_obj(f_idx);
 		int32_t dim = f->get_dim_feature_space();
-		result += f->dense_dot(vec_idx1, &vec2[offs], dim)*f->get_combined_feature_weight();
+		result += f->dense_dot(vec_idx1, &vec2[offs], dim) *
+		          f->get_combined_feature_weight();
 		offs += dim;
 
 		SG_UNREF(f);

--- a/src/shogun/features/CombinedDotFeatures.cpp
+++ b/src/shogun/features/CombinedDotFeatures.cpp
@@ -114,7 +114,7 @@ float64_t CCombinedDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t 
 	return result;
 }
 
-float64_t CCombinedDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CCombinedDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	float64_t result=0;
 
@@ -124,7 +124,7 @@ float64_t CCombinedDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec
 	{
 		CDotFeatures* f = get_feature_obj(f_idx);
 		int32_t dim = f->get_dim_feature_space();
-		result += f->dense_dot(vec_idx1, vec2+offs, dim)*get_subfeature_weight(f_idx);
+		result += f->dense_dot(vec_idx1, &vec2[offs], dim)*f->get_combined_feature_weight();
 		offs += dim;
 
 		SG_UNREF(f);

--- a/src/shogun/features/CombinedDotFeatures.h
+++ b/src/shogun/features/CombinedDotFeatures.h
@@ -87,7 +87,8 @@ class CCombinedDotFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** Compute the dot product for a range of vectors. This function makes use of dense_dot
 		 * alphas[i] * sparse[i]^T * w + b

--- a/src/shogun/features/CombinedDotFeatures.h
+++ b/src/shogun/features/CombinedDotFeatures.h
@@ -88,7 +88,7 @@ class CCombinedDotFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** Compute the dot product for a range of vectors. This function makes use of dense_dot
 		 * alphas[i] * sparse[i]^T * w + b

--- a/src/shogun/features/CombinedDotFeatures.h
+++ b/src/shogun/features/CombinedDotFeatures.h
@@ -85,10 +85,9 @@ class CCombinedDotFeatures : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** Compute the dot product for a range of vectors. This function makes use of dense_dot
 		 * alphas[i] * sparse[i]^T * w + b

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -634,60 +634,9 @@ template <typename ST>
 float64_t
 CDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2.vlen == num_features)
-
-	int32_t vlen;
-	bool vfree;
-	ST* vec1 = get_feature_vector(vec_idx1, vlen, vfree);
-
-	ASSERT(vlen == num_features)
-	float64_t result = 0;
-
-	for (int32_t i = 0; i < num_features; i++)
-		result += vec1[i] * vec2[i];
-
-	free_feature_vector(vec1, vec_idx1, vfree);
-
-	return result;
-}
-
-template <>
-float64_t CDenseFeatures<bool>::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
-{
-	ASSERT(vec2.vlen == num_features)
-
-	int32_t vlen;
-	bool vfree;
-	bool* vec1 = get_feature_vector(vec_idx1, vlen, vfree);
-
-	ASSERT(vlen == num_features)
-	float64_t result = 0;
-
-	for (int32_t i = 0; i < num_features; i++)
-		result += vec1[i] ? vec2[i] : 0;
-
-	free_feature_vector(vec1, vec_idx1, vfree);
-
-	return result;
-}
-
-template <>
-float64_t CDenseFeatures<float64_t>::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
-{
-	ASSERT(vec2.vlen == num_features)
-
-	int32_t vlen;
-	bool vfree;
-	float64_t* vec1 = get_feature_vector(vec_idx1, vlen, vfree);
-	SGVector<float64_t> sg_vec1(vec1, vlen, false);
-
-	ASSERT(vlen == num_features)
-	float64_t result = linalg::dot(sg_vec1, vec2);
-
-	free_feature_vector(vec1, vec_idx1, vfree);
-
+	SGVector<ST> vec1 = get_feature_vector(vec_idx1);
+	float64_t result = linalg::dot(vec1, vec2, allow_cast{});
+	free_feature_vector(vec1);
 	return result;
 }
 

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -631,10 +631,9 @@ GET_FEATURE_TYPE(F_LONGREAL, floatmax_t)
 #undef GET_FEATURE_TYPE
 
 template<typename ST>
-float64_t CDenseFeatures<ST>::dense_dot(int32_t vec_idx1,
-        const float64_t* vec2, int32_t vec2_len) const
+float64_t CDenseFeatures<ST>::dot(int32_t vec_idx1,const SGVector<float64_t> vec2) const
 {
-    ASSERT(vec2_len == num_features)
+    ASSERT(vec2.vlen == num_features)
 
 	int32_t vlen;
 	bool vfree;
@@ -651,10 +650,10 @@ float64_t CDenseFeatures<ST>::dense_dot(int32_t vec_idx1,
 	return result;
 }
 
-template<> float64_t CDenseFeatures<bool>::dense_dot(
-		int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+template<>
+float64_t CDenseFeatures<bool>::dot(int32_t vec_idx1,const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2_len == num_features)
+    ASSERT(vec2.vlen == num_features)
 
 	int32_t vlen;
 	bool vfree;
@@ -671,10 +670,10 @@ template<> float64_t CDenseFeatures<bool>::dense_dot(
 	return result;
 }
 
-template<> float64_t CDenseFeatures<float64_t>::dense_dot(
-		int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+template<>
+float64_t CDenseFeatures<float64_t>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2_len == num_features)
+	ASSERT(vec2.vlen == num_features)
 
 	int32_t vlen;
 	bool vfree;
@@ -682,8 +681,7 @@ template<> float64_t CDenseFeatures<float64_t>::dense_dot(
 	SGVector<float64_t> sg_vec1(vec1, vlen, false);
 
 	ASSERT(vlen == num_features)
-	SGVector<float64_t> tmp(const_cast<float64_t*>(vec2), vec2_len, false);
-	float64_t result = linalg::dot(sg_vec1, tmp);
+	float64_t result = linalg::dot(sg_vec1, vec2);
 
 	free_feature_vector(vec1, vec_idx1, vfree);
 

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -632,7 +632,7 @@ GET_FEATURE_TYPE(F_LONGREAL, floatmax_t)
 
 template <typename ST>
 float64_t
-CDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	SGVector<ST> vec1 = get_feature_vector(vec_idx1);
 	float64_t result = linalg::dot(vec2, vec1, linalg::allow_cast{});

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -635,8 +635,8 @@ float64_t
 CDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	SGVector<ST> vec1 = get_feature_vector(vec_idx1);
-	float64_t result = linalg::dot(vec1, vec2, allow_cast{});
-	free_feature_vector(vec1);
+	float64_t result = linalg::dot(vec2, vec1, linalg::allow_cast{});
+	free_feature_vector(vec1, vec_idx1);
 	return result;
 }
 

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -630,10 +630,11 @@ GET_FEATURE_TYPE(F_DREAL, float64_t)
 GET_FEATURE_TYPE(F_LONGREAL, floatmax_t)
 #undef GET_FEATURE_TYPE
 
-template<typename ST>
-float64_t CDenseFeatures<ST>::dot(int32_t vec_idx1,const SGVector<float64_t> vec2) const
+template <typename ST>
+float64_t
+CDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-    ASSERT(vec2.vlen == num_features)
+	ASSERT(vec2.vlen == num_features)
 
 	int32_t vlen;
 	bool vfree;
@@ -650,10 +651,11 @@ float64_t CDenseFeatures<ST>::dot(int32_t vec_idx1,const SGVector<float64_t> vec
 	return result;
 }
 
-template<>
-float64_t CDenseFeatures<bool>::dot(int32_t vec_idx1,const SGVector<float64_t> vec2) const
+template <>
+float64_t CDenseFeatures<bool>::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-    ASSERT(vec2.vlen == num_features)
+	ASSERT(vec2.vlen == num_features)
 
 	int32_t vlen;
 	bool vfree;
@@ -670,8 +672,9 @@ float64_t CDenseFeatures<bool>::dot(int32_t vec_idx1,const SGVector<float64_t> v
 	return result;
 }
 
-template<>
-float64_t CDenseFeatures<float64_t>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+template <>
+float64_t CDenseFeatures<float64_t>::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	ASSERT(vec2.vlen == num_features)
 

--- a/src/shogun/features/DenseFeatures.h
+++ b/src/shogun/features/DenseFeatures.h
@@ -343,7 +343,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/DenseFeatures.h
+++ b/src/shogun/features/DenseFeatures.h
@@ -344,7 +344,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/DenseFeatures.h
+++ b/src/shogun/features/DenseFeatures.h
@@ -341,11 +341,9 @@ public:
 	 * possible with subset
 	 *
 	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
+	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2,
-			int32_t vec2_len) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/DenseSubSamplesFeatures.cpp
+++ b/src/shogun/features/DenseSubSamplesFeatures.cpp
@@ -139,7 +139,7 @@ template<class ST> float64_t CDenseSubSamplesFeatures<ST>::dot(
 
 template <class ST>
 float64_t CDenseSubSamplesFeatures<ST>::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	check_bound(vec_idx1);
 	return m_fea->dot(m_idx[vec_idx1], vec2);

--- a/src/shogun/features/DenseSubSamplesFeatures.cpp
+++ b/src/shogun/features/DenseSubSamplesFeatures.cpp
@@ -137,11 +137,11 @@ template<class ST> float64_t CDenseSubSamplesFeatures<ST>::dot(
 	return res;
 }
 
-template<class ST> float64_t CDenseSubSamplesFeatures<ST>::dense_dot(
-	int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+template<class ST>
+float64_t CDenseSubSamplesFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	check_bound(vec_idx1);
-	return m_fea->dense_dot(m_idx[vec_idx1], vec2, vec2_len);
+	return m_fea->dot(m_idx[vec_idx1], vec2);
 }
 
 template<class ST> void CDenseSubSamplesFeatures<ST>::check_bound(int32_t index) const

--- a/src/shogun/features/DenseSubSamplesFeatures.cpp
+++ b/src/shogun/features/DenseSubSamplesFeatures.cpp
@@ -137,8 +137,9 @@ template<class ST> float64_t CDenseSubSamplesFeatures<ST>::dot(
 	return res;
 }
 
-template<class ST>
-float64_t CDenseSubSamplesFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+template <class ST>
+float64_t CDenseSubSamplesFeatures<ST>::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	check_bound(vec_idx1);
 	return m_fea->dot(m_idx[vec_idx1], vec2);

--- a/src/shogun/features/DenseSubSamplesFeatures.h
+++ b/src/shogun/features/DenseSubSamplesFeatures.h
@@ -121,7 +121,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/DenseSubSamplesFeatures.h
+++ b/src/shogun/features/DenseSubSamplesFeatures.h
@@ -122,7 +122,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/DenseSubSamplesFeatures.h
+++ b/src/shogun/features/DenseSubSamplesFeatures.h
@@ -119,11 +119,9 @@ public:
 	/** compute dot product between vector1 and a dense vector
 	 *
 	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
+	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2,
-		int32_t vec2_len) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/DenseSubsetFeatures.h
+++ b/src/shogun/features/DenseSubsetFeatures.h
@@ -139,14 +139,14 @@ public:
 	 * @param vec2 pointer to real valued vector
 	 * @param vec2_len length of real valued vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 	{
-		if (m_idx.vlen != vec2_len)
+		if (m_idx.vlen != vec2.vlen)
 			SG_ERROR("Cannot dot vectors of different length\n")
 		SGVector<ST> vec1 = m_fea->get_feature_vector(vec_idx1);
 
 		float64_t sum=0;
-		for (int32_t i=0; i < vec2_len; ++i)
+		for (int32_t i=0; i < vec2.vlen; ++i)
 			sum += vec1[m_idx[i]] * vec2[i];
 
 		return sum;

--- a/src/shogun/features/DenseSubsetFeatures.h
+++ b/src/shogun/features/DenseSubsetFeatures.h
@@ -120,14 +120,14 @@ public:
 		if (dsf == NULL)
 			SG_ERROR("Require DenseSubsetFeatures of the same kind to perform dot\n")
 
-		if (m_idx.vlen != dsf->m_idx.vlen)
+		if (m_idx.size() != dsf->m_idx.size())
 			SG_ERROR("Cannot dot vectors of different length\n")
 
 		SGVector<ST> vec1 = m_fea->get_feature_vector(vec_idx1);
 		SGVector<ST> vec2 = dsf->m_fea->get_feature_vector(vec_idx2);
 
 		float64_t sum = 0;
-		for (int32_t i=0; i < m_idx.vlen; ++i)
+		for (int32_t i=0; i < m_idx.size(); ++i)
 			sum += vec1[m_idx[i]] * vec2[dsf->m_idx[i]];
 
 		return sum;

--- a/src/shogun/features/DenseSubsetFeatures.h
+++ b/src/shogun/features/DenseSubsetFeatures.h
@@ -140,7 +140,7 @@ public:
 	 * @param vec2_len length of real valued vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 	{
 		REQUIRE(
 			m_idx.vlen == vec2.vlen, "Cannot dot vectors of different length\n")

--- a/src/shogun/features/DenseSubsetFeatures.h
+++ b/src/shogun/features/DenseSubsetFeatures.h
@@ -139,14 +139,15 @@ public:
 	 * @param vec2 pointer to real valued vector
 	 * @param vec2_len length of real valued vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 	{
 		if (m_idx.vlen != vec2.vlen)
 			SG_ERROR("Cannot dot vectors of different length\n")
 		SGVector<ST> vec1 = m_fea->get_feature_vector(vec_idx1);
 
 		float64_t sum=0;
-		for (int32_t i=0; i < vec2.vlen; ++i)
+		for (int32_t i = 0; i < vec2.vlen; ++i)
 			sum += vec1[m_idx[i]] * vec2[i];
 
 		return sum;

--- a/src/shogun/features/DenseSubsetFeatures.h
+++ b/src/shogun/features/DenseSubsetFeatures.h
@@ -142,8 +142,8 @@ public:
 	virtual float64_t
 	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 	{
-		if (m_idx.vlen != vec2.vlen)
-			SG_ERROR("Cannot dot vectors of different length\n")
+		REQUIRE(
+			m_idx.vlen == vec2.vlen, "Cannot dot vectors of different length\n")
 		SGVector<ST> vec1 = m_fea->get_feature_vector(vec_idx1);
 
 		float64_t sum=0;

--- a/src/shogun/features/DirectorDotFeatures.h
+++ b/src/shogun/features/DirectorDotFeatures.h
@@ -78,7 +78,7 @@ IGNORE_IN_CLASSLIST class CDirectorDotFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot_sgvec(int32_t vec_idx1, const SGVector<float64_t> vec2)
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2)
 		{
 			SG_NOTIMPLEMENTED
 			return 0;
@@ -105,7 +105,7 @@ IGNORE_IN_CLASSLIST class CDirectorDotFeatures : public CDotFeatures
 		 */
 		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len)
 		{
-			return dense_dot_sgvec(vec_idx1, SGVector<float64_t>((float64_t*) vec2, vec2_len, false));
+			return dot(vec_idx1, SGVector<float64_t>((float64_t*) vec2, vec2_len, false));
 		}
 
 		/** add vector 1 multiplied with alpha to dense vector2

--- a/src/shogun/features/DirectorDotFeatures.h
+++ b/src/shogun/features/DirectorDotFeatures.h
@@ -97,17 +97,6 @@ IGNORE_IN_CLASSLIST class CDirectorDotFeatures : public CDotFeatures
 			SG_NOTIMPLEMENTED
 		}
 
-		/** compute dot product between vector1 and a dense vector
-		 *
-		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
-		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len)
-		{
-			return dot(vec_idx1, SGVector<float64_t>((float64_t*) vec2, vec2_len, false));
-		}
-
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *
 		 * @param alpha scalar alpha

--- a/src/shogun/features/DirectorDotFeatures.h
+++ b/src/shogun/features/DirectorDotFeatures.h
@@ -78,7 +78,7 @@ IGNORE_IN_CLASSLIST class CDirectorDotFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2)
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) override
 		{
 			SG_NOTIMPLEMENTED
 			return 0;

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -43,7 +43,7 @@ CDotFeatures::CDotFeatures(CFile* loader)
 	init();
 }
 
-float64_t CDotFeatures::dense_dot_sgvec(int32_t vec_idx1, SGVector<float64_t> vec2) const
+float64_t CDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	return dense_dot(vec_idx1, vec2.vector, vec2.vlen);
 }

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -43,9 +43,11 @@ CDotFeatures::CDotFeatures(CFile* loader)
 	init();
 }
 
-float64_t CDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CDotFeatures::dense_dot(
+    int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
 {
-	return dot(vec_idx1, SGVector<float64_t>((float64_t*) vec2, vec2_len, false));
+	return dot(
+	    vec_idx1, SGVector<float64_t>((float64_t*)vec2, vec2_len, false));
 }
 
 void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t stop, float64_t* alphas, float64_t* vec, int32_t dim, float64_t b) const

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -43,9 +43,9 @@ CDotFeatures::CDotFeatures(CFile* loader)
 	init();
 }
 
-float64_t CDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
 {
-	return dense_dot(vec_idx1, vec2.vector, vec2.vlen);
+	return dot(vec_idx1, SGVector<float64_t>((float64_t*) vec2, vec2_len, false));
 }
 
 void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t stop, float64_t* alphas, float64_t* vec, int32_t dim, float64_t b) const

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -43,13 +43,6 @@ CDotFeatures::CDotFeatures(CFile* loader)
 	init();
 }
 
-float64_t CDotFeatures::dense_dot(
-    int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
-{
-	return dot(
-	    vec_idx1, SGVector<float64_t>((float64_t*)vec2, vec2_len, false));
-}
-
 void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t stop, float64_t* alphas, float64_t* vec, int32_t dim, float64_t b) const
 {
 	ASSERT(output)

--- a/src/shogun/features/DotFeatures.cpp
+++ b/src/shogun/features/DotFeatures.cpp
@@ -59,6 +59,7 @@ void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t sto
 
 	int32_t num_vectors=stop-start;
 	ASSERT(num_vectors>0)
+	SGVector<float64_t> sgvec(vec, dim, false);
 
 	int32_t num_threads;
 	int32_t step;
@@ -92,9 +93,9 @@ void CDotFeatures::dense_dot_range(float64_t* output, int32_t start, int32_t sto
 #endif
 		{
 			if (alphas)
-				output[i]=alphas[i]*this->dense_dot(i + start, vec, dim)+b;
+				output[i]=alphas[i]*this->dot(i + start, sgvec)+b;
 			else
-				output[i]=this->dense_dot(i + start, vec, dim)+b;
+				output[i]=this->dot(i + start, sgvec)+b;
 			pb.print_progress();
 		}
 	}
@@ -106,6 +107,7 @@ void CDotFeatures::dense_dot_range_subset(int32_t* sub_index, int32_t num, float
 	ASSERT(sub_index)
 	ASSERT(output)
 
+	SGVector<float64_t> sgvec(vec, dim, false);
 	auto pb = SG_PROGRESS(range(num));
 	int32_t num_threads;
 	int32_t step;
@@ -138,9 +140,9 @@ void CDotFeatures::dense_dot_range_subset(int32_t* sub_index, int32_t num, float
 #endif
 		{
 			if (alphas)
-				output[i]=alphas[sub_index[i]]*this->dense_dot(sub_index[i], vec, dim)+b;
+				output[i]=alphas[sub_index[i]]*this->dot(sub_index[i], sgvec)+b;
 			else
-				output[i]=this->dense_dot(sub_index[i], vec, dim)+b;
+				output[i]=this->dot(sub_index[i], sgvec)+b;
 			pb.print_progress();
 		}
 	}

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -83,7 +83,7 @@ class CDotFeatures : public CFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const = 0;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const = 0;
 
 		/** compute dot product between vector1 and a dense vector
 		 *

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -82,7 +82,7 @@ class CDotFeatures : public CFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const = 0;
 
 		/** compute dot product between vector1 and a dense vector
 		 *
@@ -90,7 +90,7 @@ class CDotFeatures : public CFeatures
 		 * @param vec2 pointer to real valued vector
 		 * @param vec2_len length of real valued vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const = 0;
+		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -85,15 +85,6 @@ class CDotFeatures : public CFeatures
 		virtual float64_t
 		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const = 0;
 
-		/** compute dot product between vector1 and a dense vector
-		 *
-		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
-		 */
-		virtual float64_t dense_dot(
-		    int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
-
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *
 		 * @param alpha scalar alpha

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -82,7 +82,7 @@ class CDotFeatures : public CFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot_sgvec(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute dot product between vector1 and a dense vector
 		 *

--- a/src/shogun/features/DotFeatures.h
+++ b/src/shogun/features/DotFeatures.h
@@ -82,7 +82,8 @@ class CDotFeatures : public CFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const = 0;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const = 0;
 
 		/** compute dot product between vector1 and a dense vector
 		 *
@@ -90,7 +91,8 @@ class CDotFeatures : public CFeatures
 		 * @param vec2 pointer to real valued vector
 		 * @param vec2_len length of real valued vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dense_dot(
+		    int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/ExplicitSpecFeatures.cpp
+++ b/src/shogun/features/ExplicitSpecFeatures.cpp
@@ -72,7 +72,8 @@ float64_t CExplicitSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 	return linalg::dot(vec1, vec2);
 }
 
-float64_t CExplicitSpecFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CExplicitSpecFeatures::dot(
+    int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	ASSERT(vec2.vlen == spec_size)
 	ASSERT(vec_idx1 < num_strings)

--- a/src/shogun/features/ExplicitSpecFeatures.cpp
+++ b/src/shogun/features/ExplicitSpecFeatures.cpp
@@ -72,17 +72,13 @@ float64_t CExplicitSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 	return linalg::dot(vec1, vec2);
 }
 
-float64_t CExplicitSpecFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CExplicitSpecFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2_len == spec_size)
+	ASSERT(vec2.vlen == spec_size)
 	ASSERT(vec_idx1 < num_strings)
 	SGVector<float64_t> vec1(k_spectrum[vec_idx1], spec_size, false);
-	SGVector<float64_t> vec2_wrapper(const_cast<float64_t*>(vec2), vec2_len, false);
-	float64_t result=0;
 
-	linalg::dot(vec1, vec2_wrapper);
-
-	return result;
+	return linalg::dot(vec1, vec2);
 }
 
 void CExplicitSpecFeatures::add_to_dense_vec(float64_t alpha, int32_t vec_idx1, float64_t* vec2, int32_t vec2_len, bool abs_val) const

--- a/src/shogun/features/ExplicitSpecFeatures.cpp
+++ b/src/shogun/features/ExplicitSpecFeatures.cpp
@@ -73,7 +73,7 @@ float64_t CExplicitSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 }
 
 float64_t CExplicitSpecFeatures::dot(
-    int32_t vec_idx1, const SGVector<float64_t> vec2) const
+    int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	ASSERT(vec2.size() == spec_size)
 	ASSERT(vec_idx1 < num_strings)

--- a/src/shogun/features/ExplicitSpecFeatures.cpp
+++ b/src/shogun/features/ExplicitSpecFeatures.cpp
@@ -75,7 +75,7 @@ float64_t CExplicitSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 float64_t CExplicitSpecFeatures::dot(
     int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2.vlen == spec_size)
+	ASSERT(vec2.size() == spec_size)
 	ASSERT(vec_idx1 < num_strings)
 	SGVector<float64_t> vec1(k_spectrum[vec_idx1], spec_size, false);
 

--- a/src/shogun/features/ExplicitSpecFeatures.h
+++ b/src/shogun/features/ExplicitSpecFeatures.h
@@ -71,7 +71,7 @@ class CExplicitSpecFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/ExplicitSpecFeatures.h
+++ b/src/shogun/features/ExplicitSpecFeatures.h
@@ -68,10 +68,9 @@ class CExplicitSpecFeatures : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/ExplicitSpecFeatures.h
+++ b/src/shogun/features/ExplicitSpecFeatures.h
@@ -70,7 +70,8 @@ class CExplicitSpecFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
@@ -169,7 +169,7 @@ float64_t CImplicitWeightedSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df,
 float64_t CImplicitWeightedSpecFeatures::dot(
     int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2.vlen == spec_size)
+	ASSERT(vec2.size() == spec_size)
 	ASSERT(vec_idx1 < num_strings)
 
 	float64_t result=0;

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
@@ -166,7 +166,8 @@ float64_t CImplicitWeightedSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df,
 		return result;
 }
 
-float64_t CImplicitWeightedSpecFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CImplicitWeightedSpecFeatures::dot(
+    int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	ASSERT(vec2.vlen == spec_size)
 	ASSERT(vec_idx1 < num_strings)

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
@@ -166,9 +166,9 @@ float64_t CImplicitWeightedSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df,
 		return result;
 }
 
-float64_t CImplicitWeightedSpecFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CImplicitWeightedSpecFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2_len == spec_size)
+	ASSERT(vec2.vlen == spec_size)
 	ASSERT(vec_idx1 < num_strings)
 
 	float64_t result=0;

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.cpp
@@ -167,7 +167,7 @@ float64_t CImplicitWeightedSpecFeatures::dot(int32_t vec_idx1, CDotFeatures* df,
 }
 
 float64_t CImplicitWeightedSpecFeatures::dot(
-    int32_t vec_idx1, const SGVector<float64_t> vec2) const
+    int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	ASSERT(vec2.size() == spec_size)
 	ASSERT(vec_idx1 < num_strings)

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.h
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.h
@@ -71,10 +71,9 @@ class CImplicitWeightedSpecFeatures : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.h
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.h
@@ -74,7 +74,7 @@ class CImplicitWeightedSpecFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/ImplicitWeightedSpecFeatures.h
+++ b/src/shogun/features/ImplicitWeightedSpecFeatures.h
@@ -73,7 +73,8 @@ class CImplicitWeightedSpecFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/LBPPyrDotFeatures.cpp
+++ b/src/shogun/features/LBPPyrDotFeatures.cpp
@@ -166,10 +166,13 @@ uint32_t* CLBPPyrDotFeatures::get_image(int32_t index, int32_t& width, int32_t& 
 	return img;
 }
 
-float64_t CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != vec_nDim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2.vlen, vec_nDim)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2.vlen,
+		    vec_nDim)
 
 	int32_t ww;
 	int32_t hh;

--- a/src/shogun/features/LBPPyrDotFeatures.cpp
+++ b/src/shogun/features/LBPPyrDotFeatures.cpp
@@ -166,10 +166,10 @@ uint32_t* CLBPPyrDotFeatures::get_image(int32_t index, int32_t& width, int32_t& 
 	return img;
 }
 
-float64_t CLBPPyrDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != vec_nDim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2_len, vec_nDim)
+	if (vec2.vlen != vec_nDim)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2.vlen, vec_nDim)
 
 	int32_t ww;
 	int32_t hh;

--- a/src/shogun/features/LBPPyrDotFeatures.cpp
+++ b/src/shogun/features/LBPPyrDotFeatures.cpp
@@ -169,10 +169,10 @@ uint32_t* CLBPPyrDotFeatures::get_image(int32_t index, int32_t& width, int32_t& 
 float64_t
 CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != vec_nDim)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2.vlen,
-		    vec_nDim)
+	REQUIRE(
+	    vec2.vlen == vec_nDim,
+	    "Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2.vlen,
+	    vec_nDim)
 
 	int32_t ww;
 	int32_t hh;

--- a/src/shogun/features/LBPPyrDotFeatures.cpp
+++ b/src/shogun/features/LBPPyrDotFeatures.cpp
@@ -167,7 +167,7 @@ uint32_t* CLBPPyrDotFeatures::get_image(int32_t index, int32_t& width, int32_t& 
 }
 
 float64_t
-CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.size() == vec_nDim,

--- a/src/shogun/features/LBPPyrDotFeatures.cpp
+++ b/src/shogun/features/LBPPyrDotFeatures.cpp
@@ -170,7 +170,7 @@ float64_t
 CLBPPyrDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-	    vec2.vlen == vec_nDim,
+	    vec2.size() == vec_nDim,
 	    "Dimensions don't match, vec2_dim=%d, vec_nDim=%d\n", vec2.vlen,
 	    vec_nDim)
 

--- a/src/shogun/features/LBPPyrDotFeatures.h
+++ b/src/shogun/features/LBPPyrDotFeatures.h
@@ -132,14 +132,12 @@ class CLBPPyrDotFeatures : public CDotFeatures
 		 */
 		virtual const char* get_name() const { return "LBPPyrDotFeatures"; }
 
-		/** compute dot product of vector with index arg1
-		 *  with an given second vector
+		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 second vector
-		 * @param vec2_len length of second vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/LBPPyrDotFeatures.h
+++ b/src/shogun/features/LBPPyrDotFeatures.h
@@ -137,7 +137,8 @@ class CLBPPyrDotFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/LBPPyrDotFeatures.h
+++ b/src/shogun/features/LBPPyrDotFeatures.h
@@ -138,7 +138,7 @@ class CLBPPyrDotFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/PolyFeatures.cpp
+++ b/src/shogun/features/PolyFeatures.cpp
@@ -136,10 +136,10 @@ float64_t CPolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx
 	return sum;
 }
 
-float64_t CPolyFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != m_output_dimensions)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n", vec2_len, m_output_dimensions)
+	if (vec2.vlen != m_output_dimensions)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n", vec2.vlen, m_output_dimensions)
 
 	int32_t len;
 	bool do_free;
@@ -148,7 +148,7 @@ float64_t CPolyFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int3
 
 	int cnt=0;
 	float64_t sum=0;
-	for (int j=0; j<vec2_len; j++)
+	for (int j=0; j<vec2.vlen; j++)
 	{
 		float64_t output=m_multinomial_coefficients[j];
 		for (int k=0; k<m_degree; k++)
@@ -164,6 +164,7 @@ float64_t CPolyFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int3
 	m_feat->free_feature_vector(vec, len, do_free);
 	return sum;
 }
+
 void CPolyFeatures::add_to_dense_vec(float64_t alpha, int32_t vec_idx1, float64_t* vec2, int32_t vec2_len, bool abs_val) const
 {
 	if (vec2_len != m_output_dimensions)

--- a/src/shogun/features/PolyFeatures.cpp
+++ b/src/shogun/features/PolyFeatures.cpp
@@ -136,10 +136,13 @@ float64_t CPolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx
 	return sum;
 }
 
-float64_t CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != m_output_dimensions)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n", vec2.vlen, m_output_dimensions)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
+		    vec2.vlen, m_output_dimensions)
 
 	int32_t len;
 	bool do_free;
@@ -148,7 +151,7 @@ float64_t CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) c
 
 	int cnt=0;
 	float64_t sum=0;
-	for (int j=0; j<vec2.vlen; j++)
+	for (int j = 0; j < vec2.vlen; j++)
 	{
 		float64_t output=m_multinomial_coefficients[j];
 		for (int k=0; k<m_degree; k++)

--- a/src/shogun/features/PolyFeatures.cpp
+++ b/src/shogun/features/PolyFeatures.cpp
@@ -137,7 +137,7 @@ float64_t CPolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx
 }
 
 float64_t
-CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.size() == m_output_dimensions,

--- a/src/shogun/features/PolyFeatures.cpp
+++ b/src/shogun/features/PolyFeatures.cpp
@@ -139,10 +139,10 @@ float64_t CPolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx
 float64_t
 CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != m_output_dimensions)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
-		    vec2.vlen, m_output_dimensions)
+	REQUIRE(
+	    vec2.vlen == m_output_dimensions,
+	    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
+	    vec2.vlen, m_output_dimensions)
 
 	int32_t len;
 	bool do_free;

--- a/src/shogun/features/PolyFeatures.cpp
+++ b/src/shogun/features/PolyFeatures.cpp
@@ -140,9 +140,9 @@ float64_t
 CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-	    vec2.vlen == m_output_dimensions,
+	    vec2.size() == m_output_dimensions,
 	    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
-	    vec2.vlen, m_output_dimensions)
+	    vec2.size(), m_output_dimensions)
 
 	int32_t len;
 	bool do_free;
@@ -151,7 +151,7 @@ CPolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 
 	int cnt=0;
 	float64_t sum=0;
-	for (int j = 0; j < vec2.vlen; j++)
+	for (int j = 0; j < vec2.size(); j++)
 	{
 		float64_t output=m_multinomial_coefficients[j];
 		for (int k=0; k<m_degree; k++)

--- a/src/shogun/features/PolyFeatures.h
+++ b/src/shogun/features/PolyFeatures.h
@@ -103,7 +103,7 @@ class CPolyFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/PolyFeatures.h
+++ b/src/shogun/features/PolyFeatures.h
@@ -102,7 +102,8 @@ class CPolyFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/PolyFeatures.h
+++ b/src/shogun/features/PolyFeatures.h
@@ -97,14 +97,12 @@ class CPolyFeatures : public CDotFeatures
 		 */
 		virtual const char* get_name() const { return "PolyFeatures"; }
 
-		/** compute dot product of vector with index arg1
-		 *  with an given second vector
+		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 second vector
-		 * @param vec2_len length of second vector
+		 * @param vec2 dense vector
 		 */
-		float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
@@ -107,7 +107,7 @@ float64_t CRandomKitchenSinksDotFeatures::dot(
 	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	SG_DEBUG("entering dense_dot()\n");
-	ASSERT(vec2.vlen == get_dim_feature_space());
+	ASSERT(vec2.size() == get_dim_feature_space());
 
 	float64_t dot_product = 0;
 	for (index_t i=0; i<num_samples; i++)
@@ -194,8 +194,8 @@ SGMatrix<float64_t> CRandomKitchenSinksDotFeatures::get_random_coefficients()
 
 float64_t CRandomKitchenSinksDotFeatures::dot(index_t vec_idx, index_t par_idx) const
 {
-	return feats->dense_dot(vec_idx, random_coeff.get_column_vector(par_idx),
-					feats->get_dim_feature_space());
+	auto vec2 = random_coeff.get_column(par_idx).slice(0, feats->get_dim_feature_space());
+	return feats->dot(vec_idx, vec2);
 }
 
 float64_t CRandomKitchenSinksDotFeatures::post_dot(float64_t dot_result, index_t par_idx) const

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
@@ -104,7 +104,7 @@ float64_t CRandomKitchenSinksDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df
 }
 
 float64_t CRandomKitchenSinksDotFeatures::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	SG_DEBUG("entering dense_dot()\n");
 	ASSERT(vec2.size() == get_dim_feature_space());

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
@@ -103,11 +103,10 @@ float64_t CRandomKitchenSinksDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df
 	return dot_product;
 }
 
-float64_t CRandomKitchenSinksDotFeatures::dense_dot(
-	int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CRandomKitchenSinksDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	SG_DEBUG("entering dense_dot()\n");
-	ASSERT(vec2_len == get_dim_feature_space());
+	ASSERT(vec2.vlen == get_dim_feature_space());
 
 	float64_t dot_product = 0;
 	for (index_t i=0; i<num_samples; i++)

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.cpp
@@ -103,7 +103,8 @@ float64_t CRandomKitchenSinksDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df
 	return dot_product;
 }
 
-float64_t CRandomKitchenSinksDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CRandomKitchenSinksDotFeatures::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	SG_DEBUG("entering dense_dot()\n");
 	ASSERT(vec2.vlen == get_dim_feature_space());

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.h
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.h
@@ -107,14 +107,10 @@ public:
 
 	/** compute dot product between vector1 and a dense vector
 	 *
-	 * possible with subset
-	 *
 	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
+	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2,
-			int32_t vec2_len) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.h
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.h
@@ -111,7 +111,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/RandomKitchenSinksDotFeatures.h
+++ b/src/shogun/features/RandomKitchenSinksDotFeatures.h
@@ -110,7 +110,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/SNPFeatures.cpp
+++ b/src/shogun/features/SNPFeatures.cpp
@@ -189,8 +189,8 @@ float64_t
 CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
-	    vec2.vlen, w_dim)
+	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.size(), w_dim)
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/SNPFeatures.cpp
+++ b/src/shogun/features/SNPFeatures.cpp
@@ -188,9 +188,9 @@ float64_t CSNPFeatures::dot(int32_t idx_a, CDotFeatures* df, int32_t idx_b) cons
 float64_t
 CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != w_dim)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+	REQUIRE(
+	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/SNPFeatures.cpp
+++ b/src/shogun/features/SNPFeatures.cpp
@@ -185,10 +185,12 @@ float64_t CSNPFeatures::dot(int32_t idx_a, CDotFeatures* df, int32_t idx_b) cons
 	return total;
 }
 
-float64_t CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/SNPFeatures.cpp
+++ b/src/shogun/features/SNPFeatures.cpp
@@ -185,10 +185,10 @@ float64_t CSNPFeatures::dot(int32_t idx_a, CDotFeatures* df, int32_t idx_b) cons
 	return total;
 }
 
-float64_t CSNPFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2_len, w_dim)
+	if (vec2.vlen != w_dim)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/SNPFeatures.cpp
+++ b/src/shogun/features/SNPFeatures.cpp
@@ -186,7 +186,7 @@ float64_t CSNPFeatures::dot(int32_t idx_a, CDotFeatures* df, int32_t idx_b) cons
 }
 
 float64_t
-CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CSNPFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",

--- a/src/shogun/features/SNPFeatures.h
+++ b/src/shogun/features/SNPFeatures.h
@@ -62,10 +62,9 @@ class CSNPFeatures : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/SNPFeatures.h
+++ b/src/shogun/features/SNPFeatures.h
@@ -65,7 +65,7 @@ class CSNPFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/SNPFeatures.h
+++ b/src/shogun/features/SNPFeatures.h
@@ -64,7 +64,8 @@ class CSNPFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/SparseFeatures.cpp
+++ b/src/shogun/features/SparseFeatures.cpp
@@ -457,10 +457,14 @@ template<> float64_t CSparseFeatures<complex128_t>::dot(int32_t vec_idx1,
 	return 0.0;
 }
 
-template<class ST> float64_t CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+template <class ST>
+float64_t
+CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	REQUIRE(vec2.vlen>=get_num_features(),
-		"dot(vec_idx1=%d,vec2_len=%d): vec2_len should contain number of features %d %d\n",
+	REQUIRE(
+		vec2.vlen >= get_num_features(),
+		"dot(vec_idx1=%d,vec2_len=%d): vec2_len should contain number of "
+		"features %d %d\n",
 		vec_idx1, vec2.vlen, get_num_features());
 
 	float64_t result=0;
@@ -472,8 +476,10 @@ template<class ST> float64_t CSparseFeatures<ST>::dot(int32_t vec_idx1, const SG
 			"sparse_matrix[%d] check failed (matrix features %d >= vector dimension %d)\n",
 			vec_idx1, get_num_features(), sv.get_num_dimensions());
 
-		REQUIRE(vec2.vlen >= sv.get_num_dimensions(),
-			"sparse_matrix[%d] check failed (dense vector dimension %d >= vector dimension %d)\n",
+		REQUIRE(
+			vec2.vlen >= sv.get_num_dimensions(),
+			"sparse_matrix[%d] check failed (dense vector dimension %d >= "
+			"vector dimension %d)\n",
 			vec_idx1, vec2.vlen, sv.get_num_dimensions());
 
 		for (int32_t i=0; i<sv.num_feat_entries; i++)
@@ -485,7 +491,9 @@ template<class ST> float64_t CSparseFeatures<ST>::dot(int32_t vec_idx1, const SG
 	return result;
 }
 
-template<> float64_t CSparseFeatures<complex128_t>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+template <>
+float64_t CSparseFeatures<complex128_t>::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	SG_NOTIMPLEMENTED;
 	return 0.0;

--- a/src/shogun/features/SparseFeatures.cpp
+++ b/src/shogun/features/SparseFeatures.cpp
@@ -462,10 +462,10 @@ float64_t
 CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-		vec2.vlen >= get_num_features(),
+		vec2.size() >= get_num_features(),
 		"dot(vec_idx1=%d,vec2_len=%d): vec2_len should contain number of "
 		"features %d %d\n",
-		vec_idx1, vec2.vlen, get_num_features());
+		vec_idx1, vec2.size(), get_num_features());
 
 	float64_t result=0;
 	SGSparseVector<ST> sv=get_sparse_feature_vector(vec_idx1);
@@ -477,10 +477,10 @@ CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 			vec_idx1, get_num_features(), sv.get_num_dimensions());
 
 		REQUIRE(
-			vec2.vlen >= sv.get_num_dimensions(),
+			vec2.size() >= sv.get_num_dimensions(),
 			"sparse_matrix[%d] check failed (dense vector dimension %d >= "
 			"vector dimension %d)\n",
-			vec_idx1, vec2.vlen, sv.get_num_dimensions());
+			vec_idx1, vec2.size(), sv.get_num_dimensions());
 
 		for (int32_t i=0; i<sv.num_feat_entries; i++)
 			result+=vec2[sv.features[i].feat_index]*sv.features[i].entry;

--- a/src/shogun/features/SparseFeatures.cpp
+++ b/src/shogun/features/SparseFeatures.cpp
@@ -457,13 +457,11 @@ template<> float64_t CSparseFeatures<complex128_t>::dot(int32_t vec_idx1,
 	return 0.0;
 }
 
-template<class ST> float64_t CSparseFeatures<ST>::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+template<class ST> float64_t CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	REQUIRE(vec2, "dense_dot(vec_idx1=%d,vec2_len=%d): vec2 must not be NULL\n",
-		vec_idx1, vec2_len);
-	REQUIRE(vec2_len>=get_num_features(),
-		"dense_dot(vec_idx1=%d,vec2_len=%d): vec2_len should contain number of features %d %d\n",
-		vec_idx1, vec2_len, get_num_features());
+	REQUIRE(vec2.vlen>=get_num_features(),
+		"dot(vec_idx1=%d,vec2_len=%d): vec2_len should contain number of features %d %d\n",
+		vec_idx1, vec2.vlen, get_num_features());
 
 	float64_t result=0;
 	SGSparseVector<ST> sv=get_sparse_feature_vector(vec_idx1);
@@ -474,9 +472,9 @@ template<class ST> float64_t CSparseFeatures<ST>::dense_dot(int32_t vec_idx1, co
 			"sparse_matrix[%d] check failed (matrix features %d >= vector dimension %d)\n",
 			vec_idx1, get_num_features(), sv.get_num_dimensions());
 
-		REQUIRE(vec2_len >= sv.get_num_dimensions(),
+		REQUIRE(vec2.vlen >= sv.get_num_dimensions(),
 			"sparse_matrix[%d] check failed (dense vector dimension %d >= vector dimension %d)\n",
-			vec_idx1, vec2_len, sv.get_num_dimensions());
+			vec_idx1, vec2.vlen, sv.get_num_dimensions());
 
 		for (int32_t i=0; i<sv.num_feat_entries; i++)
 			result+=vec2[sv.features[i].feat_index]*sv.features[i].entry;
@@ -487,8 +485,7 @@ template<class ST> float64_t CSparseFeatures<ST>::dense_dot(int32_t vec_idx1, co
 	return result;
 }
 
-template<> float64_t CSparseFeatures<complex128_t>::dense_dot(int32_t vec_idx1,
-	const float64_t* vec2, int32_t vec2_len) const
+template<> float64_t CSparseFeatures<complex128_t>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	SG_NOTIMPLEMENTED;
 	return 0.0;

--- a/src/shogun/features/SparseFeatures.cpp
+++ b/src/shogun/features/SparseFeatures.cpp
@@ -459,7 +459,7 @@ template<> float64_t CSparseFeatures<complex128_t>::dot(int32_t vec_idx1,
 
 template <class ST>
 float64_t
-CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 		vec2.size() >= get_num_features(),
@@ -493,7 +493,7 @@ CSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 
 template <>
 float64_t CSparseFeatures<complex128_t>::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	SG_NOTIMPLEMENTED;
 	return 0.0;

--- a/src/shogun/features/SparseFeatures.h
+++ b/src/shogun/features/SparseFeatures.h
@@ -391,7 +391,7 @@ template <class ST> class CSparseFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 		/** iterator for sparse features */

--- a/src/shogun/features/SparseFeatures.h
+++ b/src/shogun/features/SparseFeatures.h
@@ -390,9 +390,10 @@ template <class ST> class CSparseFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
-		#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 		/** iterator for sparse features */
 		struct sparse_feature_iterator
 		{

--- a/src/shogun/features/SparseFeatures.h
+++ b/src/shogun/features/SparseFeatures.h
@@ -388,10 +388,9 @@ template <class ST> class CSparseFeatures : public CDotFeatures
 		 * possible with subset
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		#ifndef DOXYGEN_SHOULD_SKIP_THIS
 		/** iterator for sparse features */

--- a/src/shogun/features/SparseFeatures.h
+++ b/src/shogun/features/SparseFeatures.h
@@ -49,6 +49,8 @@ template <class T> class CCache;
 template <class ST> class CSparseFeatures : public CDotFeatures
 {
 	public:
+		using CDotFeatures::dense_dot;
+
 		/** constructor
 		 *
 		 * @param size cache size

--- a/src/shogun/features/SparseFeatures.h
+++ b/src/shogun/features/SparseFeatures.h
@@ -49,8 +49,6 @@ template <class T> class CCache;
 template <class ST> class CSparseFeatures : public CDotFeatures
 {
 	public:
-		using CDotFeatures::dense_dot;
-
 		/** constructor
 		 *
 		 * @param size cache size

--- a/src/shogun/features/SparsePolyFeatures.cpp
+++ b/src/shogun/features/SparsePolyFeatures.cpp
@@ -126,10 +126,13 @@ float64_t CSparsePolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t v
 	return result;
 }
 
-float64_t CSparsePolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CSparsePolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != m_output_dimensions)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n", vec2.vlen, m_output_dimensions)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
+		    vec2.vlen, m_output_dimensions)
 
 	SGSparseVector<float64_t> vec=m_feat->get_sparse_feature_vector(vec_idx1);
 

--- a/src/shogun/features/SparsePolyFeatures.cpp
+++ b/src/shogun/features/SparsePolyFeatures.cpp
@@ -127,7 +127,7 @@ float64_t CSparsePolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t v
 }
 
 float64_t
-CSparsePolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CSparsePolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.vlen == m_output_dimensions,

--- a/src/shogun/features/SparsePolyFeatures.cpp
+++ b/src/shogun/features/SparsePolyFeatures.cpp
@@ -126,10 +126,10 @@ float64_t CSparsePolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t v
 	return result;
 }
 
-float64_t CSparsePolyFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CSparsePolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != m_output_dimensions)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n", vec2_len, m_output_dimensions)
+	if (vec2.vlen != m_output_dimensions)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n", vec2.vlen, m_output_dimensions)
 
 	SGSparseVector<float64_t> vec=m_feat->get_sparse_feature_vector(vec_idx1);
 

--- a/src/shogun/features/SparsePolyFeatures.cpp
+++ b/src/shogun/features/SparsePolyFeatures.cpp
@@ -129,10 +129,10 @@ float64_t CSparsePolyFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t v
 float64_t
 CSparsePolyFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != m_output_dimensions)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
-		    vec2.vlen, m_output_dimensions)
+	REQUIRE(
+	    vec2.vlen == m_output_dimensions,
+	    "Dimensions don't match, vec2_dim=%d, m_output_dimensions=%d\n",
+	    vec2.vlen, m_output_dimensions);
 
 	SGSparseVector<float64_t> vec=m_feat->get_sparse_feature_vector(vec_idx1);
 

--- a/src/shogun/features/SparsePolyFeatures.h
+++ b/src/shogun/features/SparsePolyFeatures.h
@@ -147,14 +147,12 @@ class CSparsePolyFeatures : public CDotFeatures
 		 */
 		virtual const char* get_name() const { return "SparsePolyFeatures"; }
 
-		/** compute dot product of vector with index arg1
-		 *  with an given second vector
+		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 second vector
-		 * @param vec2_len length of second vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/SparsePolyFeatures.h
+++ b/src/shogun/features/SparsePolyFeatures.h
@@ -152,7 +152,8 @@ class CSparsePolyFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/SparsePolyFeatures.h
+++ b/src/shogun/features/SparsePolyFeatures.h
@@ -153,7 +153,7 @@ class CSparsePolyFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** compute alpha*x+vec2
 		 *

--- a/src/shogun/features/WDFeatures.cpp
+++ b/src/shogun/features/WDFeatures.cpp
@@ -113,10 +113,12 @@ float64_t CWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx2)
 	return sum/CMath::sq(normalization_const);
 }
 
-float64_t CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/WDFeatures.cpp
+++ b/src/shogun/features/WDFeatures.cpp
@@ -116,9 +116,9 @@ float64_t CWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx2)
 float64_t
 CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != w_dim)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+	REQUIRE(
+	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/WDFeatures.cpp
+++ b/src/shogun/features/WDFeatures.cpp
@@ -114,7 +114,7 @@ float64_t CWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx2)
 }
 
 float64_t
-CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",

--- a/src/shogun/features/WDFeatures.cpp
+++ b/src/shogun/features/WDFeatures.cpp
@@ -113,10 +113,10 @@ float64_t CWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec_idx2)
 	return sum/CMath::sq(normalization_const);
 }
 
-float64_t CWDFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2_len, w_dim)
+	if (vec2.vlen != w_dim)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/WDFeatures.cpp
+++ b/src/shogun/features/WDFeatures.cpp
@@ -117,8 +117,8 @@ float64_t
 CWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
-	    vec2.vlen, w_dim)
+	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.size(), w_dim)
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/WDFeatures.h
+++ b/src/shogun/features/WDFeatures.h
@@ -66,7 +66,8 @@ class CWDFeatures : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/WDFeatures.h
+++ b/src/shogun/features/WDFeatures.h
@@ -64,10 +64,9 @@ class CWDFeatures : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/WDFeatures.h
+++ b/src/shogun/features/WDFeatures.h
@@ -67,7 +67,7 @@ class CWDFeatures : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** add vector 1 multiplied with alpha to dense vector2
 		 *

--- a/src/shogun/features/hashed/HashedDenseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDenseFeatures.cpp
@@ -122,7 +122,7 @@ float64_t CHashedDenseFeatures<ST>::dot(int32_t vec_idx1, CDotFeatures* df,
 
 template <class ST>
 float64_t CHashedDenseFeatures<ST>::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	ASSERT(vec2.size() == dim)
 

--- a/src/shogun/features/hashed/HashedDenseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDenseFeatures.cpp
@@ -121,10 +121,9 @@ float64_t CHashedDenseFeatures<ST>::dot(int32_t vec_idx1, CDotFeatures* df,
 }
 
 template <class ST>
-float64_t CHashedDenseFeatures<ST>::dense_dot(int32_t vec_idx1, const float64_t* vec2,
-	int32_t vec2_len) const
+float64_t CHashedDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2_len == dim)
+	ASSERT(vec2.vlen == dim)
 
 	SGVector<ST> vec = dense_feats->get_feature_vector(vec_idx1);
 

--- a/src/shogun/features/hashed/HashedDenseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDenseFeatures.cpp
@@ -121,7 +121,8 @@ float64_t CHashedDenseFeatures<ST>::dot(int32_t vec_idx1, CDotFeatures* df,
 }
 
 template <class ST>
-float64_t CHashedDenseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CHashedDenseFeatures<ST>::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	ASSERT(vec2.vlen == dim)
 

--- a/src/shogun/features/hashed/HashedDenseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDenseFeatures.cpp
@@ -124,16 +124,16 @@ template <class ST>
 float64_t CHashedDenseFeatures<ST>::dot(
 	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2.vlen == dim)
+	ASSERT(vec2.size() == dim)
 
 	SGVector<ST> vec = dense_feats->get_feature_vector(vec_idx1);
 
 	float64_t result = 0;
 
-	int32_t hash_cache_size = use_quadratic ? vec.vlen : 0;
+	int32_t hash_cache_size = use_quadratic ? vec.size() : 0;
 	SGVector<uint32_t> hash_cache(hash_cache_size);
 
-	for (index_t i=0; i<vec.vlen; i++)
+	for (index_t i=0; i<vec.size(); i++)
 	{
 		uint32_t h_idx = CHash::MurmurHash3((uint8_t* ) &i, sizeof (index_t), i);
 		if (use_quadratic)

--- a/src/shogun/features/hashed/HashedDenseFeatures.h
+++ b/src/shogun/features/hashed/HashedDenseFeatures.h
@@ -111,7 +111,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedDenseFeatures.h
+++ b/src/shogun/features/hashed/HashedDenseFeatures.h
@@ -112,7 +112,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedDenseFeatures.h
+++ b/src/shogun/features/hashed/HashedDenseFeatures.h
@@ -109,11 +109,9 @@ public:
 	 * possible with subset
 	 *
 	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
+	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2,
-			int32_t vec2_len) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedDocDotFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.cpp
@@ -9,6 +9,8 @@
 #include <shogun/lib/Hash.h>
 #include <shogun/mathematics/Math.h>
 
+#include <cmath>
+
 namespace shogun
 {
 CHashedDocDotFeatures::CHashedDocDotFeatures(int32_t hash_bits, CStringFeatures<char>* docs,
@@ -97,9 +99,9 @@ float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 }
 
 float64_t CHashedDocDotFeatures::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
-	ASSERT(vec2.size() == CMath::pow(2,num_bits))
+	ASSERT(vec2.size() == std::pow(2,num_bits))
 
 	SGVector<char> sv = doc_collection->get_feature_vector(vec_idx1);
 

--- a/src/shogun/features/hashed/HashedDocDotFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.cpp
@@ -96,7 +96,8 @@ float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 	return result;
 }
 
-float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CHashedDocDotFeatures::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	return dense_dot(vec_idx1, vec2.vector, vec2.vlen);
 }

--- a/src/shogun/features/hashed/HashedDocDotFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.cpp
@@ -99,12 +99,7 @@ float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 float64_t CHashedDocDotFeatures::dot(
 	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	return dense_dot(vec_idx1, vec2.vector, vec2.vlen);
-}
-
-float64_t CHashedDocDotFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
-{
-	ASSERT(vec2_len == CMath::pow(2,num_bits))
+	ASSERT(vec2.size() == CMath::pow(2,num_bits))
 
 	SGVector<char> sv = doc_collection->get_feature_vector(vec_idx1);
 

--- a/src/shogun/features/hashed/HashedDocDotFeatures.cpp
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.cpp
@@ -96,7 +96,7 @@ float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t
 	return result;
 }
 
-float64_t CHashedDocDotFeatures::dense_dot_sgvec(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CHashedDocDotFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	return dense_dot(vec_idx1, vec2.vector, vec2.vlen);
 }

--- a/src/shogun/features/hashed/HashedDocDotFeatures.h
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.h
@@ -86,14 +86,6 @@ public:
 	virtual float64_t
 	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
-	/** compute dot product between vector1 and a dense vector
-	 *
-	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
-	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
-
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *
 	 * @param alpha scalar alpha

--- a/src/shogun/features/hashed/HashedDocDotFeatures.h
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.h
@@ -83,7 +83,7 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot_sgvec(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** compute dot product between vector1 and a dense vector
 	 *

--- a/src/shogun/features/hashed/HashedDocDotFeatures.h
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.h
@@ -84,7 +84,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedDocDotFeatures.h
+++ b/src/shogun/features/hashed/HashedDocDotFeatures.h
@@ -83,7 +83,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** compute dot product between vector1 and a dense vector
 	 *

--- a/src/shogun/features/hashed/HashedSparseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedSparseFeatures.cpp
@@ -186,7 +186,8 @@ float64_t CHashedSparseFeatures<ST>::dot(int32_t vec_idx1, CDotFeatures* df,
 }
 
 template <class ST>
-float64_t CHashedSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CHashedSparseFeatures<ST>::dot(
+	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	ASSERT(vec2.vlen == dim)
 

--- a/src/shogun/features/hashed/HashedSparseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedSparseFeatures.cpp
@@ -189,7 +189,7 @@ template <class ST>
 float64_t CHashedSparseFeatures<ST>::dot(
 	int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2.vlen == dim)
+	ASSERT(vec2.size() == dim)
 
 	SGSparseVector<ST> vec = sparse_feats->get_sparse_feature_vector(vec_idx1);
 

--- a/src/shogun/features/hashed/HashedSparseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedSparseFeatures.cpp
@@ -187,7 +187,7 @@ float64_t CHashedSparseFeatures<ST>::dot(int32_t vec_idx1, CDotFeatures* df,
 
 template <class ST>
 float64_t CHashedSparseFeatures<ST>::dot(
-	int32_t vec_idx1, const SGVector<float64_t> vec2) const
+	int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	ASSERT(vec2.size() == dim)
 

--- a/src/shogun/features/hashed/HashedSparseFeatures.cpp
+++ b/src/shogun/features/hashed/HashedSparseFeatures.cpp
@@ -186,10 +186,9 @@ float64_t CHashedSparseFeatures<ST>::dot(int32_t vec_idx1, CDotFeatures* df,
 }
 
 template <class ST>
-float64_t CHashedSparseFeatures<ST>::dense_dot(int32_t vec_idx1, const float64_t* vec2,
-	int32_t vec2_len) const
+float64_t CHashedSparseFeatures<ST>::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	ASSERT(vec2_len == dim)
+	ASSERT(vec2.vlen == dim)
 
 	SGSparseVector<ST> vec = sparse_feats->get_sparse_feature_vector(vec_idx1);
 

--- a/src/shogun/features/hashed/HashedSparseFeatures.h
+++ b/src/shogun/features/hashed/HashedSparseFeatures.h
@@ -102,7 +102,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedSparseFeatures.h
+++ b/src/shogun/features/hashed/HashedSparseFeatures.h
@@ -99,11 +99,9 @@ public:
 	 * possible with subset
 	 *
 	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
+	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2,
-			int32_t vec2_len) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedSparseFeatures.h
+++ b/src/shogun/features/hashed/HashedSparseFeatures.h
@@ -101,7 +101,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedWDFeatures.cpp
+++ b/src/shogun/features/hashed/HashedWDFeatures.cpp
@@ -123,10 +123,12 @@ float64_t CHashedWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec
 	return sum/CMath::sq(normalization_const);
 }
 
-float64_t CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t
+CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/hashed/HashedWDFeatures.cpp
+++ b/src/shogun/features/hashed/HashedWDFeatures.cpp
@@ -123,10 +123,10 @@ float64_t CHashedWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec
 	return sum/CMath::sq(normalization_const);
 }
 
-float64_t CHashedWDFeatures::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2_len, w_dim)
+	if (vec2.vlen != w_dim)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/hashed/HashedWDFeatures.cpp
+++ b/src/shogun/features/hashed/HashedWDFeatures.cpp
@@ -126,9 +126,9 @@ float64_t CHashedWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec
 float64_t
 CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != w_dim)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+	REQUIRE(
+	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.vlen, w_dim);
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/hashed/HashedWDFeatures.cpp
+++ b/src/shogun/features/hashed/HashedWDFeatures.cpp
@@ -127,8 +127,8 @@ float64_t
 CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
-	    vec2.vlen, w_dim);
+	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.size(), w_dim);
 
 	float64_t sum=0;
 	int32_t lim=CMath::min(degree, string_length);

--- a/src/shogun/features/hashed/HashedWDFeatures.cpp
+++ b/src/shogun/features/hashed/HashedWDFeatures.cpp
@@ -124,7 +124,7 @@ float64_t CHashedWDFeatures::dot(int32_t vec_idx1, CDotFeatures* df, int32_t vec
 }
 
 float64_t
-CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+CHashedWDFeatures::dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",

--- a/src/shogun/features/hashed/HashedWDFeatures.h
+++ b/src/shogun/features/hashed/HashedWDFeatures.h
@@ -72,7 +72,8 @@ public:
 	 * @param vec_idx1 index of first vector
 	 * @param vec2 dense vector
 	 */
-	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	virtual float64_t
+	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedWDFeatures.h
+++ b/src/shogun/features/hashed/HashedWDFeatures.h
@@ -70,11 +70,9 @@ public:
 	/** compute dot product between vector1 and a dense vector
 	 *
 	 * @param vec_idx1 index of first vector
-	 * @param vec2 pointer to real valued vector
-	 * @param vec2_len length of real valued vector
+	 * @param vec2 dense vector
 	 */
-	virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2,
-			int32_t vec2_len) const;
+	virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedWDFeatures.h
+++ b/src/shogun/features/hashed/HashedWDFeatures.h
@@ -73,7 +73,7 @@ public:
 	 * @param vec2 dense vector
 	 */
 	virtual float64_t
-	dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+	dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 	/** add vector 1 multiplied with alpha to dense vector2
 	 *

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
@@ -153,10 +153,10 @@ float64_t CHashedWDFeaturesTransposed::dot(int32_t vec_idx1, CDotFeatures* df, i
 	return sum/CMath::sq(normalization_const);
 }
 
-float64_t CHashedWDFeaturesTransposed::dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const
+float64_t CHashedWDFeaturesTransposed::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2_len != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2_len, w_dim)
+	if (vec2.vlen != w_dim)
+		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
@@ -153,10 +153,12 @@ float64_t CHashedWDFeaturesTransposed::dot(int32_t vec_idx1, CDotFeatures* df, i
 	return sum/CMath::sq(normalization_const);
 }
 
-float64_t CHashedWDFeaturesTransposed::dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const
+float64_t CHashedWDFeaturesTransposed::dot(
+    int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	if (vec2.vlen != w_dim)
-		SG_ERROR("Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+		SG_ERROR(
+		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
@@ -154,7 +154,7 @@ float64_t CHashedWDFeaturesTransposed::dot(int32_t vec_idx1, CDotFeatures* df, i
 }
 
 float64_t CHashedWDFeaturesTransposed::dot(
-    int32_t vec_idx1, const SGVector<float64_t> vec2) const
+    int32_t vec_idx1, const SGVector<float64_t>& vec2) const
 {
 	REQUIRE(
 	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
@@ -157,8 +157,8 @@ float64_t CHashedWDFeaturesTransposed::dot(
     int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
 	REQUIRE(
-	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
-	    vec2.vlen, w_dim);
+	    vec2.size() == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.size(), w_dim);
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.cpp
@@ -156,9 +156,9 @@ float64_t CHashedWDFeaturesTransposed::dot(int32_t vec_idx1, CDotFeatures* df, i
 float64_t CHashedWDFeaturesTransposed::dot(
     int32_t vec_idx1, const SGVector<float64_t> vec2) const
 {
-	if (vec2.vlen != w_dim)
-		SG_ERROR(
-		    "Dimensions don't match, vec2_dim=%d, w_dim=%d\n", vec2.vlen, w_dim)
+	REQUIRE(
+	    vec2.vlen == w_dim, "Dimensions don't match, vec2_dim=%d, w_dim=%d\n",
+	    vec2.vlen, w_dim);
 
 	float64_t sum=0;
 	int32_t len;

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.h
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.h
@@ -70,10 +70,9 @@ class CHashedWDFeaturesTransposed : public CDotFeatures
 		/** compute dot product between vector1 and a dense vector
 		 *
 		 * @param vec_idx1 index of first vector
-		 * @param vec2 pointer to real valued vector
-		 * @param vec2_len length of real valued vector
+		 * @param vec2 dense vector
 		 */
-		virtual float64_t dense_dot(int32_t vec_idx1, const float64_t* vec2, int32_t vec2_len) const;
+		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** Compute the dot product for a range of vectors. This function makes use of dense_dot
 		 * alphas[i] * sparse[i]^T * w + b

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.h
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.h
@@ -73,7 +73,7 @@ class CHashedWDFeaturesTransposed : public CDotFeatures
 		 * @param vec2 dense vector
 		 */
 		virtual float64_t
-		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		dot(int32_t vec_idx1, const SGVector<float64_t>& vec2) const override;
 
 		/** Compute the dot product for a range of vectors. This function makes use of dense_dot
 		 * alphas[i] * sparse[i]^T * w + b

--- a/src/shogun/features/hashed/HashedWDFeaturesTransposed.h
+++ b/src/shogun/features/hashed/HashedWDFeaturesTransposed.h
@@ -72,7 +72,8 @@ class CHashedWDFeaturesTransposed : public CDotFeatures
 		 * @param vec_idx1 index of first vector
 		 * @param vec2 dense vector
 		 */
-		virtual float64_t dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
+		virtual float64_t
+		dot(int32_t vec_idx1, const SGVector<float64_t> vec2) const;
 
 		/** Compute the dot product for a range of vectors. This function makes use of dense_dot
 		 * alphas[i] * sparse[i]^T * w + b

--- a/src/shogun/features/iterators/DotIterator.cpp
+++ b/src/shogun/features/iterators/DotIterator.cpp
@@ -38,7 +38,7 @@ namespace shogun
 	float64_t
 	DotIterator::feature_vector::dot(const SGVector<float64_t>& v) const
 	{
-		return m_features->dense_dot(m_idx, v.vector, v.vlen);
+		return m_features->dot(m_idx, v);
 	}
 
 	void DotIterator::feature_vector::add(

--- a/src/shogun/kernel/LinearKernel.cpp
+++ b/src/shogun/kernel/LinearKernel.cpp
@@ -87,7 +87,6 @@ bool CLinearKernel::delete_optimization()
 float64_t CLinearKernel::compute_optimized(int32_t idx)
 {
 	ASSERT(get_is_initialized())
-	float64_t result = ((CDotFeatures*) rhs)->
-		dense_dot(idx, normal.vector, normal.size());
+	float64_t result = ((CDotFeatures*) rhs)->dot(idx, normal);
 	return normalizer->normalize_rhs(result, idx);
 }

--- a/src/shogun/machine/LinearMachine.cpp
+++ b/src/shogun/machine/LinearMachine.cpp
@@ -49,7 +49,7 @@ CLinearMachine::~CLinearMachine()
 
 float64_t CLinearMachine::apply_one(int32_t vec_idx)
 {
-	return features->dense_dot(vec_idx, m_w.vector, m_w.vlen) + bias;
+	return features->dot(vec_idx, m_w) + bias;
 }
 
 CRegressionLabels* CLinearMachine::apply_regression(CFeatures* data)

--- a/src/shogun/regression/svr/LibLinearRegression.cpp
+++ b/src/shogun/regression/svr/LibLinearRegression.cpp
@@ -243,7 +243,7 @@ void CLibLinearRegression::solve_l2r_l1l2_svr(SGVector<float64_t>& w, const libl
 			G = -y[i] + lambda[GETI(i)]*beta[i];
 			H = QD[i] + lambda[GETI(i)];
 
-			G += prob->x->dense_dot(i, w.vector, w_size);
+			G += prob->x->dot(i, w);
 			if (prob->use_bias)
 				G+=w.vector[w_size];
 

--- a/src/shogun/structure/HierarchicalMultilabelModel.cpp
+++ b/src/shogun/structure/HierarchicalMultilabelModel.cpp
@@ -244,8 +244,8 @@ CResultSet * CHierarchicalMultilabelModel::argmax(SGVector<float64_t> w,
 		int32_t node = nodes_to_traverse->get_element(0);
 		nodes_to_traverse->delete_element(0);
 
-		float64_t score = dot_feats->dense_dot(feat_idx, w.vector + node * feats_dim,
-		                                       feats_dim);
+		float64_t score = dot_feats->dot(feat_idx, w.slice(node * feats_dim,
+		                                       node * feats_dim + feats_dim));
 
 		// if the score is greater than zero, then all the children nodes are
 		// to be traversed next

--- a/src/shogun/structure/MulticlassModel.cpp
+++ b/src/shogun/structure/MulticlassModel.cpp
@@ -89,7 +89,7 @@ CResultSet* CMulticlassModel::argmax(
 
 	for ( int32_t c = 0 ; c < m_num_classes ; ++c )
 	{
-		score = df->dense_dot(feat_idx, w.vector+c*feats_dim, feats_dim);
+		score = df->dot(feat_idx, w.slice(c*feats_dim, c*feats_dim + feats_dim));
 		if ( training )
 			score += delta_loss(feat_idx, c);
 

--- a/src/shogun/structure/MultilabelCLRModel.cpp
+++ b/src/shogun/structure/MultilabelCLRModel.cpp
@@ -202,15 +202,15 @@ CResultSet * CMultilabelCLRModel::argmax(SGVector<float64_t> w, int32_t feat_idx
 	float64_t score = 0, calibrated_score = 0;
 
 	// last label (m_num_class + 1)th label is the calibrated/virtual label
-	calibrated_score = dot_feats->dense_dot(feat_idx, w.vector + m_num_classes * feats_dim,
-	                                        feats_dim);
+	calibrated_score = dot_feats->dot(feat_idx, w.slice(m_num_classes * feats_dim,
+	                                        m_num_classes * feats_dim + feats_dim));
 
 	SGVector<float64_t> class_product(m_num_classes);
 
 	for (index_t i = 0; i < m_num_classes; i++)
 	{
-		score = dot_feats->dense_dot(feat_idx, w.vector + i * feats_dim,
-		                             feats_dim);
+		score = dot_feats->dot(feat_idx, w.slice(i * feats_dim,
+		                             i * feats_dim + feats_dim));
 		class_product[i] = score - calibrated_score;
 	}
 

--- a/src/shogun/structure/MultilabelModel.cpp
+++ b/src/shogun/structure/MultilabelModel.cpp
@@ -175,7 +175,7 @@ CResultSet * CMultilabelModel::argmax(SGVector<float64_t> w, int32_t feat_idx,
 
 	for (int32_t c = 0; c < m_num_classes; c++)
 	{
-		score = dot_feats->dense_dot(feat_idx, w.vector + c * feats_dim, feats_dim);
+		score = dot_feats->dot(feat_idx, w.slice(c * feats_dim, c * feats_dim + feats_dim));
 
 		if (score > 0)
 		{

--- a/src/shogun/transfer/multitask/LibLinearMTL.cpp
+++ b/src/shogun/transfer/multitask/LibLinearMTL.cpp
@@ -286,8 +286,8 @@ void CLibLinearMTL::solve_l2r_l1l2_svc(const liblinear_problem *prob, double eps
                 float64_t sim = it->second;
 
 				// fetch vector
-				float64_t* tmp_w = V.get_column_vector(e_i);
-				inner_sum += sim * yi * prob->x->dense_dot(i, tmp_w, n);
+				SGVector<float64_t> tmp_w = V.get_column(e_i);
+				inner_sum += sim * yi * prob->x->dot(i, tmp_w);
 
 				//possibly deal with bias
 				//if (prob->use_bias)
@@ -471,8 +471,8 @@ return obj
 	for(int32_t i=0; i<num_vec; i++)
 	{
 		int32_t ti = task_indicator_lhs[i];
-		float64_t* w_t = W.get_column_vector(ti);
-		float64_t residual = ((CBinaryLabels*)m_labels)->get_label(i) * features->dense_dot(i, w_t, w_size);
+		SGVector<float64_t> w_t = W.get_column(ti);
+		float64_t residual = ((CBinaryLabels*)m_labels)->get_label(i) * features->dot(i, w_t);
 
 		// hinge loss
 		obj += C1 * CMath::max(0.0, 1 - residual);

--- a/tests/unit/features/CombinedDotFeatures_unittest.cc
+++ b/tests/unit/features/CombinedDotFeatures_unittest.cc
@@ -108,18 +108,17 @@ TEST(CombinedDotFeaturesTest, dot_products)
 	EXPECT_EQ(result, 1*3*28 - 2*1*14 - 3*2*28);
 	SG_SINFO("Completed dot() testing");
 
-	SG_SINFO("Beginning dense_dot() testing");
-	float64_t* vector = new float64_t[9];
+	SG_SINFO("Beginning dot() testing");
+	SGVector<float64_t> vector(9);
 	for (index_t i=0; i<9; i++)
 	{
 		vector[i] = 10 + i;
 	}
 
-	result = comb_feat_1->dense_dot(1, vector, 9);
+	result = comb_feat_1->dot(1, vector);
 	EXPECT_EQ(result, 1 * 134 - 2 * 170 + 3 * 412);
 	SG_SINFO("Completed dense_dot() testing");
 
-	delete [] vector;
 	SG_UNREF(comb_feat_1);
 	SG_UNREF(comb_feat_2);
 }

--- a/tests/unit/features/HashedDenseFeatures_unittest.cc
+++ b/tests/unit/features/HashedDenseFeatures_unittest.cc
@@ -141,7 +141,7 @@ TEST(HashedDenseFeaturesTest, dense_dot)
 		for (index_t j=0; j<hashing_dim; j++)
 			dot_product += tmp[j] * tmp[j];
 
-		float64_t feat_dot = h_feats->dense_dot(i, tmp.vector, tmp.vlen);
+		float64_t feat_dot = h_feats->dot(i, tmp);
 		EXPECT_EQ(feat_dot, dot_product);
 	}
 
@@ -199,7 +199,7 @@ TEST(HashedDenseFeaturesTest, quadratic_dense_dot)
 		for (index_t j=0; j<hashing_dim; j++)
 			dot_product += tmp[j] * tmp[j];
 
-		float64_t feat_dot = h_feats->dense_dot(i, tmp.vector, tmp.vlen);
+		float64_t feat_dot = h_feats->dot(i, tmp);
 		EXPECT_EQ(feat_dot, dot_product);
 	}
 

--- a/tests/unit/features/HashedDocDotFeatures_unittest.cc
+++ b/tests/unit/features/HashedDocDotFeatures_unittest.cc
@@ -127,7 +127,7 @@ TEST(HashedDocDotFeaturesTest, dense_dot_test)
 		for (index_t j=0; j<dimension; j++)
 			converter_result += sv[j] * vec[j];
 
-		float64_t features_result = hddf->dense_dot(i, vec.vector, dimension);
+		float64_t features_result = hddf->dot(i, vec);
 		EXPECT_EQ(features_result, converter_result);
 	}
 
@@ -216,9 +216,9 @@ TEST(HashedDocDotFeaturesTest, quadratic_dense_dot)
 		dot_product += i * vec[i];
 	}
 
-	float64_t hashed_dot_product = hddf->dense_dot(0, dense_vec.vector, dense_vec.vlen);
+	float64_t hashed_dot_product = hddf->dot(0, dense_vec);
 	EXPECT_EQ(hashed_dot_product, dot_product);
-	float64_t sparse_dot_product = sf->dense_dot(0, dense_vec.vector, dense_vec.vlen);
+	float64_t sparse_dot_product = sf->dot(0, dense_vec);
 	EXPECT_EQ(sparse_dot_product, dot_product);
 
 	SG_UNREF(sf);

--- a/tests/unit/features/HashedSparseFeatures_unittest.cc
+++ b/tests/unit/features/HashedSparseFeatures_unittest.cc
@@ -154,7 +154,7 @@ TEST(HashedSparseFeaturesTest, dense_dot)
 		for (index_t j=0; j<hashing_dim; j++)
 			dot_product += tmp[j] * tmp[j];
 
-		float64_t feat_dot = h_feats->dense_dot(i, tmp.vector, tmp.vlen);
+		float64_t feat_dot = h_feats->dot(i, tmp);
 		EXPECT_EQ(feat_dot, dot_product);
 	}
 
@@ -219,7 +219,7 @@ TEST(HashedSparseFeaturesTest, quadratic_dense_dot)
 		for (index_t j=0; j<hashing_dim; j++)
 			dot_product += tmp[j] * tmp[j];
 
-		float64_t feat_dot = h_feats->dense_dot(i, tmp.vector, tmp.vlen);
+		float64_t feat_dot = h_feats->dot(i, tmp);
 		EXPECT_EQ(feat_dot, dot_product);
 	}
 

--- a/tests/unit/features/LBPPyrDotFeatures_unittest.cc
+++ b/tests/unit/features/LBPPyrDotFeatures_unittest.cc
@@ -60,7 +60,7 @@ TEST(LBPPyrDotFeatures, dense_dot_test)
 	SGVector<float64_t> tmp(vec.vlen);
 	for (index_t i=0; i<vec.vlen; i++)
 		tmp[i] = vec[i];
-	float64_t result = lbp_feat->dense_dot(0, tmp.vector, vec.vlen);
+	float64_t result = lbp_feat->dot(0, tmp);
 	EXPECT_EQ(result, correct_result);
 
 	SG_UNREF(lbp_feat);

--- a/tests/unit/features/RandomFourierDotFeatures_unittest.cc
+++ b/tests/unit/features/RandomFourierDotFeatures_unittest.cc
@@ -116,7 +116,7 @@ TEST(RandomFourierDotFeatures, dense_dot_test)
 	{
 		SGVector<float64_t> ones(D);
 		SGVector<float64_t>::fill_vector(ones.vector, ones.vlen, 1);
-		float64_t dot = r_feats->dense_dot(i, ones.vector, ones.vlen);
+		float64_t dot = r_feats->dot(i, ones);
 		EXPECT_NEAR(dot, vec[i], e);
 	}
 	SG_UNREF(r_feats);

--- a/tests/unit/structure/HierarchicalMultilabelModel_unittest.cc
+++ b/tests/unit/structure/HierarchicalMultilabelModel_unittest.cc
@@ -264,8 +264,9 @@ TEST(HierarchicalMultilabelModel, argmax)
 	for (index_t i = 0; i < slabel_1.vlen; i++)
 	{
 		int32_t label = slabel_1[i];
-		float64_t score = ((CDotFeatures *)features)->dense_dot(0,
-		                  w.vector + label * dim_features, dim_features);
+		float64_t score = features->dot(
+		    0,
+		    w.slice(label * dim_features, label * dim_features + dim_features));
 
 		// score for ROOT should be greater than 0
 		if (label == 0)
@@ -277,8 +278,7 @@ TEST(HierarchicalMultilabelModel, argmax)
 		// zero
 		else
 		{
-			float64_t score_0 = ((CDotFeatures *)features)->dense_dot(0,
-			                    w.vector, dim_features);
+			float64_t score_0 = features->dot(0, w.slice(0, dim_features));
 			EXPECT_GE(score_0, 0);
 			EXPECT_GE(score, 0);
 		}
@@ -292,8 +292,9 @@ TEST(HierarchicalMultilabelModel, argmax)
 	for (index_t i = 0; i < slabel_2.vlen; i++)
 	{
 		int32_t label = slabel_2[i];
-		float64_t score = ((CDotFeatures *)features)->dense_dot(0,
-		                  w.vector + label * dim_features, dim_features);
+		float64_t score = features->dot(
+		    0,
+		    w.slice(label * dim_features, label * dim_features + dim_features));
 
 		// score for ROOT should be greater than 0
 		if (label == 0)
@@ -305,8 +306,7 @@ TEST(HierarchicalMultilabelModel, argmax)
 		// zero
 		else
 		{
-			float64_t score_0 = ((CDotFeatures *)features)->dense_dot(0,
-			                    w.vector, dim_features);
+			float64_t score_0 = features->dot(0, w.slice(0, dim_features));
 			EXPECT_GE(score_0, 0);
 			EXPECT_GE(score, 0);
 		}
@@ -383,12 +383,12 @@ TEST(HierarchicalMultilabelModel, argmax_leaf_nodes_mandatory)
 		// if node is not the ROOT, then along with the score
 		// of that node, the score for its parent should also be greater than
 		// zero
-		float64_t score_0 = ((CDotFeatures *)features)->dense_dot(0,
-		                    w.vector, dim_features);
+		float64_t score_0 = features->dot(0, w.slice(0, dim_features));
 		EXPECT_GE(score_0, 0);
 
-		float64_t score = ((CDotFeatures *)features)->dense_dot(0,
-		                  w.vector + label * dim_features, dim_features);
+		float64_t score = features->dot(
+		    0,
+		    w.slice(label * dim_features, label * dim_features + dim_features));
 		EXPECT_GE(score, 0);
 	}
 
@@ -407,12 +407,12 @@ TEST(HierarchicalMultilabelModel, argmax_leaf_nodes_mandatory)
 		// if node is not the ROOT, then along with the score
 		// of that node, the score for its parent should also be greater than
 		// zero
-		float64_t score_0 = ((CDotFeatures *)features)->dense_dot(0,
-		                    w.vector, dim_features);
+		float64_t score_0 = features->dot(0, w.slice(0, dim_features));
 		EXPECT_GE(score_0, 0);
 
-		float64_t score = ((CDotFeatures *)features)->dense_dot(0,
-		                  w.vector + label * dim_features, dim_features);
+		float64_t score = features->dot(
+		    0,
+		    w.slice(label * dim_features, label * dim_features + dim_features));
 		EXPECT_GE(score, 0);
 	}
 

--- a/tests/unit/structure/MultilabelCLRModel_unittest.cc
+++ b/tests/unit/structure/MultilabelCLRModel_unittest.cc
@@ -224,14 +224,17 @@ TEST(MultilabelCLRModel, argmax)
 	SGVector<int32_t> slabel_1 = y_1->get_data();
 
 	// calibrated/virtual label is considered to be last label
-	float64_t calibrated_score = ((CDotFeatures *)features)->dense_dot(0,
-	                             w.vector + labels->get_num_classes() * DIMS, DIMS);
+	float64_t calibrated_score = features->dot(
+	    0, w.slice(
+	           labels->get_num_classes() * DIMS,
+	           labels->get_num_classes() * DIMS + DIMS));
 
 	for (index_t i = 0; i < slabel_1.vlen; i++)
 	{
 		int32_t label = slabel_1[i];
-		float64_t score = ((CDotFeatures *)features)->dense_dot(0,
-		                  w.vector + label * DIMS, DIMS) - calibrated_score;
+		float64_t score =
+		    features->dot(0, w.slice(label * DIMS, label * DIMS + DIMS)) -
+		    calibrated_score;
 
 		// true label in this case is lab_2
 		if (label != lab_2[0])
@@ -253,8 +256,7 @@ TEST(MultilabelCLRModel, argmax)
 
 	for (index_t i = 0; i < labels->get_num_classes(); i++)
 	{
-		float64_t score = ((CDotFeatures *)features)->dense_dot(0,
-		                  w.vector + i * DIMS, DIMS);
+		float64_t score = features->dot(0, w.slice(i * DIMS, i * DIMS + DIMS));
 
 		bool present = false;
 


### PR DESCRIPTION
This is part of getting rid of raw pointers in Features. I renamed `dense_dot` to `dot`, and now it uses `SGVector`. Currently `dense_dot` just calls `dot` so as not to break current algorithms. If this is ok, I will change the rest of the code to use this instead of the one with raw pointers.