### PR TITLE
Use aligned malloc for SGVector and SGMatrix allocation

### DIFF
--- a/doc/OpenCV_docs/OpenCV_KNN_vs_Shogun_KNN.md
+++ b/doc/OpenCV_docs/OpenCV_KNN_vs_Shogun_KNN.md
@@ -12,6 +12,7 @@ Let's start with the includes!
 #include <shogun/labels/MulticlassLabels.h>
 #include <shogun/lib/OpenCV/CV2SGFactory.h>
 #include <shogun/features/DataGenerator.h>
+#include <shogun/mathematics/linalg/LinalgNamespace>
 
 // OpenCV includes.
 #include <opencv2/core/core.hpp>
@@ -161,8 +162,7 @@ We, as usual, prepare the ```CDenseFeatures``` object namely ```shogun_trainfeat
 ```CPP
 
     SGMatrix<float64_t> shogun_traindata = CV2SGFactory::get_sgmatrix<float64_t>(traindata);
-    SGMatrix<float64_t>::transpose_matrix(shogun_traindata.matrix,
-    		shogun_traindata.num_rows, shogun_traindata.num_cols);
+    shogun_traindata = linalg::transpose_matrix(shogun_traindata);
     CDenseFeatures<float64_t>* shogun_trainfeatures = new CDenseFeatures<float64_t>(shogun_traindata);
 ```
 
@@ -177,8 +177,7 @@ We form the ```CMulticlassLabels``` object named ```labels``` for containing the
 We, as usual, prepare the ```CDenseFeatures``` object namely ```shogun_testfeatures``` for testing.
 ```CPP
     SGMatrix<float64_t> shogun_testdata = CV2SGFactory::get_sgmatrix<float64_t>(testdata);
-    SGMatrix<float64_t>::transpose_matrix(shogun_testdata.matrix,
-    		shogun_testdata.num_rows, shogun_testdata.num_cols);
+    shogun_testdata = linalg::transpose_matrix(shogun_testdata);
     CDenseFeatures<float64_t>* shogun_testfeatures = new CDenseFeatures<float64_t>(shogun_testdata);
 ```
 ___

--- a/doc/OpenCV_docs/OpenCV_NN_vs_Shogun_NN.md
+++ b/doc/OpenCV_docs/OpenCV_NN_vs_Shogun_NN.md
@@ -15,6 +15,7 @@ Let's start with the includes!
 #include <shogun/neuralnets/NeuralInputLayer.h>
 #include <shogun/neuralnets/NeuralLogisticLayer.h>
 #include <shogun/lib/OpenCV/CV2SGFactory.h>
+#include <shogun/mathematics/linalg/LinalgNamespace>
 
 // standard library.
 #include <iostream>
@@ -222,7 +223,7 @@ As usual, we start with creating a ```DenseFeatures``` object with the training 
 
 ```CPP
     SGMatrix<float64_t> shogun_traindata = CV2SGFactory::get_sgmatrix<float64_t>(traindata);
-    SGMatrix<float64_t>::transpose_matrix(shogun_traindata.matrix, shogun_traindata.num_rows, shogun_traindata.num_cols);
+    shogun_traindata = linalg::transpose_matrix(shogun_traindata);
     CDenseFeatures<float64_t>* shogun_trainfeatures = new CDenseFeatures<float64_t>(shogun_traindata);
 ```
 
@@ -238,7 +239,7 @@ The training responses are in an object of type ```MulticlassLabels```.
 Prepare the testing data.
 ```CPP
     SGMatrix<float64_t> shogun_testdata = CV2SGFactory::get_sgmatrix<float64_t>(testdata);
