### PR TITLE
automatic broadcasting of binary ops

### DIFF
--- a/src/shogun/mathematics/graph/nodes/Add_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Add_test.cc
@@ -69,13 +69,10 @@ TYPED_TEST(GraphTest, vector_scalar_add)
 	auto output = input1 + input2;
 
 	auto graph = make_shared<Graph>(
-	    vector{input1, input2},
-	    vector<shared_ptr<node::Node>>{output});
+	    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
 
 	for (auto&& backend : this->m_backends)
 	{
-		if (backend == GRAPH_BACKEND::SHOGUN)
-			continue;
 		graph->build(backend);
 
 		std::vector<std::shared_ptr<shogun::graph::Tensor>> result =

--- a/src/shogun/mathematics/graph/nodes/Add_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Add_test.cc
@@ -90,6 +90,51 @@ TYPED_TEST(GraphTest, vector_scalar_add)
 	}
 }
 
+
+TYPED_TEST(GraphTest, scalar_vector_add)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+
+	NumericType X1{1};
+	auto X2 = SGVector<NumericType>(10);
+	X2.range_fill();
+
+	auto expected_result1 = X2.clone();
+	expected_result1.add(X1);
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+	auto output = input1 + input2;
+
+	auto graph = make_shared<Graph>(
+	    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		graph->build(backend);
+
+		std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+		    graph->evaluate(
+		        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+		                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+		auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+		for (const auto& [expected_i, result_i] :
+		     shogun::zip_iterator(expected_result1, result1))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+	}
+}
+
+
 TYPED_TEST(GraphTest, matrix_add)
 {
 	using NumericType = TypeParam;

--- a/src/shogun/mathematics/graph/nodes/Add_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Add_test.cc
@@ -46,6 +46,53 @@ TYPED_TEST(GraphTest, vector_add)
 	    graph, X1, X2, expected_result1, expected_result2);
 }
 
+TYPED_TEST(GraphTest, vector_scalar_add)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+
+	auto X1 = SGVector<NumericType>(10);
+	NumericType X2{1};
+
+	X1.range_fill();
+
+	auto expected_result1 = X1.clone();
+	expected_result1.add(X2);
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+
+	auto output = input1 + input2;
+
+	auto graph = make_shared<Graph>(
+	    vector{input1, input2},
+	    vector<shared_ptr<node::Node>>{output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		if (backend == GRAPH_BACKEND::SHOGUN)
+			continue;
+		graph->build(backend);
+
+		std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+		    graph->evaluate(
+		        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+		                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+		auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+		for (const auto& [expected_i, result_i] :
+		     shogun::zip_iterator(expected_result1, result1))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+	}
+}
+
 TYPED_TEST(GraphTest, matrix_add)
 {
 	using NumericType = TypeParam;

--- a/src/shogun/mathematics/graph/nodes/Add_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Add_test.cc
@@ -90,7 +90,6 @@ TYPED_TEST(GraphTest, vector_scalar_add)
 	}
 }
 
-
 TYPED_TEST(GraphTest, scalar_vector_add)
 {
 	using NumericType = TypeParam;
@@ -133,7 +132,6 @@ TYPED_TEST(GraphTest, scalar_vector_add)
 		}
 	}
 }
-
 
 TYPED_TEST(GraphTest, matrix_add)
 {

--- a/src/shogun/mathematics/graph/nodes/BinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/BinaryNode.h
@@ -41,7 +41,8 @@ namespace shogun
 				    const std::tuple<BinaryShapeCompatibity, Shape>& shape,
 				    const element_type& type)
 				    : Node({node1, node2}, std::get<Shape>(shape), type),
-				      m_shape_compatibility(std::get<BinaryShapeCompatibity>(shape))
+				      m_shape_compatibility(
+				          std::get<BinaryShapeCompatibity>(shape))
 				{
 				}
 
@@ -56,14 +57,15 @@ namespace shogun
 				}
 
 			protected:
-
-				static std::tuple<BinaryShapeCompatibity, Shape> check_shape_compatible(
+				static std::tuple<BinaryShapeCompatibity, Shape>
+				check_shape_compatible(
 				    const std::shared_ptr<Node>& node1,
 				    const std::shared_ptr<Node>& node2)
 				{
 					// by default assume that this is going to be a binary
 					// operation of two nodes with the same number of elements
-					auto shape_compatibility = BinaryShapeCompatibity::ArrayArray;
+					auto shape_compatibility =
+					    BinaryShapeCompatibity::ArrayArray;
 
 					const auto& node1_shapes = node1->get_shapes();
 					const auto& node2_shapes = node2->get_shapes();
@@ -86,8 +88,9 @@ namespace shogun
 					if (node1_shape.is_scalar() || node2_shape.is_scalar())
 					{
 						return std::make_tuple(
-							shape_compatibility,
-							scalar_binary_op(node1_shape, node2_shape, shape_compatibility));
+						    shape_compatibility,
+						    scalar_binary_op(
+						        node1_shape, node2_shape, shape_compatibility));
 					}
 					else if (node1_shape.size() != node2_shape.size())
 					{
@@ -97,8 +100,8 @@ namespace shogun
 						    node1->to_string(), node2->to_string());
 					}
 					return std::make_tuple(
-							shape_compatibility,
-							same_shape_binary_op(node1_shape, node2_shape));
+					    shape_compatibility,
+					    same_shape_binary_op(node1_shape, node2_shape));
 				}
 
 			private:
@@ -169,14 +172,15 @@ namespace shogun
 				BinaryShapeCompatibity m_shape_compatibility;
 			};
 
-			class BinaryNode: public BaseBinaryNode
+			class BinaryNode : public BaseBinaryNode
 			{
 			public:
 				BinaryNode(
 				    const std::shared_ptr<Node>& node1,
 				    const std::shared_ptr<Node>& node2)
 				    : BaseBinaryNode(
-				          node1, node2, BaseBinaryNode::check_shape_compatible(node1, node2),
+				          node1, node2,
+				          BaseBinaryNode::check_shape_compatible(node1, node2),
 				          check_type_compatible(node1, node2))
 				{
 				}

--- a/src/shogun/mathematics/graph/nodes/BinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/BinaryNode.h
@@ -18,8 +18,14 @@ namespace shogun
 	{
 		namespace node
 		{
-			IGNORE_IN_CLASSLIST class BinaryNode : public Node
+			class BinaryNode;
+			class LogicalBinaryNode;
+
+			IGNORE_IN_CLASSLIST class BaseBinaryNode : public Node
 			{
+
+				friend class BinaryNode;
+				friend class LogicalBinaryNode;
 
 			public:
 				enum class BinaryShapeCompatibity
@@ -29,12 +35,13 @@ namespace shogun
 					BroadcastAlongAxis = 2
 				};
 
-				BinaryNode(
+				BaseBinaryNode(
 				    const std::shared_ptr<Node>& node1,
-				    const std::shared_ptr<Node>& node2)
-				    : Node(
-				          {node1, node2}, check_shape_compatible(node1, node2),
-				          check_type_compatible(node1, node2))
+				    const std::shared_ptr<Node>& node2,
+				    const std::tuple<BinaryShapeCompatibity, Shape>& shape,
+				    const element_type& type)
+				    : Node({node1, node2}, std::get<Shape>(shape), type),
+				      m_shape_compatibility(std::get<BinaryShapeCompatibity>(shape))
 				{
 				}
 
@@ -49,38 +56,14 @@ namespace shogun
 				}
 
 			protected:
-				element_type check_type_compatible(
+
+				static std::tuple<BinaryShapeCompatibity, Shape> check_shape_compatible(
 				    const std::shared_ptr<Node>& node1,
 				    const std::shared_ptr<Node>& node2)
 				{
-					const auto& node1_types = node1->get_types();
-					const auto& node2_types = node2->get_types();
-
-					if (node1_types.size() > 1)
-						error(
-						    "Expected first node to have only one output "
-						    "tensor, but got {}",
-						    node1_types.size());
-
-					if (node2_types.size() > 1)
-						error(
-						    "Expected second node to have only one output "
-						    "tensor, but got {}",
-						    node2_types.size());
-
-					if (node1_types[0] != node2_types[0])
-						error("Expected types to be the same");
-
-					return node1_types[0];
-				}
-
-				Shape check_shape_compatible(
-				    const std::shared_ptr<Node>& node1,
-				    const std::shared_ptr<Node>& node2)
-				{
-					// by default assume that this is going to be a binary operation 
-					// of two nodes with the same number of elements
-					m_shape_compatibility = BinaryShapeCompatibity::ArrayArray;
+					// by default assume that this is going to be a binary
+					// operation of two nodes with the same number of elements
+					auto shape_compatibility = BinaryShapeCompatibity::ArrayArray;
 
 					const auto& node1_shapes = node1->get_shapes();
 					const auto& node2_shapes = node2->get_shapes();
@@ -102,7 +85,9 @@ namespace shogun
 
 					if (node1_shape.is_scalar() || node2_shape.is_scalar())
 					{
-						return scalar_binary_op(node1_shape, node2_shape);
+						return std::make_tuple(
+							shape_compatibility,
+							scalar_binary_op(node1_shape, node2_shape, shape_compatibility));
 					}
 					else if (node1_shape.size() != node2_shape.size())
 					{
@@ -111,22 +96,28 @@ namespace shogun
 						    "Number of dimension mismatch between {} and {}.",
 						    node1->to_string(), node2->to_string());
 					}
-					return same_shape_binary_op(node1_shape, node2_shape);
+					return std::make_tuple(
+							shape_compatibility,
+							same_shape_binary_op(node1_shape, node2_shape));
 				}
 
 			private:
-				Shape scalar_binary_op(const Shape& node1_shape, const Shape& node2_shape)
+				static Shape scalar_binary_op(
+				    const Shape& node1_shape, const Shape& node2_shape,
+				    BinaryShapeCompatibity& shape_compatibility)
 				{
 					// xor shapes -> one is a scalar other is an array
 					if (!node1_shape.is_scalar() != !node2_shape.is_scalar())
-						m_shape_compatibility = BinaryShapeCompatibity::ArrayScalar;
+						shape_compatibility =
+						    BinaryShapeCompatibity::ArrayScalar;
 					if (node1_shape.is_scalar())
 						return node2_shape;
 					if (node2_shape.is_scalar())
 						return node1_shape;
 				}
 
-				Shape same_shape_binary_op(const Shape& node1_shape, const Shape& node2_shape)
+				static Shape same_shape_binary_op(
+				    const Shape& node1_shape, const Shape& node2_shape)
 				{
 					std::vector<Shape::shape_type> output_shape_vector;
 
@@ -166,7 +157,8 @@ namespace shogun
 						}
 						else
 						{
-							error("BinaryNode: Unexpected path, contact a dev or raise an "
+							error("BinaryNode: Unexpected path, contact a dev "
+							      "or raise an "
 							      "issue!");
 						}
 					}
@@ -175,6 +167,45 @@ namespace shogun
 				}
 
 				BinaryShapeCompatibity m_shape_compatibility;
+			};
+
+			class BinaryNode: public BaseBinaryNode
+			{
+			public:
+				BinaryNode(
+				    const std::shared_ptr<Node>& node1,
+				    const std::shared_ptr<Node>& node2)
+				    : BaseBinaryNode(
+				          node1, node2, BaseBinaryNode::check_shape_compatible(node1, node2),
+				          check_type_compatible(node1, node2))
+				{
+				}
+
+			private:
+				element_type check_type_compatible(
+				    const std::shared_ptr<Node>& node1,
+				    const std::shared_ptr<Node>& node2)
+				{
+					const auto& node1_types = node1->get_types();
+					const auto& node2_types = node2->get_types();
+
+					if (node1_types.size() > 1)
+						error(
+						    "Expected first node to have only one output "
+						    "tensor, but got {}",
+						    node1_types.size());
+
+					if (node2_types.size() > 1)
+						error(
+						    "Expected second node to have only one output "
+						    "tensor, but got {}",
+						    node2_types.size());
+
+					if (node1_types[0] != node2_types[0])
+						error("Expected types to be the same");
+
+					return node1_types[0];
+				}
 			};
 		} // namespace node
 	}     // namespace graph

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -105,7 +105,7 @@ TYPED_TEST(GraphTest, scalar_vector_divide)
 		NumericType X1{100};
 		SGVector<NumericType> X2{1, 2, 4, 5, 10, 20, 25, 50, 100};
 
