### PR TITLE
dot op implementation

### DIFF
--- a/src/shogun/mathematics/graph/CMakeLists.txt
+++ b/src/shogun/mathematics/graph/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SHOGUN_CORE_GRAPH_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/nodes/Divide.h
 	${CMAKE_CURRENT_SOURCE_DIR}/nodes/Subtract.h
 	${CMAKE_CURRENT_SOURCE_DIR}/nodes/Input.h
+	${CMAKE_CURRENT_SOURCE_DIR}/nodes/Dot.h
 	${CMAKE_CURRENT_SOURCE_DIR}/ops/abstract/Operator.h
 	${CMAKE_CURRENT_SOURCE_DIR}/ops/abstract/BinaryOperator.h
 	)
@@ -33,6 +34,7 @@ set(SHOGUN_GRAPH_IMPLEMENTATION_HEADERS
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/shogun/Divide.h
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/shogun/Input.h
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/shogun/Multiply.h
+		${CMAKE_CURRENT_SOURCE_DIR}/runtime/shogun/Dot.h
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/shogun/Subtract.h
 		${CMAKE_CURRENT_SOURCE_DIR}/ShogunGraph.h
 		)
@@ -42,6 +44,7 @@ set(SHOGUN_GRAPH_IMPLEMENTATION_SOURCES
 
 set(NGRAPH_IMPLEMENTATION_HEADERS
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ngraph/Add.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/runtime/ngraph/Dot.h
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/ngraph/Equal.h
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/ngraph/LogicalAnd.h
 		${CMAKE_CURRENT_SOURCE_DIR}/runtime/ngraph/LogicalOr.h
@@ -122,4 +125,5 @@ IF (ENABLE_TESTING)
 	add_graph_test(nodes/LogicalAnd_test)
 	add_graph_test(nodes/LogicalOr_test)
 	add_graph_test(nodes/LogicalXor_test)
+	add_graph_test(nodes/Dot_test)
 ENDIF()

--- a/src/shogun/mathematics/graph/Graph.cpp
+++ b/src/shogun/mathematics/graph/Graph.cpp
@@ -98,7 +98,7 @@ void Graph::build_backend_graph(
 		order_graph_visit_(node.first, unordered_nodes, ordered_nodes);
 	}
 
-	// get input operatos
+	// get input operators
 	for (const auto& node : m_inputs)
 	{
 		m_executor->add_input_operator(node);
@@ -131,5 +131,7 @@ void Graph::order_graph_visit_(
 	}
 
 	node_status = STATUS::MARKED;
+	if (node->requires_column_major_conversion())
+		m_executor->set_requires_major_conversion(true);
 	result.push_back(node);
 }

--- a/src/shogun/mathematics/graph/GraphExecutor.h
+++ b/src/shogun/mathematics/graph/GraphExecutor.h
@@ -39,12 +39,17 @@ namespace shogun
 			add_input_operator(const std::shared_ptr<node::Node>& node) = 0;
 			virtual void
 			add_operator_node(const std::shared_ptr<node::Node>& node) = 0;
+			void set_requires_major_conversion(bool requires_major_conversion)
+			{
+				m_requires_major_conversion = requires_major_conversion;
+			}
 
 		protected:
 			std::vector<std::shared_ptr<detail::RuntimeNode>>
 			    m_cached_input_operators;
 			std::vector<std::shared_ptr<detail::RuntimeNode>>
 			    m_cached_operators;
+			bool m_requires_major_conversion = false;
 		};
 
 		static constexpr std::string_view kShogunExecutorName =

--- a/src/shogun/mathematics/graph/NGraph.cpp
+++ b/src/shogun/mathematics/graph/NGraph.cpp
@@ -3,11 +3,13 @@
 #include <shogun/mathematics/graph/nodes/Node.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Add.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Divide.h>
+#include <shogun/mathematics/graph/runtime/ngraph/Dot.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Equal.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Input.h>
 #include <shogun/mathematics/graph/runtime/ngraph/LogicalAnd.h>
 #include <shogun/mathematics/graph/runtime/ngraph/LogicalOr.h>
 #include <shogun/mathematics/graph/runtime/ngraph/LogicalXor.h>
+#include <shogun/mathematics/graph/runtime/ngraph/MatMul.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Multiply.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Subtract.h>
 
@@ -34,24 +36,67 @@ std::vector<std::shared_ptr<Tensor>> NGraph::execute(
 	for (const auto& tensor : tensors)
 	{
 		const auto& shape = tensor->get_shape();
-		ngraph_input_tensors.push_back(backend->create_tensor(
-		    get_ngraph_type_from_enum(tensor->get_type()),
-		    to_ngraph_shape(shape)));
-		ngraph_input_tensors.back()->write(
-		    tensor->data(), tensor->size_in_bytes());
+		if (tensor->get_shape().size() < 2)
+		{
+			auto& input =
+			    ngraph_input_tensors.emplace_back(backend->create_tensor(
+			        get_ngraph_type_from_enum(tensor->get_type()),
+			        to_ngraph_shape(shape)));
+			input->write(tensor->data(), tensor->size_in_bytes());
+		}
+		else if (tensor->get_shape().size() == 2)
+		{
+			const auto ngraph_shape = to_ngraph_shape(shape);
+			auto& input =
+			    ngraph_input_tensors.emplace_back(backend->create_tensor(
+			        get_ngraph_type_from_enum(tensor->get_type()),
+			        ngraph::Shape{ngraph_shape[1], ngraph_shape[0]}));
+			input->write(tensor->data(), tensor->size_in_bytes());
+			auto& transpose_param = ngraph_input_tensors.emplace_back(
+			    backend->create_tensor(ngraph::element::i64, ngraph::Shape{2}));
+			transpose_param->write(&kTranspose, 2 * sizeof(int64_t));
+		}
+		else
+		{
+			error("NGraph interface cannot handle tensors with more than 2 "
+			      "dimensions.");
+		}
 	}
 
 	ngraph::ParameterVector inputs;
 	ngraph::OutputVector outputs;
 
-	for (const auto& el : m_input_output_nodes)
+	for (const auto& node : m_input_output_nodes)
 	{
-		inputs.push_back(std::static_pointer_cast<ngraph::op::Parameter>(el));
+		auto input_node = std::static_pointer_cast<ngraph::op::Parameter>(node);
+		inputs.push_back(input_node);
 	}
 
 	for (const auto& el : output_nodes)
 	{
-		outputs.push_back(m_lookup.at(el));
+		const auto& shape = el->get_shapes()[0];
+		const auto& ngraph_shape = to_ngraph_shape(shape);
+
+		if (shape.size() < 2)
+		{
+			outputs.push_back(m_lookup.at(el));
+		}
+		else if (shape.size() == 2)
+		{
+			auto perm = std::make_shared<ngraph::op::Parameter>(
+			    ngraph::element::i64, ngraph::Shape{2});
+			outputs.push_back(
+			    std::make_shared<ngraph::op::Transpose>(m_lookup.at(el), perm));
+			inputs.push_back(perm);
+			auto& transpose_param = ngraph_input_tensors.emplace_back(
+			    backend->create_tensor(ngraph::element::i64, ngraph::Shape{2}));
+			transpose_param->write(&kTranspose, 2 * sizeof(int64_t));
+		}
+		else
+		{
+			error("NGraph interface cannot handle tensors with more than 2 "
+			      "dimensions.");
+		}
 	}
 
 	auto f = std::make_shared<ngraph::Function>(outputs, inputs);
@@ -68,16 +113,17 @@ std::vector<std::shared_ptr<Tensor>> NGraph::execute(
 		{
 			ngraph_output_tensors.push_back(backend->create_dynamic_tensor(
 			    get_ngraph_type_from_enum(type),
-			    to_ngraph_partial_shape(shape)));
+			    to_ngraph_partial_shape(shape.inverse())));
 		}
 		else
 		{
 			ngraph_output_tensors.push_back(backend->create_tensor(
-			    get_ngraph_type_from_enum(type), to_ngraph_shape(shape)));
+			    get_ngraph_type_from_enum(type),
+			    to_ngraph_shape(shape.inverse())));
 		}
 	}
 
