### PR TITLE
Fixed Hyperlink in BrayCurtis Distance

### DIFF
--- a/doc/cookbook/conf.py.in
+++ b/doc/cookbook/conf.py.in
@@ -315,6 +315,7 @@ texinfo_documents = [
 extlinks = {
 'sgissue': ('https://github.com/shogun-toolbox/shogun/issues/%s',        'issue '),
 'sgclass': ('http://www.shogun-toolbox.org/%s',        ''),
-'wiki': ('https://en.wikipedia.org/wiki/%s',        'Wikipedia: ')
+'wiki': ('https://en.wikipedia.org/wiki/%s',        'Wikipedia: '),
+'BrayCurtis_Distance':('https://people.revoledu.com/kardi/tutorial/Similarity/%s.html','BrayCurtis_Distance')
 
 }

--- a/doc/cookbook/source/examples/distance/braycurtis.rst
+++ b/doc/cookbook/source/examples/distance/braycurtis.rst
@@ -33,7 +33,7 @@ We can use the same instance with new :sgclass:`DenseFeatures` to compute asymme
 ----------
 References
 ----------
-'BrayCurtis Distance <http://people.revoledu.com/kardi/tutorial/Similarity/BrayCurtisDistance.html>'
+:BrayCurtis_Distance:`BrayCurtisDistance`
 
 .. bibliography:: ../../references.bib
     :filter: docname in docnames


### PR DESCRIPTION
Updated conf.py.in and braycurtis.rst to reflect changes in the hyperlink of the **BrayCurtis Distance** in the reference  section of 
 https://www.shogun-toolbox.org/examples/latest/examples/distance/braycurtis.html 