-		SGVector<NumericType> expected_result1 {100, 50, 25, 20, 10, 5, 4, 2, 1};
+		SGVector<NumericType> expected_result1{100, 50, 25, 20, 10, 5, 4, 2, 1};
 
 		auto input1 = make_shared<node::Input>(
 		    Shape{}, get_enum_from_type<NumericType>::type);

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -93,3 +93,46 @@ TYPED_TEST(GraphTest, vector_scalar_divide)
 		}
 	}
 }
+
+TYPED_TEST(GraphTest, scalar_vector_divide)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	else
+	{
+		NumericType X1{100};
+		SGVector<NumericType> X2{1, 2, 4, 5, 10, 20, 25, 50, 100};
+
+		SGVector<NumericType> expected_result1 {100, 50, 25, 20, 10, 5, 4, 2, 1};
+
+		auto input1 = make_shared<node::Input>(
+		    Shape{}, get_enum_from_type<NumericType>::type);
+		auto input2 = make_shared<node::Input>(
+		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+		auto output = input1 / input2;
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+			auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     shogun::zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -49,3 +49,50 @@ TYPED_TEST(GraphTest, divide)
 	this->test_binary_op_results(
 	    graph, X1, X2, expected_result1, expected_result2);
 }
+
+TYPED_TEST(GraphTest, vector_scalar_divide)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	else 
+	{
+		SGVector<NumericType> X1 {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+		NumericType X2{2};
+
+		auto expected_result1 = SGVector<NumericType>(10);
+		expected_result1.range_fill();
+
+		auto input1 = make_shared<node::Input>(
+		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+		auto input2 = make_shared<node::Input>(
+		    Shape{}, get_enum_from_type<NumericType>::type);
+
+		auto output = input1 / input2;
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2},
+		    vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			if (backend == GRAPH_BACKEND::SHOGUN)
+				continue;
+			graph->build(backend);
+
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+			auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     shogun::zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -56,9 +56,9 @@ TYPED_TEST(GraphTest, vector_scalar_divide)
 
 	if constexpr (std::is_same_v<NumericType, bool>)
 		return;
-	else 
+	else
 	{
-		SGVector<NumericType> X1 {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+		SGVector<NumericType> X1{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
 		NumericType X2{2};
 
 		auto expected_result1 = SGVector<NumericType>(10);
@@ -72,13 +72,10 @@ TYPED_TEST(GraphTest, vector_scalar_divide)
 		auto output = input1 / input2;
 
 		auto graph = make_shared<Graph>(
-		    vector{input1, input2},
-		    vector<shared_ptr<node::Node>>{output});
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
 
 		for (auto&& backend : this->m_backends)
 		{
-			if (backend == GRAPH_BACKEND::SHOGUN)
-				continue;
 			graph->build(backend);
 
 			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =

--- a/src/shogun/mathematics/graph/nodes/Dot_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Dot_test.cc
@@ -276,7 +276,6 @@ TYPED_TEST(GraphTest, matrix_matrix_dot2)
 	}
 }
 
-
 TYPED_TEST(GraphTest, simple_perceptron_inference)
 {
 	using NumericType = TypeParam;
@@ -306,10 +305,9 @@ TYPED_TEST(GraphTest, simple_perceptron_inference)
 		{
 			graph->build(backend);
 
-			vector<shared_ptr<Tensor>> result = graph->evaluate(
-			    vector{make_shared<Tensor>(features), 
-			    	   make_shared<Tensor>(weights), 
-			    	   make_shared<Tensor>(bias)});
+			vector<shared_ptr<Tensor>> result = graph->evaluate(vector{
+			    make_shared<Tensor>(features), make_shared<Tensor>(weights),
+			    make_shared<Tensor>(bias)});
 
 			auto result1 = result[0]->as<SGVector<NumericType>>();
 

--- a/src/shogun/mathematics/graph/nodes/Equal_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Equal_test.cc
@@ -32,7 +32,6 @@ TYPED_TEST(GraphTest, equal)
 
 	for (auto&& backend : this->m_backends)
 	{
-		// need to figure out how to handle logical operators
 		graph->build(backend);
 
 		vector<shared_ptr<Tensor>> result = graph->evaluate(
@@ -45,6 +44,84 @@ TYPED_TEST(GraphTest, equal)
 		for (const auto& [result_i, el1, el2] : zip_iterator(result1, X1, X2))
 		{
 			EXPECT_EQ(result_i, static_cast<bool>(el1 == el2));
+		}
+
+		EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+	}
+}
+
+TYPED_TEST(GraphTest, vector_scalar_equal)
+{
+	using NumericType = TypeParam;
+
+	auto X1 = SGVector<NumericType>(10);
+	NumericType X2 = 1;
+
+	X1.range_fill();
+
+	auto input = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+	auto input1 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+
+	auto output = make_shared<node::Equal>(input, input1);
+
+	auto graph = make_shared<Graph>(
+	    vector{input, input1}, vector<shared_ptr<node::Node>>{output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		graph->build(backend);
+
+		vector<shared_ptr<Tensor>> result = graph->evaluate(
+		    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+		EXPECT_EQ(result.size(), 1);
+
+		auto result1 = result[0]->as<SGVector<bool>>();
+
+		for (const auto& [result_i, el1] : zip_iterator(result1, X1))
+		{
+			EXPECT_EQ(result_i, static_cast<bool>(el1 == X2));
+		}
+
+		EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+	}
+}
+
+TYPED_TEST(GraphTest, scalar_vector_equal)
+{
+	using NumericType = TypeParam;
+
+	NumericType X1 = 1;
+	auto X2 = SGVector<NumericType>(10);
+
+	X2.range_fill();
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+	auto output = make_shared<node::Equal>(input1, input2);
+
+	auto graph = make_shared<Graph>(
+	    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		graph->build(backend);
+
+		vector<shared_ptr<Tensor>> result = graph->evaluate(
+		    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+		EXPECT_EQ(result.size(), 1);
+
+		auto result1 = result[0]->as<SGVector<bool>>();
+
+		for (const auto& [result_i, el1] : zip_iterator(result1, X2))
+		{
+			EXPECT_EQ(result_i, static_cast<bool>(el1 == X1));
 		}
 
 		EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);

--- a/src/shogun/mathematics/graph/nodes/LogicalAnd_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalAnd_test.cc
@@ -58,7 +58,6 @@ TYPED_TEST(GraphTest, and)
 	}
 }
 
-
 TYPED_TEST(GraphTest, vector_scalar_and)
 {
 	using NumericType = TypeParam;
@@ -72,7 +71,7 @@ TYPED_TEST(GraphTest, vector_scalar_and)
 	{
 		SGVector<NumericType> X1{true, false, true, false};
 		NumericType X2{true};
-		
+
 		auto output = make_shared<node::LogicalAnd>(input1, input2);
 
 		auto graph = make_shared<Graph>(
@@ -90,8 +89,7 @@ TYPED_TEST(GraphTest, vector_scalar_and)
 
 			auto result1 = result[0]->as<SGVector<bool>>();
 
-			for (const auto& [result_i, el1] :
-			     zip_iterator(result1, X1))
+			for (const auto& [result_i, el1] : zip_iterator(result1, X1))
 			{
 				EXPECT_EQ(result_i, static_cast<bool>(el1 && X2));
 			}
@@ -106,7 +104,6 @@ TYPED_TEST(GraphTest, vector_scalar_and)
 		    make_shared<node::LogicalAnd>(input1, input2), ShogunException);
 	}
 }
-
 
 TYPED_TEST(GraphTest, scalar_vector_and)
 {
@@ -139,8 +136,7 @@ TYPED_TEST(GraphTest, scalar_vector_and)
 
 			auto result1 = result[0]->as<SGVector<bool>>();
 
-			for (const auto& [result_i, el1] :
-			     zip_iterator(result1, X2))
+			for (const auto& [result_i, el1] : zip_iterator(result1, X2))
 			{
 				EXPECT_EQ(result_i, static_cast<bool>(el1 && X1));
 			}

--- a/src/shogun/mathematics/graph/nodes/LogicalAnd_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalAnd_test.cc
@@ -57,3 +57,101 @@ TYPED_TEST(GraphTest, and)
 		    make_shared<node::LogicalAnd>(input, input1), ShogunException);
 	}
 }
+
+
+TYPED_TEST(GraphTest, vector_scalar_and)
+{
+	using NumericType = TypeParam;
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+	{
+		SGVector<NumericType> X1{true, false, true, false};
+		NumericType X2{true};
+		
+		auto output = make_shared<node::LogicalAnd>(input1, input2);
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			// need to figure out how to handle logical operators
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			EXPECT_EQ(result.size(), 1);
+
+			auto result1 = result[0]->as<SGVector<bool>>();
+
+			for (const auto& [result_i, el1] :
+			     zip_iterator(result1, X1))
+			{
+				EXPECT_EQ(result_i, static_cast<bool>(el1 && X2));
+			}
+
+			EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+		}
+	}
+	else
+	{
+		// LogicalAnd only works when both inputs are bool
+		EXPECT_THROW(
+		    make_shared<node::LogicalAnd>(input1, input2), ShogunException);
+	}
+}
+
+
+TYPED_TEST(GraphTest, scalar_vector_and)
+{
+	using NumericType = TypeParam;
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+	{
+		NumericType X1{true};
+		SGVector<NumericType> X2{true, false, true, false};
+
+		auto output = make_shared<node::LogicalAnd>(input1, input2);
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			// need to figure out how to handle logical operators
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			EXPECT_EQ(result.size(), 1);
+
+			auto result1 = result[0]->as<SGVector<bool>>();
+
+			for (const auto& [result_i, el1] :
+			     zip_iterator(result1, X2))
+			{
+				EXPECT_EQ(result_i, static_cast<bool>(el1 && X1));
+			}
+
+			EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+		}
+	}
+	else
+	{
+		// LogicalAnd only works when both inputs are bool
+		EXPECT_THROW(
+		    make_shared<node::LogicalAnd>(input1, input2), ShogunException);
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/LogicalBinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/LogicalBinaryNode.h
@@ -7,8 +7,7 @@
 #ifndef SHOGUN_NODES_BINARY_LOGICAL_NODE_H_
 #define SHOGUN_NODES_BINARY_LOGICAL_NODE_H_
 
-#include <shogun/mathematics/graph/nodes/Node.h>
-#include <shogun/util/enumerate.h>
+#include <shogun/mathematics/graph/nodes/BinaryNode.h>
 
 #define IGNORE_IN_CLASSLIST
 
@@ -18,24 +17,19 @@ namespace shogun
 	{
 		namespace node
 		{
-			IGNORE_IN_CLASSLIST class LogicalBinaryNode : public Node
+			IGNORE_IN_CLASSLIST class LogicalBinaryNode : public BaseBinaryNode
 			{
 			public:
 				LogicalBinaryNode(
 				    const std::shared_ptr<Node>& node1,
 				    const std::shared_ptr<Node>& node2)
-				    : Node(
-				          {node1, node2}, check_shape_compatible(node1, node2),
+				    : BaseBinaryNode(
+				          node1, node2, BaseBinaryNode::check_shape_compatible(node1, node2),
 				          check_type_compatible(node1, node2))
 				{
 				}
 
-				bool requires_column_major_conversion() const override
-				{
-					return false;
-				}
-
-			protected:
+			private:
 				element_type check_type_compatible(
 				    const std::shared_ptr<Node>& node1,
 				    const std::shared_ptr<Node>& node2)
@@ -61,78 +55,6 @@ namespace shogun
 						error("Expected type of second node to be bool");
 
 					return element_type::BOOLEAN;
-				}
-
-				Shape check_shape_compatible(
-				    const std::shared_ptr<Node>& node1,
-				    const std::shared_ptr<Node>& node2)
-				{
-					const auto& node1_shapes = node1->get_shapes();
-					const auto& node2_shapes = node2->get_shapes();
-
-					if (node1_shapes.size() > 1)
-						error(
-						    "Expected first node to have only one output "
-						    "tensor, but got {}",
-						    node1_shapes.size());
-
-					if (node2_shapes.size() > 1)
-						error(
-						    "Expected second node to have only one output "
-						    "tensor, but got {}",
-						    node2_shapes.size());
-
-					if (node1_shapes[0].size() != node2_shapes[0].size())
-					{
-						error(
-						    "Number of dimension mismatch between {} and {}.",
-						    node1, node2);
-					}
-
-					std::vector<Shape::shape_type> output_shape_vector;
-
-					for (const auto& [idx, shape1, shape2] :
-					     enumerate(node1_shapes[0], node2_shapes[0]))
-					{
-						if (shape1 == shape2)
-						{
-							output_shape_vector.push_back(shape1);
-						}
-						else if (
-						    shape1 == Shape::Dynamic &&
-						    shape2 == Shape::Dynamic)
-						{
-							output_shape_vector.push_back(Shape::Dynamic);
-						}
-						else if (
-						    shape1 != Shape::Dynamic &&
-						    shape2 != Shape::Dynamic && shape1 != shape2)
-						{
-							// this is a mismatch, it can't possible go well at
-							// runtime
-							error(
-							    "Shape mismatch in dimension {} when comparing "
-							    "{} and {}",
-							    idx, shape1, shape2);
-						}
-						else if (shape1 == Shape::Dynamic)
-						{
-							// shape2 is more restrictive so pick that one
-							output_shape_vector.push_back(shape2);
-						}
-						else if (shape2 == Shape::Dynamic)
-						{
-							// shape1 is more restrictive so pick that one
-							output_shape_vector.push_back(shape1);
-						}
-						else
-						{
-							error("Unexpected path: contact a dev or raise an "
-							      "issue!");
-						}
-					}
-
-					return Shape{output_shape_vector};
 				}
 			};
 		} // namespace node

--- a/src/shogun/mathematics/graph/nodes/LogicalBinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/LogicalBinaryNode.h
@@ -24,7 +24,8 @@ namespace shogun
 				    const std::shared_ptr<Node>& node1,
 				    const std::shared_ptr<Node>& node2)
 				    : BaseBinaryNode(
-				          node1, node2, BaseBinaryNode::check_shape_compatible(node1, node2),
+				          node1, node2,
+				          BaseBinaryNode::check_shape_compatible(node1, node2),
 				          check_type_compatible(node1, node2))
 				{
 				}

--- a/src/shogun/mathematics/graph/nodes/LogicalOr_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalOr_test.cc
@@ -57,7 +57,6 @@ TYPED_TEST(GraphTest, or)
 	}
 }
 
-
 TYPED_TEST(GraphTest, vector_scalar_or)
 {
 	using NumericType = TypeParam;
@@ -89,8 +88,7 @@ TYPED_TEST(GraphTest, vector_scalar_or)
 
 			auto result1 = result[0]->as<SGVector<bool>>();
 
-			for (const auto& [result_i, el1] :
-			     zip_iterator(result1, X1))
+			for (const auto& [result_i, el1] : zip_iterator(result1, X1))
 			{
 				EXPECT_EQ(result_i, static_cast<bool>(el1 || X2));
 			}
@@ -104,7 +102,6 @@ TYPED_TEST(GraphTest, vector_scalar_or)
 		    make_shared<node::LogicalOr>(input1, input2), ShogunException);
 	}
 }
-
 
 TYPED_TEST(GraphTest, scalar_vector_or)
 {
@@ -137,8 +134,7 @@ TYPED_TEST(GraphTest, scalar_vector_or)
 
 			auto result1 = result[0]->as<SGVector<bool>>();
 
-			for (const auto& [result_i, el1] :
-			     zip_iterator(result1, X2))
+			for (const auto& [result_i, el1] : zip_iterator(result1, X2))
 			{
 				EXPECT_EQ(result_i, static_cast<bool>(el1 || X1));
 			}

--- a/src/shogun/mathematics/graph/nodes/LogicalOr_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalOr_test.cc
@@ -14,9 +14,6 @@ TYPED_TEST(GraphTest, or)
 {
 	using NumericType = TypeParam;
 
-	SGVector<NumericType> X1{true, false, true, false};
-	SGVector<NumericType> X2{true, false, false, true};
-
 	auto input = make_shared<node::Input>(
 	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
 	auto input1 = make_shared<node::Input>(
@@ -24,6 +21,9 @@ TYPED_TEST(GraphTest, or)
 
 	if constexpr (std::is_same_v<NumericType, bool>)
 	{
+		SGVector<NumericType> X1{true, false, true, false};
+		SGVector<NumericType> X2{true, false, false, true};
+
 		auto output = make_shared<node::LogicalOr>(input, input1);
 
 		auto graph = make_shared<Graph>(
@@ -54,5 +54,101 @@ TYPED_TEST(GraphTest, or)
 	{
 		EXPECT_THROW(
 		    make_shared<node::LogicalOr>(input, input1), ShogunException);
+	}
+}
+
+
+TYPED_TEST(GraphTest, vector_scalar_or)
+{
+	using NumericType = TypeParam;
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+	{
+		SGVector<NumericType> X1{true, false, true, false};
+		NumericType X2{true};
+
+		auto output = make_shared<node::LogicalOr>(input1, input2);
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			// need to figure out how to handle logical operators
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			EXPECT_EQ(result.size(), 1);
+
+			auto result1 = result[0]->as<SGVector<bool>>();
+
+			for (const auto& [result_i, el1] :
+			     zip_iterator(result1, X1))
+			{
+				EXPECT_EQ(result_i, static_cast<bool>(el1 || X2));
+			}
+
+			EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+		}
+	}
+	else
+	{
+		EXPECT_THROW(
+		    make_shared<node::LogicalOr>(input1, input2), ShogunException);
+	}
+}
+
+
+TYPED_TEST(GraphTest, scalar_vector_or)
+{
+	using NumericType = TypeParam;
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+	{
+		NumericType X1{true};
+		SGVector<NumericType> X2{true, false, true, false};
+
+		auto output = make_shared<node::LogicalOr>(input1, input2);
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			// need to figure out how to handle logical operators
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			EXPECT_EQ(result.size(), 1);
+
+			auto result1 = result[0]->as<SGVector<bool>>();
+
+			for (const auto& [result_i, el1] :
+			     zip_iterator(result1, X2))
+			{
+				EXPECT_EQ(result_i, static_cast<bool>(el1 || X1));
+			}
+
+			EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+		}
+	}
+	else
+	{
+		EXPECT_THROW(
+		    make_shared<node::LogicalOr>(input1, input2), ShogunException);
 	}
 }

--- a/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
@@ -70,7 +70,7 @@ TYPED_TEST(GraphTest, vector_scalar_xor)
 	{
 		SGVector<NumericType> X1{true, false, true, false};
 		NumericType X2{true};
-		
+
 		auto output = make_shared<node::LogicalXor>(input1, input2);
 
 		auto graph = make_shared<Graph>(
@@ -88,8 +88,7 @@ TYPED_TEST(GraphTest, vector_scalar_xor)
 
 			auto result1 = result[0]->as<SGVector<bool>>();
 
-			for (const auto& [result_i, el1] :
-			     zip_iterator(result1, X1))
+			for (const auto& [result_i, el1] : zip_iterator(result1, X1))
 			{
 				EXPECT_EQ(result_i, static_cast<bool>(!el1 != !X2));
 			}
@@ -117,7 +116,7 @@ TYPED_TEST(GraphTest, scalar_vector_xor)
 	{
 		NumericType X1{true};
 		SGVector<NumericType> X2{true, false, true, false};
-		
+
 		auto output = make_shared<node::LogicalXor>(input1, input2);
 
 		auto graph = make_shared<Graph>(
@@ -135,8 +134,7 @@ TYPED_TEST(GraphTest, scalar_vector_xor)
 
 			auto result1 = result[0]->as<SGVector<bool>>();
 
-			for (const auto& [result_i, el1] :
-			     zip_iterator(result1, X2))
+			for (const auto& [result_i, el1] : zip_iterator(result1, X2))
 			{
 				EXPECT_EQ(result_i, static_cast<bool>(!el1 != !X1));
 			}

--- a/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
@@ -14,9 +14,6 @@ TYPED_TEST(GraphTest, xor)
 {
 	using NumericType = TypeParam;
 
-	SGVector<NumericType> X1{true, false, true, false};
-	SGVector<NumericType> X2{true, false, false, true};
-
 	auto input = make_shared<node::Input>(
 	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
 	auto input1 = make_shared<node::Input>(
@@ -24,6 +21,9 @@ TYPED_TEST(GraphTest, xor)
 
 	if constexpr (std::is_same_v<NumericType, bool>)
 	{
+		SGVector<NumericType> X1{true, false, true, false};
+		SGVector<NumericType> X2{true, false, false, true};
+
 		auto output = make_shared<node::LogicalXor>(input, input1);
 
 		auto graph = make_shared<Graph>(
@@ -54,5 +54,99 @@ TYPED_TEST(GraphTest, xor)
 	{
 		EXPECT_THROW(
 		    make_shared<node::LogicalXor>(input, input1), ShogunException);
+	}
+}
+
+TYPED_TEST(GraphTest, vector_scalar_xor)
+{
+	using NumericType = TypeParam;
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+	{
+		SGVector<NumericType> X1{true, false, true, false};
+		NumericType X2{true};
+		
+		auto output = make_shared<node::LogicalXor>(input1, input2);
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			// need to figure out how to handle logical operators
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			EXPECT_EQ(result.size(), 1);
+
+			auto result1 = result[0]->as<SGVector<bool>>();
+
+			for (const auto& [result_i, el1] :
+			     zip_iterator(result1, X1))
+			{
+				EXPECT_EQ(result_i, static_cast<bool>(!el1 != !X2));
+			}
+
+			EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+		}
+	}
+	else
+	{
+		EXPECT_THROW(
+		    make_shared<node::LogicalXor>(input1, input2), ShogunException);
+	}
+}
+
+TYPED_TEST(GraphTest, scalar_vector_xor)
+{
+	using NumericType = TypeParam;
+
+	auto input1 = make_shared<node::Input>(
+	    Shape{}, get_enum_from_type<NumericType>::type);
+	auto input2 = make_shared<node::Input>(
+	    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+	{
+		NumericType X1{true};
+		SGVector<NumericType> X2{true, false, true, false};
+		
+		auto output = make_shared<node::LogicalXor>(input1, input2);
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			// need to figure out how to handle logical operators
+			graph->build(backend);
+
+			vector<shared_ptr<Tensor>> result = graph->evaluate(
+			    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+			EXPECT_EQ(result.size(), 1);
+
+			auto result1 = result[0]->as<SGVector<bool>>();
+
+			for (const auto& [result_i, el1] :
+			     zip_iterator(result1, X2))
+			{
+				EXPECT_EQ(result_i, static_cast<bool>(!el1 != !X1));
+			}
+
+			EXPECT_THROW(result[0]->as<SGVector<float32_t>>(), ShogunException);
+		}
+	}
+	else
+	{
+		EXPECT_THROW(
+		    make_shared<node::LogicalXor>(input1, input2), ShogunException);
 	}
 }

--- a/src/shogun/mathematics/graph/nodes/Multiply_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Multiply_test.cc
@@ -95,3 +95,48 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 		}
 	}
 }
+
+TYPED_TEST(GraphTest, scalar_vector_multiply)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	else
+	{
+		NumericType X1{2};
+		auto X2 = SGVector<NumericType>(10);
+		X2.range_fill();
+
+		SGVector<NumericType> expected_result1{0,  2,  4,  6,  8, 10,
+		                                       12, 14, 16, 18, 20};
+
+		auto input1 = make_shared<node::Input>(
+		    Shape{}, get_enum_from_type<NumericType>::type);
+		auto input2 = make_shared<node::Input>(
+		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+
+		auto output = input1 * input2;
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+			auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     shogun::zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/Multiply_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Multiply_test.cc
@@ -56,14 +56,15 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 
 	if constexpr (std::is_same_v<NumericType, bool>)
 		return;
-	else 
+	else
 	{
 		auto X1 = SGVector<NumericType>(10);
 		X1.range_fill();
 
 		NumericType X2{2};
 
-		SGVector<NumericType> expected_result1{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+		SGVector<NumericType> expected_result1{0,  2,  4,  6,  8, 10,
+		                                       12, 14, 16, 18, 20};
 
 		auto input1 = make_shared<node::Input>(
 		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
@@ -73,13 +74,10 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 		auto output = input1 * input2;
 
 		auto graph = make_shared<Graph>(
-		    vector{input1, input2},
-		    vector<shared_ptr<node::Node>>{output});
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
 
 		for (auto&& backend : this->m_backends)
 		{
-			if (backend == GRAPH_BACKEND::SHOGUN)
-				continue;
 			graph->build(backend);
 
 			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =

--- a/src/shogun/mathematics/graph/nodes/Multiply_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Multiply_test.cc
@@ -49,3 +49,51 @@ TYPED_TEST(GraphTest, multiply)
 	this->test_binary_op_results(
 	    graph, X1, X2, expected_result1, expected_result2);
 }
+
+TYPED_TEST(GraphTest, vector_scalar_multiply)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	else 
+	{
+		auto X1 = SGVector<NumericType>(10);
+		X1.range_fill();
+
+		NumericType X2{2};
+
+		SGVector<NumericType> expected_result1{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+
+		auto input1 = make_shared<node::Input>(
+		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+		auto input2 = make_shared<node::Input>(
+		    Shape{}, get_enum_from_type<NumericType>::type);
+
+		auto output = input1 * input2;
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2},
+		    vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			if (backend == GRAPH_BACKEND::SHOGUN)
+				continue;
+			graph->build(backend);
+
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+			auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     shogun::zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -105,11 +105,11 @@ TYPED_TEST(GraphTest, scalar_vector_subtract)
 	else
 	{
 		NumericType X1{10};
-	
+
 		auto X2 = SGVector<NumericType>(10);
 		X2.range_fill(0);
 
-		SGVector<NumericType> expected_result1 {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+		SGVector<NumericType> expected_result1{10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
 
 		auto input1 = make_shared<node::Input>(
 		    Shape{}, get_enum_from_type<NumericType>::type);

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -49,3 +49,52 @@ TYPED_TEST(GraphTest, subtract)
 	this->test_binary_op_results(
 	    graph, X1, X2, expected_result1, expected_result2);
 }
+
+TYPED_TEST(GraphTest, vector_scalar_multiply)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	else 
+	{
+		auto X1 = SGVector<NumericType>(10);
+		X1.range_fill(1);
+
+		NumericType X2{1};
+
+		auto expected_result1 = SGVector<NumericType>(10);
+		expected_result1.range_fill();
+
+		auto input1 = make_shared<node::Input>(
+		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
+		auto input2 = make_shared<node::Input>(
+		    Shape{}, get_enum_from_type<NumericType>::type);
+
+		auto output = input1 - input2;
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2},
+		    vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			if (backend == GRAPH_BACKEND::SHOGUN)
+				continue;
+			graph->build(backend);
+
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+			auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     shogun::zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -56,7 +56,7 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 
 	if constexpr (std::is_same_v<NumericType, bool>)
 		return;
-	else 
+	else
 	{
 		auto X1 = SGVector<NumericType>(10);
 		X1.range_fill(1);
@@ -74,13 +74,10 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 		auto output = input1 - input2;
 
 		auto graph = make_shared<Graph>(
-		    vector{input1, input2},
-		    vector<shared_ptr<node::Node>>{output});
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
 
 		for (auto&& backend : this->m_backends)
 		{
-			if (backend == GRAPH_BACKEND::SHOGUN)
-				continue;
 			graph->build(backend);
 
 			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -50,7 +50,7 @@ TYPED_TEST(GraphTest, subtract)
 	    graph, X1, X2, expected_result1, expected_result2);
 }
 
-TYPED_TEST(GraphTest, vector_scalar_multiply)
+TYPED_TEST(GraphTest, vector_scalar_subtract)
 {
 	using NumericType = TypeParam;
 
@@ -70,6 +70,51 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
 		auto input2 = make_shared<node::Input>(
 		    Shape{}, get_enum_from_type<NumericType>::type);
+
+		auto output = input1 - input2;
+
+		auto graph = make_shared<Graph>(
+		    vector{input1, input2}, vector<shared_ptr<node::Node>>{output});
+
+		for (auto&& backend : this->m_backends)
+		{
+			graph->build(backend);
+
+			std::vector<std::shared_ptr<shogun::graph::Tensor>> result =
+			    graph->evaluate(
+			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
+			                    std::make_shared<shogun::graph::Tensor>(X2)});
+
+			auto result1 = result[0]->as<shogun::SGVector<NumericType>>();
+
+			for (const auto& [expected_i, result_i] :
+			     shogun::zip_iterator(expected_result1, result1))
+			{
+				EXPECT_EQ(expected_i, result_i);
+			}
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, scalar_vector_subtract)
+{
+	using NumericType = TypeParam;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	else
+	{
+		NumericType X1{10};
+	
+		auto X2 = SGVector<NumericType>(10);
+		X2.range_fill(0);
+
+		SGVector<NumericType> expected_result1 {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+
+		auto input1 = make_shared<node::Input>(
+		    Shape{}, get_enum_from_type<NumericType>::type);
+		auto input2 = make_shared<node::Input>(
+		    Shape{Shape::Dynamic}, get_enum_from_type<NumericType>::type);
 
 		auto output = input1 - input2;
 

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -55,7 +55,7 @@ namespace shogun
 						kernel(
 						    input_tensor1->data(), input_tensor2->data(),
 						    output_tensor->data(), output_tensor->size(),
-						    output_tensor->get_type());
+						    input_tensor1->get_type());
 					}
 					else if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayScalar)
 					{
@@ -63,7 +63,7 @@ namespace shogun
 						kernel_scalar(
 						    input_tensor1->data(), input_tensor2->data(),
 						    output_tensor->data(), output_tensor->size(),
-						    output_tensor->get_type(), scalar_first);
+						    input_tensor1->get_type(), scalar_first);
 					}
 				}
 

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -9,6 +9,7 @@
 
 #include <shogun/mathematics/graph/ops/abstract/Operator.h>
 #include <shogun/mathematics/graph/runtime/shogun/OutputNode.h>
+#include <shogun/mathematics/graph/nodes/BinaryNode.h>
 
 namespace shogun
 {
@@ -32,6 +33,15 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
+					auto binary_node = std::static_pointer_cast<node::BaseBinaryNode>(m_node);
+					const auto shape_compatibility = binary_node->get_binary_tensor_compatibility();
+
+					if (input_nodes.size() != 2)
+						error("Binary operation expected two inputs.");
+
+					if (m_output_tensors.size() != 1)
+						error("Binary operation expected one output.");
+
 					const auto& input_tensor1 =
 					    input_nodes[0]->get_output_tensors()[0];
 					const auto& input_tensor2 =
@@ -39,28 +49,32 @@ namespace shogun
 					const auto& output_tensor = m_output_tensors[0];
 
 					runtime_checks_and_allocation(
-					    std::vector{input_tensor1, input_tensor2});
-
-					kernel(
-					    input_tensor1->data(), input_tensor2->data(),
-					    output_tensor->data(), output_tensor->size(),
-					    output_tensor->get_type());
+					    input_tensor1, input_tensor2, shape_compatibility);
+					if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayArray)
+					{
+						kernel(
+						    input_tensor1->data(), input_tensor2->data(),
+						    output_tensor->data(), output_tensor->size(),
+						    output_tensor->get_type());
+					}
+					else if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayScalar)
+					{
+						const bool scalar_first = input_tensor1->get_shape().is_scalar();
+						kernel_scalar(
+						    input_tensor1->data(), input_tensor2->data(),
+						    output_tensor->data(), output_tensor->size(),
+						    output_tensor->get_type(), scalar_first);
+					}
 				}
 
 			protected:
 				void runtime_checks_and_allocation(
-				    const std::vector<std::shared_ptr<Tensor>>& tensors)
+				    const std::shared_ptr<Tensor>& input_tensor1, 
+				    const std::shared_ptr<Tensor>& input_tensor2,
+				    const node::BaseBinaryNode::BinaryShapeCompatibity& shape_compatibility)
 				{
-					if (tensors.size() != 2)
-						error("Binary operation expected two inputs.");
-					if (m_output_tensors.size() != 1)
-						error("Binary operation expected one output.");
-
-					const auto& input_tensor1 = tensors[0];
-					const auto& input_tensor2 = tensors[1];
-
 					allocate_tensor(
-					    runtime_shape_check(input_tensor1, input_tensor2));
+					    runtime_shape_check(input_tensor1, input_tensor2, shape_compatibility));
 				}
 
 				void allocate_tensor(const Shape& shape)
@@ -70,31 +84,44 @@ namespace shogun
 
 				const Shape& runtime_shape_check(
 				    const std::shared_ptr<Tensor>& tensor1,
-				    const std::shared_ptr<Tensor>& tensor2)
+				    const std::shared_ptr<Tensor>& tensor2,
+				    const node::BaseBinaryNode::BinaryShapeCompatibity& shape_compatibility)
 				{
-					for (auto [idx, shape1, shape2] :
-					     enumerate(tensor1->get_shape(), tensor2->get_shape()))
+					if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayArray)
 					{
-						if (shape1 != shape2)
+						for (auto [idx, shape1, shape2] :
+						     enumerate(tensor1->get_shape(), tensor2->get_shape()))
 						{
-							error(
-							    "Runtime shape mismatch in dimension {}. Got "
-							    "{} and {}.",
-							    idx, shape1, shape2);
+							if (shape1 != shape2)
+							{
+								error(
+								    "Runtime shape mismatch in dimension {}. Got "
+								    "{} and {}.",
+								    idx, shape1, shape2);
+							}
+							if (shape1 == Shape::Dynamic)
+							{
+								error("Could not infer runtime shape.");
+							}
 						}
-						if (shape1 == Shape::Dynamic)
-						{
-							error("Could not infer runtime shape.");
-						}
+						// shapes have to match exactly so can return either one
+						return tensor1->get_shape();
 					}
-
-					// shapes have to match exeactly so can return either one
-					return tensor1->get_shape();
+					else if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayScalar)
+					{
+						if (tensor1->get_shape().is_scalar())
+							return tensor2->get_shape();
+						return tensor1->get_shape();
+					}
+					else
+					{
+						error("NotImplemented");
+					}
 				}
 
 				void kernel(
-				    void* input1, void* input2, void* output, size_t size,
-				    element_type type)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const element_type type)
 				{
 
 #define CALL_KERNEL_IMPLEMENTATION(SHOGUN_TYPE)                                \
@@ -102,6 +129,46 @@ namespace shogun
 	    ->template kernel_implementation<                                      \
 	        get_type_from_enum<SHOGUN_TYPE>::type>(                            \
 	        input1, input2, output, size);                                     \
+	break;
+
+					switch (type)
+					{
+					case element_type::BOOLEAN:
+						CALL_KERNEL_IMPLEMENTATION(element_type::BOOLEAN)
+					case element_type::INT8:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT8)
+					case element_type::INT16:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT16)
+					case element_type::INT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT32)
+					case element_type::INT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::INT64)
+					case element_type::UINT8:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT8)
+					case element_type::UINT16:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT16)
+					case element_type::UINT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT32)
+					case element_type::UINT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::UINT64)
+					case element_type::FLOAT32:
+						CALL_KERNEL_IMPLEMENTATION(element_type::FLOAT32)
+					case element_type::FLOAT64:
+						CALL_KERNEL_IMPLEMENTATION(element_type::FLOAT64)
+					}
+#undef CALL_KERNEL_IMPLEMENTATION
+				}
+
+				void kernel_scalar(
+				    void* input1, void* input2, void* output, const size_t size,
+				    const element_type type, const bool scalar_first)
+				{
+
+#define CALL_KERNEL_IMPLEMENTATION(SHOGUN_TYPE)                                \
+	static_cast<DerivedOperator*>(this)                                        \
+	    ->template kernel_scalar_implementation<                               \
+	        get_type_from_enum<SHOGUN_TYPE>::type>(                            \
+	        input1, input2, output, size, scalar_first);                       \
 	break;
 
 					switch (type)

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -7,9 +7,9 @@
 #ifndef SHOGUNBINARYOPERATOR_H_
 #define SHOGUNBINARYOPERATOR_H_
 
+#include <shogun/mathematics/graph/nodes/BinaryNode.h>
 #include <shogun/mathematics/graph/ops/abstract/Operator.h>
 #include <shogun/mathematics/graph/runtime/shogun/OutputNode.h>
-#include <shogun/mathematics/graph/nodes/BinaryNode.h>
 
 namespace shogun
 {
@@ -33,8 +33,10 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
-					auto binary_node = std::static_pointer_cast<node::BaseBinaryNode>(m_node);
-					const auto shape_compatibility = binary_node->get_binary_tensor_compatibility();
+					auto binary_node =
+					    std::static_pointer_cast<node::BaseBinaryNode>(m_node);
+					const auto shape_compatibility =
+					    binary_node->get_binary_tensor_compatibility();
 
 					if (input_nodes.size() != 2)
 						error("Binary operation expected two inputs.");
@@ -50,16 +52,22 @@ namespace shogun
 
 					runtime_checks_and_allocation(
 					    input_tensor1, input_tensor2, shape_compatibility);
-					if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayArray)
+					if (shape_compatibility ==
+					    node::BaseBinaryNode::BinaryShapeCompatibity::
+					        ArrayArray)
 					{
 						kernel(
 						    input_tensor1->data(), input_tensor2->data(),
 						    output_tensor->data(), output_tensor->size(),
 						    input_tensor1->get_type());
 					}
-					else if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayScalar)
+					else if (
+					    shape_compatibility ==
+					    node::BaseBinaryNode::BinaryShapeCompatibity::
+					        ArrayScalar)
 					{
-						const bool scalar_first = input_tensor1->get_shape().is_scalar();
+						const bool scalar_first =
+						    input_tensor1->get_shape().is_scalar();
 						kernel_scalar(
 						    input_tensor1->data(), input_tensor2->data(),
 						    output_tensor->data(), output_tensor->size(),
@@ -69,12 +77,13 @@ namespace shogun
 
 			protected:
 				void runtime_checks_and_allocation(
-				    const std::shared_ptr<Tensor>& input_tensor1, 
+				    const std::shared_ptr<Tensor>& input_tensor1,
 				    const std::shared_ptr<Tensor>& input_tensor2,
-				    const node::BaseBinaryNode::BinaryShapeCompatibity& shape_compatibility)
+				    const node::BaseBinaryNode::BinaryShapeCompatibity&
+				        shape_compatibility)
 				{
-					allocate_tensor(
-					    runtime_shape_check(input_tensor1, input_tensor2, shape_compatibility));
+					allocate_tensor(runtime_shape_check(
+					    input_tensor1, input_tensor2, shape_compatibility));
 				}
 
 				void allocate_tensor(const Shape& shape)
@@ -85,17 +94,21 @@ namespace shogun
 				const Shape& runtime_shape_check(
 				    const std::shared_ptr<Tensor>& tensor1,
 				    const std::shared_ptr<Tensor>& tensor2,
-				    const node::BaseBinaryNode::BinaryShapeCompatibity& shape_compatibility)
+				    const node::BaseBinaryNode::BinaryShapeCompatibity&
+				        shape_compatibility)
 				{
-					if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayArray)
+					if (shape_compatibility ==
+					    node::BaseBinaryNode::BinaryShapeCompatibity::
+					        ArrayArray)
 					{
-						for (auto [idx, shape1, shape2] :
-						     enumerate(tensor1->get_shape(), tensor2->get_shape()))
+						for (auto [idx, shape1, shape2] : enumerate(
+						         tensor1->get_shape(), tensor2->get_shape()))
 						{
 							if (shape1 != shape2)
 							{
 								error(
-								    "Runtime shape mismatch in dimension {}. Got "
+								    "Runtime shape mismatch in dimension {}. "
+								    "Got "
 								    "{} and {}.",
 								    idx, shape1, shape2);
 							}
@@ -107,7 +120,10 @@ namespace shogun
 						// shapes have to match exactly so can return either one
 						return tensor1->get_shape();
 					}
-					else if (shape_compatibility == node::BaseBinaryNode::BinaryShapeCompatibity::ArrayScalar)
+					else if (
+					    shape_compatibility ==
+					    node::BaseBinaryNode::BinaryShapeCompatibity::
+					        ArrayScalar)
 					{
 						if (tensor1->get_shape().is_scalar())
 							return tensor2->get_shape();

--- a/src/shogun/mathematics/graph/ops/shogun/Add.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Add.h
@@ -35,15 +35,41 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
-					// if we have SYCL or MSVC we could add parallel execution
-					// or just use Eigen here
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::plus<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return *static_cast<const T*>(input1) + val;
+						    });	
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val + *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Add.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Add.h
@@ -46,28 +46,25 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return *static_cast<const T*>(input1) + val;
-						    });	
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return *static_cast<const T*>(input1) + val;
+						    });
 					}
 					else
 					{
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val + *static_cast<const T*>(input2);
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return val + *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/Divide.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Divide.h
@@ -46,17 +46,16 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return *static_cast<const T*>(input1) / val;
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return *static_cast<const T*>(input1) / val;
 						    });
 					}
 					else