-    SGMatrix<float64_t>::transpose_matrix(shogun_testdata.matrix, shogun_testdata.num_rows, shogun_testdata.num_cols);
+    shogun_testdata = linalg::transpose_matrix(shogun_testdata);
     CDenseFeatures<float64_t>* testfeatures = new CDenseFeatures<float64_t>(shogun_testdata);
 ```
 

--- a/doc/OpenCV_docs/OpenCV_SVM_vs_Shogun_SVM.md
+++ b/doc/OpenCV_docs/OpenCV_SVM_vs_Shogun_SVM.md
@@ -22,6 +22,7 @@ Let's start with the includes!
 #include <shogun/multiclass/MulticlassLibSVM.h>
 #include <shogun/labels/MulticlassLabels.h>
 #include <shogun/kernel/LinearKernel.h>
+#include <shogun/mathematics/linalg/LinalgNamespace>
 
 // for measuring time
 #include <omp.h>
@@ -191,7 +192,7 @@ We start with creating the training data as the ```DenseFeatures```.
 
 ```CPP
     SGMatrix<float64_t> shogun_traindata = CV2SGFactory::get_sgmatrix<float64_t>(traindata);
-    SGMatrix<float64_t>::transpose_matrix(shogun_traindata.matrix, shogun_traindata.num_rows, shogun_traindata.num_cols);
+    shogun_traindata = linalg::transpose_matrix(shogun_traindata);
     CDenseFeatures<float64_t>* shogun_trainfeatures = new CDenseFeatures<float64_t>(shogun_traindata);
 ```
 
@@ -220,7 +221,7 @@ Now we are ready to initialize the SVM for Shogun. We train it here!
 Prepare the testing data.
 ```CPP
     SGMatrix<float64_t> shogun_testdata=CV2SGFactory::get_sgmatrix<float64_t>(testdata);
