### PR TITLE
safe visitable

### DIFF
--- a/src/shogun/base/SGObject.cpp
+++ b/src/shogun/base/SGObject.cpp
@@ -669,16 +669,9 @@ std::string CSGObject::to_string() const
 		{
 			ss << string_enum_reverse_lookup(it->first.name(), any_cast<machine_int_t>(value));
 		}
-		else if (value.visitable())
+		else if (value.safe_visitable())
 		{
-			try
-			{
-				value.visit(visitor.get());
-			}
-			catch(...)
-			{
-				ss << "null";
-			}
+			value.visit(visitor.get());
 		}
 		else
 		{
@@ -779,8 +772,7 @@ void CSGObject::for_each_param_of_type(
 
 	std::for_each(param_map.begin(), param_map.end(), [&](auto& pair) {
 		Any any_param = pair.second.get_value();
-		// functions aren't cloneable, but are visitable
-		if (any_param.cloneable())
+		if (any_param.safe_visitable())
 		{
 			const std::string name = pair.first.name();
 			visitor->set_name(name);

--- a/src/shogun/lib/any.cpp
+++ b/src/shogun/lib/any.cpp
@@ -164,6 +164,12 @@ namespace shogun
 		return !policy->is_functional() || (policy->is_functional() && !policy->is_void());
 	}
 
+	bool Any::safe_visitable() const
+	{
+		const bool is_safe = policy->is_functional() ? policy->is_nothrow() : true;
+		return visitable() && is_safe;
+	}
+
 	bool Any::hashable() const
 	{
 		return !policy->is_functional();

--- a/src/shogun/lib/any.h
+++ b/src/shogun/lib/any.h
@@ -790,6 +790,8 @@ namespace shogun
 
 		virtual bool is_void() const = 0;
 
+		virtual bool is_nothrow() const = 0;
+
 		virtual size_t hash(void* storage) const = 0;
 	};
 
@@ -832,6 +834,13 @@ namespace shogun
 			if constexpr (traits::is_functional<T>::value)
 				return std::is_same_v<typename T::result_type, void>;
 			return std::is_same_v<T, void>;
+		}
+
+		virtual bool is_nothrow() const override
+		{
+			if constexpr (traits::is_functional<T>::value)
+				return std::is_nothrow_invocable_v<T>;
+			return true;
 		}
 	};
 
@@ -1145,6 +1154,11 @@ namespace shogun
 
 		/** @return true if Any object is visitable. */
 		bool visitable() const;
+
+		/** @return true if Any object is safely visitable, i.e.
+		  * does not throw an exception
+		  */
+		bool safe_visitable() const;
 
 		/** @return true if Any object is comparable. */
 		bool comparable() const;


### PR DESCRIPTION
this doesn't change anything, just introduces the concept of something being safely visitable. For example a function can throw, so it might not always be a good idea to visit it.

Currently C++ doesn't have std::function<T() noexcept> but one day it might, and then we could actually have safe visitable functions where no error can be thrown. Or maybe we can think of some hack around this.