### PR TITLE
added most "normal" types

### DIFF
--- a/src/shogun/mathematics/graph/Allocator.h
+++ b/src/shogun/mathematics/graph/Allocator.h
@@ -16,34 +16,67 @@ namespace shogun
 
 		inline void* allocator_dispatch(size_t size, element_type type)
 		{
+#define ALLOCATE_TYPE(TYPE) return new get_type_from_enum<TYPE>::type[size]();
 			switch (type)
 			{
 			case element_type::FLOAT32:
-				return new get_type_from_enum<
-				    element_type::FLOAT32>::type[size]();
+				ALLOCATE_TYPE(element_type::FLOAT32)
 			case element_type::FLOAT64:
-				return new get_type_from_enum<
-				    element_type::FLOAT64>::type[size]();
+				ALLOCATE_TYPE(element_type::FLOAT64)
 			case element_type::BOOLEAN:
-				return new get_type_from_enum<
-				    element_type::BOOLEAN>::type[size]();
+				ALLOCATE_TYPE(element_type::BOOLEAN)
+			case element_type::INT8:
+				ALLOCATE_TYPE(element_type::INT8)
+			case element_type::INT16:
+				ALLOCATE_TYPE(element_type::INT16)
+			case element_type::INT32:
+				ALLOCATE_TYPE(element_type::INT32)
+			case element_type::INT64:
+				ALLOCATE_TYPE(element_type::INT64)
+			case element_type::UINT8:
+				ALLOCATE_TYPE(element_type::UINT8)
+			case element_type::UINT16:
+				ALLOCATE_TYPE(element_type::UINT16)
+			case element_type::UINT32:
+				ALLOCATE_TYPE(element_type::UINT32)
+			case element_type::UINT64:
+				ALLOCATE_TYPE(element_type::UINT64)
 			}
+#undef ALLOCATE_TYPE
 		}
 
 		inline void deallocator_dispatch(void* data, element_type type)
 		{
+#define DEALLOCATE_TYPE(TYPE)                                                  \
+	return delete (get_type_from_enum<TYPE>::type*)data;                       \
+	break;
+
 			switch (type)
 			{
 			case element_type::FLOAT32:
-				delete (float32_t*)data;
-				break;
+				DEALLOCATE_TYPE(element_type::FLOAT32)
 			case element_type::FLOAT64:
-				delete (float64_t*)data;
-				break;
+				DEALLOCATE_TYPE(element_type::FLOAT64)
 			case element_type::BOOLEAN:
-				delete (bool*)data;
-				break;
+				DEALLOCATE_TYPE(element_type::BOOLEAN)
+			case element_type::INT8:
+				DEALLOCATE_TYPE(element_type::INT8)
+			case element_type::INT16:
+				DEALLOCATE_TYPE(element_type::INT16)
+			case element_type::INT32:
+				DEALLOCATE_TYPE(element_type::INT32)
+			case element_type::INT64:
+				DEALLOCATE_TYPE(element_type::INT64)
+			case element_type::UINT8:
+				DEALLOCATE_TYPE(element_type::UINT8)
+			case element_type::UINT16:
+				DEALLOCATE_TYPE(element_type::UINT16)
+			case element_type::UINT32:
+				DEALLOCATE_TYPE(element_type::UINT32)
+			case element_type::UINT64:
+				DEALLOCATE_TYPE(element_type::UINT64)
 			}
+#undef DEALLOCATE_TYPE
 		}
 	} // namespace graph
 } // namespace shogun

--- a/src/shogun/mathematics/graph/Types.h
+++ b/src/shogun/mathematics/graph/Types.h
@@ -18,8 +18,16 @@ namespace shogun
 		enum class element_type
 		{
 			BOOLEAN = 0,
-			FLOAT32 = 1,
-			FLOAT64 = 2,
+			INT8 = 1,
+			INT16 = 2,
+			INT32 = 3,
+			INT64 = 4,
+			UINT8 = 5,
+			UINT16 = 6,
+			UINT32 = 7,
+			UINT64 = 8,
+			FLOAT32 = 9,
+			FLOAT64 = 10,
 		};
 
 		template <element_type EnumVal>
@@ -27,57 +35,63 @@ namespace shogun
 		{
 		};
 
-		template <>
-		struct get_type_from_enum<element_type::BOOLEAN>
-		{
-			using type = bool;
-		};
-
-		template <>
-		struct get_type_from_enum<element_type::FLOAT32>
-		{
-			using type = float32_t;
-		};
-
-		template <>
-		struct get_type_from_enum<element_type::FLOAT64>
-		{
-			using type = float64_t;
-		};
-
 		template <typename T>
 		struct get_enum_from_type
 		{
 		};
 
