### PR TITLE
fix string representation

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -671,7 +671,7 @@ std::string CSGObject::to_string() const
 		}
 		if (std::next(it) != (self->map.end()))
 		{
-			ss << ",";
+			ss << ", ";
 		}
 	}
 	ss << ")";

--- a/src/shogun/io/visitors/ToStringVisitor.cpp
+++ b/src/shogun/io/visitors/ToStringVisitor.cpp
@@ -10,59 +10,59 @@
 using namespace shogun;
 
 void ToStringVisitor::on(bool *v) {
-	stream() << (*v ? "true" : "false") << " ";
+	stream() << (*v ? "true" : "false");
 }
 
 void ToStringVisitor::on(int32_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(int64_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(int8_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(int16_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(std::string *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(CSGObject **v) {
 	if (*v) {
 		stream() << (*v)->get_name() << "(...) ";
 	} else {
-		stream() << "null ";
+		stream() << "null";
 	}
 }
 
 void ToStringVisitor::on(char *string) {
-	stream() << *string << " ";
+	stream() << *string;
 }
 
 void ToStringVisitor::on(uint8_t *uint8) {
-	stream() << *uint8 << " ";
+	stream() << *uint8;
 }
 
 void ToStringVisitor::on(uint16_t *uint16) {
-	stream() << *uint16 << " ";
+	stream() << *uint16;
 }
 
 void ToStringVisitor::on(uint32_t *uint32) {
-	stream() << *uint32 << " ";
+	stream() << *uint32;
 }
 
 void ToStringVisitor::on(uint64_t *uint64) {
-	stream() << *uint64 << " ";
+	stream() << *uint64;
 }
 
 void ToStringVisitor::on(complex128_t *complex128) {
-	stream() << *complex128 << " ";
+	stream() << *complex128;
 }
 
 void ToStringVisitor::enter_matrix(index_t *rows, index_t *cols) {
@@ -82,15 +82,15 @@ void ToStringVisitor::enter_map(size_t *size) {
 }
 
 void ToStringVisitor::on(float32_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(float64_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::on(floatmax_t *v) {
-	stream() << *v << " ";
+	stream() << *v;
 }
 
 void ToStringVisitor::exit_matrix(index_t *rows, index_t *cols) {


### PR DESCRIPTION
imo it makes more sense to have the space after the comma rather than before, like this:
```python
LibSVM(C1=1, C2=1, epsilon=1e-05, kernel=null, labels=null, libsvm_solver_type=LIBSVM_C_SVC, 
linear_term=Vector<0>( ), m_alpha=Vector<0>( ), m_bias=0, m_svs=Vector<0>( ), max_train_time=0,
 mkl=null, nu=0.5, num_subscriptions={function}, objective=0, qpsize=41, solver_type=ST_AUTO,
 svm_loaded=false, tube_epsilon=0.01, use_batch_computation=true, use_bias=true,
 use_linadd=true, use_shrinking=true)
```