-	handle->call_with_validate(ngraph_output_tensors, ngraph_input_tensors);
+	handle->call(ngraph_output_tensors, ngraph_input_tensors);
 
 	std::vector<std::shared_ptr<Tensor>> results;
 	for (const auto& ngraph_tensor : ngraph_output_tensors)
@@ -110,12 +156,33 @@ NGraph::get_operator(const std::shared_ptr<node::Node>& node) const
 
 void NGraph::add_input_operator(const std::shared_ptr<node::Node>& node)
 {
-
 	auto input = get_operator(node);
-	m_lookup[node] =
-	    std::static_pointer_cast<detail::ngraph::InputNGraph>(input)
-	        ->build_input(node);
-	m_input_output_nodes.push_back(m_lookup.at(node));
+	const auto shape = node->get_shapes()[0];
+
+	if (shape.size() < 2)
+	{
+		m_lookup[node] =
+		    std::static_pointer_cast<detail::ngraph::InputNGraph>(input)
+		        ->build_input(node);
+		m_input_output_nodes.push_back(m_lookup.at(node));
+	}
+	else if (shape.size() == 2)
+	{
+		auto input_node = std::make_shared<::ngraph::op::Parameter>(
+		    get_ngraph_type_from_enum(node->get_types()[0]),
+		    to_ngraph_partial_shape(Shape{shape[1], shape[0]}));
+		auto perm = std::make_shared<ngraph::op::Parameter>(
+		    ngraph::element::i64, ngraph::Shape{2});
+		m_lookup[node] =
+		    std::make_shared<ngraph::op::Transpose>(input_node, perm);
+		m_input_output_nodes.push_back(input_node);
+		m_input_output_nodes.push_back(perm);
+	}
+	else
+	{
+		error("NGraph interface cannot handle tensors with more than 2 "
+		      "dimensions.");
+	}
 }
 
 void NGraph::add_operator_node(const std::shared_ptr<node::Node>& node)
@@ -141,6 +208,8 @@ REGISTER_OP(detail::ngraph::SubtractNGraph);
 REGISTER_OP(detail::ngraph::LogicalAndNGraph);
 REGISTER_OP(detail::ngraph::LogicalOrNGraph);
 REGISTER_OP(detail::ngraph::LogicalXorNGraph);
+// REGISTER_OP(detail::ngraph::MatMulNGraph);
+REGISTER_OP(detail::ngraph::DotNGraph);
 
 BEGIN_EXECUTOR_MANIFEST("NGraph based graph executor")
 EXPORT_EXECUTOR(NGraph)

--- a/src/shogun/mathematics/graph/NGraph.h
+++ b/src/shogun/mathematics/graph/NGraph.h
@@ -38,6 +38,8 @@ namespace shogun
 
 			std::vector<std::shared_ptr<ngraph::Node>> m_input_output_nodes;
 			std::vector<std::shared_ptr<ngraph::Node>> m_operator_output_nodes;
+
+			static inline constexpr int64_t kTranspose[2] = {1, 0};
 		};
 	} // namespace graph
 } // namespace shogun

--- a/src/shogun/mathematics/graph/Shape.h
+++ b/src/shogun/mathematics/graph/Shape.h
@@ -58,6 +58,9 @@ namespace shogun
 
 			bool partial_compare(size_t idx, shape_type other) const
 			{
+				if (is_scalar())
+					error("Cannot do Shape::partial_compare with scalar shape "
+					      "representations");
 				if (m_shape[idx] == Shape::Dynamic || other == Shape::Dynamic)
 					return true;
 				return m_shape[idx] == other;
@@ -71,6 +74,11 @@ namespace shogun
 						return false;
 				}
 				return true;
+			}
+
+			bool is_scalar() const
+			{
+				return m_shape.size() == 0;
 			}
 
 			Shape switch_major() const

--- a/src/shogun/mathematics/graph/Shape.h
+++ b/src/shogun/mathematics/graph/Shape.h
@@ -73,10 +73,16 @@ namespace shogun
 				return true;
 			}
 
-			Shape inverse() const
+			Shape switch_major() const
 			{
-				return Shape(
-				    std::vector<shape_type>{m_shape.rbegin(), m_shape.rend()});
+				if (m_shape.size() < 2)
+					return *this;
+				else
+				{
+					auto result = m_shape;
+					std::swap(result[0], result[1]);
+					return Shape{result};
+				}
 			}
 
 			[[nodiscard]] auto begin() const

--- a/src/shogun/mathematics/graph/Shape.h
+++ b/src/shogun/mathematics/graph/Shape.h
@@ -29,11 +29,16 @@ namespace shogun
 
 			static constexpr shape_type Dynamic = -1;
 
-			Shape(std::initializer_list<shape_type> shape) : m_shape(shape)
+			Shape(const std::initializer_list<shape_type>& shape)
+			    : m_shape(shape)
 			{
 			}
 
-			Shape(std::vector<shape_type> shape)
+			Shape(const std::vector<shape_type>& shape) : m_shape(shape)
+			{
+			}
+
+			Shape(std::vector<shape_type>&& shape)
 			    : m_shape(std::move(shape)){}
 
 			          [[nodiscard]] shape_type size() const
@@ -49,6 +54,29 @@ namespace shogun
 			shape_type& operator[](size_t idx)
 			{
 				return m_shape[idx];
+			}
+
+			bool partial_compare(size_t idx, shape_type other) const
+			{
+				if (m_shape[idx] == Shape::Dynamic || other == Shape::Dynamic)
+					return true;
+				return m_shape[idx] == other;
+			}
+
+			bool is_static() const
+			{
+				for (const auto& dim : m_shape)
+				{
+					if (dim == Shape::Dynamic)
+						return false;
+				}
+				return true;
+			}
+
+			Shape inverse() const
+			{
+				return Shape(
+				    std::vector<shape_type>{m_shape.rbegin(), m_shape.rend()});
 			}
 
 			[[nodiscard]] auto begin() const

--- a/src/shogun/mathematics/graph/ShogunGraph.cpp
+++ b/src/shogun/mathematics/graph/ShogunGraph.cpp
@@ -2,6 +2,7 @@
 #include <shogun/mathematics/graph/nodes/Node.h>
 #include <shogun/mathematics/graph/runtime/shogun/Add.h>
 #include <shogun/mathematics/graph/runtime/shogun/Divide.h>
+#include <shogun/mathematics/graph/runtime/shogun/Dot.h>
 #include <shogun/mathematics/graph/runtime/shogun/Equal.h>
 #include <shogun/mathematics/graph/runtime/shogun/Input.h>
 #include <shogun/mathematics/graph/runtime/shogun/LogicalAnd.h>
@@ -112,6 +113,7 @@ REGISTER_OP(detail::shogun::DivideShogun);
 REGISTER_OP(detail::shogun::LogicalAndShogun);
 REGISTER_OP(detail::shogun::LogicalOrShogun);
 REGISTER_OP(detail::shogun::LogicalXorShogun);
+REGISTER_OP(detail::shogun::DotShogun);
 
 BEGIN_EXECUTOR_MANIFEST("Shogun default graph executor")
 EXPORT_EXECUTOR(ShogunGraph)