-    SGMatrix<float64_t>::transpose_matrix(shogun_testdata.matrix, shogun_testdata.num_rows, shogun_testdata.num_cols);
+    shogun_testdata = linalg::transpose_matrix(shogun_testdata);
     CDenseFeatures<float64_t>* testfeatures=new CDenseFeatures<float64_t>(shogun_testdata);
 ```
 

--- a/examples/undocumented/libshogun/mathematics_lapack.cpp
+++ b/examples/undocumented/libshogun/mathematics_lapack.cpp
@@ -10,6 +10,7 @@
 #include <shogun/lib/SGMatrix.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/lapack.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -68,9 +69,9 @@ void test_matrix_multiply()
 	SGMatrix<float64_t> A(n, m);
 	SGVector<float64_t>::range_fill_vector(A.matrix, m*n);
 	SGMatrix<float64_t>::display_matrix(I, "I");
-	SGMatrix<float64_t>::transpose_matrix(A.matrix, A.num_rows, A.num_cols);
+	A = linalg::transpose_matrix(A);
 	SGMatrix<float64_t>::display_matrix(A, "A transposed");
-	SGMatrix<float64_t>::transpose_matrix(A.matrix, A.num_rows, A.num_cols);
+	A = linalg::transpose_matrix(A);
 	SGMatrix<float64_t>::display_matrix(A, "A");
 
 	SG_SPRINT("multiply A by I and check result\n");

--- a/src/shogun/classifier/svm/NewtonSVM.cpp
+++ b/src/shogun/classifier/svm/NewtonSVM.cpp
@@ -91,7 +91,6 @@ void CNewtonSVM::iteration()
 		sgv = features->get_computed_dot_feature_vector(sv[k]);
 		sg_memcpy(&Xsv.matrix[k * x_d], sgv.data(), sizeof(float64_t) * (x_d));
 	}
-	Xsv = linalg::transpose_matrix(Xsv);
 
 	SGMatrix<float64_t> lcrossdiag(x_d + 1, x_d + 1);
 	SGVector<float64_t> vector(x_d + 1);
@@ -103,9 +102,9 @@ void CNewtonSVM::iteration()
 	SGMatrix<float64_t>::create_diagonal_matrix(
 	    lcrossdiag.data(), vector.data(), x_d + 1);
 	SGMatrix<float64_t> Xsv2(x_d, x_d);
-	linalg::matrix_prod(Xsv, Xsv, Xsv2, true);
+	linalg::matrix_prod(Xsv, Xsv, Xsv2, false, true);
 
-	SGVector<float64_t> sum = linalg::colwise_sum(Xsv);
+	SGVector<float64_t> sum = linalg::rowwise_sum(Xsv);
 
 	SGMatrix<float64_t> Xsv2sum(x_d + 1, x_d + 1);
 

--- a/src/shogun/lib/OpenCV/CV2SGFactory.h
+++ b/src/shogun/lib/OpenCV/CV2SGFactory.h
@@ -85,7 +85,7 @@ template<typename SG_T> SGMatrix<SG_T> CV2SGFactory::get_sgmatrix
 	const int inType=OpenCVTypeName<SG_T>::get_opencv_type();
 	cvMat.convertTo(cvMat,inType);
 	sg_memcpy(sgMat.matrix, cvMat.data, num_rows*num_cols*sizeof(SG_T));
-	SGMatrix<SG_T>::transpose_matrix(sgMat.matrix, num_cols, num_rows);
+	sgMat = linalg::transpose_matrix(sgMat);
 	return sgMat;
 }
 }

--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -363,24 +363,6 @@ T* SGMatrix<T>::clone_matrix(const T* matrix, int32_t nrows, int32_t ncols)
 }
 
 template <class T>
-void SGMatrix<T>::transpose_matrix(T*& matrix, int32_t& num_feat, int32_t& num_vec)
-{
-	/* this should be done in-place! Heiko */
-	T* transposed=SG_ALIGNED_MALLOC(
-		T, int64_t(num_vec)*num_feat, alignment::container_alignment);
-	for (int64_t i=0; i<num_vec; i++)
-	{
-		for (int64_t j=0; j<num_feat; j++)
-			transposed[i+j*num_vec]=matrix[i*num_feat+j];
-	}
-
-	SG_FREE(matrix);
-	matrix=transposed;
-
-	CMath::swap(num_feat, num_vec);
-}
-
-template <class T>
 void SGMatrix<T>::create_diagonal_matrix(T* matrix, T* v,int32_t size)
 {
 	/* Need assert v.size() */

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -329,10 +329,6 @@ template<class T> class SGMatrix : public SGReferencedData
 		/** Clone matrix */
 		static T* clone_matrix(const T* matrix, int32_t nrows, int32_t ncols);
 
-		/** Transpose matrix */
-		static void transpose_matrix(
-			T*& matrix, int32_t& num_feat, int32_t& num_vec);
-
 		/** Create diagonal matrix */
 		static void create_diagonal_matrix(T* matrix, T* v,int32_t size);
 

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -88,7 +88,8 @@ template<class T>
 SGVector<T>::SGVector(index_t len, bool ref_counting)
 : SGReferencedData(ref_counting), vlen(len), gpu_ptr(NULL)
 {
-	vector=SG_CALLOC(T, len);
+	vector=SG_ALIGNED_MALLOC(T, len, alignment::container_alignment);
+	std::fill_n(vector, len, 0);
 	m_on_gpu.store(false, std::memory_order_release);
 }
 
@@ -271,7 +272,7 @@ T* SGVector<T>::clone_vector(const T* vec, int32_t len)
 
 	REQUIRE(len > 0, "Number of elements (%d) has to be positive!\n", len);
 
-	T* result = SG_MALLOC(T, len);
+	T* result = SG_ALIGNED_MALLOC(T, len, alignment::container_alignment);
 	sg_memcpy(result, vec, sizeof(T)*len);
 	return result;
 }
@@ -887,7 +888,7 @@ void SGVector<T>::convert_to_matrix(T*& matrix, index_t nrows, index_t ncols, co
 
 	if (matrix!=NULL)
 		SG_FREE(matrix);
-	matrix=SG_MALLOC(T, nrows*ncols);
+	matrix=SG_ALIGNED_MALLOC(T, nrows*ncols, alignment::container_alignment);
 
 	if (fortran_order)
 	{

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -106,7 +106,7 @@ template<class T> class SGVector : public SGReferencedData
 			vlen(std::distance(beginIt, endIt)),
 			gpu_ptr(nullptr)
 		{
-			vector = SG_MALLOC(T, vlen);
+			vector = SG_ALIGNED_MALLOC(T, vlen, alignment::container_alignment);
 			std::copy(beginIt, endIt, vector);
 			m_on_gpu.store(false, std::memory_order_release);
 		}

--- a/src/shogun/lib/memory.h
+++ b/src/shogun/lib/memory.h
@@ -50,6 +50,8 @@ void operator delete(void *p, std::align_val_t al);
 void operator delete[](void *p, std::align_val_t al);
 #endif // HAVE_ALIGNED_NEW
 #define SG_ALIGNED_MALLOC(type, len, al) sg_aligned_malloc<type>(size_t(len), al)
+#else
+#define SG_ALIGNED_MALLOC(type, len, al) sg_generic_malloc<type>(size_t(len))
 #endif // HAVE_ALIGNED_MALLOC
 
 #define SG_MALLOC(type, len) sg_generic_malloc<type>(size_t(len))
@@ -130,6 +132,11 @@ T* sg_aligned_malloc(size_t len, size_t al)
 	return (T*) sg_aligned_malloc(sizeof(T)*len, al);
 }
 #endif // HAVE_ALIGNED_MALLOC
+
+namespace alignment
+{
+	static constexpr index_t container_alignment = 16;
+}
 
 void* get_copy(void* src, size_t len);
 char* get_strdup(const char* str);

--- a/src/shogun/lib/memory.h
+++ b/src/shogun/lib/memory.h
@@ -51,6 +51,11 @@ void operator delete[](void *p, std::align_val_t al);
 #endif // HAVE_ALIGNED_NEW
 #define SG_ALIGNED_MALLOC(type, len, al) sg_aligned_malloc<type>(size_t(len), al)
 #else
+#ifdef _MSC_VER
+#pragma message("Aligned malloc is not available")
+#elif defined(__GNUC__) || defined(__clang__)
+#warning "Aligned malloc is not available"
+#endif
 #define SG_ALIGNED_MALLOC(type, len, al) sg_generic_malloc<type>(size_t(len))
 #endif // HAVE_ALIGNED_MALLOC
 

--- a/src/shogun/mathematics/Statistics.cpp
+++ b/src/shogun/mathematics/Statistics.cpp
@@ -15,6 +15,7 @@
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/Statistics.h>
 #include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace Eigen;
 
@@ -731,7 +732,7 @@ SGMatrix<float64_t> CStatistics::sample_from_gaussian(SGVector<float64_t> mean,
 		s=ldlt.solve(s);
 	}
 
-	SGMatrix<float64_t>::transpose_matrix(S.matrix, S.num_rows, S.num_cols);
+	S = linalg::transpose_matrix(S);
 
 	if( !precision_matrix )
 	{
@@ -806,7 +807,7 @@ SGMatrix<float64_t> CStatistics::sample_from_gaussian(SGVector<float64_t> mean,
 	// permute the samples back with x=P^-1*xP
 	s=llt.permutationPinv()*s;
 
-	SGMatrix<float64_t>::transpose_matrix(S.matrix, S.num_rows, S.num_cols);
+	S = linalg::transpose_matrix(S);
 	// add the mean
 	Map<MatrixXd> x(S.matrix, S.num_rows, S.num_cols);
 	for( int32_t i=0; i<N; ++i )

--- a/tests/unit/mathematics/Statistics_unittest.cc
+++ b/tests/unit/mathematics/Statistics_unittest.cc
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <gtest/gtest.h>
 #include <shogun/mathematics/Math.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
 
 using namespace shogun;
 
@@ -160,7 +161,7 @@ TEST(Statistics, sample_from_gaussian_dense1)
 
 	// calculate the sample mean and covariance
 	SGVector<float64_t> s_mean=CStatistics::matrix_mean(samples);
-	SGMatrix<float64_t>::transpose_matrix(samples.matrix, samples.num_rows, samples.num_cols); // TODO: refactor sample_from_gaussian to return column vectors!
+	samples = linalg::transpose_matrix(samples); // TODO: refactor sample_from_gaussian to return column vectors!
 	SGMatrix<float64_t> s_cov=CStatistics::covariance_matrix(samples);
 	Map<MatrixXd> s_c(s_cov.matrix, s_cov.num_rows, s_cov.num_cols);
 	Map<VectorXd> s_mu(s_mean.vector, s_mean.vlen);
@@ -197,7 +198,7 @@ TEST(Statistics, sample_from_gaussian_dense2)
 
 	// calculate the sample mean and covariance
 	SGVector<float64_t> s_mean=CStatistics::matrix_mean(samples);
-	SGMatrix<float64_t>::transpose_matrix(samples.matrix, samples.num_rows, samples.num_cols); // TODO: refactor sample_from_gaussian to return column vectors!
+	samples = linalg::transpose_matrix(samples); // TODO: refactor sample_from_gaussian to return column vectors!
 	SGMatrix<float64_t> s_cov=CStatistics::covariance_matrix(samples);
 	Map<MatrixXd> s_c(s_cov.matrix, s_cov.num_rows, s_cov.num_cols);
 	Map<VectorXd> s_mu(s_mean.vector, s_mean.vlen);
@@ -259,7 +260,7 @@ TEST(Statistics, sample_from_gaussian_sparse1)
 
 	// calculate the sample mean and covariance
 	SGVector<float64_t> s_mean=CStatistics::matrix_mean(samples);
-	SGMatrix<float64_t>::transpose_matrix(samples.matrix, samples.num_rows, samples.num_cols); // TODO: refactor sample_from_gaussian to return column vectors!
+	samples = linalg::transpose_matrix(samples); // TODO: refactor sample_from_gaussian to return column vectors!
 	SGMatrix<float64_t> s_cov=CStatistics::covariance_matrix(samples);
 	Map<MatrixXd> s_c(s_cov.matrix, s_cov.num_rows, s_cov.num_cols);
 	Map<VectorXd> s_mu(s_mean.vector, s_mean.vlen);

--- a/tests/unit/mathematics/linalg/NormalSampler_unittest.cc
+++ b/tests/unit/mathematics/linalg/NormalSampler_unittest.cc
@@ -11,6 +11,8 @@
 #include <shogun/mathematics/Statistics.h>
 #include <shogun/mathematics/eigen3.h>
 #include <shogun/mathematics/linalg/ratapprox/tracesampler/NormalSampler.h>
+#include <shogun/mathematics/linalg/LinalgNamespace.h>
+
 
 using namespace shogun;
 using namespace Eigen;
@@ -33,7 +35,7 @@ TEST(NormalSampler, sample)
 	SGVector<float64_t> mean=CStatistics::matrix_mean(samples);
 	Map<VectorXd> map_mean(mean.vector, mean.vlen);
 	EXPECT_NEAR((map_mean-VectorXd::Zero(dimension)).norm(), 0.0, 0.1);
-	SGMatrix<float64_t>::transpose_matrix(samples.matrix, samples.num_rows, samples.num_cols); // TODO: refactor sample_from_gaussian to return column vectors!
+	samples = linalg::transpose_matrix(samples); // TODO: refactor sample_from_gaussian to return column vectors!
 	SGMatrix<float64_t> cov=CStatistics::covariance_matrix(samples);
 	Map<MatrixXd> map_cov(cov.matrix, cov.num_rows, cov.num_cols);
 	EXPECT_NEAR((map_cov-MatrixXd::Identity(dimension, dimension)).norm(),


### PR DESCRIPTION
@vigsterkr I made SG_ALIGNED_MALLOC reduce to SG_MALLOC if aligned malloc is not available, so as to not repeat the macroed if statement. But now SG_CALLOC is turned to aligned malloc followed by std::fill, so I'm not sure. 