### PR TITLE
allow users to compile shogun with python2

### DIFF
--- a/tests/unit/base/trained_model_serialization_test.cc.py
+++ b/tests/unit/base/trained_model_serialization_test.cc.py
@@ -4,6 +4,10 @@
 #
 # Authors: Michele Mazzoni, Sergey Lisitsyn
 
+import sys
+if sys.version_info < (3, 0):
+    import codecs
+    open = codecs.open
 
 # Classes to ignore: mostly because default initialization isn't enough
 # to setup the machine for training (i.e. Multitask and DomainAdaptation),


### PR DESCRIPTION
@vigsterkr  this should fix the encoding issue for python2