@@ -64,10 +63,8 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val / *static_cast<const T*>(input2);
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return val / *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/Divide.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Divide.h
@@ -35,15 +35,41 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
-					// if we have SYCL or MSVC we could add parallel execution
-					// or just use Eigen here
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::divides<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return *static_cast<const T*>(input1) / val;
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val / *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Equal.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Equal.h
@@ -35,13 +35,41 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::equal_to<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return val == *static_cast<const T*>(input1);
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val == *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Equal.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Equal.h
@@ -40,7 +40,7 @@ namespace shogun
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
-					    static_cast<const T*>(input2), static_cast<T*>(output),
+					    static_cast<const T*>(input2), static_cast<bool*>(output),
 					    std::equal_to<T>());
 				}
 
@@ -53,7 +53,7 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
+						    static_cast<bool*>(output),
 						    [&input1](const T& val)
 						    {
 						    	return val == *static_cast<const T*>(input1);
@@ -64,7 +64,7 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
+						    static_cast<bool*>(output),
 						    [&input2](const T& val)
 						    {
 						    	return val == *static_cast<const T*>(input2);

--- a/src/shogun/mathematics/graph/ops/shogun/Equal.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Equal.h
@@ -40,13 +40,14 @@ namespace shogun
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
-					    static_cast<const T*>(input2), static_cast<bool*>(output),
-					    std::equal_to<T>());
+					    static_cast<const T*>(input2),
+					    static_cast<bool*>(output), std::equal_to<T>());
 				}
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
@@ -54,9 +55,8 @@ namespace shogun
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
 						    static_cast<bool*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return val == *static_cast<const T*>(input1);
