### PR TITLE
python style enumerate

### DIFF
--- a/src/shogun/solver/LDASolver.h
+++ b/src/shogun/solver/LDASolver.h
@@ -38,7 +38,7 @@
 #include <shogun/labels/MulticlassLabels.h>
 #include <shogun/lib/config.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
-#include <shogun/util/zip_iterator.h>
+#include <shogun/util/enumerate.h>
 #include <vector>
 
 namespace shogun
@@ -144,14 +144,12 @@ namespace shogun
 		    SGMatrix<T>(num_features, m_features->get_num_vectors());
 
 		// Center data with respect to each data point's class
-		size_t counter = 0;
-		for (const auto& [data_i, label_i] : zip_iterator(m_features, m_labels))
+		for (const auto& [idx, data_i, label_i] : enumerate(m_features, m_labels))
 		{
 			mean_matrix.set_column(
-			    counter, linalg::add(
+			    idx, linalg::add(
 			                 m_class_mean.at(label_i), data_i,
 			                 static_cast<T>(1), static_cast<T>(-1)));
-			++counter;
 		}
 		// holds the feature matrix for each class
 		std::vector<SGMatrix<T>> centered_class(num_class);
@@ -164,14 +162,12 @@ namespace shogun
 			centered_class[i] = SGMatrix<T>(num_features, m_class_count[i]);
 			linalg::zero(centered_class[i]);
 		}
-		counter = 0;
-		for (const auto& label_i : *m_labels)
+		for (const auto& [idx, label_i] : enumerate(*m_labels))
 		{
 			auto c = static_cast<index_t>(label_i);
 			centered_class[c].set_column(
-			    centered_class_col[c], mean_matrix.get_column(counter));
+			    centered_class_col[c], mean_matrix.get_column(idx));
 			++centered_class_col[c];
-			++counter;
 		}
 		for (index_t i = 0; i < num_class; ++i)
 		{

--- a/src/shogun/util/ZipIterator_benchmark.cc
+++ b/src/shogun/util/ZipIterator_benchmark.cc
@@ -6,8 +6,7 @@
 
 #include <benchmark/benchmark.h>
 #include <shogun/lib/SGMatrix.h>
-#include <shogun/util/zip_iterator.h>
-#include <shogun/base/range.h>
+#include <shogun/util/enumerate.h>
 
 #include <random>
 #include <iostream>
@@ -57,8 +56,7 @@ void BM_with_zip_iterator(benchmark::State& state)
         const SGMatrix<float64_t> mat2 = createRandomData(state);
 
         auto result = SGMatrix<float64_t>(state.range(0), state.range(0));
-        const auto range_iterator = range(mat1.size());
-        for (const auto& [idx, el1, el2]: zip_iterator(range_iterator, mat1, mat2))
+        for (const auto& [idx, el1, el2]: enumerate(mat1, mat2))
     		result[idx] = el1 * el2;
 	}
 }

--- a/src/shogun/util/enumerate.h
+++ b/src/shogun/util/enumerate.h
@@ -1,0 +1,76 @@
+#include <shogun/util/zip_iterator.h>
+#include <shogun/base/range.h>
+
+
+namespace shogun {
+
+	template <typename... Args>
+	IGNORE_IN_CLASSLIST class enumerate
+	{
+	public:
+
+		enumerate(Args&... args) : m_container_tuples(args...)
+		{
+		}
+
+		template <typename... IteratorTypes>
+		IGNORE_IN_CLASSLIST class Enumerate: public zip_iterator_detail::ZipIteratorBase<Enumerate<IteratorTypes...>, IteratorTypes...>
+		{
+		public:
+			using iterator_category = std::forward_iterator_tag;
+
+
+			Enumerate(std::tuple<IteratorTypes...>&& iterators)
+			    : zip_iterator_detail::ZipIteratorBase<Enumerate<IteratorTypes...>, IteratorTypes...>(std::move(iterators)), m_index(0)
+			{
+			}
+
+			Enumerate<IteratorTypes...>& operator++()
+			{
+				zip_iterator_detail::increment_iterators(
+				    this->m_iterators_tuple,
+				    std::index_sequence_for<IteratorTypes...>{});
+				m_index++;
+				return *this;
+			}
+
+			const Enumerate<IteratorTypes...> operator++(int)
+			{
+				Enumerate<IteratorTypes...> retval(this);
+				++(this);
+				return retval;
+			}
+
+			auto operator*()
+			{
+				return std::tuple_cat(std::make_tuple(m_index), zip_iterator_detail::dereference_iterators(
+				    this->m_iterators_tuple,
+				    std::index_sequence_for<IteratorTypes...>{}));
+			}
+
+		private:
+			size_t m_index;
+		};
+
+#ifdef __clang__
+		template <typename... IteratorTypes>
+		Enumerate(std::tuple<IteratorTypes...>)
+		    ->Enumerate<IteratorTypes...>;
+#endif
+
+		auto begin() const
+		{
+			return Enumerate(zip_iterator_detail::containers_begin(
+			    m_container_tuples, std::index_sequence_for<Args...>{}));
+		}
+
+		auto end() const
+		{
+			return Enumerate(zip_iterator_detail::containers_end(
+			    m_container_tuples, std::index_sequence_for<Args...>{}));
+		}
+
+	private:
+		std::tuple<Args&...> m_container_tuples;
+	};
+}