-		template <>
-		struct get_enum_from_type<float32_t>
-		{
-			static constexpr element_type type = element_type::FLOAT32;
-		};
+#define TYPE_ENUM_MAPPING(SHOGUN_TYPE, TYPE)                                   \
+	template <>                                                                \
+	struct get_type_from_enum<SHOGUN_TYPE>                                     \
+	{                                                                          \
+		using type = TYPE;                                                     \
+	};                                                                         \
+	template <>                                                                \
+	struct get_enum_from_type<TYPE>                                            \
+	{                                                                          \
+		static constexpr element_type type = SHOGUN_TYPE;                      \
+	};
 
-		template <>
-		struct get_enum_from_type<float64_t>
-		{
-			static constexpr element_type type = element_type::FLOAT64;
-		};
+		TYPE_ENUM_MAPPING(element_type::BOOLEAN, bool)
+		TYPE_ENUM_MAPPING(element_type::INT8, int8_t)
+		TYPE_ENUM_MAPPING(element_type::INT16, int16_t)
+		TYPE_ENUM_MAPPING(element_type::INT32, int32_t)
+		TYPE_ENUM_MAPPING(element_type::INT64, int64_t)
+		TYPE_ENUM_MAPPING(element_type::UINT8, uint8_t)
+		TYPE_ENUM_MAPPING(element_type::UINT16, uint16_t)
+		TYPE_ENUM_MAPPING(element_type::UINT32, uint32_t)
+		TYPE_ENUM_MAPPING(element_type::UINT64, uint64_t)
+		TYPE_ENUM_MAPPING(element_type::FLOAT32, float32_t)
+		TYPE_ENUM_MAPPING(element_type::FLOAT64, float64_t)
 
-		template <>
-		struct get_enum_from_type<bool>
-		{
-			static constexpr element_type type = element_type::BOOLEAN;
-		};
+#undef TYPE_ENUM_MAPPING
 
 		inline std::ostream& operator<<(std::ostream& os, element_type type)
 		{
 			switch (type)
 			{
+			case element_type::BOOLEAN:
+				return os << "bool";
+			case element_type::INT8:
+				return os << "int8";
+			case element_type::INT16:
+				return os << "int16";
+			case element_type::INT32:
+				return os << "int32";
+			case element_type::INT64:
+				return os << "int64";
+			case element_type::UINT8:
+				return os << "uint8";
+			case element_type::UINT16:
+				return os << "uint16";
+			case element_type::UINT32:
+				return os << "uint32";
+			case element_type::UINT64:
+				return os << "uint64";
 			case element_type::FLOAT32:
 				return os << "float32";
 			case element_type::FLOAT64:
 				return os << "float64";
-			case element_type::BOOLEAN:
-				return os << "bool";
 			}
 		}
 
@@ -85,12 +99,28 @@ namespace shogun
 		{
 			switch (type)
 			{
+			case element_type::BOOLEAN:
+				return sizeof(bool);
+			case element_type::INT8:
+				return sizeof(int8_t);
+			case element_type::INT16:
+				return sizeof(int16_t);
+			case element_type::INT32:
+				return sizeof(int32_t);
+			case element_type::INT64:
+				return sizeof(int64_t);
+			case element_type::UINT8:
+				return sizeof(uint8_t);
+			case element_type::UINT16:
+				return sizeof(uint16_t);
+			case element_type::UINT32:
+				return sizeof(uint32_t);
+			case element_type::UINT64:
+				return sizeof(uint64_t);
 			case element_type::FLOAT32:
 				return sizeof(float32_t);
 			case element_type::FLOAT64:
 				return sizeof(float64_t);
-			case element_type::BOOLEAN:
-				return sizeof(bool);
 			}
 		}
 	} // namespace graph