--- a/src/shogun/mathematics/graph/Tensor.h
+++ b/src/shogun/mathematics/graph/Tensor.h
@@ -58,7 +58,7 @@ namespace shogun
 
 			void allocate_tensor(const Shape& shape)
 			{
-				if (m_free)
+				if (m_data != nullptr)
 					error("Tensor already owns data!");
 				set_shape(shape);
 				m_data = allocator_dispatch(size(), m_type);
@@ -98,8 +98,7 @@ namespace shogun
 				{
 					error(
 					    "Mismatch in the number of dimensions, expected {}, "
-					    "but "
-					    "got {}",
+					    "but got {}",
 					    m_shape.size(), shape.size());
 				}
 

--- a/src/shogun/mathematics/graph/Tensor.h
+++ b/src/shogun/mathematics/graph/Tensor.h
@@ -28,10 +28,20 @@ namespace shogun
 		{
 		public:
 			template <typename T>
+			Tensor(const T& scalar)
+			    : m_free(true), m_data(new T(scalar)), m_shape({}),
+			      m_type(get_enum_from_type<T>::type)
+			{
+			}
+
+			template <typename T>
 			Tensor(const SGVector<T>& vec)
 			    : m_free(false), m_data(vec.vector), m_shape(Shape{vec.size()}),
 			      m_type(get_enum_from_type<T>::type)
 			{
+				// this represents a scalar
+				if (vec.size() == 1)
+					m_shape = Shape{};
 			}
 
 			template <typename T>

--- a/src/shogun/mathematics/graph/nodes/BinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/BinaryNode.h
@@ -30,6 +30,11 @@ namespace shogun
 				{
 				}
 
+				bool requires_column_major_conversion() const final
+				{
+					return false;
+				}
+
 			protected:
 				element_type check_type_compatible(
 				    const std::shared_ptr<Node>& node1,

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -47,5 +47,5 @@ TYPED_TEST(GraphTest, divide)
 	    vector<shared_ptr<node::Node>>{intermediate, output});
 
 	this->test_binary_op_results(
-		graph, X1, X2, expected_result1, expected_result2);
+	    graph, X1, X2, expected_result1, expected_result2);
 }

--- a/src/shogun/mathematics/graph/nodes/Dot.h
+++ b/src/shogun/mathematics/graph/nodes/Dot.h
@@ -51,6 +51,11 @@ namespace shogun
 					return "Dot";
 				}
 
+				bool requires_column_major_conversion() const final
+				{
+					return true;
+				}
+
 			protected:
 				element_type check_type_compatible(
 				    const std::shared_ptr<Node>& A,

--- a/src/shogun/mathematics/graph/nodes/Dot.h
+++ b/src/shogun/mathematics/graph/nodes/Dot.h
@@ -108,6 +108,16 @@ namespace shogun
 					m_reduction_axis_b =
 					    shape_b.size() <= 1 ? 0 : shape_b.size() - 2;
 
+					// one of the values is a scalar
+					if (shape_a.is_scalar())
+					{
+						return shape_b;
+					}
+					else if (shape_b.is_scalar())
+					{
+						return shape_a;
+					}
+
 					if (!shape_a.partial_compare(
 					        m_reduction_axis_a, shape_b[m_reduction_axis_b]))
 						error(

--- a/src/shogun/mathematics/graph/nodes/Dot.h
+++ b/src/shogun/mathematics/graph/nodes/Dot.h
@@ -1,0 +1,141 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_NODES_MATMUL_NODE_H_
+#define SHOGUN_NODES_MATMUL_NODE_H_
+
+#include <shogun/mathematics/graph/nodes/Node.h>
+#include <shogun/util/enumerate.h>
+
+#define IGNORE_IN_CLASSLIST
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace node
+		{
+			IGNORE_IN_CLASSLIST class Dot : public Node
+			{
+			public:
+				Dot(const std::shared_ptr<Node>& A,
+				    const std::shared_ptr<Node>& B)
+				    : Node(
+				          {A, B}, check_shape_compatible(A, B),
+				          check_type_compatible(A, B))
+				{
+				}
+
+				const auto& get_reduction_axis_a()
+				{
+					return m_reduction_axis_a;
+				}
+
+				const auto& get_reduction_axis_b()
+				{
+					return m_reduction_axis_b;
+				}
+
+				std::string to_string() const final
+				{
+					return fmt::format(
+					    "Dot(shape={}, type={})", get_shapes()[0],
+					    get_types()[0]);
+				}
+
+				std::string_view get_node_name() const final
+				{
+					return "Dot";
+				}
+
+			protected:
+				element_type check_type_compatible(
+				    const std::shared_ptr<Node>& A,
+				    const std::shared_ptr<Node>& B)
+				{
+					const auto& node1_types = A->get_types();
+					const auto& node2_types = B->get_types();
+
+					if (node1_types.size() > 1)
+						error(
+						    "Expected first node to have only one output "
+						    "tensor, but got {}",
+						    node1_types.size());
+
+					if (node2_types.size() > 1)
+						error(
+						    "Expected second node to have only one output "
+						    "tensor, but got {}",
+						    node2_types.size());
+
+					if (node1_types[0] != node2_types[0])
+						error("Expected types to be the same");
+
+					return node1_types[0];
+				}
+
+				Shape check_shape_compatible(
+				    const std::shared_ptr<Node>& A,
+				    const std::shared_ptr<Node>& B)
+				{
+					const auto& node_a_shapes = A->get_shapes();
+					const auto& node_b_shapes = B->get_shapes();
+
+					if (node_a_shapes.size() > 1)
+						error(
+						    "Expected first node to have only one output "
+						    "tensor, but got {}",
+						    node_a_shapes.size());
+
+					if (node_b_shapes.size() > 1)
+						error(
+						    "Expected second node to have only one output "
+						    "tensor, but got {}",
+						    node_b_shapes.size());
+
+					const auto& shape_a = node_a_shapes[0];
+					const auto& shape_b = node_b_shapes[0];
+
+					m_reduction_axis_a = shape_a.size() - 1;
+					m_reduction_axis_b =
+					    shape_b.size() <= 1 ? 0 : shape_b.size() - 2;
+
+					if (!shape_a.partial_compare(
+					        m_reduction_axis_a, shape_b[m_reduction_axis_b]))
+						error(
+						    "shapes {} and {} not aligned: {} (dim {}) != {} "
+						    "(dim {})",
+						    shape_a.to_string(), shape_b.to_string(),
+						    shape_a[m_reduction_axis_a], m_reduction_axis_a,
+						    shape_b[m_reduction_axis_b], m_reduction_axis_b);
+
+					std::vector<Shape::shape_type> output_shape_vector;
+
+					for (const auto& [idx, el] : enumerate(shape_a))
+					{
+						if (idx != m_reduction_axis_a)
+							output_shape_vector.push_back(el);
+					}
+
+					for (const auto& [idx, el] : enumerate(shape_b))
+					{
+						if (idx != m_reduction_axis_b)
+							output_shape_vector.push_back(el);
+					}
+
+					return Shape{output_shape_vector};
+				}
+
+			private:
+				index_t m_reduction_axis_a;
+				index_t m_reduction_axis_b;
+			};
+
+		} // namespace node
+	}     // namespace graph
+} // namespace shogun
+
+#endif