+						    [&input1](const T& val) {
+							    return val == *static_cast<const T*>(input1);
 						    });
 					}
 					else
@@ -65,9 +65,8 @@ namespace shogun
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
 						    static_cast<bool*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val == *static_cast<const T*>(input2);
+						    [&input2](const T& val) {
+							    return val == *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalAnd.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalAnd.h
@@ -46,17 +46,16 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return val && *static_cast<const T*>(input1);
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return val && *static_cast<const T*>(input1);
 						    });
 					}
 					else
@@ -64,10 +63,8 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val && *static_cast<const T*>(input2);
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return val && *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalAnd.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalAnd.h
@@ -35,13 +35,41 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::logical_and<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return val && *static_cast<const T*>(input1);
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val && *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalOr.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalOr.h
@@ -35,13 +35,41 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
 					std::transform(
 					    static_cast<const T*>(input1),
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::logical_or<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool is_scalar)
+				{
+					if (is_scalar)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return val || *static_cast<const T*>(input1);
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val || *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalOr.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalOr.h
@@ -46,17 +46,16 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool is_scalar)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool is_scalar)
 				{
 					if (is_scalar)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return val || *static_cast<const T*>(input1);
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return val || *static_cast<const T*>(input1);
 						    });
 					}
 					else
@@ -64,10 +63,8 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val || *static_cast<const T*>(input2);
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return val || *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalXor.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalXor.h
@@ -48,17 +48,17 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return !val != !(*static_cast<const T*>(input1));
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return !val !=
+							           !(*static_cast<const T*>(input1));
 						    });
 					}
 					else
