### PR TITLE
Fixed typo in OpenCV_KNN_vs_Shogan_KNN.md

### DIFF
--- a/doc/OpenCV_docs/OpenCV_KNN_vs_Shogun_KNN.md
+++ b/doc/OpenCV_docs/OpenCV_KNN_vs_Shogun_KNN.md
@@ -1,6 +1,6 @@
 ## k-Nearest Neighbours comparison between Shogun and OpenCV.
 
-We will do a between Shogun's and OpenCV's k-NN implementations using a standard multi-class data-set available [here.](http://archive.ics.uci.edu/ml/machine-learning-databases/car/car.data). Our dataset consists of 1728 examples in which we will use the first half (864) as the training data and the rest as the testing data.
+We will do a comparison between Shogun's and OpenCV's k-NN implementations using a standard multi-class data-set available [here.](http://archive.ics.uci.edu/ml/machine-learning-databases/car/car.data). Our dataset consists of 1728 examples in which we will use the first half (864) as the training data and the rest as the testing data.
 
 Let's start with the includes!
 ```CPP


### PR DESCRIPTION
Fixed typo in shogan/doc/OpenCV_docs/OpenCV_KNN_vs_Shogan_KNN.md 