### PR TITLE
Helps in fixing #4817

### DIFF
--- a/doc/cookbook/extensions/sgexample.py
+++ b/doc/cookbook/extensions/sgexample.py
@@ -122,6 +122,8 @@ class ShogunExample(LiteralInclude):
             self.options['end-before'] = section
         elif section == 'end':
             self.options['start-after'] = section
+        elif section == 'entire':
+            pass
         else:
             self.options['start-after'] = section
             self.options['end-before'] = section


### PR DESCRIPTION
Helps in Fixing #4817

This adds the functionality to print entire code from a file generated by a metaexample, I have tested it and rendered cookbooks and it works well.

The command to be added to .rst files is 
```.. sgexample:: filename.sg:entire```

I will create a python script to add this to each file if this is merged.