@@ -66,10 +66,9 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return !val != !(*static_cast<const T*>(input2));
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return !val !=
+							           !(*static_cast<const T*>(input2));
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/LogicalXor.h
+++ b/src/shogun/mathematics/graph/ops/shogun/LogicalXor.h
@@ -35,7 +35,7 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
 					std::transform(
 					    static_cast<const T*>(input1),
@@ -44,6 +44,34 @@ namespace shogun
 					    [](const T& lhs, const T& rhs) {
 						    return (!lhs != !rhs);
 					    });
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return !val != !(*static_cast<const T*>(input1));
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return !val != !(*static_cast<const T*>(input2));
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Multiply.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Multiply.h
@@ -35,7 +35,7 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
 					// if we have SYCL or MSVC we could add parallel execution
 					// or just use Eigen here
@@ -44,6 +44,34 @@ namespace shogun
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::multiplies<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return val * *static_cast<const T*>(input1);
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val * *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Multiply.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Multiply.h
@@ -48,17 +48,16 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return val * *static_cast<const T*>(input1);
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return val * *static_cast<const T*>(input1);
 						    });
 					}
 					else
@@ -66,10 +65,8 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val * *static_cast<const T*>(input2);
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return val * *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/ops/shogun/Subtract.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Subtract.h
@@ -36,7 +36,7 @@ namespace shogun
 			protected:
 				template <typename T>
 				void kernel_implementation(
-				    void* input1, void* input2, void* output, size_t size)
+				    void* input1, void* input2, void* output, const size_t size)
 				{
 					// if we have SYCL or MSVC we could add parallel execution
 					// or just use Eigen here
@@ -45,6 +45,34 @@ namespace shogun
 					    static_cast<const T*>(input1) + size,
 					    static_cast<const T*>(input2), static_cast<T*>(output),
 					    std::minus<T>());