--- a/src/shogun/mathematics/graph/nodes/Dot_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Dot_test.cc
@@ -1,0 +1,224 @@
+#include <gtest/gtest.h>
+
+#include <shogun/mathematics/graph/Graph.h>
+#include <shogun/mathematics/graph/nodes/Dot.h>
+#include <shogun/mathematics/graph/nodes/Input.h>
+
+#include "../test/GraphTest.h"
+
+using namespace shogun;
+using namespace shogun::graph;
+using namespace std;
+
+TYPED_TEST(GraphTest, vector_vector_dot)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<TypeParam, bool>)
+		return;
+	else
+	{
+		SGVector<NumericType> X1{1, 2, 3};
+		SGVector<NumericType> X2{4, 5, 6};
+		NumericType expected_result = 32;
+
+		auto A = make_shared<node::Input>(
+		    Shape{3}, get_enum_from_type<NumericType>::type);
+		auto B = make_shared<node::Input>(
+		    Shape{3}, get_enum_from_type<NumericType>::type);
+
+		auto output = make_shared<node::Dot>(A, B);
+
+		auto graph = make_shared<Graph>(
+		    vector{A, B}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			auto result1 = result[0]->as<SGVector<NumericType>>();
+
+			EXPECT_EQ(result1[0], expected_result);
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, matrix_vector_dot)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<TypeParam, bool>)
+		return;
+	else
+	{
+		SGMatrix<NumericType> X1{{1, 3, 5}, {2, 4, 6}};
+		SGVector<NumericType> X2{1, 2};
+		SGVector<NumericType> expected_result = {5, 11, 17};
+
+		auto A = make_shared<node::Input>(
+		    Shape{3, 2}, get_enum_from_type<NumericType>::type);
+		auto B = make_shared<node::Input>(
+		    Shape{2}, get_enum_from_type<NumericType>::type);
+
+		auto output = make_shared<node::Dot>(A, B);
+
+		auto graph = make_shared<Graph>(
+		    vector{A, B}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			auto result1 = result[0]->as<SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     zip_iterator(expected_result, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, vector_matrix_dot)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<TypeParam, bool>)
+		return;
+	else
+	{
+		SGVector<NumericType> X1{1, 3, 5};
+		SGMatrix<NumericType> X2{{1, 3, 5}, {2, 4, 6}};
+		SGVector<NumericType> expected_result{35, 44};
+
+		auto A = make_shared<node::Input>(
+		    Shape{3}, get_enum_from_type<NumericType>::type);
+		auto B = make_shared<node::Input>(
+		    Shape{3, 2}, get_enum_from_type<NumericType>::type);
+
+		auto output = make_shared<node::Dot>(A, B);
+
+		auto graph = make_shared<Graph>(
+		    vector{A, B}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			auto result1 = result[0]->as<SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     zip_iterator(expected_result, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, matrix_matrix_dot1)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<TypeParam, bool>)
+		return;
+	else
+	{
+		SGMatrix<NumericType> X1{{1, 3, 5}, {2, 4, 6}};
+		SGMatrix<NumericType> X2{{1, 2}, {3, 4}, {5, 6}};
+
+		SGMatrix<NumericType> expected_result = {
+		    {5, 11, 17}, {11, 25, 39}, {17, 39, 61}};
+
+		auto A = make_shared<node::Input>(
+		    Shape{3, 2}, get_enum_from_type<NumericType>::type);
+		auto B = make_shared<node::Input>(
+		    Shape{2, 3}, get_enum_from_type<NumericType>::type);
+
+		auto output = make_shared<node::Dot>(A, B);
+
+		auto graph = make_shared<Graph>(
+		    vector{A, B}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			auto result1 = result[0]->as<SGMatrix<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     zip_iterator(expected_result, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, matrix_matrix_dot2)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (
+	    std::is_same_v<NumericType, bool> ||
+	    std::is_same_v<NumericType, uint8_t> ||
+	    std::is_same_v<NumericType, int8_t>)
+		return;
+	else
+	{
+		SGMatrix<NumericType> X1{{1, 3, 5}, {2, 4, 6}};
+		SGMatrix<NumericType> X2{{1, 2}, {3, 4}, {5, 6}};
+
+		SGMatrix<NumericType> expected_result1 = {
+		    {5, 11, 17}, {11, 25, 39}, {17, 39, 61}};
+		SGMatrix<NumericType> expected_result2 = {{123, 281, 439},
+		                                          {156, 356, 556}};
+
+		auto A = make_shared<node::Input>(
+		    Shape{3, 2}, get_enum_from_type<NumericType>::type);
+		auto B = make_shared<node::Input>(
+		    Shape{2, 3}, get_enum_from_type<NumericType>::type);
+
+		auto output1 = make_shared<node::Dot>(A, B);
+		auto output2 = make_shared<node::Dot>(output1, A);
+
+		auto graph = make_shared<Graph>(
+		    vector{A, B}, vector<shared_ptr<node::Node>>{output1, output2});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			auto result1 = result[0]->as<SGMatrix<NumericType>>();
+			auto result2 = result[1]->as<SGMatrix<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+
+			for (const auto& [expected_i, result_i] :
+			     zip_iterator(expected_result2, result2))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/Input.h
+++ b/src/shogun/mathematics/graph/nodes/Input.h
@@ -38,6 +38,11 @@ namespace shogun
 					    "Input(shape={}, type={})", get_shapes()[0],
 					    get_types()[0]);
 				}
+
+				bool requires_column_major_conversion() const final
+				{
+					return false;
+				}
 			};
 		} // namespace node
 	}     // namespace graph

--- a/src/shogun/mathematics/graph/nodes/LogicalBinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/LogicalBinaryNode.h
@@ -30,6 +30,11 @@ namespace shogun
 				{
 				}
 
