### PR TITLE
Split RandomMixin into prng and seed classes

### DIFF
--- a/src/interfaces/swig/Distribution.i
+++ b/src/interfaces/swig/Distribution.i
@@ -26,6 +26,7 @@
 %include <shogun/distributions/Distribution.h>
 
 /** Instantiate RandomMixin */
+%template(SeedableDistribution) shogun::Seedable<shogun::CDistribution>;
 %template(RandomMixinDistribution) shogun::RandomMixin<shogun::CDistribution, std::mt19937_64>;
 
 %include <shogun/distributions/Histogram.h>

--- a/src/interfaces/swig/Features.i
+++ b/src/interfaces/swig/Features.i
@@ -364,6 +364,7 @@ namespace shogun
     %template(StreamingRealFeatures) CStreamingDenseFeatures<float64_t>;
 
     /** Instantiate RandomMixin */
+    %template(SeedableStreamingDense) shogun::Seedable<shogun::CStreamingDenseFeatures<float64_t>>;
     %template(RandomMixinStreamingDense) shogun::RandomMixin<shogun::CStreamingDenseFeatures<float64_t>, std::mt19937_64>;
 #endif
 }

--- a/src/interfaces/swig/Machine.i
+++ b/src/interfaces/swig/Machine.i
@@ -153,6 +153,7 @@ APPLY_LATENT(CLatentSVM);
 %include <shogun/machine/Machine.h>
 
 /** Instantiate RandomMixin */
+%template(SeedableMachine) shogun::Seedable<shogun::CMachine>;
 %template(RandomMixinMachine) shogun::RandomMixin<shogun::CMachine, std::mt19937_64>;
 
 %include <shogun/machine/Pipeline.h>

--- a/src/interfaces/swig/Multiclass.i
+++ b/src/interfaces/swig/Multiclass.i
@@ -79,6 +79,7 @@ namespace shogun
     %template(TreeMachineWithCHAIDTreeNodeData) CTreeMachine<CHAIDTreeNodeData>;
 
     /** Instantiate RandomMixin */
+    %template(SeedableTreeMachine) shogun::Seedable<CTreeMachine<CARTreeNodeData>>;
     %template(RandomMixinTreeMachine) RandomMixin<CTreeMachine<CARTreeNodeData>, std::mt19937_64>;
 }
 

--- a/src/interfaces/swig/RandomMixin.i
+++ b/src/interfaces/swig/RandomMixin.i
@@ -1,5 +1,7 @@
 %{
+ #include <shogun/mathematics/Seedable.h>
  #include <shogun/mathematics/RandomMixin.h>
 %}
 
+%include <shogun/mathematics/Seedable.h>
 %include <shogun/mathematics/RandomMixin.h>

