### PR TITLE
option to set default parameter bitmask value

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -88,8 +88,10 @@ using stringToEnumMapType = std::unordered_map<std::string, std::unordered_map<s
 
 #define SG_ADD3(param, name, description)                                      \
 	{                                                                          \
+		auto pprop =                                                           \
+		    AnyParameterProperties(description, this->m_default_mask);         \
 		this->m_parameters->add(param, name, description);                     \
-		this->watch_param(name, param, AnyParameterProperties(description));   \
+		this->watch_param(name, param, pprop);                                 \
 	}
 
 #define SG_ADD4(param, name, description, param_properties)                    \
@@ -98,8 +100,10 @@ using stringToEnumMapType = std::unordered_map<std::string, std::unordered_map<s
 		    !static_cast<bool>((param_properties)&ParameterProperties::AUTO),  \
 		    "Expected a lambda when passing param with "                       \
 		    "ParameterProperty::AUTO");                                        \
+		auto mask = param_properties;                                          \
+		mask |= this->m_default_mask;                                          \
 		AnyParameterProperties pprop =                                         \
-		    AnyParameterProperties(description, param_properties);             \
+		    AnyParameterProperties(description, mask);                         \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(name, param, pprop);                                 \
 		if (pprop.has_property(ParameterProperties::HYPER))                    \
@@ -108,10 +112,13 @@ using stringToEnumMapType = std::unordered_map<std::string, std::unordered_map<s
 			this->m_gradient_parameters->add(param, name, description);        \
 	}
 
-#define SG_ADD5(param, name, description, param_properties, auto_or_constraint)\
+#define SG_ADD5(                                                               \
+    param, name, description, param_properties, auto_or_constraint)            \
 	{                                                                          \
+		auto mask = param_properties;                                          \
+		mask |= this->m_default_mask;                                          \
 		AnyParameterProperties pprop =                                         \
-		    AnyParameterProperties(description, param_properties);             \
+		    AnyParameterProperties(description, mask);                         \
 		this->m_parameters->add(param, name, description);                     \
 		this->watch_param(name, param, auto_or_constraint, pprop);             \
 		if (pprop.has_property(ParameterProperties::HYPER))                    \
@@ -1025,6 +1032,20 @@ protected:
 
 	/** Initialises all parameters with ParameterProperties::AUTO flag */
 	void init_auto_params();
+
+	/**
+	 * Set a default mask value that is added to any other mask
+	 * passed to watch_param. The default mask is by default
+	 * ParameterProperties::NONE.
+	 * @param mask the default mask
+	 */
+	void set_default_mask(ParameterProperties mask) noexcept
+	{
+		m_default_mask = mask;
+	}
+
+	/** The default mask for all registered parameters */
+	ParameterProperties m_default_mask = ParameterProperties::NONE;
 
 private:
 	void set_global_objects();

--- a/src/shogun/features/DenseFeatures.cpp
+++ b/src/shogun/features/DenseFeatures.cpp
@@ -606,8 +606,7 @@ template<class ST> void CDenseFeatures<ST>::init()
 	SG_ADD(&num_vectors, "num_vectors", "Number of vectors.");
 	SG_ADD(&num_features, "num_features", "Number of features.");
 	SG_ADD(&feature_matrix, "feature_matrix",
-			"Matrix of feature vectors / 1 vector per column.",
-			ParameterProperties::READONLY);
+			"Matrix of feature vectors / 1 vector per column.");
 }
 
 #define GET_FEATURE_TYPE(f_type, sg_type)	\

--- a/src/shogun/features/Features.cpp
+++ b/src/shogun/features/Features.cpp
@@ -52,6 +52,8 @@ CFeatures::~CFeatures()
 
 void CFeatures::init()
 {
+	set_default_mask(ParameterProperties::READONLY);
+
 	SG_ADD(&properties, "properties", "Feature properties");
 	SG_ADD(&cache_size, "cache_size", "Size of cache in MB");
 


### PR DESCRIPTION
@theartful @karlnapf this is how you could set the bitmask values for all parameters added via SG_ADD.
The issue is that there are also the watch_param methods... I think we really need the replacement from SG_ADD macro to a variadic method in SGObject, so we can add all this logic in one place.