+				bool requires_column_major_conversion() const override
+				{
+					return false;
+				}
+
 			protected:
 				element_type check_type_compatible(
 				    const std::shared_ptr<Node>& node1,

--- a/src/shogun/mathematics/graph/nodes/MatMul.h
+++ b/src/shogun/mathematics/graph/nodes/MatMul.h
@@ -101,16 +101,14 @@
 // 					const auto& shape_b = node_b_shapes[0];
 
 // 					if (shape_a.size() <= 2)
-// 						error("Currently MatMul cannot handle tensors with more than
-// two
-// dimensions. " 							"Node A output tensor has {} dimensions.",
-// shape_a.size());
+// 						error("Currently MatMul cannot handle tensors with more
+// than two dimensions. " 							"Node A output tensor has {}
+// dimensions.", shape_a.size());
 
 // 					if (shape_b.size() <= 2)
-// 						error("Currently MatMul cannot handle tensors with more than
-// two
-// dimensions. " 							"Node B output tensor has {} dimensions.",
-// shape_b.size());
+// 						error("Currently MatMul cannot handle tensors with more
+// than two dimensions. " 							"Node B output tensor has {}
+// dimensions.", shape_b.size());
 
 // 					std::vector<Shape::shape_type> output_shape_vector;
 // 					if (shape_a.size() == 1 && shape_b.size() == 1)
@@ -121,35 +119,40 @@
 // 					if (m_transpose_a && !m_transpose_b)
 // 					{
 // 						if (shape_a[1] == Shape::Dynamic && shape_b[1] ==
-// Shape::Dynamic) 							output_shape_vector[0] = Shape::Dynamic; 						else if
-// (shape_a[1]
+// Shape::Dynamic) 							output_shape_vector[0] = Shape::Dynamic; 						else
+// if (shape_a[1]
 // == Shape::Dynamic && shape_b[1] != Shape::Dynamic)
 // output_shape_vector[0] = shape_b[1]; 						else if
 // (shape_a[1] != Shape::Dynamic && shape_b[1] == Shape::Dynamic)
-// output_shape_vector[0] = shape_a[1]; 						else if (shape_a[1]
+// output_shape_vector[0] = shape_a[1]; 						else if
+// (shape_a[1]
 // !=
-// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs
+// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {}
+// vs
 // {}", shape_a, shape_b); 						else
 // error("Undefined state...");
 // 					}
 // 					else if (m_transpose_b && !m_transpose_a)
 // 					{
 // 						if (shape_a[0] == Shape::Dynamic && shape_b[0] ==
-// Shape::Dynamic) 							output_shape_vector[1] = Shape::Dynamic; 						else if
-// (shape_a[0]
+// Shape::Dynamic) 							output_shape_vector[1] = Shape::Dynamic; 						else
+// if (shape_a[0]
 // == Shape::Dynamic && shape_b[0] != Shape::Dynamic)
 // output_shape_vector[1] = shape_b[0]; 						else if
 // (shape_a[0] != Shape::Dynamic && shape_b[0] == Shape::Dynamic)
-// output_shape_vector[1] = shape_a[0]; 						else if (shape_a[1]
+// output_shape_vector[1] = shape_a[0]; 						else if
+// (shape_a[1]
 // !=
-// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs
+// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {}
+// vs
 // {}", shape_a, shape_b); 						else
 // error("Undefined state...");
 // 					}
 // 					else if (m_transpose_a && m_transpose_b)
 // 					{
 // 						if (shape_a[1] != shape_b[0])
-// 							error("MatMul B transpose tensor dimension mismatch. {} vs
+// 							error("MatMul B transpose tensor dimension mismatch. {}
+// vs
 // {}", shape_a, shape_b) 						output_shape_vector[0] =
 // shape_a[1]; 						output_shape_vector[1] = shape_a[0];
 // 					}

--- a/src/shogun/mathematics/graph/nodes/MatMul.h
+++ b/src/shogun/mathematics/graph/nodes/MatMul.h
@@ -101,12 +101,16 @@
 // 					const auto& shape_b = node_b_shapes[0];
 
 // 					if (shape_a.size() <= 2)
-// 						error("Currently MatMul cannot handle tensors with more than two
-// dimensions. " 							"Node A output tensor has {} dimensions.", shape_a.size());
+// 						error("Currently MatMul cannot handle tensors with more than
+// two
+// dimensions. " 							"Node A output tensor has {} dimensions.",
+// shape_a.size());
 
 // 					if (shape_b.size() <= 2)
-// 						error("Currently MatMul cannot handle tensors with more than two
-// dimensions. " 							"Node B output tensor has {} dimensions.", shape_b.size());
+// 						error("Currently MatMul cannot handle tensors with more than
+// two
+// dimensions. " 							"Node B output tensor has {} dimensions.",
+// shape_b.size());
 
 // 					std::vector<Shape::shape_type> output_shape_vector;
 // 					if (shape_a.size() == 1 && shape_b.size() == 1)
@@ -117,29 +121,37 @@
 // 					if (m_transpose_a && !m_transpose_b)
 // 					{
 // 						if (shape_a[1] == Shape::Dynamic && shape_b[1] ==
-// Shape::Dynamic) 							output_shape_vector[0] = Shape::Dynamic; 						else if (shape_a[1]
-// == Shape::Dynamic && shape_b[1] != Shape::Dynamic) 							output_shape_vector[0] =
-// shape_b[1]; 						else if (shape_a[1] != Shape::Dynamic && shape_b[1] ==
-// Shape::Dynamic) 							output_shape_vector[0] = shape_a[1]; 						else if (shape_a[1] !=
-// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs {}",
-// shape_a, shape_b); 						else 							error("Undefined state...");
+// Shape::Dynamic) 							output_shape_vector[0] = Shape::Dynamic; 						else if
+// (shape_a[1]
+// == Shape::Dynamic && shape_b[1] != Shape::Dynamic)
+// output_shape_vector[0] = shape_b[1]; 						else if
+// (shape_a[1] != Shape::Dynamic && shape_b[1] == Shape::Dynamic)
+// output_shape_vector[0] = shape_a[1]; 						else if (shape_a[1]
+// !=
+// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs
+// {}", shape_a, shape_b); 						else
+// error("Undefined state...");
 // 					}
 // 					else if (m_transpose_b && !m_transpose_a)
 // 					{
 // 						if (shape_a[0] == Shape::Dynamic && shape_b[0] ==
-// Shape::Dynamic) 							output_shape_vector[1] = Shape::Dynamic; 						else if (shape_a[0]
-// == Shape::Dynamic && shape_b[0] != Shape::Dynamic) 							output_shape_vector[1] =
-// shape_b[0]; 						else if (shape_a[0] != Shape::Dynamic && shape_b[0] ==
-// Shape::Dynamic) 							output_shape_vector[1] = shape_a[0]; 						else if (shape_a[1] !=
-// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs {}",
-// shape_a, shape_b); 						else 							error("Undefined state...");
+// Shape::Dynamic) 							output_shape_vector[1] = Shape::Dynamic; 						else if
+// (shape_a[0]
+// == Shape::Dynamic && shape_b[0] != Shape::Dynamic)
+// output_shape_vector[1] = shape_b[0]; 						else if
+// (shape_a[0] != Shape::Dynamic && shape_b[0] == Shape::Dynamic)
+// output_shape_vector[1] = shape_a[0]; 						else if (shape_a[1]
+// !=
+// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs
+// {}", shape_a, shape_b); 						else
+// error("Undefined state...");
 // 					}
 // 					else if (m_transpose_a && m_transpose_b)
 // 					{
 // 						if (shape_a[1] != shape_b[0])
-// 							error("MatMul B transpose tensor dimension mismatch. {} vs {}",
-// shape_a, shape_b) 						output_shape_vector[0] = shape_a[1]; 						output_shape_vector[1]
-// = shape_a[0];
+// 							error("MatMul B transpose tensor dimension mismatch. {} vs
+// {}", shape_a, shape_b) 						output_shape_vector[0] =
+// shape_a[1]; 						output_shape_vector[1] = shape_a[0];
 // 					}
 // 					else
 // 					{

--- a/src/shogun/mathematics/graph/nodes/MatMul.h
+++ b/src/shogun/mathematics/graph/nodes/MatMul.h
@@ -1,0 +1,162 @@
+// /*
+//  * This software is distributed under BSD 3-clause license (see LICENSE
+//  file).
+//  *
+//  * Authors: Gil Hoben
+//  */
+
+// #ifndef SHOGUN_NODES_MATMUL_NODE_H_
+// #define SHOGUN_NODES_MATMUL_NODE_H_
+
+// #include <shogun/mathematics/graph/nodes/Node.h>
+// #include <shogun/util/enumerate.h>
+
+// #define IGNORE_IN_CLASSLIST
+
+// namespace shogun
+// {
+// 	namespace graph
+// 	{
+// 		namespace node
+// 		{
+// 			IGNORE_IN_CLASSLIST class MatMul : public Node
+// 			{
+// 			public:
+// 				MatMul(
+// 				    const std::shared_ptr<Node>& A,
+// 				    const std::shared_ptr<Node>& B,
+// 				    bool transpose_a,
+// 				    bool transpose_b)
+// 				    : Node(
+// 				          {A, B}, check_shape_compatible(A, B),
+// 				          check_type_compatible(A, B))
+// 				    , m_transpose_a(transpose_a)
+// 				    , m_transpose_b(transpose_b)
+// 				{
+// 				}
+
+// 			bool get_transpose_a()
+// 			{
+// 				return m_transpose_a;
+// 			}
+
+// 			bool get_transpose_b()
+// 			{
+// 				return m_transpose_b;
+// 			}
+
+// 			protected:
+// 				element_type check_type_compatible(
+// 				    const std::shared_ptr<Node>& A,
+// 				    const std::shared_ptr<Node>& B)
+// 				{
+// 					const auto& node1_types = A->get_types();
+// 					const auto& node2_types = B->get_types();
+
+// 					if (node1_types.size() > 1)
+// 						error(
+// 						    "Expected first node to have only one output "
+// 						    "tensor, but got {}",
+// 						    node1_types.size());
+
+// 					if (node2_types.size() > 1)
+// 						error(
+// 						    "Expected second node to have only one output "
+// 						    "tensor, but got {}",
+// 						    node2_types.size());
+
+// 					if (node1_types[0] != node2_types[0])
+// 						error("Expected types to be the same");
+
+// 					return node1_types[0];
+// 				}
+
+// 				Shape check_shape_compatible(
+// 				    const std::shared_ptr<Node>& A,
+// 				    const std::shared_ptr<Node>& B)
+// 				{
+// 					const auto& node_a_shapes = A->get_shapes();
+// 					const auto& node_b_shapes = B->get_shapes();
+
+// 					if (node_a_shapes.size() > 1)
+// 						error(
+// 						    "Expected first node to have only one output "
+// 						    "tensor, but got {}",
+// 						    node1_shapes.size());
+
+// 					if (node_b_shapes.size() > 1)
+// 						error(
+// 						    "Expected second node to have only one output "
+// 						    "tensor, but got {}",
+// 						    node_b_shapes.size());
+
+// 					if (node_a_shapes[0].size() != node_b_shapes[0].size())
+// 					{
+// 						error(
+// 						    "Number of dimension mismatch between {} and {}.",
+// 						    node1, node2);
+// 					}
+
+// 					const auto& shape_a = node_a_shapes[0];
+// 					const auto& shape_b = node_b_shapes[0];
+
+// 					if (shape_a.size() <= 2)
+// 						error("Currently MatMul cannot handle tensors with more than two
+// dimensions. " 							"Node A output tensor has {} dimensions.", shape_a.size());
+
+// 					if (shape_b.size() <= 2)
+// 						error("Currently MatMul cannot handle tensors with more than two
+// dimensions. " 							"Node B output tensor has {} dimensions.", shape_b.size());
+
+// 					std::vector<Shape::shape_type> output_shape_vector;
+// 					if (shape_a.size() == 1 && shape_b.size() == 1)
+// 					{
+// 					}
+// 					else if ()
+
+// 					if (m_transpose_a && !m_transpose_b)
+// 					{
+// 						if (shape_a[1] == Shape::Dynamic && shape_b[1] ==
+// Shape::Dynamic) 							output_shape_vector[0] = Shape::Dynamic; 						else if (shape_a[1]
+// == Shape::Dynamic && shape_b[1] != Shape::Dynamic) 							output_shape_vector[0] =
+// shape_b[1]; 						else if (shape_a[1] != Shape::Dynamic && shape_b[1] ==
+// Shape::Dynamic) 							output_shape_vector[0] = shape_a[1]; 						else if (shape_a[1] !=
+// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs {}",
+// shape_a, shape_b); 						else 							error("Undefined state...");
+// 					}
+// 					else if (m_transpose_b && !m_transpose_a)
+// 					{
+// 						if (shape_a[0] == Shape::Dynamic && shape_b[0] ==
+// Shape::Dynamic) 							output_shape_vector[1] = Shape::Dynamic; 						else if (shape_a[0]
+// == Shape::Dynamic && shape_b[0] != Shape::Dynamic) 							output_shape_vector[1] =
+// shape_b[0]; 						else if (shape_a[0] != Shape::Dynamic && shape_b[0] ==
+// Shape::Dynamic) 							output_shape_vector[1] = shape_a[0]; 						else if (shape_a[1] !=
+// shape_b[1]) 							error("MatMul A transpose tensor dimension mismatch. {} vs {}",
+// shape_a, shape_b); 						else 							error("Undefined state...");
+// 					}
+// 					else if (m_transpose_a && m_transpose_b)
+// 					{
+// 						if (shape_a[1] != shape_b[0])
+// 							error("MatMul B transpose tensor dimension mismatch. {} vs {}",
+// shape_a, shape_b) 						output_shape_vector[0] = shape_a[1]; 						output_shape_vector[1]
+// = shape_a[0];
+// 					}
+// 					else
+// 					{
+// 						if (shape_a[0] == Shape::Dynamic && shape_b[1] !=
+// Shape::Dynamic)
+
+// 					}
+
+// 					return Shape{output_shape_vector};
+// 				}
+
+// 			private:
+// 				const bool m_transpose_a;
+// 				const bool m_transpose_b;
+// 			};
+// 		} // namespace node
+// 	}     // namespace graph
+// } // namespace shogun
+
+// #endif

--- a/src/shogun/mathematics/graph/nodes/MatMul_test.cc
+++ b/src/shogun/mathematics/graph/nodes/MatMul_test.cc
@@ -1,0 +1,59 @@
+// #include <gtest/gtest.h>
+
+// #include <shogun/mathematics/graph/Graph.h>
+// #include <shogun/mathematics/graph/nodes/MatMul.h>
+// #include <shogun/mathematics/graph/nodes/Input.h>
+
+// #include "../test/GraphTest.h"
+
+// using namespace shogun;
+// using namespace shogun::graph;
+// using namespace std;
+
+// TYPED_TEST(GraphTest, matrix_2D_2D_no_transpose)
+// {
+// 	using NumericType = TypeParam;
+
+//     if constexpr(std::is_same_v<TypeParam, bool>)
+//     	return;
+
+// 	SGMatrix<NumericType> X1 {{1,3,5},{2,4,6}};
+// 	SGMatrix<NumericType> X2 {{1,2},{3,4}, {5,6}};
+// 	SGMatrix<NumericType> expected_result{{5,11,17},{11,25,39},{17,39,61}};
+
+// 	auto A = make_shared<node::Input>(
+// 	    Shape{Shape::Dynamic, Shape::Dynamic},
+// get_enum_from_type<NumericType>::type); 	auto B = make_shared<node::Input>(
+// 	    Shape{Shape::Dynamic, Shape::Dynamic},
+// get_enum_from_type<NumericType>::type);
+
+// 	auto output = make_shared<node::MatMul>(A, B);
+
+// 	auto graph = make_shared<Graph>(
+// 	    vector{A, B},
+// 	    vector<shared_ptr<node::Node>>{intermediate, output});
+
+// 	for (auto&& backend : this->m_backends)
+// 	{
+// 		if (backend == GRAPH_BACKEND::SHOGUN)
+// 			continue;
+// 		graph->build(backend);
+
+// 		vector<shared_ptr<Tensor>> result = graph->evaluate(
+// 		    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+// 		auto result1 = result[0]->as<SGMatrix<NumericType>>();
+
+// 		for (const auto& [expected_i, result_i] :
+// 		     zip_iterator(expected_result1, result1))
+// 		{
+// 			EXPECT_EQ(expected_i, result_i);
+// 		}
+
+// 		for (const auto& [expected_i, result_i] :
+// 		     zip_iterator(expected_result2, result2))
+// 		{
+// 			EXPECT_EQ(expected_i, result_i);
+// 		}
+// 	}
+// }

--- a/src/shogun/mathematics/graph/nodes/Multiply_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Multiply_test.cc
@@ -47,5 +47,5 @@ TYPED_TEST(GraphTest, multiply)
 	    vector<shared_ptr<node::Node>>{intermediate, output});
 
 	this->test_binary_op_results(
-		graph, X1, X2, expected_result1, expected_result2);
+	    graph, X1, X2, expected_result1, expected_result2);
 }