--- a/src/shogun/util/zip_iterator.h
+++ b/src/shogun/util/zip_iterator.h
@@ -22,7 +22,7 @@ namespace shogun
 		    const std::tuple<Args2...>& iterators2, std::index_sequence<Idx...>)
 		{
 			return (
-			    (std::get<Idx>(iterators1) == std::get<Idx>(iterators2)) &&
+			    (std::get<Idx>(iterators1) == std::get<Idx>(iterators2)) ||
 			    ...);
 		}
 
@@ -87,6 +87,7 @@ namespace shogun
 		public:
 			using iterator_category = std::forward_iterator_tag;
 
+			virtual ~ZipIteratorBase() {}
 
 			ZipIteratorBase(std::tuple<IteratorTypes...>&& iterators)
 			    : m_iterators_tuple(std::move(iterators))
@@ -142,8 +143,6 @@ namespace shogun
 			    : zip_iterator_detail::ZipIteratorBase<ZipIterator<IteratorTypes...>, IteratorTypes...>(std::move(iterators))
 			{
 			}
-
-			virtual ~ZipIterator() {}
 
 			auto operator*()
 			{

--- a/src/shogun/util/zip_iterator.h
+++ b/src/shogun/util/zip_iterator.h
@@ -10,6 +10,8 @@
 #include <shogun/base/macros.h>
 #include <tuple>
 
+#define IGNORE_IN_CLASSLIST
+
 namespace shogun
 {
 	namespace zip_iterator_detail
@@ -78,9 +80,54 @@ namespace shogun
 		{
 			return std::make_tuple((get_end(std::get<Idx>(container)))...);
 		}
+
+		template <typename Derived, typename... IteratorTypes>
+		IGNORE_IN_CLASSLIST class ZipIteratorBase
+		{
+		public:
+			using iterator_category = std::forward_iterator_tag;
+
+
+			ZipIteratorBase(std::tuple<IteratorTypes...>&& iterators)
+			    : m_iterators_tuple(std::move(iterators))
+			{
+			}
+
+			Derived& operator++()
+			{
+				return static_cast<Derived*>(this)->operator++();
+			}
+
+			const Derived operator++(int)
+			{
+				return static_cast<Derived*>(this)->operator++(int{});
+			}
+
+			auto operator*()
+			{
+				return static_cast<Derived*>(this)->operator*();
+			}
+
+			bool operator==(const ZipIteratorBase& other) const
+			{
+				return iterators_equal(
+				    m_iterators_tuple, other.m_iterators_tuple,
+				    std::index_sequence_for<IteratorTypes...>{});
+			}
+
+			bool operator!=(const ZipIteratorBase& other) const
+			{
+				return !(*this == other);
+			}
+
+		protected:
+			std::tuple<IteratorTypes...> m_iterators_tuple;
+		};	
+
 	} // namespace zip_iterator_detail
+
 	template <typename... Args>
-	class zip_iterator
+	IGNORE_IN_CLASSLIST class zip_iterator
 	{
 	public:
 		zip_iterator(Args&... args) : m_container_tuples(args...)
@@ -88,54 +135,39 @@ namespace shogun
 		}
 
 		template <typename... IteratorTypes>
-		class ZipIterator
+		IGNORE_IN_CLASSLIST class ZipIterator: public zip_iterator_detail::ZipIteratorBase<ZipIterator<IteratorTypes...>, IteratorTypes...>
 		{
 		public:
-			using iterator_category = std::forward_iterator_tag;
-
-
 			ZipIterator(std::tuple<IteratorTypes...>&& iterators)
-			    : m_iterators_tuple(std::move(iterators))
+			    : zip_iterator_detail::ZipIteratorBase<ZipIterator<IteratorTypes...>, IteratorTypes...>(std::move(iterators))
 			{
 			}
 
-			ZipIterator<IteratorTypes...>& operator++()
-			{
-				zip_iterator_detail::increment_iterators(
-				    m_iterators_tuple,
-				    std::index_sequence_for<IteratorTypes...>{});
-				return *this;
-			}
-
-			const ZipIterator<IteratorTypes...> operator++(int)
-			{
-				ZipIterator<IteratorTypes...> retval(this);
-				++(this);
-				return retval;
-			}
+			virtual ~ZipIterator() {}
 
 			auto operator*()
 			{
 				return zip_iterator_detail::dereference_iterators(
-				    m_iterators_tuple,
+				    this->m_iterators_tuple,
 				    std::index_sequence_for<IteratorTypes...>{});
 			}
 
-			bool operator==(const ZipIterator& other) const
+			ZipIterator& operator++()
 			{
-				return zip_iterator_detail::iterators_equal(
-				    m_iterators_tuple, other.m_iterators_tuple,
+				zip_iterator_detail::increment_iterators(
+				    this->m_iterators_tuple,
 				    std::index_sequence_for<IteratorTypes...>{});
+				return *this;
 			}
 
-			bool operator!=(const ZipIterator& other) const
+			const ZipIterator operator++(int)
 			{
-				return !(*this == other);
+				ZipIterator retval(this);
+				++(this);
+				return retval;
 			}
-
-		private:
-			std::tuple<IteratorTypes...> m_iterators_tuple;
 		};
+
 
 		// conveniently gcc doesn't need a deduction guide
 		// however there is a bug where "subobjects" cannot have a deduction


### PR DESCRIPTION
Python style `enumerate`, because why shouldn't C++ look like Python:

```cpp
for (const auto& [idx, label_i] : enumerate(*m_labels))
{
    auto c = static_cast<index_t>(label_i);
    centered_class[c].set_column(
	centered_class_col[c], mean_matrix.get_column(idx));
    ++centered_class_col[c];
}
```