### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Note that some folders are submodules that can be checked out with
 - *benchmarks* - speed benchmarks
 - *cmake* - cmake build scripts
 
+## Building shogun - Using vcpkg
+
+You can download and install shogun using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install shogun
+
+The shogun port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## License
 ----------
 Shogun is distributed under [BSD 3-clause license](doc/license/LICENSE.md), with

--- a/README.md
+++ b/README.md
@@ -72,18 +72,6 @@ Note that some folders are submodules that can be checked out with
 - *benchmarks* - speed benchmarks
 - *cmake* - cmake build scripts
 
-## Building shogun - Using vcpkg
-
-You can download and install shogun using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install shogun
-
-The shogun port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
 ## License
 ----------
 Shogun is distributed under [BSD 3-clause license](doc/license/LICENSE.md), with

--- a/doc/readme/INSTALL.md
+++ b/doc/readme/INSTALL.md
@@ -111,6 +111,17 @@ You can do this via passing an additional option
 
 See the Docker documentation for further details.
 
+## Building shogun - Using vcpkg
+
+You can download and install shogun using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install shogun
+
+The shogun port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Integration with interface language build systems <a name="language"></a>
 Shogun is can be automatically built from source from the following langauges.


### PR DESCRIPTION
Shogun is available as a port in vcpkg, a C++ library manager that simplifies installation for shogun and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build shogun, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.