--- a/src/shogun/mathematics/graph/nodes/Node.h
+++ b/src/shogun/mathematics/graph/nodes/Node.h
@@ -87,6 +87,8 @@ namespace shogun
 					return os << node.to_string();
 				}
 
+				virtual bool requires_column_major_conversion() const = 0;
+
 			protected:
 				std::vector<std::shared_ptr<Node>> m_input_nodes;
 				std::vector<Shape> m_shapes;

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -47,5 +47,5 @@ TYPED_TEST(GraphTest, subtract)
 	    vector<shared_ptr<node::Node>>{intermediate, output});
 
 	this->test_binary_op_results(
-		graph, X1, X2, expected_result1, expected_result2);
+	    graph, X1, X2, expected_result1, expected_result2);
 }

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -31,9 +31,6 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
-					// if (input_nodes.size() != 2)
-					// 	error("Expected 2 input nodes in binary operation");
-
 					const auto& input_tensor1 =
 					    input_nodes[0]->get_output_tensors()[0];
 					const auto& input_tensor2 =
@@ -81,8 +78,7 @@ namespace shogun
 						{
 							error(
 							    "Runtime shape mismatch in dimension {}. Got "
-							    "{} and "
-							    "{}.",
+							    "{} and {}.",
 							    idx, shape1, shape2);
 						}
 						if (shape1 == Shape::Dynamic)