+				}
+
+				template <typename T>
+				void kernel_scalar_implementation(
+				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				{
+					if (scalar_first)
+					{
+						std::transform(
+						    static_cast<const T*>(input2),
+						    static_cast<const T*>(input2) + size,
+						    static_cast<T*>(output),
+						    [&input1](const T& val)
+						    {
+						    	return *static_cast<const T*>(input1) - val;
+						    });
+					}
+					else
+					{
+						std::transform(
+						    static_cast<const T*>(input1),
+						    static_cast<const T*>(input1) + size,
+						    static_cast<T*>(output),
+						    [&input2](const T& val)
+						    {
+						    	return val - *static_cast<const T*>(input2);
+						    });
+					}
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Subtract.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Subtract.h
@@ -49,17 +49,16 @@ namespace shogun
 
 				template <typename T>
 				void kernel_scalar_implementation(
-				    void* input1, void* input2, void* output, const size_t size, const bool scalar_first)
+				    void* input1, void* input2, void* output, const size_t size,
+				    const bool scalar_first)
 				{
 					if (scalar_first)
 					{
 						std::transform(
 						    static_cast<const T*>(input2),
 						    static_cast<const T*>(input2) + size,
-						    static_cast<T*>(output),
-						    [&input1](const T& val)
-						    {
-						    	return *static_cast<const T*>(input1) - val;
+						    static_cast<T*>(output), [&input1](const T& val) {
+							    return *static_cast<const T*>(input1) - val;
 						    });
 					}
 					else
@@ -67,10 +66,8 @@ namespace shogun
 						std::transform(
 						    static_cast<const T*>(input1),
 						    static_cast<const T*>(input1) + size,
-						    static_cast<T*>(output),
-						    [&input2](const T& val)
-						    {
-						    	return val - *static_cast<const T*>(input2);
+						    static_cast<T*>(output), [&input2](const T& val) {
+							    return val - *static_cast<const T*>(input2);
 						    });
 					}
 				}

--- a/src/shogun/mathematics/graph/runtime/ngraph/Add.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Add.h
@@ -38,10 +38,20 @@ namespace shogun
 					build_implementation(
 					    const std::shared_ptr<node::Node>& node) const final {
 						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "AddNGraph.");
-						return std::make_shared<::ngraph::op::Add>(
-						    m_input_nodes[0], m_input_nodes[1]);
+							error("Expected two input nodes in AddNGraph.");
+
+						auto add_node = std::static_pointer_cast<node::Add>(node);
+						if (add_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						{
+							return std::make_shared<::ngraph::op::Add>(
+							    m_input_nodes[0], m_input_nodes[1]);
+						}
+						else if (add_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						{
+							return std::make_shared<::ngraph::op::Add>(
+								    m_input_nodes[0], m_input_nodes[1],
+									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Add.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Add.h
@@ -8,7 +8,7 @@
 #define SHOGUN_ADD_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/Add.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/add.hpp>
 
@@ -21,44 +21,16 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class AddNGraph
-
-				    : public RuntimeNodeTemplate<node::Add, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<node::Add, ::ngraph::op::Add>
 				{
 				public:
-					AddNGraph() : RuntimeNodeTemplate()
+					AddNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "Add";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in AddNGraph.");
-
-						auto add_node =
-						    std::static_pointer_cast<node::Add>(node);
-						if (add_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayArray)
-						{
-							return std::make_shared<::ngraph::op::Add>(
-							    m_input_nodes[0], m_input_nodes[1]);
-						}
-						else if (
-						    add_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayScalar)
-						{
-							return std::make_shared<::ngraph::op::Add>(
-							    m_input_nodes[0], m_input_nodes[1],
-							    ::ngraph::op::AutoBroadcastSpec(
-							        ::ngraph::op::AutoBroadcastType::NUMPY));
-						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Add.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Add.h
@@ -40,17 +40,24 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error("Expected two input nodes in AddNGraph.");
 
-						auto add_node = std::static_pointer_cast<node::Add>(node);
-						if (add_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						auto add_node =
+						    std::static_pointer_cast<node::Add>(node);
+						if (add_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayArray)
 						{
 							return std::make_shared<::ngraph::op::Add>(
 							    m_input_nodes[0], m_input_nodes[1]);
 						}
-						else if (add_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						else if (
+						    add_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayScalar)
 						{
 							return std::make_shared<::ngraph::op::Add>(
-								    m_input_nodes[0], m_input_nodes[1],
-									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+							    m_input_nodes[0], m_input_nodes[1],
+							    ::ngraph::op::AutoBroadcastSpec(
+							        ::ngraph::op::AutoBroadcastType::NUMPY));
 						}
 					}
 				};

--- a/src/shogun/mathematics/graph/runtime/ngraph/Add.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Add.h
@@ -21,7 +21,8 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class AddNGraph
-				    : public BinaryRuntimeNodeNGraph<node::Add, ::ngraph::op::Add>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::Add, ::ngraph::op::Add>
 				{
 				public:
 					AddNGraph() : BinaryRuntimeNodeNGraph()

--- a/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
@@ -1,0 +1,64 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_BINARY_RUNTIME_NODE_NGRAPH_H_
+#define SHOGUN_BINARY_RUNTIME_NODE_NGRAPH_H_
+
+#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+
+#include <ngraph/op/add.hpp>
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace detail
+		{
+			namespace ngraph
+			{
+				template <typename NodeType, typename OperatorType>
+				IGNORE_IN_CLASSLIST class BinaryRuntimeNodeNGraph
+
+				    : public RuntimeNodeTemplate<NodeType, ::ngraph::Node>
+				{
+				public:
+					BinaryRuntimeNodeNGraph() : RuntimeNodeTemplate<NodeType, ::ngraph::Node>()
+					{
+					}
+
+					[[nodiscard]] std::shared_ptr<::ngraph::Node>
+					build_implementation(
+					    const std::shared_ptr<node::Node>& node) const final {
+						if (this->m_input_nodes.size() != 2)
+							error("Expected two input nodes in BinaryRuntimeNodeNGraph.");
+
+						auto binary_node =
+						    std::static_pointer_cast<NodeType>(node);
+						if (binary_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayArray)
+						{
+							return std::make_shared<OperatorType>(
+							    this->m_input_nodes[0], this->m_input_nodes[1]);
+						}
+						else if (
+						    binary_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayScalar)
+						{
+							return std::make_shared<OperatorType>(
+							    this->m_input_nodes[0], this->m_input_nodes[1],
+							    ::ngraph::op::AutoBroadcastSpec(
+							        ::ngraph::op::AutoBroadcastType::NUMPY));
+						}
+					}
+				};
+			} // namespace ngraph
+		}     // namespace detail
+	}         // namespace graph
+} // namespace shogun
+
+#endif

--- a/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
@@ -25,15 +25,17 @@ namespace shogun
 				    : public RuntimeNodeTemplate<NodeType, ::ngraph::Node>
 				{
 				public:
-					BinaryRuntimeNodeNGraph() : RuntimeNodeTemplate<NodeType, ::ngraph::Node>()
-					{
-					}
+					BinaryRuntimeNodeNGraph()
+					    : RuntimeNodeTemplate<NodeType, ::ngraph::Node>(){}
 
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
+					          [[nodiscard]] std::
+					              shared_ptr<::ngraph::Node> build_implementation(
+					                  const std::shared_ptr<node::Node>& node)
+					                  const final
+					{
 						if (this->m_input_nodes.size() != 2)
-							error("Expected two input nodes in BinaryRuntimeNodeNGraph.");
+							error("Expected two input nodes in "
+							      "BinaryRuntimeNodeNGraph.");
 
 						auto binary_node =
 						    std::static_pointer_cast<NodeType>(node);

--- a/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
@@ -21,7 +21,8 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class DivideNGraph
-				    : public BinaryRuntimeNodeNGraph<node::Divide, ::ngraph::op::Divide>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::Divide, ::ngraph::op::Divide>
 				{
 				public:
 					DivideNGraph() : BinaryRuntimeNodeNGraph()

--- a/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
@@ -8,7 +8,7 @@
 #define SHOGUN_DIVIDE_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/Divide.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/divide.hpp>
 
@@ -21,44 +21,16 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class DivideNGraph
-
-				    : public RuntimeNodeTemplate<node::Divide, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<node::Divide, ::ngraph::op::Divide>
 				{
 				public:
-					DivideNGraph() : RuntimeNodeTemplate()
+					DivideNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "Divide";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "DivideNGraph.");
-						auto divide_node =
-						    std::static_pointer_cast<node::Divide>(node);
-						if (divide_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayArray)
-						{
-							return std::make_shared<::ngraph::op::Divide>(
-							    m_input_nodes[0], m_input_nodes[1]);
-						}
-						else if (
-						    divide_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayScalar)
-						{
-							return std::make_shared<::ngraph::op::Divide>(
-							    m_input_nodes[0], m_input_nodes[1],
-							    ::ngraph::op::AutoBroadcastSpec(
-							        ::ngraph::op::AutoBroadcastType::NUMPY));
-						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
@@ -40,17 +40,24 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error("Expected two input nodes in "
 							      "DivideNGraph.");
-						auto divide_node = std::static_pointer_cast<node::Divide>(node);
-						if (divide_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						auto divide_node =
+						    std::static_pointer_cast<node::Divide>(node);
+						if (divide_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayArray)
 						{
 							return std::make_shared<::ngraph::op::Divide>(
 							    m_input_nodes[0], m_input_nodes[1]);
 						}
-						else if (divide_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						else if (
+						    divide_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayScalar)
 						{
 							return std::make_shared<::ngraph::op::Divide>(
-								    m_input_nodes[0], m_input_nodes[1],
-									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+							    m_input_nodes[0], m_input_nodes[1],
+							    ::ngraph::op::AutoBroadcastSpec(
+							        ::ngraph::op::AutoBroadcastType::NUMPY));
 						}
 					}
 				};

--- a/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Divide.h
@@ -40,8 +40,18 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error("Expected two input nodes in "
 							      "DivideNGraph.");
-						return std::make_shared<::ngraph::op::Divide>(
-						    m_input_nodes[0], m_input_nodes[1]);
+						auto divide_node = std::static_pointer_cast<node::Divide>(node);
+						if (divide_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						{
+							return std::make_shared<::ngraph::op::Divide>(
+							    m_input_nodes[0], m_input_nodes[1]);
+						}
+						else if (divide_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						{
+							return std::make_shared<::ngraph::op::Divide>(
+								    m_input_nodes[0], m_input_nodes[1],
+									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Equal.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Equal.h
@@ -8,7 +8,7 @@
 #define SHOGUN_EQUAL_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/Equal.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/equal.hpp>
 
@@ -21,27 +21,16 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class EqualNGraph
-
-				    : public RuntimeNodeTemplate<node::Equal, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<node::Equal, ::ngraph::op::Equal>
 				{
 				public:
-					EqualNGraph() : RuntimeNodeTemplate()
+					EqualNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "Equal";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "EqualNGraph.");
-						return std::make_shared<::ngraph::op::Equal>(
-						    m_input_nodes[0], m_input_nodes[1]);
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Equal.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Equal.h
@@ -21,7 +21,8 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class EqualNGraph
-				    : public BinaryRuntimeNodeNGraph<node::Equal, ::ngraph::op::Equal>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::Equal, ::ngraph::op::Equal>
 				{
 				public:
 					EqualNGraph() : BinaryRuntimeNodeNGraph()

--- a/src/shogun/mathematics/graph/runtime/ngraph/LogicalAnd.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/LogicalAnd.h
@@ -8,7 +8,7 @@
 #define SHOGUN_LOGICAL_AND_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/LogicalAnd.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/and.hpp>
 
@@ -21,28 +21,17 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class LogicalAndNGraph
-
-				    : public RuntimeNodeTemplate<
-				          node::LogicalAnd, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::LogicalAnd, ::ngraph::op::And>
 				{
 				public:
-					LogicalAndNGraph() : RuntimeNodeTemplate()
+					LogicalAndNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "LogicalAnd";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "LogicalAndNGraph.");
-						return std::make_shared<::ngraph::op::And>(
-						    m_input_nodes[0], m_input_nodes[1]);
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/LogicalOr.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/LogicalOr.h
@@ -8,7 +8,7 @@
 #define SHOGUN_LOGICAL_OR_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/LogicalOr.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/or.hpp>
 
@@ -21,28 +21,17 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class LogicalOrNGraph
-
-				    : public RuntimeNodeTemplate<
-				          node::LogicalOr, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::LogicalOr, ::ngraph::op::Or>
 				{
 				public:
-					LogicalOrNGraph() : RuntimeNodeTemplate()
+					LogicalOrNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "LogicalOr";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "LogicalOrNGraph.");
-						return std::make_shared<::ngraph::op::Or>(
-						    m_input_nodes[0], m_input_nodes[1]);
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/LogicalXor.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/LogicalXor.h
@@ -8,7 +8,7 @@
 #define SHOGUN_LOGICAL_XOR_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/LogicalXor.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/xor.hpp>
 
@@ -21,28 +21,17 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class LogicalXorNGraph
-
-				    : public RuntimeNodeTemplate<
-				          node::LogicalXor, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::LogicalXor, ::ngraph::op::Xor>
 				{
 				public:
-					LogicalXorNGraph() : RuntimeNodeTemplate()
+					LogicalXorNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "LogicalXor";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "LogicalXor.");
-						return std::make_shared<::ngraph::op::Xor>(
-						    m_input_nodes[0], m_input_nodes[1]);
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Multiply.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Multiply.h
@@ -40,17 +40,24 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error(
 							    "Expected two input nodes in MultiplyNGraph.");
-						auto multiply_node = std::static_pointer_cast<node::Multiply>(node);
-						if (multiply_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						auto multiply_node =
+						    std::static_pointer_cast<node::Multiply>(node);
+						if (multiply_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayArray)
 						{
 							return std::make_shared<::ngraph::op::Multiply>(
 							    m_input_nodes[0], m_input_nodes[1]);
 						}
-						else if (multiply_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						else if (
+						    multiply_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayScalar)
 						{
 							return std::make_shared<::ngraph::op::Multiply>(
-								    m_input_nodes[0], m_input_nodes[1],
-									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+							    m_input_nodes[0], m_input_nodes[1],
+							    ::ngraph::op::AutoBroadcastSpec(
+							        ::ngraph::op::AutoBroadcastType::NUMPY));
 						}
 					}
 				};

--- a/src/shogun/mathematics/graph/runtime/ngraph/Multiply.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Multiply.h
@@ -8,7 +8,7 @@
 #define SHOGUN_MULTIPLY_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/Multiply.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/multiply.hpp>
 
@@ -21,44 +21,17 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class MultiplyNGraph
-
-				    : public RuntimeNodeTemplate<node::Multiply, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::Multiply, ::ngraph::op::Multiply>
 				{
 				public:
-					MultiplyNGraph() : RuntimeNodeTemplate()
+					MultiplyNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "Multiply";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error(
-							    "Expected two input nodes in MultiplyNGraph.");
-						auto multiply_node =
-						    std::static_pointer_cast<node::Multiply>(node);
-						if (multiply_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayArray)
-						{
-							return std::make_shared<::ngraph::op::Multiply>(
-							    m_input_nodes[0], m_input_nodes[1]);
-						}
-						else if (
-						    multiply_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayScalar)
-						{
-							return std::make_shared<::ngraph::op::Multiply>(
-							    m_input_nodes[0], m_input_nodes[1],
-							    ::ngraph::op::AutoBroadcastSpec(
-							        ::ngraph::op::AutoBroadcastType::NUMPY));
-						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Multiply.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Multiply.h
@@ -40,8 +40,18 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error(
 							    "Expected two input nodes in MultiplyNGraph.");
-						return std::make_shared<::ngraph::op::Multiply>(
-						    m_input_nodes[0], m_input_nodes[1]);
+						auto multiply_node = std::static_pointer_cast<node::Multiply>(node);
+						if (multiply_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						{
+							return std::make_shared<::ngraph::op::Multiply>(
+							    m_input_nodes[0], m_input_nodes[1]);
+						}
+						else if (multiply_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						{
+							return std::make_shared<::ngraph::op::Multiply>(
+								    m_input_nodes[0], m_input_nodes[1],
+									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Subtract.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Subtract.h
@@ -40,17 +40,24 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error("Expected two input nodes in "
 							      "SubtractNGraph.");
-						auto subtract_node = std::static_pointer_cast<node::Subtract>(node);
-						if (subtract_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						auto subtract_node =
+						    std::static_pointer_cast<node::Subtract>(node);
+						if (subtract_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayArray)
 						{
 							return std::make_shared<::ngraph::op::Subtract>(
 							    m_input_nodes[0], m_input_nodes[1]);
 						}
-						else if (subtract_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						else if (
+						    subtract_node->get_binary_tensor_compatibility() ==
+						    node::BinaryNode::BinaryShapeCompatibity::
+						        ArrayScalar)
 						{
 							return std::make_shared<::ngraph::op::Subtract>(
-								    m_input_nodes[0], m_input_nodes[1],
-									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+							    m_input_nodes[0], m_input_nodes[1],
+							    ::ngraph::op::AutoBroadcastSpec(
+							        ::ngraph::op::AutoBroadcastType::NUMPY));
 						}
 					}
 				};

--- a/src/shogun/mathematics/graph/runtime/ngraph/Subtract.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Subtract.h
@@ -8,7 +8,7 @@
 #define SHOGUN_SUBTRACT_NGRAPH_H_
 
 #include <shogun/mathematics/graph/nodes/Subtract.h>
-#include <shogun/mathematics/graph/runtime/RuntimeNode.h>
+#include <shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h>
 
 #include <ngraph/op/subtract.hpp>
 
@@ -21,44 +21,17 @@ namespace shogun
 			namespace ngraph
 			{
 				IGNORE_IN_CLASSLIST class SubtractNGraph
-
-				    : public RuntimeNodeTemplate<node::Subtract, ::ngraph::Node>
+				    : public BinaryRuntimeNodeNGraph<
+				          node::Subtract, ::ngraph::op::Subtract>
 				{
 				public:
-					SubtractNGraph() : RuntimeNodeTemplate()
+					SubtractNGraph() : BinaryRuntimeNodeNGraph()
 					{
 					}
 
 					std::string_view get_runtime_node_name() const final
 					{
 						return "Subtract";
-					}
-
-					[[nodiscard]] std::shared_ptr<::ngraph::Node>
-					build_implementation(
-					    const std::shared_ptr<node::Node>& node) const final {
-						if (m_input_nodes.size() != 2)
-							error("Expected two input nodes in "
-							      "SubtractNGraph.");
-						auto subtract_node =
-						    std::static_pointer_cast<node::Subtract>(node);
-						if (subtract_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayArray)
-						{
-							return std::make_shared<::ngraph::op::Subtract>(
-							    m_input_nodes[0], m_input_nodes[1]);
-						}
-						else if (
-						    subtract_node->get_binary_tensor_compatibility() ==
-						    node::BinaryNode::BinaryShapeCompatibity::
-						        ArrayScalar)
-						{
-							return std::make_shared<::ngraph::op::Subtract>(
-							    m_input_nodes[0], m_input_nodes[1],
-							    ::ngraph::op::AutoBroadcastSpec(
-							        ::ngraph::op::AutoBroadcastType::NUMPY));
-						}
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Subtract.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Subtract.h
@@ -40,8 +40,18 @@ namespace shogun
 						if (m_input_nodes.size() != 2)
 							error("Expected two input nodes in "
 							      "SubtractNGraph.");
-						return std::make_shared<::ngraph::op::Subtract>(
-						    m_input_nodes[0], m_input_nodes[1]);
+						auto subtract_node = std::static_pointer_cast<node::Subtract>(node);
+						if (subtract_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayArray)
+						{
+							return std::make_shared<::ngraph::op::Subtract>(
+							    m_input_nodes[0], m_input_nodes[1]);
+						}
+						else if (subtract_node->get_binary_tensor_compatibility() == node::BinaryNode::BinaryShapeCompatibity::ArrayScalar)
+						{
+							return std::make_shared<::ngraph::op::Subtract>(
+								    m_input_nodes[0], m_input_nodes[1],
+									::ngraph::op::AutoBroadcastSpec(::ngraph::op::AutoBroadcastType::NUMPY));
+						}
 					}
 				};
 			} // namespace ngraph


### PR DESCRIPTION
Allows users to do binary ops with array and scalar, e.g.:
```
auto X = make_shared<node::Input>(Shape{Shape::Dynamic, num_feat}, element_type::FLOAT64);
auto w = make_shared<node::Input>(Shape{num_feat}, element_type::FLOAT64);
auto b = make_shared<node::Input>(Shape{}, element_type::FLOAT64);

auto prediction = make_shared<Dot>(X, w) + b;
``` 

- [x] abstract node implementation
- [x] ngraph implementation
- [x] shogun implementation
- [x] add tests for logical operators and equals using scalar array operations