--- a/src/shogun/mathematics/graph/nodes/Add_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Add_test.cc
@@ -14,6 +14,9 @@ TYPED_TEST(GraphTest, add)
 {
 	using NumericType = TypeParam;
 
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+
 	auto X1 = SGVector<NumericType>(10);
 	auto X2 = SGVector<NumericType>(10);
 

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -14,6 +14,9 @@ TYPED_TEST(GraphTest, divide)
 {
 	using NumericType = TypeParam;
 
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+
 	auto X1 = SGVector<NumericType>(10);
 	auto X2 = SGVector<NumericType>(10);
 

--- a/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
@@ -10,7 +10,7 @@ using namespace shogun;
 using namespace shogun::graph;
 using namespace std;
 
-TYPED_TEST(GraphTest, or)
+TYPED_TEST(GraphTest, xor)
 {
 	using NumericType = TypeParam;
 

--- a/src/shogun/mathematics/graph/nodes/Multiply_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Multiply_test.cc
@@ -14,6 +14,9 @@ TYPED_TEST(GraphTest, multiply)
 {
 	using NumericType = TypeParam;
 
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+
 	auto X1 = SGVector<NumericType>(10);
 	auto X2 = SGVector<NumericType>(10);
 

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -14,6 +14,9 @@ TYPED_TEST(GraphTest, subtract)
 {
 	using NumericType = TypeParam;
 
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+
 	auto X1 = SGVector<NumericType>(10);
 	auto X2 = SGVector<NumericType>(10);
 

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -99,27 +99,40 @@ namespace shogun
 				    void* input1, void* input2, void* output, size_t size,
 				    element_type type)
 				{
+
+#define CALL_KERNEL_IMPLEMENTATION(SHOGUN_TYPE)                                \
+	static_cast<DerivedOperator*>(this)                                        \
+	    ->template kernel_implementation<                                      \
+	        get_type_from_enum<SHOGUN_TYPE>::type>(                            \
+	        input1, input2, output, size);                                     \
+	break;
+
 					switch (type)
 					{
-					case element_type::FLOAT32:
-						static_cast<DerivedOperator*>(this)
-						    ->template kernel_implementation<get_type_from_enum<
-						        element_type::FLOAT32>::type>(
-						        input1, input2, output, size);
-						break;
-					case element_type::FLOAT64:
-						static_cast<DerivedOperator*>(this)
-						    ->template kernel_implementation<get_type_from_enum<
-						        element_type::FLOAT64>::type>(
-						        input1, input2, output, size);
-						break;
 					case element_type::BOOLEAN:
-						static_cast<DerivedOperator*>(this)
-						    ->template kernel_implementation<get_type_from_enum<
-						        element_type::BOOLEAN>::type>(
-						        input1, input2, output, size);
-						break;
+						CALL_KERNEL_IMPLEMENTATION(element_type::BOOLEAN)
+					case element_type::INT8:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT8)
+					case element_type::INT16:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT16)
+					case element_type::INT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT32)
+					case element_type::INT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT64)
+					case element_type::UINT8:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT8)
+					case element_type::UINT16:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT16)
+					case element_type::UINT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT32)
+					case element_type::UINT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT64)
+					case element_type::FLOAT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::FLOAT32)
+					case element_type::FLOAT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::FLOAT64)
 					}
+#undef CALL_KERNEL_IMPLEMENTATION
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalXor.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalXor.h
@@ -42,7 +42,7 @@ namespace shogun
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    [](const T& lhs, const T& rhs) {
-						    return !lhs != !rhs;
+						    return (!lhs != !rhs);
 					    });
 				}
 			};

--- a/src/shogun/mathematics/graph/runtime/ngraph/Input.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Input.h
@@ -31,6 +31,28 @@ namespace shogun
 						return element_type::FLOAT64;
 					case ::ngraph::element::Type_t::boolean:
 						return element_type::BOOLEAN;
+					case ::ngraph::element::Type_t::i8:
+						return element_type::INT8;
+					case ::ngraph::element::Type_t::i16:
+						return element_type::INT16;
+					case ::ngraph::element::Type_t::i32:
+						return element_type::INT32;
+					case ::ngraph::element::Type_t::i64:
+						return element_type::INT64;
+					case ::ngraph::element::Type_t::u8:
+						return element_type::UINT8;
+					case ::ngraph::element::Type_t::u16:
+						return element_type::UINT16;
+					case ::ngraph::element::Type_t::u32:
+						return element_type::UINT32;
+					case ::ngraph::element::Type_t::u64:
+						return element_type::UINT64;
+					case ::ngraph::element::Type_t::undefined:
+					case ::ngraph::element::Type_t::dynamic:
+					case ::ngraph::element::Type_t::bf16:
+					case ::ngraph::element::Type_t::f16:
+					case ::ngraph::element::Type_t::u1:
+						error("Cannot handle type {)", type);
 					}
 				}
 
@@ -45,6 +67,22 @@ namespace shogun
 						return ::ngraph::element::Type_t::f64;
 					case element_type::BOOLEAN:
 						return ::ngraph::element::Type_t::boolean;
+					case element_type::INT8:
+						return ::ngraph::element::Type_t::i8;
+					case element_type::INT16:
+						return ::ngraph::element::Type_t::i16;
+					case element_type::INT32:
+						return ::ngraph::element::Type_t::i32;
+					case element_type::INT64:
+						return ::ngraph::element::Type_t::i64;
+					case element_type::UINT8:
+						return ::ngraph::element::Type_t::u8;
+					case element_type::UINT16:
+						return ::ngraph::element::Type_t::u16;
+					case element_type::UINT32:
+						return ::ngraph::element::Type_t::u32;
+					case element_type::UINT64:
+						return ::ngraph::element::Type_t::u64;
 					}
 				}
 

--- a/src/shogun/mathematics/graph/test/GraphTest.h
+++ b/src/shogun/mathematics/graph/test/GraphTest.h
@@ -15,6 +15,8 @@ protected:
 	std::set<GRAPH_BACKEND> m_backends;
 };
 
-using GraphTypes = ::testing::Types<float32_t, float64_t, bool>;
+using GraphTypes = ::testing::Types<
+    bool, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t,
+    float32_t, float64_t>;
 
 TYPED_TEST_CASE(GraphTest, GraphTypes);


### PR DESCRIPTION
In ngraph we cannot use boolean types for any non-logical operation, which I guess makes sense and we should do the same