--- a/src/shogun/mathematics/graph/ops/shogun/Dot.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Dot.h
@@ -1,0 +1,247 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_DOT_SHOGUN_H_
+#define SHOGUN_DOT_SHOGUN_H_
+
+#include <shogun/mathematics/graph/nodes/Dot.h>
+#include <shogun/mathematics/graph/ops/abstract/BinaryOperator.h>
+
+#include <shogun/mathematics/eigen3.h>
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace op
+		{
+			IGNORE_IN_CLASSLIST class DotShogun : public Operator
+			{
+			public:
+				DotShogun(const std::shared_ptr<node::Node>& node)
+				    : Operator(node)
+				{
+				}
+
+				std::string_view get_operator_name() const final
+				{
+					return "Dot";
+				}
+
+				void call(const std::vector<std::shared_ptr<
+				              detail::shogun::OutputNode>>& input_nodes) final
+				{
+					const auto& input_tensor1 =
+					    input_nodes[0]->get_output_tensors()[0];
+					const auto& input_tensor2 =
+					    input_nodes[1]->get_output_tensors()[0];
+					const auto& output_tensor = m_output_tensors[0];
+
+					runtime_checks_and_allocation(
+					    std::vector{input_tensor1, input_tensor2});
+
+					dot_product_type_dispatch(
+					    input_tensor1, input_tensor2, output_tensor);
+				}
+
+			private:
+				void runtime_checks_and_allocation(
+				    const std::vector<std::shared_ptr<Tensor>>& tensors) final
+				{
+					if (tensors.size() != 2)
+						error("Binary operation expected two inputs.");
+					if (m_output_tensors.size() != 1)
+						error("Binary operation expected one output.");
+
+					const auto& input_tensor1 = tensors[0];
+					const auto& input_tensor2 = tensors[1];
+					const auto& shape_a = input_tensor1->get_shape();
+					const auto& shape_b = input_tensor2->get_shape();
+
+					const auto& reduction_axis_a =
+					    std::static_pointer_cast<node::Dot>(m_node)
+					        ->get_reduction_axis_a();
+					const auto& reduction_axis_b =
+					    std::static_pointer_cast<node::Dot>(m_node)
+					        ->get_reduction_axis_b();
+
+					if (shape_a[reduction_axis_a] != shape_b[reduction_axis_b])
+					{
+						error(
+						    "Runtime Dot shape mismatch. "
+						    "shapes {} and {} not aligned: {} (dim {}) != {} "
+						    "(dim {})",
+						    shape_a.to_string(), shape_b.to_string(),
+						    shape_a[reduction_axis_a], reduction_axis_a,
+						    shape_b[reduction_axis_b], reduction_axis_b);
+					}
+
+					std::vector<Shape::shape_type> output_shape_vector;
+
+					for (const auto& [idx, el] : enumerate(shape_a))
+					{
+						if (idx != reduction_axis_a)
+							output_shape_vector.push_back(el);
+					}
+
+					for (const auto& [idx, el] : enumerate(shape_b))
+					{
+						if (idx != reduction_axis_b)
+							output_shape_vector.push_back(el);
+					}
+
+					m_output_tensors[0]->allocate_tensor(
+					    Shape{output_shape_vector});
+				}
+
+				template <typename T>
+				void dot_product_dispatch(
+				    const std::shared_ptr<Tensor>& input_tensor1,
+				    const std::shared_ptr<Tensor>& input_tensor2,
+				    const std::shared_ptr<Tensor>& output_tensor)
+				{
+					if (input_tensor1->get_shape().size() == 1 &&
+					    input_tensor2->get_shape().size() == 1)
+						dot_product_vector_vector_implementation<T>(
+						    input_tensor1, input_tensor2, output_tensor);
+					else if (
+					    input_tensor1->get_shape().size() == 1 &&
+					    input_tensor2->get_shape().size() == 2)
+						dot_product_vector_matrix_implementation<T>(
+						    input_tensor1, input_tensor2, output_tensor);
+					else if (
+					    input_tensor1->get_shape().size() == 2 &&
+					    input_tensor2->get_shape().size() == 1)
+						dot_product_matrix_vector_implementation<T>(
+						    input_tensor1, input_tensor2, output_tensor);
+					else if (
+					    input_tensor1->get_shape().size() == 2 &&
+					    input_tensor2->get_shape().size() == 2)
+						dot_product_matrix_matrix_implementation<T>(
+						    input_tensor1, input_tensor2, output_tensor);
+					else
+					{
+						// this would require using Eigen::Tensor, like in
+						// ngraph
+						error("Dot cannot handle tensors with more than 2 "
+						      "dimensions yet");
+					}
+				}
+
+				void dot_product_type_dispatch(
+				    const std::shared_ptr<Tensor>& A,
+				    const std::shared_ptr<Tensor>& B,
+				    const std::shared_ptr<Tensor>& Out)
+				{
+#define CALL_KERNEL_IMPLEMENTATION(SHOGUN_TYPE)                                \
+	dot_product_dispatch<get_type_from_enum<SHOGUN_TYPE>::type>(A, B, Out);    \
+	break;
+
+					switch (A->get_type())
+					{
+					case element_type::BOOLEAN:
+						CALL_KERNEL_IMPLEMENTATION(element_type::BOOLEAN)
+					case element_type::INT8:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT8)
+					case element_type::INT16:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT16)
+					case element_type::INT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT32)
+					case element_type::INT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT64)
+					case element_type::UINT8:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT8)
+					case element_type::UINT16:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT16)
+					case element_type::UINT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT32)
+					case element_type::UINT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT64)
+					case element_type::FLOAT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::FLOAT32)
+					case element_type::FLOAT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::FLOAT64)
+					}
+#undef CALL_KERNEL_IMPLEMENTATION
+				}
+
+				template <typename T>
+				void dot_product_vector_vector_implementation(
+				    const std::shared_ptr<Tensor>& A,
+				    const std::shared_ptr<Tensor>& B,
+				    const std::shared_ptr<Tensor>& Out)
+				{
+					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> A_eig(
+					    static_cast<T*>(A->data()), A->size());
+					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> B_eig(
+					    static_cast<T*>(B->data()), B->size());
+
+					static_cast<T*>(Out->data())[0] = A_eig.dot(B_eig);
+				}
+
+				template <typename T>
+				void dot_product_vector_matrix_implementation(
+				    const std::shared_ptr<Tensor>& A,
+				    const std::shared_ptr<Tensor>& B,
+				    const std::shared_ptr<Tensor>& Out)
+				{
+					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> A_eig(
+					    static_cast<T*>(A->data()), A->size());
+					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
+					B_eig(
+					    static_cast<T*>(B->data()), B->get_shape()[0],
+					    B->get_shape()[1]);
+					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> Out_eig(
+					    static_cast<T*>(Out->data()), Out->size());
+
+					Out_eig = A_eig * B_eig;
+				}
+
+				template <typename T>
+				void dot_product_matrix_vector_implementation(
+				    const std::shared_ptr<Tensor>& A,
+				    const std::shared_ptr<Tensor>& B,
+				    const std::shared_ptr<Tensor>& Out)
+				{
+					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
+					A_eig(
+					    static_cast<T*>(A->data()), A->get_shape()[0],
+					    A->get_shape()[1]);
+					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> B_eig(
+					    static_cast<T*>(B->data()), B->size());
+					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> Out_eig(
+					    static_cast<T*>(Out->data()), Out->size());
+
+					Out_eig = A_eig * B_eig;
+				}
+
+				template <typename T>
+				void dot_product_matrix_matrix_implementation(
+				    const std::shared_ptr<Tensor>& A,
+				    const std::shared_ptr<Tensor>& B,
+				    const std::shared_ptr<Tensor>& Out)
+				{
+					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
+					A_eig(
+					    static_cast<T*>(A->data()), A->get_shape()[0],
+					    A->get_shape()[1]);
+					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
+					B_eig(
+					    static_cast<T*>(B->data()), B->get_shape()[0],
+					    B->get_shape()[1]);
+					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
+					Out_eig(
+					    static_cast<T*>(Out->data()), Out->get_shape()[0],
+					    Out->get_shape()[1]);
+
+					Out_eig = A_eig * B_eig;
+				}
+			};
+		} // namespace op
+	}     // namespace graph
+} // namespace shogun
+
+#endif