--- a/src/interfaces/swig/SGBase.i
+++ b/src/interfaces/swig/SGBase.i
@@ -334,6 +334,7 @@ namespace std {
 %include <shogun/base/SGObject.h>
 
 /** Instantiate RandomMixin */
+%template(SeedableSGObject) shogun::Seedable<shogun::CSGObject>;
 %template(RandomMixinSGObject) shogun::RandomMixin<shogun::CSGObject, std::mt19937_64>;
 
 %include <shogun/io/SGIO.h>

--- a/src/interfaces/swig/Statistics.i
+++ b/src/interfaces/swig/Statistics.i
@@ -32,6 +32,7 @@
 %include <shogun/statistical_testing/TwoSampleTest.h>
 
 /** Instantiate RandomMixin */
+%template(SeedableTwoSampleTest) shogun::Seedable<shogun::CTwoSampleTest>;
 %template(RandomMixinTwoSampleTest) shogun::RandomMixin<shogun::CTwoSampleTest, std::mt19937_64>;
 
 %include <shogun/statistical_testing/MMD.h>

--- a/src/interfaces/swig/Structure.i
+++ b/src/interfaces/swig/Structure.i
@@ -105,6 +105,7 @@
 %include <shogun/machine/LinearStructuredOutputMachine.h>
 
 /** Instantiate RandomMixin */
+%template(SeedableLinearStructured) shogun::Seedable<shogun::CLinearStructuredOutputMachine>;
 %template(RandomMixinLinearStructured) shogun::RandomMixin<shogun::CLinearStructuredOutputMachine, std::mt19937_64>;
 
 %include <shogun/machine/KernelStructuredOutputMachine.h>

--- a/src/shogun/evaluation/CrossValidation.cpp
+++ b/src/shogun/evaluation/CrossValidation.cpp
@@ -20,7 +20,7 @@
 
 using namespace shogun;
 
-CCrossValidation::CCrossValidation() : RandomMixin<CMachineEvaluation>()
+CCrossValidation::CCrossValidation() : Seedable<CMachineEvaluation>()
 {
 	init();
 }
@@ -28,7 +28,7 @@ CCrossValidation::CCrossValidation() : RandomMixin<CMachineEvaluation>()
 CCrossValidation::CCrossValidation(
     CMachine* machine, CFeatures* features, CLabels* labels,
     CSplittingStrategy* splitting_strategy, CEvaluation* evaluation_criterion)
-    : RandomMixin<CMachineEvaluation>(
+    : Seedable<CMachineEvaluation>(
           machine, features, labels, splitting_strategy, evaluation_criterion)
 {
 	init();
@@ -37,7 +37,7 @@ CCrossValidation::CCrossValidation(
 CCrossValidation::CCrossValidation(
     CMachine* machine, CLabels* labels, CSplittingStrategy* splitting_strategy,
     CEvaluation* evaluation_criterion)
-    : RandomMixin<CMachineEvaluation>(
+    : Seedable<CMachineEvaluation>(
           machine, labels, splitting_strategy, evaluation_criterion)
 {
 	init();

--- a/src/shogun/evaluation/CrossValidation.h
+++ b/src/shogun/evaluation/CrossValidation.h
@@ -13,7 +13,7 @@
 
 #include <shogun/evaluation/EvaluationResult.h>
 #include <shogun/evaluation/MachineEvaluation.h>
-#include <shogun/mathematics/RandomMixin.h>
+#include <shogun/mathematics/Seedable.h>
 
 namespace shogun
 {
@@ -123,7 +123,7 @@ namespace shogun
 	 * HP Laboratories.] for details on this subject.
 	 *
 	 */
-	class CCrossValidation : public RandomMixin<CMachineEvaluation>
+	class CCrossValidation : public Seedable<CMachineEvaluation>
 	{
 	public:
 		/** constructor */

--- a/src/shogun/mathematics/Seedable.h
+++ b/src/shogun/mathematics/Seedable.h
@@ -1,0 +1,77 @@
+#ifndef __SEEDABLE_H__
+#define __SEEDABLE_H__
+
+#include <shogun/base/SGObject.h>
+#include <shogun/lib/common.h>
+
+#include <functional>
+
+namespace shogun
+{
+	namespace random
+	{
+		/** Seeds an SGObject using a specific seed
+		 */
+		template <
+		    typename T, typename PRNG,
+		    std::enable_if_t<std::is_base_of<
+		        CSGObject, typename std::remove_pointer<T>::type>::value>* =
+		        nullptr>
+		static inline void seed(T* object, int32_t seed)
+		{
+			if (object->has("seed"))
+				object->put("seed", seed);
+		}
+	} // namespace random
+
+	static inline void seed_callback(CSGObject*, int32_t);
+
+	template <typename Parent>
+	class Seedable : public Parent
+	{
+	public:
+		template <typename... T>
+		Seedable(T... args) : Parent(args...)
+		{
+			init();
+		}
+
+	private:
+		void init()
+		{
+			Parent::watch_param("seed", &m_seed);
+			Parent::add_callback_function(
+			    "seed", std::bind(seed_callback, this, std::ref(m_seed)));
+		}
+
+	protected:
+		/** Seeds an SGObject using the current object seed
+		 * This is intended to seed non-parameter SGObjects created inside
+		 * methods
+		 */
+		template <
+		    typename T,
+		    std::enable_if_t<std::is_base_of<
+		        CSGObject, typename std::remove_pointer<T>::type>::value>* =
+		        nullptr>
+		inline void seed(T* object) const
+		{
+			random::seed(object, m_seed);
+		}
+
+		int32_t m_seed;
+	};
+
+	static inline void seed_callback(CSGObject* obj, int32_t seed)
+	{
+		obj->for_each_param_of_type<CSGObject*>(
+		    [&](const std::string& name, CSGObject** param) {
+			    if ((*param)->has("seed"))
+				    (*param)->put("seed", seed);
+			    else
+				    seed_callback(*param, seed);
+		    });
+	}
+} // namespace shogun
+
+#endif // __SEEDABLE_H__


### PR DESCRIPTION
This has the artifact that if a parent class has the Seedable mixin, a derived class can't have RandomMixin (seed will be registered twice). It can be solved using SFINAE
```
RandomMixin : public Parent (if parent has Seedable)
RandomMixin : public Seedable<Parent> (if parent doesn't have Seedable)
```
but I'm not sure it's worth it, as it would complicate swig. 