### PR TITLE
Rearrange operations to adhere to documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ IF(POLICY CMP0054)
 	SET(CMAKE_POLICY_DEFAULT_CMP0054 NEW)
 ENDIF(POLICY CMP0054)
 
-project(shogun)
 cmake_minimum_required(VERSION 3.8)
+project(shogun)
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 include(ShogunUtils)
 


### PR DESCRIPTION
fixes #4776

[The documentation of cmake_minimum_required](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) says:

> Note: Call the cmake_minimum_required() command at the beginning of the top-level CMakeLists.txt file even before calling the project() command. It is important to establish version and policy settings before invoking other commands whose behavior they may affect. See also policy CMP0000.