--- a/src/shogun/mathematics/graph/runtime/ngraph/Dot.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Dot.h
@@ -1,0 +1,53 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_DOT_NGRAPH_H_
+#define SHOGUN_DOT_NGRAPH_H_
+
+#include <shogun/mathematics/graph/nodes/Dot.h>
+#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+
+#include <ngraph/op/dot.hpp>
+#include <ngraph/op/fused/matmul.hpp>
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace detail
+		{
+			namespace ngraph
+			{
+				IGNORE_IN_CLASSLIST class DotNGraph
+
+				    : public RuntimeNodeTemplate<node::Dot, ::ngraph::Node>
+				{
+				public:
+					DotNGraph() : RuntimeNodeTemplate()
+					{
+					}
+
+					std::string_view get_runtime_node_name() const final
+					{
+						return "Dot";
+					}
+
+					[[nodiscard]] std::shared_ptr<::ngraph::Node>
+					build_implementation(
+					    const std::shared_ptr<node::Node>& node) const final {
+						if (m_input_nodes.size() != 2)
+							error("Expected two input nodes in "
+							      "DotNGraph.");
+						return std::make_shared<::ngraph::op::Dot>(
+						    m_input_nodes[0], m_input_nodes[1]);
+					}
+				};
+			} // namespace ngraph
+		}     // namespace detail
+	}         // namespace graph
+} // namespace shogun
+
+#endif

--- a/src/shogun/mathematics/graph/runtime/ngraph/MatMul.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/MatMul.h
@@ -1,0 +1,58 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_ADD_NGRAPH_H_
+#define SHOGUN_ADD_NGRAPH_H_
+
+#include <shogun/mathematics/graph/nodes/Add.h>
+#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+
+#include <ngraph/op/fused/matmul.hpp>
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace detail
+		{
+			namespace ngraph
+			{
+				IGNORE_IN_CLASSLIST class AddNGraph
+
+				    : public RuntimeNodeTemplate<node::MatMul, ::ngraph::Node>
+				{
+				public:
+					AddNGraph() : RuntimeNodeTemplate()
+					{
+					}
+
+					std::string_view get_runtime_node_name() const final
+					{
+						return "Add";
+					}
+
+					[[nodiscard]] std::shared_ptr<::ngraph::Node>
+					build_implementation(
+					    const std::shared_ptr<node::Node>& node) const final {
+						const auto input_node =
+						    std::static_pointer_cast<node::MatMul>(node);
+						if (input_node.size() != 2)
+							error("Expected two input nodes in "
+							      "AddNGraph.");
+						const bool transpose_a = input_node->get_transpose_a();
+						const bool transpose_b = input_node->get_transpose_b();
+
+						return std::make_shared<::ngraph::op::MatMul>(
+						    input_node[0], input_node[1], transpose_a,
+						    transpose_b);
+					}
+				};
+			} // namespace ngraph
+		}     // namespace detail
+	}         // namespace graph
+} // namespace shogun
+
+#endif

--- a/src/shogun/mathematics/graph/runtime/shogun/Dot.h
+++ b/src/shogun/mathematics/graph/runtime/shogun/Dot.h
@@ -1,0 +1,55 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_DETAIL_DOT_SHOGUN_H_
+#define SHOGUN_DETAIL_DOT_SHOGUN_H_
+
+#include <shogun/mathematics/graph/nodes/Dot.h>
+#include <shogun/mathematics/graph/ops/shogun/Dot.h>
+#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace detail
+		{
+			namespace shogun
+			{
+				IGNORE_IN_CLASSLIST class DotShogun
+				    : public RuntimeNodeTemplate<node::Dot, OutputNode>
+				{
+				public:
+					DotShogun() : RuntimeNodeTemplate()
+					{
+					}
+
+					std::string_view get_runtime_node_name() const final
+					{
+						return "Dot";
+					}
+
+					[[nodiscard]] std::shared_ptr<OutputNode>
+					build_implementation(const std::shared_ptr<node::Node>&
+					                         graph_node) const final {
+						if (this->m_input_nodes.size() != 2)
+							error(
+							    "Expected two input nodes in a dot operation.");
+
+						const auto& input_node1 = this->m_input_nodes[0];
+						const auto& input_node2 = this->m_input_nodes[1];
+
+						return std::make_shared<OutputNode>(
+						    std::make_shared<op::DotShogun>(graph_node),
+						    input_node1, input_node2);
+					}
+				};
+			} // namespace shogun
+		}     // namespace detail
+	}         // namespace graph
+} // namespace shogun
+
+#endif

--- a/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
+++ b/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
@@ -66,6 +66,7 @@ namespace shogun
 
 				private:
 					std::shared_ptr<op::Operator> m_op;
+					// bool m_;
 					std::vector<std::shared_ptr<OutputNode>> m_input_nodes;
 					std::vector<std::shared_ptr<Tensor>> m_output_tensors;
 				};

--- a/src/shogun/mathematics/graph/test/GraphTest.h
+++ b/src/shogun/mathematics/graph/test/GraphTest.h
@@ -13,31 +13,32 @@ protected:
 	{
 	}
 
-	void test_binary_op_results(const std::shared_ptr<shogun::graph::Graph>& graph,
-		const shogun::SGVector<T>& X1,
-		const shogun::SGVector<T>& X2,
-		const shogun::SGVector<T>& expected_result1,
-		const shogun::SGVector<T>& expected_result2)
+	void test_binary_op_results(
+	    const std::shared_ptr<shogun::graph::Graph>& graph,
+	    const shogun::SGVector<T>& X1, const shogun::SGVector<T>& X2,
+	    const shogun::SGVector<T>& expected_result1,
+	    const shogun::SGVector<T>& expected_result2)
 	{
 		for (auto&& backend : this->m_backends)
 		{
 			graph->build(backend);
 
-			std::vector<std::shared_ptr<shogun::graph::Tensor>> result = graph->evaluate(
-				std::vector{std::make_shared<shogun::graph::Tensor>(X1),
-					std::make_shared<shogun::graph::Tensor>(X2)});
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
 
 			auto result1 = result[0]->template as<shogun::SGVector<T>>();
 			auto result2 = result[1]->template as<shogun::SGVector<T>>();
 
 			for (const auto& [expected_i, result_i] :
-				shogun::zip_iterator(expected_result1, result1))
+			     shogun::zip_iterator(expected_result1, result1))
 			{
 				EXPECT_EQ(expected_i, result_i);
 			}
 
 			for (const auto& [expected_i, result_i] :
-				shogun::zip_iterator(expected_result2, result2))
+			     shogun::zip_iterator(expected_result2, result2))
 			{
 				EXPECT_EQ(expected_i, result_i);
 			}
@@ -48,7 +49,7 @@ protected:
 };
 
 using GraphTypes = ::testing::Types<
-    bool, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t,
-    float32_t, float64_t>;
+    bool, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t,
+    uint64_t, float32_t, float64_t>;
 
 TYPED_TEST_CASE(GraphTest, GraphTypes);


### PR DESCRIPTION
Transpose and reshape is used for column to row major conversion.
  - [x] add scalar dot 
  - [x] vector/matrix dot
  - [x] add "optimisation" where graphs with only coefficient wise computations don't convert column to row major

Next PR (out of scope for this PR):
  - add/finish MatMul and MatMulBias implementation
  -  add "optimisation" where ngraph uses MatMul to do the transpose in the backend