### PR TITLE
Ignore GPU backend when user doesn't compile with viennacl

### DIFF
--- a/src/shogun/lib/SGMatrix.cpp
+++ b/src/shogun/lib/SGMatrix.cpp
@@ -38,7 +38,9 @@ SGMatrix<T>::SGMatrix(T* m, index_t nrows, index_t ncols, bool ref_counting)
 	: SGReferencedData(ref_counting), matrix(m),
 	num_rows(nrows), num_cols(ncols), gpu_ptr(nullptr)
 {
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -46,7 +48,9 @@ SGMatrix<T>::SGMatrix(T* m, index_t nrows, index_t ncols, index_t offset)
 	: SGReferencedData(false), matrix(m+offset),
 	num_rows(nrows), num_cols(ncols)
 {
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -56,7 +60,9 @@ SGMatrix<T>::SGMatrix(index_t nrows, index_t ncols, bool ref_counting)
 	matrix=SG_ALIGNED_MALLOC(
 		T, ((int64_t) nrows)*ncols, alignment::container_alignment);
 	std::fill_n(matrix, ((int64_t) nrows)*ncols, 0);
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -67,7 +73,9 @@ SGMatrix<T>::SGMatrix(SGVector<T> vec) : SGReferencedData(vec)
 	num_rows=vec.vlen;
 	num_cols=1;
 	gpu_ptr = vec.gpu_ptr;
-	m_on_gpu.store(vec.on_gpu(), std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(vec.on_gpu(), std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -85,7 +93,9 @@ SGMatrix<T>::SGMatrix(SGVector<T> vec, index_t nrows, index_t ncols)
 	num_rows=nrows;
 	num_cols=ncols;
 	gpu_ptr = vec.gpu_ptr;
-	m_on_gpu.store(vec.on_gpu(), std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(vec.on_gpu(), std::memory_order_release);
+#endif
 }
 
 template<class T>
@@ -93,7 +103,9 @@ SGMatrix<T>::SGMatrix(GPUMemoryBase<T>* mat, index_t nrows, index_t ncols)
 	: SGReferencedData(true), matrix(NULL), num_rows(nrows), num_cols(ncols),
 	gpu_ptr(std::shared_ptr<GPUMemoryBase<T>>(mat))
 {
-	m_on_gpu.store(true, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(true, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -107,7 +119,9 @@ SGMatrix<T>::SGMatrix(EigenMatrixXt& mat)
 : SGReferencedData(false), matrix(mat.data()),
 	num_rows(mat.rows()), num_cols(mat.cols()), gpu_ptr(nullptr)
 {
+#ifdef HAVE_VIENNACL
 	m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -118,7 +132,9 @@ SGMatrix<T>::SGMatrix(const std::initializer_list<std::initializer_list<T>>& lis
 	gpu_ptr(nullptr)
 {
 	matrix = SG_CALLOC(T, ((int64_t) num_rows)*num_cols);
+#ifdef HAVE_VIENNACL
 	m_on_gpu.store(false, std::memory_order_release);
+#endif
 	int64_t curr_pos = 0;
 	for (const auto& r: list)
 		for (const auto& c: r)
@@ -889,8 +905,10 @@ void SGMatrix<T>::copy_data(const SGReferencedData &orig)
 	matrix=((SGMatrix*)(&orig))->matrix;
 	num_rows=((SGMatrix*)(&orig))->num_rows;
 	num_cols=((SGMatrix*)(&orig))->num_cols;
-	m_on_gpu.store(((SGMatrix*)(&orig))->m_on_gpu.load(
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(((SGMatrix*)(&orig))->m_on_gpu.load(
 		std::memory_order_acquire), std::memory_order_release);
+#endif
 }
 
 template<class T>
@@ -900,7 +918,9 @@ void SGMatrix<T>::init_data()
 	num_rows=0;
 	num_cols=0;
 	gpu_ptr=nullptr;
+#ifdef HAVE_VIENNACL
 	m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template<class T>

--- a/src/shogun/lib/SGMatrix.h
+++ b/src/shogun/lib/SGMatrix.h
@@ -83,7 +83,11 @@ template<class T> class SGMatrix : public SGReferencedData
 #endif
 		bool on_gpu() const
 		{
+#ifdef HAVE_VIENNACL
 			return gpu_ptr != NULL;
+#else
+			return false;
+#endif
 		}
 
 #ifndef SWIG // SWIG should skip this part
@@ -481,9 +485,10 @@ template<class T> class SGMatrix : public SGReferencedData
 		virtual void free_data();
 
   private:
+#ifdef HAVE_VIENNACL
 		/** Atomic variable of vector on_gpu status */
 		std::atomic<bool> m_on_gpu;
-
+#endif
 		/** Assert whether the data is on GPU
 		 * and raise error if the data is on GPU
 		 */

--- a/src/shogun/lib/SGVector.cpp
+++ b/src/shogun/lib/SGVector.cpp
@@ -74,14 +74,18 @@ template<class T>
 SGVector<T>::SGVector(T* v, index_t len, bool ref_counting)
 : SGReferencedData(ref_counting), vector(v), vlen(len), gpu_ptr(NULL)
 {
+#ifdef HAVE_VIENNACL
 	m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template<class T>
 SGVector<T>::SGVector(T* m, index_t len, index_t offset)
 : SGReferencedData(false), vector(m+offset), vlen(len)
 {
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template<class T>
@@ -90,7 +94,9 @@ SGVector<T>::SGVector(index_t len, bool ref_counting)
 {
 	vector=SG_ALIGNED_MALLOC(T, len, alignment::container_alignment);
 	std::fill_n(vector, len, 0);
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -100,7 +106,9 @@ SGVector<T>::SGVector(SGMatrix<T> matrix)
 {
 	ASSERT(!matrix.on_gpu())
 	vector = matrix.data();
+#ifdef HAVE_VIENNACL
 	m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -108,7 +116,9 @@ SGVector<T>::SGVector(GPUMemoryBase<T>* gpu_vector, index_t len)
 	: SGReferencedData(true), vector(NULL), vlen(len),
 	  gpu_ptr(std::shared_ptr<GPUMemoryBase<T>>(gpu_vector))
 {
-	m_on_gpu.store(true, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(true, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -152,14 +162,18 @@ template <class T>
 SGVector<T>::SGVector(EigenVectorXt& vec)
 : SGReferencedData(false), vector(vec.data()), vlen(vec.size()), gpu_ptr(NULL)
 {
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
 SGVector<T>::SGVector(EigenRowVectorXt& vec)
 : SGReferencedData(false), vector(vec.data()), vlen(vec.size()), gpu_ptr(NULL)
 {
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template <class T>
@@ -371,8 +385,10 @@ void SGVector<T>::copy_data(const SGReferencedData &orig)
 	gpu_ptr=std::shared_ptr<GPUMemoryBase<T>>(((SGVector*)(&orig))->gpu_ptr);
 	vector=((SGVector*)(&orig))->vector;
 	vlen=((SGVector*)(&orig))->vlen;
-	m_on_gpu.store(((SGVector*)(&orig))->m_on_gpu.load(
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(((SGVector*)(&orig))->m_on_gpu.load(
 		std::memory_order_acquire), std::memory_order_release);
+#endif
 }
 
 template<class T>
@@ -381,7 +397,9 @@ void SGVector<T>::init_data()
 	vector=NULL;
 	vlen=0;
 	gpu_ptr=NULL;
-	m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+    m_on_gpu.store(false, std::memory_order_release);
+#endif
 }
 
 template<class T>

--- a/src/shogun/lib/SGVector.h
+++ b/src/shogun/lib/SGVector.h
@@ -90,7 +90,11 @@ template<class T> class SGVector : public SGReferencedData
 #endif
 		bool on_gpu() const
 		{
+#ifdef HAVE_VIENNACL
 			return gpu_ptr != NULL;
+#else
+			return false;
+#endif
 		}
 
 #ifndef SWIG // SWIG should skip this part
@@ -107,7 +111,9 @@ template<class T> class SGVector : public SGReferencedData
 		{
 			vector = SG_ALIGNED_MALLOC(T, vlen, alignment::container_alignment);
 			std::copy(beginIt, endIt, vector);
-			m_on_gpu.store(false, std::memory_order_release);
+#ifdef HAVE_VIENNACL
+            m_on_gpu.store(false, std::memory_order_release);
+#endif
 		}
 
 		/** Construct SGVector from initializer list */
@@ -588,8 +594,10 @@ template<class T> class SGVector : public SGReferencedData
 		virtual void free_data();
 
 	private:
+#ifdef HAVE_VIENNACL
 		/** Atomic variable of vector on_gpu status */
 		std::atomic<bool> m_on_gpu;
+#endif
 
 		/** Assert whether the data is on GPU
 		 * and raise error if the data is on GPU
@@ -599,8 +607,10 @@ template<class T> class SGVector : public SGReferencedData
 #endif
 		void assert_on_cpu() const
 		{
-			if (on_gpu())
+#ifdef HAVE_VIENNACL
+            if (on_gpu())
 				error("Direct memory access not possible when data is in GPU memory.");
+#endif
 		}
 
 	public:

--- a/src/shogun/mathematics/linalg/LinalgNamespace.h
+++ b/src/shogun/mathematics/linalg/LinalgNamespace.h
@@ -54,6 +54,7 @@ namespace shogun
 		LinalgBackendBase* infer_backend(const Container<T>& a)
 		{
 			auto sg_linalg = env()->linalg();
+#ifdef HAVE_VIENNACL
 			if (a.on_gpu())
 			{
 				if (sg_linalg->get_gpu_backend())
@@ -69,6 +70,9 @@ namespace shogun
 			}
 			else
 				return sg_linalg->get_cpu_backend();
+#else
+			return sg_linalg->get_cpu_backend();
+#endif
 		}
 
 		/** Infer the appropriate backend for linalg operations
@@ -84,7 +88,8 @@ namespace shogun
 		infer_backend(const Container<T>& a, const Container<U>& b)
 		{
 			auto sg_linalg = env()->linalg();
-			if (a.on_gpu() && b.on_gpu())
+#ifdef HAVE_VIENNACL
+            if (a.on_gpu() && b.on_gpu())
 			{
 				if (sg_linalg->get_gpu_backend())
 					return sg_linalg->get_gpu_backend();
@@ -107,6 +112,9 @@ namespace shogun
 			}
 			else
 				return sg_linalg->get_cpu_backend();
+#else
+            return sg_linalg->get_cpu_backend();
+#endif
 		}
 
 		/** Infer the appropriate backend for linalg operations
@@ -123,6 +131,7 @@ namespace shogun
 		    const Container<T>& a, const Container<T>& b, const Container<T>& c)
 		{
 			auto sg_linalg = env()->linalg();
+#ifdef HAVE_VIENNACL
 			if (a.on_gpu() && b.on_gpu() && c.on_gpu())
 			{
 				if (sg_linalg->get_gpu_backend())
@@ -147,6 +156,9 @@ namespace shogun
 			}
 			else
 				return sg_linalg->get_cpu_backend();
+#else
+			return sg_linalg->get_cpu_backend();
+#endif
 		}
 
 		/**


### PR DESCRIPTION
This PR removes GPU backend checks when users don't compile shogun with viennacl and therefore can't use the GPU at any point at runtime
You shouldn't pay for what you don't use, but right now:
- every linalg operation checks if memory of the containers is on the GPU
- each copy (and eventually move) of a container checks if memory is on the GPU. This is an atomic operation so is unnecessarily costly imo.. 