### PR TITLE
Separate tensor from storage

### DIFF
--- a/src/shogun/mathematics/graph/CMakeLists.txt
+++ b/src/shogun/mathematics/graph/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SHOGUN_CORE_GRAPH_SOURCES
 	)
 
 set(SHOGUN_GRAPH_IMPLEMENTATION_HEADERS
-		# ${CMAKE_CURRENT_SOURCE_DIR}/ops/abstract/UnaryOperator.h
+		${CMAKE_CURRENT_SOURCE_DIR}/ops/abstract/UnaryOperator.h
 		${CMAKE_CURRENT_SOURCE_DIR}/ops/abstract/Operator.h
 		${CMAKE_CURRENT_SOURCE_DIR}/ops/abstract/BinaryOperator.h
         ${CMAKE_CURRENT_SOURCE_DIR}/runtime/shogun/Add.h
@@ -182,5 +182,6 @@ IF (ENABLE_TESTING)
 	add_graph_test(nodes/Cast_test)
 	add_graph_test(nodes/Sign_test)
 	add_graph_test(Graph_test)
+	add_graph_test(Tensor_test)
 
 ENDIF()

--- a/src/shogun/mathematics/graph/Graph_test.cc
+++ b/src/shogun/mathematics/graph/Graph_test.cc
@@ -2,12 +2,12 @@
 
 #include "Graph.h"
 #include "nodes/Add.h"
+#include "nodes/Cast.h"
 #include "nodes/Dot.h"
+#include "nodes/Equal.h"
 #include "nodes/Input.h"
 #include "nodes/Multiply.h"
 #include "nodes/Sign.h"
-#include "nodes/Cast.h"
-#include "nodes/Equal.h"
 
 #include "test/GraphTest.h"
 

--- a/src/shogun/mathematics/graph/NGraph.cpp
+++ b/src/shogun/mathematics/graph/NGraph.cpp
@@ -6,8 +6,8 @@
 
 #include <shogun/mathematics/graph/NGraph.h>
 #include <shogun/mathematics/graph/Shape.h>
+#include <shogun/mathematics/graph/Storage.h>
 #include <shogun/mathematics/graph/nodes/Node.h>
-#include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Input.h>
 
 #include <ngraph/ngraph.hpp>
@@ -37,7 +37,7 @@ std::vector<std::shared_ptr<Tensor>> NGraph::execute(
 			        get_ngraph_type_from_enum(tensor->get_type()),
 			        to_ngraph_shape(shape)));
 			input->write(
-			    tensor->data()->m_data->m_internal_data.get(),
+			    tensor->storage()->m_data->m_internal_data.get(),
 			    tensor->size_in_bytes());
 		}
 		else if (tensor->get_shape().size() == 2 && m_requires_major_conversion)
@@ -48,7 +48,7 @@ std::vector<std::shared_ptr<Tensor>> NGraph::execute(
 			        get_ngraph_type_from_enum(tensor->get_type()),
 			        ::ngraph::Shape{ngraph_shape[1], ngraph_shape[0]}));
 			input->write(
-			    tensor->data()->m_data->m_internal_data.get(),
+			    tensor->storage()->m_data->m_internal_data.get(),
 			    tensor->size_in_bytes());
 			auto& transpose_param =
 			    ngraph_input_tensors.emplace_back(backend->create_tensor(
@@ -134,12 +134,12 @@ std::vector<std::shared_ptr<Tensor>> NGraph::execute(
 		const auto type =
 		    get_enum_from_ngraph(ngraph_tensor->get_element_type());
 
-		auto storage = std::make_shared<ShogunStorage>(shape, type);
+		auto storage = std::make_shared<Storage>(shape, type);
 		storage->allocate_storage(shape);
 		auto& tensor = results.emplace_back(from_device(storage));
 		ngraph_tensor->wait_for_read_ready();
 		ngraph_tensor->read(
-		    tensor->data()->m_data->m_internal_data.get(),
+		    tensor->storage()->m_data->m_internal_data.get(),
 		    ngraph_tensor->get_size_in_bytes());
 	}
 

--- a/src/shogun/mathematics/graph/NGraph.cpp
+++ b/src/shogun/mathematics/graph/NGraph.cpp
@@ -8,6 +8,7 @@
 #include <shogun/mathematics/graph/Shape.h>
 #include <shogun/mathematics/graph/nodes/Node.h>
 #include <shogun/mathematics/graph/runtime/ngraph/Input.h>
+#include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
 
 #include <ngraph/ngraph.hpp>
 
@@ -129,9 +130,10 @@ std::vector<std::shared_ptr<Tensor>> NGraph::execute(
 		const auto type =
 		    get_enum_from_ngraph(ngraph_tensor->get_element_type());
 
-		auto& tensor =
-		    results.emplace_back(std::make_shared<Tensor>(shape, type));
-		tensor->allocate_tensor(shape);
+		auto storage =
+		    std::make_shared<op::ShogunStorage>(shape, type);
+		storage->allocate_storage(shape);
+		auto& tensor = results.emplace_back(storage->to_tensor());
 		ngraph_tensor->wait_for_read_ready();
 		ngraph_tensor->read(tensor->data(), ngraph_tensor->get_size_in_bytes());
 	}

--- a/src/shogun/mathematics/graph/Shape.h
+++ b/src/shogun/mathematics/graph/Shape.h
@@ -17,7 +17,6 @@
 #include <shogun/io/SGIO.h>
 #include <shogun/util/zip_iterator.h>
 
-
 namespace shogun
 {
 	namespace graph
@@ -62,7 +61,7 @@ namespace shogun
 
 			bool operator==(const Shape& other)
 			{
-				for (const auto& [el1, el2]: zip_iterator(*this, other))
+				for (const auto& [el1, el2] : zip_iterator(*this, other))
 				{
 					if (el1 == Shape::Dynamic || el2 == Shape::Dynamic)
 						continue;
@@ -109,12 +108,11 @@ namespace shogun
 				}
 			}
 
-			[[nodiscard]] std::vector<Shape::shape_type>::const_iterator begin() const
-			{
-				return m_shape.begin();
-			}
+			[[nodiscard]] std::vector<Shape::shape_type>::const_iterator
+			begin() const { return m_shape.begin(); }
 
-			[[nodiscard]] std::vector<Shape::shape_type>::const_iterator end() const
+			    [[nodiscard]] std::vector<Shape::shape_type>::const_iterator
+			    end() const
 			{
 				return m_shape.end();
 			}

--- a/src/shogun/mathematics/graph/Shape.h
+++ b/src/shogun/mathematics/graph/Shape.h
@@ -27,11 +27,11 @@ namespace shogun
 		class Shape
 		{
 		public:
-			friend class Tensor;
-
 			using shape_type = int64_t;
 
 			static constexpr shape_type Dynamic = -1;
+
+			Shape() = default;
 
 			Shape(const std::initializer_list<shape_type>& shape)
 			    : m_shape(shape)
@@ -126,7 +126,7 @@ namespace shogun
 				while (shape_it != m_shape.end())
 				{
 					if (*shape_it == Dynamic)
-						result << "Dynamic";
+						result << "?";
 					else
 						result << *shape_it;
 					if (std::next(shape_it) != m_shape.end())

--- a/src/shogun/mathematics/graph/ShogunGraph.cpp
+++ b/src/shogun/mathematics/graph/ShogunGraph.cpp
@@ -44,7 +44,7 @@ std::vector<std::shared_ptr<Tensor>> ShogunGraph::execute(
 	std::vector<std::shared_ptr<Tensor>> results;
 	for (const auto& node : output_nodes)
 	{
-		results.push_back(extract_result(node));
+		results.push_back(extract_result(node)->to_tensor());
 	}
 
 	return results;
@@ -62,10 +62,10 @@ ShogunGraph::get_operator(const std::shared_ptr<node::Node>& node) const
 	return op_it->second();
 }
 
-std::shared_ptr<Tensor>
+std::shared_ptr<op::ShogunStorage>
 ShogunGraph::extract_result(const std::shared_ptr<node::Node>& node) const
 {
-	const auto& result = m_lookup.at(node)->get_output_tensors();
+	const auto& result = m_lookup.at(node)->get_outputs();
 	if (result.size() > 1)
 		error("Only one tensor for each node can be currently handled");
 	if (result.empty())

--- a/src/shogun/mathematics/graph/ShogunGraph.cpp
+++ b/src/shogun/mathematics/graph/ShogunGraph.cpp
@@ -62,7 +62,7 @@ ShogunGraph::get_operator(const std::shared_ptr<node::Node>& node) const
 	return op_it->second();
 }
 
-std::shared_ptr<ShogunStorage>
+std::shared_ptr<Storage>
 ShogunGraph::extract_result(const std::shared_ptr<node::Node>& node) const
 {
 	const auto& result = m_lookup.at(node)->get_outputs();

--- a/src/shogun/mathematics/graph/ShogunGraph.cpp
+++ b/src/shogun/mathematics/graph/ShogunGraph.cpp
@@ -44,7 +44,7 @@ std::vector<std::shared_ptr<Tensor>> ShogunGraph::execute(
 	std::vector<std::shared_ptr<Tensor>> results;
 	for (const auto& node : output_nodes)
 	{
-		results.push_back(extract_result(node)->to_tensor());
+		results.push_back(from_device(extract_result(node)));
 	}
 
 	return results;
@@ -62,7 +62,7 @@ ShogunGraph::get_operator(const std::shared_ptr<node::Node>& node) const
 	return op_it->second();
 }
 
-std::shared_ptr<op::ShogunStorage>
+std::shared_ptr<ShogunStorage>
 ShogunGraph::extract_result(const std::shared_ptr<node::Node>& node) const
 {
 	const auto& result = m_lookup.at(node)->get_outputs();

--- a/src/shogun/mathematics/graph/ShogunGraph.h
+++ b/src/shogun/mathematics/graph/ShogunGraph.h
@@ -8,8 +8,8 @@
 #define SHOGUN_GRAPH_
 
 #include <shogun/mathematics/graph/GraphExecutor.h>
-#include <shogun/mathematics/graph/runtime/shogun/OutputNode.h>
 #include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
+#include <shogun/mathematics/graph/runtime/shogun/OutputNode.h>
 
 #include <memory>
 #include <vector>
@@ -37,7 +37,7 @@ namespace shogun
 			add_operator_node(const std::shared_ptr<node::Node>& node) final;
 
 		private:
-			std::shared_ptr<op::ShogunStorage>
+			std::shared_ptr<ShogunStorage>
 			extract_result(const std::shared_ptr<node::Node>& node) const;
 			std::shared_ptr<detail::RuntimeNode>
 			get_operator(const std::shared_ptr<node::Node>& node) const;

--- a/src/shogun/mathematics/graph/ShogunGraph.h
+++ b/src/shogun/mathematics/graph/ShogunGraph.h
@@ -8,7 +8,7 @@
 #define SHOGUN_GRAPH_
 
 #include <shogun/mathematics/graph/GraphExecutor.h>
-#include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
+#include <shogun/mathematics/graph/Storage.h>
 #include <shogun/mathematics/graph/runtime/shogun/OutputNode.h>
 
 #include <memory>
@@ -37,7 +37,7 @@ namespace shogun
 			add_operator_node(const std::shared_ptr<node::Node>& node) final;
 
 		private:
-			std::shared_ptr<ShogunStorage>
+			std::shared_ptr<Storage>
 			extract_result(const std::shared_ptr<node::Node>& node) const;
 			std::shared_ptr<detail::RuntimeNode>
 			get_operator(const std::shared_ptr<node::Node>& node) const;

--- a/src/shogun/mathematics/graph/ShogunGraph.h
+++ b/src/shogun/mathematics/graph/ShogunGraph.h
@@ -9,6 +9,7 @@
 
 #include <shogun/mathematics/graph/GraphExecutor.h>
 #include <shogun/mathematics/graph/runtime/shogun/OutputNode.h>
+#include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
 
 #include <memory>
 #include <vector>
@@ -36,7 +37,7 @@ namespace shogun
 			add_operator_node(const std::shared_ptr<node::Node>& node) final;
 
 		private:
-			std::shared_ptr<Tensor>
+			std::shared_ptr<op::ShogunStorage>
 			extract_result(const std::shared_ptr<node::Node>& node) const;
 			std::shared_ptr<detail::RuntimeNode>
 			get_operator(const std::shared_ptr<node::Node>& node) const;

--- a/src/shogun/mathematics/graph/Storage.h
+++ b/src/shogun/mathematics/graph/Storage.h
@@ -107,8 +107,8 @@ namespace shogun
 				void
 				realloc(size_t size, const std::shared_ptr<NumberType>& type)
 				{
-					void* new_mem = std::realloc(
-					    m_internal_data.get(), size_in_bytes(size, type));
+					void* new_mem = SG_ALIGNED_REALLOC(
+					    m_internal_data.get(), 0, size_in_bytes(size, type), alignment::container_alignment);
 					if (new_mem)
 					{
 						// should keep old deleter

--- a/src/shogun/mathematics/graph/Tensor.cpp
+++ b/src/shogun/mathematics/graph/Tensor.cpp
@@ -13,7 +13,8 @@ using namespace shogun::graph;
 
 std::string Tensor::to_string() const
 {
-	return fmt::format("Tensor(shape={}, type={})", m_shape, m_type->to_string());
+	return fmt::format(
+	    "Tensor(shape={}, type={})", m_shape, m_type->to_string());
 }
 
 template Tensor::Tensor(const SGVector<float32_t>&);

--- a/src/shogun/mathematics/graph/Tensor.h
+++ b/src/shogun/mathematics/graph/Tensor.h
@@ -27,10 +27,11 @@ namespace shogun
 	{
 		inline std::shared_ptr<ShogunStorage> device_put(
 		    void* ptr, const Shape& shape,
-		    const std::shared_ptr<NumberType>& type)
+		    const std::shared_ptr<NumberType>& type,
+		    const bool copy)
 		{
 			return std::shared_ptr<ShogunStorage>(
-			    new ShogunStorage(ptr, shape, type));
+			    new ShogunStorage(ptr, shape, type, copy));
 		}
 
 		class Tensor
@@ -42,14 +43,14 @@ namespace shogun
 			template <typename T>
 			Tensor(const T& scalar) : m_shape({}), m_type(from<T>())
 			{
-				m_data = device_put(new T(scalar), m_shape, m_type);
+				m_data = device_put(new T(scalar), m_shape, m_type, true);
 			}
 
 			template <typename T>
 			Tensor(const SGVector<T>& vec)
 			    : m_shape(Shape{vec.size()}), m_type(from<T>())
 			{
-				m_data = device_put(vec.vector, m_shape, m_type);
+				m_data = device_put(vec.vector, m_shape, m_type, true);
 			}
 
 			template <typename T>
@@ -57,8 +58,24 @@ namespace shogun
 			    : m_shape(Shape{matrix.num_rows, matrix.num_cols}),
 			      m_type(from<T>())
 			{
-				m_data = device_put(matrix.matrix, m_shape, m_type);
+				m_data = device_put(matrix.matrix, m_shape, m_type, true);
 			}
+
+			template <typename T>
+			Tensor(SGVector<T>&& vec)
+			    : m_shape(Shape{vec.size()}), m_type(from<T>())
+			{
+				m_data = device_put(vec.vector, m_shape, m_type, false);
+			}
+
+			template <typename T>
+			Tensor(SGMatrix<T>&& matrix)
+			    : m_shape(Shape{matrix.num_rows, matrix.num_cols}),
+			      m_type(from<T>())
+			{
+				m_data = device_put(matrix.matrix, m_shape, m_type, false);
+			}
+
 
 			[[nodiscard]] const Shape& get_shape() const { return m_shape; }
 

--- a/src/shogun/mathematics/graph/Tensor_test.cc
+++ b/src/shogun/mathematics/graph/Tensor_test.cc
@@ -1,0 +1,173 @@
+#include <gtest/gtest.h>
+
+#include <shogun/mathematics/UniformIntDistribution.h>
+#include <shogun/mathematics/UniformRealDistribution.h>
+#include <shogun/mathematics/graph/Graph.h>
+#include <shogun/mathematics/graph/nodes/Add.h>
+#include <shogun/mathematics/graph/nodes/Input.h>
+
+#include "test/GraphTest.h"
+
+#include <random>
+
+using namespace shogun;
+using namespace shogun::graph;
+using namespace std;
+
+TYPED_TEST(GraphTest, tensor_lvalue)
+{
+	using NumericType = typename TypeParam::c_type;
+
+	if constexpr (std::is_same_v<TypeParam, BooleanType>)
+		return;
+
+	auto X1 = SGVector<NumericType>(10);
+	auto X2 = SGVector<NumericType>(10);
+
+	X1.range_fill();
+	X2.range_fill();
+
+	auto expected_result1 = X1 + X2;
+	auto expected_result2 = expected_result1 + X2;
+
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
+
+	auto intermediate = input1 + input1;
+
+	auto output = intermediate + input2;
+
+	auto graph = make_shared<Graph>(
+	    vector{input1, input2},
+	    vector<shared_ptr<node::Node>>{intermediate, output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		graph->build(backend);
+
+		vector<shared_ptr<Tensor>> result = graph->evaluate(
+		    vector{make_shared<Tensor>(X1), make_shared<Tensor>(X2)});
+
+		auto result1 = result[0]->as<SGVector<NumericType>>();
+		auto result2 = result[1]->as<SGVector<NumericType>>();
+
+		for (const auto& [expected_i, result_i] :
+		     zip_iterator(expected_result1, result1))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+
+		for (const auto& [expected_i, result_i] :
+		     zip_iterator(expected_result2, result2))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, tensor_rvalue)
+{
+	using NumericType = typename TypeParam::c_type;
+
+	if constexpr (std::is_same_v<TypeParam, BooleanType>)
+		return;
+
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
+
+	auto intermediate = input1 + input1;
+
+	auto output = intermediate + input2;
+
+	auto graph = make_shared<Graph>(
+	    vector{input1, input2},
+	    vector<shared_ptr<node::Node>>{intermediate, output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		// vectors reinstantiated in the loop because of the move
+		auto X1 = SGVector<NumericType>(10);
+		auto X2 = SGVector<NumericType>(10);
+
+		X1.range_fill();
+		X2.range_fill();
+
+		auto expected_result1 = X1 + X2;
+		auto expected_result2 = expected_result1 + X2;
+
+		graph->build(backend);
+
+		vector<shared_ptr<Tensor>> result =
+		    graph->evaluate(vector{make_shared<Tensor>(std::move(X1)),
+		                           make_shared<Tensor>(std::move(X2))});
+
+		auto result1 = result[0]->as<SGVector<NumericType>>();
+		auto result2 = result[1]->as<SGVector<NumericType>>();
+
+		for (const auto& [expected_i, result_i] :
+		     zip_iterator(expected_result1, result1))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+
+		for (const auto& [expected_i, result_i] :
+		     zip_iterator(expected_result2, result2))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+	}
+}
+
+TYPED_TEST(GraphTest, tensor_view)
+{
+	using NumericType = typename TypeParam::c_type;
+
+	if constexpr (std::is_same_v<TypeParam, BooleanType>)
+		return;
+
+	auto X1 = SGVector<NumericType>(10);
+	auto X2 = SGVector<NumericType>(10);
+
+	X1.range_fill();
+	X2.range_fill();
+
+	auto expected_result1 = X1 + X2;
+	auto expected_result2 = expected_result1 + X2;
+
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
+
+	auto intermediate = input1 + input1;
+
+	auto output = intermediate + input2;
+
+	auto graph = make_shared<Graph>(
+	    vector{input1, input2},
+	    vector<shared_ptr<node::Node>>{intermediate, output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		graph->build(backend);
+
+		vector<shared_ptr<Tensor>> result = graph->evaluate(
+		    std::vector{Tensor::create_view(X1), Tensor::create_view(X2)});
+
+		auto result1 = result[0]->as<SGVector<NumericType>>();
+		auto result2 = result[1]->as<SGVector<NumericType>>();
+
+		for (const auto& [expected_i, result_i] :
+		     zip_iterator(expected_result1, result1))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+
+		for (const auto& [expected_i, result_i] :
+		     zip_iterator(expected_result2, result2))
+		{
+			EXPECT_EQ(expected_i, result_i);
+		}
+	}
+}

--- a/src/shogun/mathematics/graph/Types.cpp
+++ b/src/shogun/mathematics/graph/Types.cpp
@@ -6,49 +6,49 @@ using namespace shogun::graph;
 
 bool NumberType::is_integral() const
 {
-    return !is_real();
+	return !is_real();
 }
 
 bool shogun::graph::operator==(const NumberType& left, const NumberType& right)
 {
-    if (&left == &right)
-    {
-        return true;
-    }
-    else if (left.type() == right.type())
-    {
-        return true;
-    }
-    return false;
+	if (&left == &right)
+	{
+		return true;
+	}
+	else if (left.type() == right.type())
+	{
+		return true;
+	}
+	return false;
 }
 
 bool shogun::graph::operator!=(const NumberType& left, const NumberType& right)
 {
-    return !(left == right);
+	return !(left == right);
 }
 
 std::ostream& operator<<(std::ostream& os, const NumberType& type)
 {
-    os << type.to_string();
-    return os;
+	os << type.to_string();
+	return os;
 }
 
 FloatingPointType::Precision Float32Type::precision() const
 {
-    return FloatingPointType::SINGLE;
+	return FloatingPointType::SINGLE;
 }
 
 FloatingPointType::Precision Float64Type::precision() const
 {
-    return FloatingPointType::DOUBLE;
+	return FloatingPointType::DOUBLE;
 }
 
-#define TYPE_FACTORY(NAME, KLASS)                                           \
-  std::shared_ptr<NumberType> NAME()                                        \
-  {                                                                         \
-    static std::shared_ptr<NumberType> result = std::make_shared<KLASS>();  \
-    return result;                                                          \
-  }
+#define TYPE_FACTORY(NAME, KLASS)                                              \
+	std::shared_ptr<NumberType> NAME()                                         \
+	{                                                                          \
+		static std::shared_ptr<NumberType> result = std::make_shared<KLASS>(); \
+		return result;                                                         \
+	}
 
 TYPE_FACTORY(boolean, BooleanType)
 TYPE_FACTORY(int8, Int8Type)
@@ -64,92 +64,92 @@ TYPE_FACTORY(float64, Float64Type)
 
 namespace shogun
 {
-    namespace graph
-    {
-        template <>
-        std::shared_ptr<NumberType> from<bool>()
-        {
-            return boolean();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<float>()
-        {
-            return float32();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<double>()
-        {
-            return float64();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<int8_t>()
-        {
-            return int8();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<int16_t>()
-        {
-            return int16();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<int32_t>()
-        {
-            return int32();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<int64_t>()
-        {
-            return int64();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<uint8_t>()
-        {
-            return uint8();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<uint16_t>()
-        {
-            return uint16();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<uint32_t>()
-        {
-            return uint32();
-        }
-        template <>
-        std::shared_ptr<NumberType> from<uint64_t>()
-        {
-            return uint64();
-        }
+	namespace graph
+	{
+		template <>
+		std::shared_ptr<NumberType> from<bool>()
+		{
+			return boolean();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<float>()
+		{
+			return float32();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<double>()
+		{
+			return float64();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<int8_t>()
+		{
+			return int8();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<int16_t>()
+		{
+			return int16();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<int32_t>()
+		{
+			return int32();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<int64_t>()
+		{
+			return int64();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<uint8_t>()
+		{
+			return uint8();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<uint16_t>()
+		{
+			return uint16();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<uint32_t>()
+		{
+			return uint32();
+		}
+		template <>
+		std::shared_ptr<NumberType> from<uint64_t>()
+		{
+			return uint64();
+		}
 
-        std::shared_ptr<NumberType> number_type(element_type et)
-        {
-            switch(et)
-            {
-                case element_type::BOOLEAN:
-                    return boolean();
-                case element_type::INT8:
-                    return int8();
-                case element_type::INT16:
-                    return int16();
-                case element_type::INT32:
-                    return int32();
-                case element_type::INT64:
-                    return int64();
-                case element_type::UINT8:
-                    return uint8();
-                case element_type::UINT16:
-                    return uint16();
-                case element_type::UINT32:
-                    return uint32();
-                case element_type::UINT64:
-                    return uint64();
-                case element_type::FLOAT32:
-                    return float32();
-                case element_type::FLOAT64:
-                    return float64();
-            }
-            throw std::invalid_argument("Unknown type");
-        }
-    }
-}
+		std::shared_ptr<NumberType> number_type(element_type et)
+		{
+			switch (et)
+			{
+			case element_type::BOOLEAN:
+				return boolean();
+			case element_type::INT8:
+				return int8();
+			case element_type::INT16:
+				return int16();
+			case element_type::INT32:
+				return int32();
+			case element_type::INT64:
+				return int64();
+			case element_type::UINT8:
+				return uint8();
+			case element_type::UINT16:
+				return uint16();
+			case element_type::UINT32:
+				return uint32();
+			case element_type::UINT64:
+				return uint64();
+			case element_type::FLOAT32:
+				return float32();
+			case element_type::FLOAT64:
+				return float64();
+			}
+			throw std::invalid_argument("Unknown type");
+		}
+	} // namespace graph
+} // namespace shogun

--- a/src/shogun/mathematics/graph/Types.h
+++ b/src/shogun/mathematics/graph/Types.h
@@ -34,56 +34,81 @@ namespace shogun
 
 		class SHOGUN_ENGINE_EXPORT NumberType
 		{
-			public:
-				explicit NumberType(element_type et): m_et(et) {}
-				virtual ~NumberType() = default;
+		public:
+			explicit NumberType(element_type et) : m_et(et)
+			{
+			}
+			virtual ~NumberType() = default;
 
-				friend bool operator==(const NumberType& first, const NumberType& second);
-				friend bool operator!=(const NumberType& first, const NumberType& second);
+			friend bool
+			operator==(const NumberType& first, const NumberType& second);
+			friend bool
+			operator!=(const NumberType& first, const NumberType& second);
 
-				virtual bool is_signed() const = 0;
-				virtual bool is_real() const = 0;
-				bool is_integral() const;
+			virtual bool is_signed() const = 0;
+			virtual bool is_real() const = 0;
+			bool is_integral() const;
 
-				virtual bool compatible(const NumberType& other) const = 0;
-				virtual std::string to_string() const = 0;
-				virtual size_t size() const = 0;
-				element_type type() const { return m_et; }
-				operator element_type() const { return m_et; }
-			private:
-				const element_type m_et;
+			virtual bool compatible(const NumberType& other) const = 0;
+			virtual std::string to_string() const = 0;
+			virtual size_t size() const = 0;
+			element_type type() const
+			{
+				return m_et;
+			}
+			operator element_type() const
+			{
+				return m_et;
+			}
+
+		private:
+			const element_type m_et;
 		};
 
 		std::ostream& operator<<(std::ostream& os, const NumberType& type);
 
-		class SHOGUN_ENGINE_EXPORT IntegerType: public NumberType
+		class SHOGUN_ENGINE_EXPORT IntegerType : public NumberType
 		{
-			public:
-				using NumberType::NumberType;
-				bool is_real() const override { return false; };
+		public:
+			using NumberType::NumberType;
+			bool is_real() const override
+			{
+				return false;
+			};
 		};
 
-		class SHOGUN_ENGINE_EXPORT FloatingPointType: public NumberType
+		class SHOGUN_ENGINE_EXPORT FloatingPointType : public NumberType
 		{
-			public:
-				using NumberType::NumberType;
+		public:
+			using NumberType::NumberType;
 
-				bool is_real() const override { return true; };
+			bool is_real() const override
+			{
+				return true;
+			};
 
-				enum Precision { SINGLE, DOUBLE };
-				virtual Precision precision() const = 0;
+			enum Precision
+			{
+				SINGLE,
+				DOUBLE
+			};
+			virtual Precision precision() const = 0;
 		};
 
 		namespace detail
 		{
-			template <typename DERIVED, typename BASE, element_type ELEMENT_TYPE, typename C_TYPE>
-			class TypeImpl: public BASE
+			template <
+			    typename DERIVED, typename BASE, element_type ELEMENT_TYPE,
+			    typename C_TYPE>
+			class TypeImpl : public BASE
 			{
 			public:
 				static constexpr element_type type_id = ELEMENT_TYPE;
 				using c_type = C_TYPE;
 
-				TypeImpl(): BASE(ELEMENT_TYPE) {}
+				TypeImpl() : BASE(ELEMENT_TYPE)
+				{
+				}
 
 				bool compatible(const NumberType& other) const override
 				{
@@ -101,97 +126,157 @@ namespace shogun
 					return false;
 				}
 
-				bool is_signed() const override { return std::is_signed_v<C_TYPE>; }
+				bool is_signed() const override
+				{
+					return std::is_signed_v<C_TYPE>;
+				}
 
-				size_t size() const override { return sizeof(C_TYPE); }
+				size_t size() const override
+				{
+					return sizeof(C_TYPE);
+				}
 
-				std::string to_string() const override { return DERIVED::type_name(); }
+				std::string to_string() const override
+				{
+					return DERIVED::type_name();
+				}
 			};
 
-			template <typename DERIVED, element_type ELEMENT_TYPE, typename C_TYPE>
-			class IntegerTypeImpl : public detail::TypeImpl<DERIVED, IntegerType, ELEMENT_TYPE, C_TYPE>
+			template <
+			    typename DERIVED, element_type ELEMENT_TYPE, typename C_TYPE>
+			class IntegerTypeImpl
+			    : public detail::TypeImpl<
+			          DERIVED, IntegerType, ELEMENT_TYPE, C_TYPE>
 			{
 			};
-		}
+		} // namespace detail
 
-		class SHOGUN_ENGINE_EXPORT BooleanType:
-			public detail::TypeImpl<BooleanType, NumberType, element_type::BOOLEAN, bool>
+		class SHOGUN_ENGINE_EXPORT BooleanType
+		    : public detail::TypeImpl<
+		          BooleanType, NumberType, element_type::BOOLEAN, bool>
 		{
-			public:
-				static constexpr const char* type_name() { return "bool"; }
-
-				bool is_real() const override { return false; };
-		};
-
-		class SHOGUN_ENGINE_EXPORT UInt8Type:
-			public detail::IntegerTypeImpl<UInt8Type, element_type::UINT8, uint8_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "uint8"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT Int8Type:
-			public detail::IntegerTypeImpl<Int8Type, element_type::INT8, int8_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "int8"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT UInt16Type:
-			public detail::IntegerTypeImpl<UInt16Type, element_type::UINT16, uint16_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "uint16"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT Int16Type:
-			public detail::IntegerTypeImpl<Int16Type, element_type::INT16, int16_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "int16"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT UInt32Type:
-			public detail::IntegerTypeImpl<UInt32Type, element_type::UINT32, uint32_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "uint32"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT Int32Type:
-			public detail::IntegerTypeImpl<Int32Type, element_type::INT32, int32_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "int32"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT Int64Type:
-			public detail::IntegerTypeImpl<Int64Type, element_type::INT64, int64_t>
-		{
-			public:
-				static constexpr const char* type_name() { return "int64"; }
-		};
-
-		class SHOGUN_ENGINE_EXPORT UInt64Type:
-			public detail::IntegerTypeImpl<UInt64Type, element_type::UINT64, uint64_t> {
 		public:
-			static constexpr const char* type_name() { return "uint64"; }
+			static constexpr const char* type_name()
+			{
+				return "bool";
+			}
+
+			bool is_real() const override
+			{
+				return false;
+			};
+		};
+
+		class SHOGUN_ENGINE_EXPORT UInt8Type
+		    : public detail::IntegerTypeImpl<
+		          UInt8Type, element_type::UINT8, uint8_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "uint8";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT Int8Type
+		    : public detail::IntegerTypeImpl<
+		          Int8Type, element_type::INT8, int8_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "int8";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT UInt16Type
+		    : public detail::IntegerTypeImpl<
+		          UInt16Type, element_type::UINT16, uint16_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "uint16";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT Int16Type
+		    : public detail::IntegerTypeImpl<
+		          Int16Type, element_type::INT16, int16_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "int16";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT UInt32Type
+		    : public detail::IntegerTypeImpl<
+		          UInt32Type, element_type::UINT32, uint32_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "uint32";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT Int32Type
+		    : public detail::IntegerTypeImpl<
+		          Int32Type, element_type::INT32, int32_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "int32";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT Int64Type
+		    : public detail::IntegerTypeImpl<
+		          Int64Type, element_type::INT64, int64_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "int64";
+			}
+		};
+
+		class SHOGUN_ENGINE_EXPORT UInt64Type
+		    : public detail::IntegerTypeImpl<
+		          UInt64Type, element_type::UINT64, uint64_t>
+		{
+		public:
+			static constexpr const char* type_name()
+			{
+				return "uint64";
+			}
 		};
 
 		class SHOGUN_ENGINE_EXPORT Float32Type
-			: public detail::TypeImpl<Float32Type, FloatingPointType, element_type::FLOAT32, float>
+		    : public detail::TypeImpl<
+		          Float32Type, FloatingPointType, element_type::FLOAT32, float>
 		{
-			public:
-				Precision precision() const override;
-				static constexpr const char* type_name() { return "float32"; }
+		public:
+			Precision precision() const override;
+			static constexpr const char* type_name()
+			{
+				return "float32";
+			}
 		};
 
 		class SHOGUN_ENGINE_EXPORT Float64Type
-			: public detail::TypeImpl<Float64Type, FloatingPointType, element_type::FLOAT64, double>
+		    : public detail::TypeImpl<
+		          Float64Type, FloatingPointType, element_type::FLOAT64, double>
 		{
-			public:
-				Precision precision() const override;
-				static constexpr const char* type_name() { return "float64"; }
+		public:
+			Precision precision() const override;
+			static constexpr const char* type_name()
+			{
+				return "float64";
+			}
 		};
 
 		template <typename T>
@@ -223,7 +308,8 @@ namespace shogun
 		template <>
 		SHOGUN_ENGINE_EXPORT std::shared_ptr<NumberType> from<double>();
 
-		SHOGUN_ENGINE_EXPORT std::shared_ptr<NumberType> number_type(element_type et);
+		SHOGUN_ENGINE_EXPORT std::shared_ptr<NumberType>
+		number_type(element_type et);
 	} // namespace graph
 } // namespace shogun
 

--- a/src/shogun/mathematics/graph/nodes/Add_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Add_test.cc
@@ -30,10 +30,9 @@ TYPED_TEST(GraphTest, vector_add)
 	auto expected_result1 = X1 + X2;
 	auto expected_result2 = expected_result1 + X2;
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{10}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
 
 	auto intermediate = input + input;
 
@@ -61,10 +60,9 @@ TYPED_TEST(GraphTest, vector_scalar_add)
 	auto expected_result1 = X1.clone();
 	expected_result1.add(X2);
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 	auto output = input1 + input2;
 
@@ -104,10 +102,9 @@ TYPED_TEST(GraphTest, scalar_vector_add)
 	auto expected_result1 = X2.clone();
 	expected_result1.add(X1);
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+	auto input2 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 	auto output = input1 + input2;
 
@@ -174,10 +171,10 @@ TYPED_TEST(GraphTest, matrix_add)
 	    expected_result1.data() + expected_result1.size(), X2.data(),
 	    expected_result2.data(), std::plus<NumericType>{});
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic, 5}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{10, Shape::Dynamic}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic, 5}, TypeParam::type_id);
+	auto input1 =
+	    make_shared<node::Input>(Shape{10, Shape::Dynamic}, TypeParam::type_id);
 
 	auto intermediate = input + input;
 

--- a/src/shogun/mathematics/graph/nodes/BinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/BinaryNode.h
@@ -117,6 +117,9 @@ namespace shogun
 						return node2_shape;
 					if (node2_shape.is_scalar())
 						return node1_shape;
+					else
+						error("Unhandled code path.");
+					return Shape{};
 				}
 
 				static Shape same_shape_binary_op(

--- a/src/shogun/mathematics/graph/nodes/Cast.h
+++ b/src/shogun/mathematics/graph/nodes/Cast.h
@@ -58,7 +58,7 @@ namespace shogun
 					if (!cast_type->compatible(*node_types[0]))
 						error(
 						    "There's no safe way to cast {} to {}",
-							node_types[0]->to_string(), cast_type->to_string());
+						    node_types[0]->to_string(), cast_type->to_string());
 
 					return type;
 				}

--- a/src/shogun/mathematics/graph/nodes/Cast_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Cast_test.cc
@@ -18,8 +18,8 @@ TYPED_TEST(GraphTest, cast)
 
 	X1.range_fill();
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 	auto output = make_shared<node::Cast>(input, element_type::FLOAT64);
 

--- a/src/shogun/mathematics/graph/nodes/Divide_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Divide_test.cc
@@ -33,10 +33,9 @@ TYPED_TEST(GraphTest, divide)
 	    expected_result1.data() + expected_result1.size(), X2.data(),
 	    expected_result2.data(), std::divides<NumericType>{});
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{10}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
 
 	auto intermediate = input / input;
 
@@ -64,10 +63,9 @@ TYPED_TEST(GraphTest, vector_scalar_divide)
 		auto expected_result1 = SGVector<NumericType>(10);
 		expected_result1.range_fill();
 
-		auto input1 = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
-		auto input2 = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
+		auto input1 =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 		auto output = input1 / input2;
 
@@ -107,10 +105,9 @@ TYPED_TEST(GraphTest, scalar_vector_divide)
 
 		SGVector<NumericType> expected_result1{100, 50, 25, 20, 10, 5, 4, 2, 1};
 
-		auto input1 = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
-		auto input2 = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+		auto input2 =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 		auto output = input1 / input2;
 

--- a/src/shogun/mathematics/graph/nodes/Dot_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Dot_test.cc
@@ -25,12 +25,9 @@ TYPED_TEST(GraphTest, vector_scalar_dot)
 		SGVector<NumericType> expected_result1 = {2, 4, 6};
 		SGMatrix<NumericType> expected_result2{{2, 4, 6}, {8, 10, 12}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
-		auto C = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+		auto C = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
 
 		auto output1 = make_shared<node::Dot>(A, B);
 		auto output2 = make_shared<node::Dot>(B, C);
@@ -75,10 +72,8 @@ TYPED_TEST(GraphTest, vector_vector_dot)
 		SGVector<NumericType> X2{4, 5, 6};
 		NumericType expected_result = 32;
 
-		auto A = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
 
 		auto output = make_shared<node::Dot>(A, B);
 
@@ -111,10 +106,8 @@ TYPED_TEST(GraphTest, matrix_vector_dot)
 		SGVector<NumericType> X2{1, 2};
 		SGVector<NumericType> expected_result = {5, 11, 17};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{2}, TypeParam::type_id);
 
 		auto output = make_shared<node::Dot>(A, B);
 
@@ -151,10 +144,8 @@ TYPED_TEST(GraphTest, vector_matrix_dot)
 		SGMatrix<NumericType> X2{{1, 3, 5}, {2, 4, 6}};
 		SGVector<NumericType> expected_result{35, 44};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
 
 		auto output = make_shared<node::Dot>(A, B);
 
@@ -193,10 +184,8 @@ TYPED_TEST(GraphTest, matrix_matrix_dot1)
 		SGMatrix<NumericType> expected_result = {
 		    {5, 11, 17}, {11, 25, 39}, {17, 39, 61}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{2, 3}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{2, 3}, TypeParam::type_id);
 
 		auto output = make_shared<node::Dot>(A, B);
 
@@ -240,10 +229,8 @@ TYPED_TEST(GraphTest, matrix_matrix_dot2)
 		SGMatrix<NumericType> expected_result2 = {{123, 281, 439},
 		                                          {156, 356, 556}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{2, 3}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{2, 3}, TypeParam::type_id);
 
 		auto output1 = make_shared<node::Dot>(A, B);
 		auto output2 = make_shared<node::Dot>(output1, A);
@@ -291,10 +278,8 @@ TYPED_TEST(GraphTest, simple_perceptron_inference)
 
 		auto X = make_shared<node::Input>(
 		    Shape{Shape::Dynamic, 2}, TypeParam::type_id);
-		auto w = make_shared<node::Input>(
-		    Shape{2}, TypeParam::type_id);
-		auto b = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
+		auto w = make_shared<node::Input>(Shape{2}, TypeParam::type_id);
+		auto b = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 		auto prediction = make_shared<node::Dot>(X, w) + b;
 

--- a/src/shogun/mathematics/graph/nodes/Equal_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Equal_test.cc
@@ -20,10 +20,9 @@ TYPED_TEST(GraphTest, equal)
 	X1.range_fill();
 	X2.range_fill();
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{10}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
 
 	auto output = make_shared<node::Equal>(input, input1);
 
@@ -59,10 +58,9 @@ TYPED_TEST(GraphTest, vector_scalar_equal)
 
 	X1.range_fill();
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 	auto output = make_shared<node::Equal>(input, input1);
 
@@ -98,10 +96,9 @@ TYPED_TEST(GraphTest, scalar_vector_equal)
 
 	X2.range_fill();
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+	auto input2 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 	auto output = make_shared<node::Equal>(input1, input2);
 

--- a/src/shogun/mathematics/graph/nodes/LogicalAnd_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalAnd_test.cc
@@ -17,10 +17,9 @@ TYPED_TEST(GraphTest, and)
 	SGVector<NumericType> X1{true, false, true, false};
 	SGVector<NumericType> X2{true, false, false, true};
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{4}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{4}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{
@@ -62,10 +61,9 @@ TYPED_TEST(GraphTest, vector_scalar_and)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{
@@ -109,10 +107,9 @@ TYPED_TEST(GraphTest, scalar_vector_and)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+	auto input2 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{

--- a/src/shogun/mathematics/graph/nodes/LogicalOr_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalOr_test.cc
@@ -14,10 +14,9 @@ TYPED_TEST(GraphTest, or)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{4}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{4}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{
@@ -61,10 +60,9 @@ TYPED_TEST(GraphTest, vector_scalar_or)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{
@@ -107,10 +105,9 @@ TYPED_TEST(GraphTest, scalar_vector_or)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+	auto input2 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{

--- a/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
+++ b/src/shogun/mathematics/graph/nodes/LogicalXor_test.cc
@@ -14,10 +14,9 @@ TYPED_TEST(GraphTest, xor)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{4}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{4}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{
@@ -61,10 +60,9 @@ TYPED_TEST(GraphTest, vector_scalar_xor)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{
@@ -107,10 +105,9 @@ TYPED_TEST(GraphTest, scalar_vector_xor)
 {
 	using NumericType = typename TypeParam::c_type;
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+	auto input2 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 	if constexpr (std::is_same_v<TypeParam, BooleanType>)
 	{

--- a/src/shogun/mathematics/graph/nodes/MatMul_test.cc
+++ b/src/shogun/mathematics/graph/nodes/MatMul_test.cc
@@ -16,10 +16,8 @@ TYPED_TEST(GraphTest, scalar_matmul)
 		return;
 	else
 	{
-		auto A = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 		// MatMul doesn't work with scalar, unlike Dot. See MatMul docs.
 		EXPECT_THROW(make_shared<node::MatMul>(A, B), ShogunException);
@@ -38,10 +36,8 @@ TYPED_TEST(GraphTest, vector_vector_matmul)
 		SGVector<NumericType> X2{4, 5, 6};
 		NumericType expected_result = 32;
 
-		auto A = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
 
 		auto output = make_shared<node::MatMul>(A, B);
 
@@ -74,10 +70,8 @@ TYPED_TEST(GraphTest, matrix_vector_matmul)
 		SGVector<NumericType> X2{1, 2};
 		SGVector<NumericType> expected_result = {5, 11, 17};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{2}, TypeParam::type_id);
 
 		auto output = make_shared<node::MatMul>(A, B);
 
@@ -114,10 +108,8 @@ TYPED_TEST(GraphTest, vector_matrix_matmul)
 		SGMatrix<NumericType> X2{{1, 3, 5}, {2, 4, 6}};
 		SGVector<NumericType> expected_result{35, 44};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
 
 		auto output = make_shared<node::MatMul>(A, B);
 
@@ -156,10 +148,8 @@ TYPED_TEST(GraphTest, matrix_matrix_matmul1)
 		SGMatrix<NumericType> expected_result = {
 		    {5, 11, 17}, {11, 25, 39}, {17, 39, 61}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{2, 3}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{2, 3}, TypeParam::type_id);
 
 		auto output = make_shared<node::MatMul>(A, B);
 
@@ -203,10 +193,8 @@ TYPED_TEST(GraphTest, matrix_matrix_matmul2)
 		SGMatrix<NumericType> expected_result2 = {{123, 281, 439},
 		                                          {156, 356, 556}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
-		auto B = make_shared<node::Input>(
-		    Shape{2, 3}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
+		auto B = make_shared<node::Input>(Shape{2, 3}, TypeParam::type_id);
 
 		auto output1 = make_shared<node::MatMul>(A, B);
 		auto output2 = make_shared<node::MatMul>(output1, A);
@@ -257,8 +245,7 @@ TYPED_TEST(GraphTest, matrix_matrixT_matmul)
 		SGMatrix<NumericType> expected_result2 = {{123, 281, 439},
 		                                          {156, 356, 556}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
 
 		auto output1 = make_shared<node::MatMul>(A, A, false, true);
 		EXPECT_THROW(make_shared<node::MatMul>(A, A), ShogunException);
@@ -309,8 +296,7 @@ TYPED_TEST(GraphTest, matrixT_matrix_matmul)
 		SGMatrix<NumericType> expected_result2 = {
 		    {123, 156}, {281, 356}, {439, 556}};
 
-		auto A = make_shared<node::Input>(
-		    Shape{3, 2}, TypeParam::type_id);
+		auto A = make_shared<node::Input>(Shape{3, 2}, TypeParam::type_id);
 
 		auto output1 = make_shared<node::MatMul>(A, A, true, false);
 		EXPECT_THROW(make_shared<node::MatMul>(output1, A), ShogunException);

--- a/src/shogun/mathematics/graph/nodes/Multiply_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Multiply_test.cc
@@ -33,10 +33,9 @@ TYPED_TEST(GraphTest, multiply)
 	    expected_result1.data() + expected_result1.size(), X2.data(),
 	    expected_result2.data(), std::multiplies<NumericType>{});
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{10}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
 
 	auto intermediate = input * input;
 
@@ -66,10 +65,9 @@ TYPED_TEST(GraphTest, vector_scalar_multiply)
 		SGVector<NumericType> expected_result1{0,  2,  4,  6,  8, 10,
 		                                       12, 14, 16, 18, 20};
 
-		auto input1 = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
-		auto input2 = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
+		auto input1 =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 		auto output = input1 * input2;
 
@@ -111,10 +109,9 @@ TYPED_TEST(GraphTest, scalar_vector_multiply)
 		SGVector<NumericType> expected_result1{0,  2,  4,  6,  8, 10,
 		                                       12, 14, 16, 18, 20};
 
-		auto input1 = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
-		auto input2 = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+		auto input2 =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 		auto output = input1 * input2;
 

--- a/src/shogun/mathematics/graph/nodes/Reshape_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Reshape_test.cc
@@ -19,10 +19,9 @@ TYPED_TEST(GraphTest, vector_reshape)
 	auto expected_result1 = SGMatrix<NumericType>(10, 1);
 	auto expected_result2 = SGMatrix<NumericType>(1, 10);
 
-	auto input1 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{10}, TypeParam::type_id);
+	auto input1 =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
 
 	auto output1 = make_shared<node::Reshape>(input1, Shape{10, 1});
 	auto output2 = make_shared<node::Reshape>(input2, Shape{1, 10});
@@ -62,10 +61,8 @@ TYPED_TEST(GraphTest, matrix_reshape)
 	auto expected_result2 = SGVector<NumericType>(10);
 
 	auto input1 = make_shared<node::Input>(
-	    Shape{Shape::Dynamic, Shape::Dynamic},
-	    TypeParam::type_id);
-	auto input2 = make_shared<node::Input>(
-	    Shape{10, 1}, TypeParam::type_id);
+	    Shape{Shape::Dynamic, Shape::Dynamic}, TypeParam::type_id);
+	auto input2 = make_shared<node::Input>(Shape{10, 1}, TypeParam::type_id);
 
 	auto output1 = make_shared<node::Reshape>(input1, Shape{5, 2});
 	auto output2 = make_shared<node::Reshape>(input2, Shape{10});

--- a/src/shogun/mathematics/graph/nodes/Sign_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Sign_test.cc
@@ -16,8 +16,8 @@ TYPED_TEST(GraphTest, sign)
 
 	if constexpr (std::is_unsigned_v<NumericType>)
 	{
-		auto input = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 		EXPECT_THROW(make_shared<node::Sign>(input), ShogunException);
 	}
 	else
@@ -26,8 +26,8 @@ TYPED_TEST(GraphTest, sign)
 
 		SGVector<NumericType> expected_result{-1, 0, 1, -1, 1};
 
-		auto input = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 		auto output = make_shared<node::Sign>(input);
 

--- a/src/shogun/mathematics/graph/nodes/Subtract_test.cc
+++ b/src/shogun/mathematics/graph/nodes/Subtract_test.cc
@@ -33,10 +33,9 @@ TYPED_TEST(GraphTest, subtract)
 	    expected_result1.data() + expected_result1.size(), X2.data(),
 	    expected_result2.data(), std::minus<NumericType>{});
 
-	auto input = make_shared<node::Input>(
-	    Shape{Shape::Dynamic}, TypeParam::type_id);
-	auto input1 = make_shared<node::Input>(
-	    Shape{10}, TypeParam::type_id);
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
 
 	auto intermediate = input - input;
 
@@ -66,10 +65,9 @@ TYPED_TEST(GraphTest, vector_scalar_subtract)
 		auto expected_result1 = SGVector<NumericType>(10);
 		expected_result1.range_fill();
 
-		auto input1 = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
-		auto input2 = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
+		auto input1 =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input2 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
 
 		auto output = input1 - input2;
 
@@ -111,10 +109,9 @@ TYPED_TEST(GraphTest, scalar_vector_subtract)
 
 		SGVector<NumericType> expected_result1{10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
 
-		auto input1 = make_shared<node::Input>(
-		    Shape{}, TypeParam::type_id);
-		auto input2 = make_shared<node::Input>(
-		    Shape{Shape::Dynamic}, TypeParam::type_id);
+		auto input1 = make_shared<node::Input>(Shape{}, TypeParam::type_id);
+		auto input2 =
+		    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
 
 		auto output = input1 - input2;
 

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -44,10 +44,8 @@ namespace shogun
 					if (m_outputs.size() != 1)
 						error("Binary operation expected one output.");
 
-					const auto& input1 =
-					    input_nodes[0]->get_outputs()[0];
-					const auto& input2 =
-					    input_nodes[1]->get_outputs()[0];
+					const auto& input1 = input_nodes[0]->get_outputs()[0];
+					const auto& input2 = input_nodes[1]->get_outputs()[0];
 					const auto& output = m_outputs[0];
 
 					runtime_checks_and_allocation(
@@ -57,9 +55,8 @@ namespace shogun
 					        ArrayArray)
 					{
 						kernel(
-						    input1->data(), input2->data(),
-						    output->data(), output->size(),
-						    input1->get_type());
+						    input1->data(), input2->data(), output->data(),
+						    output->size(), input1->get_type());
 					}
 					else if (
 					    shape_compatibility ==
@@ -69,9 +66,8 @@ namespace shogun
 						const bool scalar_first =
 						    input1->get_shape().is_scalar();
 						kernel_scalar(
-						    input1->data(), input2->data(),
-						    output->data(), output->size(),
-						    input1->get_type(), scalar_first);
+						    input1->data(), input2->data(), output->data(),
+						    output->size(), input1->get_type(), scalar_first);
 					}
 				}
 
@@ -141,10 +137,10 @@ namespace shogun
 				    const node::Node::type_info& type)
 				{
 
-#define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)					\
-	static_cast<DerivedOperator*>(this)							\
-	    ->template kernel_implementation<NUMBER_TYPE::c_type>(	\
-	        input1, input2, output, size);						\
+#define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)                                \
+	static_cast<DerivedOperator*>(this)                                        \
+	    ->template kernel_implementation<NUMBER_TYPE::c_type>(                 \
+	        input1, input2, output, size);                                     \
 	break;
 
 					switch (*type)
@@ -182,8 +178,7 @@ namespace shogun
 
 #define CALL_KERNEL_IMPLEMENTATION(SHOGUN_TYPE)                                \
 	static_cast<DerivedOperator*>(this)                                        \
-	    ->template kernel_scalar_implementation<                               \
-	        SHOGUN_TYPE::c_type>(                                              \
+	    ->template kernel_scalar_implementation<SHOGUN_TYPE::c_type>(          \
 	        input1, input2, output, size, scalar_first);                       \
 	break;
 

--- a/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/BinaryOperator.h
@@ -73,8 +73,8 @@ namespace shogun
 
 			protected:
 				void runtime_checks_and_allocation(
-				    const std::shared_ptr<ShogunStorage>& input1,
-				    const std::shared_ptr<ShogunStorage>& input2,
+				    const std::shared_ptr<Storage>& input1,
+				    const std::shared_ptr<Storage>& input2,
 				    const node::BaseBinaryNode::BinaryShapeCompatibity&
 				        shape_compatibility)
 				{
@@ -88,8 +88,8 @@ namespace shogun
 				}
 
 				const Shape& runtime_shape_check(
-				    const std::shared_ptr<ShogunStorage>& input1,
-				    const std::shared_ptr<ShogunStorage>& input2,
+				    const std::shared_ptr<Storage>& input1,
+				    const std::shared_ptr<Storage>& input2,
 				    const node::BaseBinaryNode::BinaryShapeCompatibity&
 				        shape_compatibility)
 				{

--- a/src/shogun/mathematics/graph/ops/abstract/Operator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/Operator.h
@@ -7,7 +7,7 @@
 #ifndef SHOGUN_GRAPH_OPERATOR_H_
 #define SHOGUN_GRAPH_OPERATOR_H_
 
-#include "ShogunStorage.h"
+#include "shogun/mathematics/graph/Storage.h"
 #include <shogun/mathematics/graph/nodes/Node.h>
 
 namespace shogun
@@ -36,15 +36,13 @@ namespace shogun
 					     zip_iterator(shapes, types))
 					{
 						m_outputs.push_back(
-						    std::make_shared<ShogunStorage>(shape, type));
+						    std::make_shared<Storage>(shape, type));
 					}
 				}
 
-				virtual ~Operator()
-				{
-				}
+				virtual ~Operator() = default;
 
-				const std::vector<std::shared_ptr<ShogunStorage>>&
+				const std::vector<std::shared_ptr<Storage>>&
 				operator()(const std::vector<
 				           std::shared_ptr<detail::shogun::OutputNode>>& inputs)
 				{
@@ -55,13 +53,13 @@ namespace shogun
 				virtual std::string_view get_operator_name() const = 0;
 
 			protected:
-				void virtual call(
-				    const std::vector<
-				        std::shared_ptr<detail::shogun::OutputNode>>&) = 0;
+				virtual void
+				call(const std::vector<
+				     std::shared_ptr<detail::shogun::OutputNode>>&) = 0;
 
 			protected:
 				std::shared_ptr<node::Node> m_node;
-				std::vector<std::shared_ptr<ShogunStorage>> m_outputs;
+				std::vector<std::shared_ptr<Storage>> m_outputs;
 			};
 		} // namespace op
 	}     // namespace graph

--- a/src/shogun/mathematics/graph/ops/abstract/Operator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/Operator.h
@@ -7,7 +7,7 @@
 #ifndef SHOGUN_GRAPH_OPERATOR_H_
 #define SHOGUN_GRAPH_OPERATOR_H_
 
-#include <shogun/mathematics/graph/Tensor.h>
+#include "ShogunStorage.h"
 #include <shogun/mathematics/graph/nodes/Node.h>
 
 namespace shogun
@@ -35,8 +35,8 @@ namespace shogun
 					for (const auto& [shape, type] :
 					     zip_iterator(shapes, types))
 					{
-						m_output_tensors.push_back(
-						    std::make_shared<Tensor>(shape, type));
+						m_outputs.push_back(
+						    std::make_shared<ShogunStorage>(shape, type));
 					}
 				}
 
@@ -44,12 +44,12 @@ namespace shogun
 				{
 				}
 
-				const std::vector<std::shared_ptr<Tensor>>&
+				const std::vector<std::shared_ptr<ShogunStorage>>&
 				operator()(const std::vector<
 				           std::shared_ptr<detail::shogun::OutputNode>>& inputs)
 				{
 					call(inputs);
-					return m_output_tensors;
+					return m_outputs;
 				}
 
 				virtual std::string_view get_operator_name() const = 0;
@@ -61,7 +61,7 @@ namespace shogun
 
 			protected:
 				std::shared_ptr<node::Node> m_node;
-				std::vector<std::shared_ptr<Tensor>> m_output_tensors;
+				std::vector<std::shared_ptr<ShogunStorage>> m_outputs;
 			};
 		} // namespace op
 	}     // namespace graph

--- a/src/shogun/mathematics/graph/ops/abstract/ShogunStorage.h
+++ b/src/shogun/mathematics/graph/ops/abstract/ShogunStorage.h
@@ -1,0 +1,268 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_OPERATOR_STORAGE_H_
+#define SHOGUN_OPERATOR_STORAGE_H_
+
+#include <shogun/lib/memory.h>
+#include <shogun/mathematics/graph/Shape.h>
+#include <shogun/mathematics/graph/Tensor.h>
+#include <shogun/mathematics/graph/Types.h>
+#include <shogun/util/zip_iterator.h>
+
+#include <numeric>
+#include <utility>
+
+namespace shogun
+{
+	namespace graph
+	{
+		namespace op
+		{
+			/* The actual CPU memory owner.
+			 */
+			class InternalStorage
+			{
+				template <typename T>
+				InternalStorage(T* data, size_t size, const std::shared_ptr<NumberType>& type): m_internal_data(data, 
+					[](void* ptr){
+						SG_ALIGNED_FREE(ptr);
+					}, 
+					[&size, &type](void* ptr){
+						ptr = sg_aligned_malloc(InternalStorage::size_in_bytes(size, type), alignment::container_alignment);
+					}) {}
+			private:
+				[[nodiscard]] static size_t size_in_bytes(size_t size, const std::shared_ptr<NumberType>& type) {
+					return size * type->size();
+				}
+				std::shared_ptr<void> m_internal_data;
+			};
+			/* A storage abstraction
+			 * The user should never see this. This is purely for 
+			 * the backend to allocate storage. The user should use
+			 * the tensor class exclusively, in order to not mess
+			 * up shapes and so on.
+			 *
+			 */
+			class ShogunStorage
+			{
+			public:
+
+				friend class ReshapeShogun;
+
+				ShogunStorage(const Shape& shape, const std::shared_ptr<NumberType>& type)
+				    : m_data(nullptr), m_shape(shape), m_type(type)
+				{
+					// shape is known at build time, let's preallocate it
+					// we could inforce immutability at this level somehow?
+					if (shape.is_static())
+						m_data = sg_aligned_malloc(size_in_bytes(), alignment::container_alignment);
+				}
+
+				~ShogunStorage()
+				{
+					if (m_data)
+					{
+						SG_ALIGNED_FREE(m_data);
+						m_data = nullptr;
+					}
+				}
+
+				ShogunStorage(ShogunStorage&& other): 
+					  m_data(std::exchange(other.m_data, nullptr))
+					, m_shape(other.m_shape)
+					, m_type(other.m_type)
+				{
+				}
+
+
+				std::shared_ptr<Tensor> to_tensor()
+				{
+					auto tensor = std::make_shared<Tensor>(m_shape, m_type);
+					// transfer data to tensor
+					sg_memcpy(tensor->data(), m_data, size_in_bytes());
+					tensor->m_free = true;
+					return tensor;
+				}
+
+				/* Equivalent as device_put in JAX. Transfers data to internal storage.
+				 */
+				static std::shared_ptr<ShogunStorage> from_tensor(const std::shared_ptr<Tensor>& tensor)
+				{
+					if (!tensor->get_shape().is_static())
+						error("Cannot copy a tensor of unknown shape.");
+					auto storage = std::make_shared<ShogunStorage>(tensor->get_shape(), tensor->get_type());
+					// transfer data from tensor
+					sg_memcpy(storage->data(), tensor->data(), storage->size_in_bytes());
+					return storage;
+				}
+
+				/* Allocates memory storage on the fly with a given shape.
+				 * If the exact is not static, e.g. the exact dimensions are
+				 * not known, at runtime, this will throw.
+				 *
+				 */
+				void allocate_storage(const Shape& shape)
+				{
+					if (!shape.is_static())
+						error("Cannot allocate tensor with shape {}, with unknown size requirements", shape.to_string());
+					// new allocation, call allocator_dispatch
+					if (m_data == nullptr)
+					{
+						set_shape(shape);
+						m_data = sg_aligned_malloc(size_in_bytes(), alignment::container_alignment);
+					}
+					else
+					{
+						// memory already allocated, and we have the right shape
+						// nothing to do
+						if (m_shape == shape)
+							return;
+						// memory has been allocated, but it isn't the same shape
+						else
+						{
+							auto old_shape = m_shape;
+							set_shape(shape);
+							// if the size requirement is larger, reallocate memory
+							if (get_size_from_shape(shape) > size())
+							{	
+								m_data = std::realloc(m_data, size_in_bytes());
+							}
+							// otherwise nothing happens, we just own a larger memory block
+							// but only use part of it
+						}
+
+					}
+				}
+
+				[[nodiscard]] const Shape& get_shape() const noexcept
+				{
+					return m_shape;
+				}
+
+				[[nodiscard]] const std::shared_ptr<NumberType>& get_type() const noexcept
+				{
+					return m_type;
+				}
+
+				[[nodiscard]] void*& data()
+				{
+					return m_data;
+				}
+
+				[[nodiscard]] size_t size_in_bytes() const {
+					return size() * m_type->size();
+				}
+
+				[[nodiscard]] size_t size() const
+				{
+					return get_size_from_shape(m_shape);
+				}
+
+			private:
+
+				struct PrivateTag{};
+
+			public:
+				ShogunStorage(PrivateTag): m_data(nullptr), m_shape(), m_type(nullptr) {}
+
+			protected:
+				/* Sets the static Shape. There is a guarantee that
+				 * the Shape passed to this function is static.
+				 */
+				void set_static_shape(const Shape& shape)
+				{
+					if (m_shape.size() != shape.size())
+					{
+						error(
+						    "Mismatch in the number of dimensions, expected {}, "
+						    "but got {}",
+						    m_shape.size(), shape.size());
+					}
+
+					for (const auto& [original_shape_dim_i, new_shape_dim_i] :
+					     zip_iterator(m_shape, shape))
+					{
+						if (original_shape_dim_i != new_shape_dim_i)
+						{
+							error(
+							    "Cannot set tensor shape. Shapes {} and {} are "
+							    "incompatible.",
+							    m_shape, shape);
+						}
+					}
+					m_shape = shape;
+				}
+
+				/* Sets the runtime Shape when static Shape allocation
+				 * was not possible, e.g. the user provided Dynamic
+				 * shapes in the Graph construction. If ShogunStorage already
+				 * owns data the checks are skipped.
+				 */
+				void set_shape(const Shape& shape)
+				{
+					if (!shape.is_static())
+						error("Cannot set dynamic shape in storage.");
+					if (m_shape.size() != shape.size())
+					{
+						error(
+						    "Mismatch in the number of dimensions, expected {}, "
+						    "but got {}",
+						    m_shape.size(), shape.size());
+					}
+
+					for (const auto& [original_shape_dim_i, new_shape_dim_i] :
+					     zip_iterator(m_shape, shape))
+					{
+						if (original_shape_dim_i == Shape::Dynamic)
+							continue;
+						if (original_shape_dim_i != new_shape_dim_i)
+						{
+							error(
+							    "Cannot set tensor shape. Shapes {} and {} are "
+							    "incompatible.",
+							    m_shape, shape);
+						}
+					}
+					m_shape = shape;
+				}
+
+
+				/* Sets the runtime Shape when static Shape allocation
+				 * was not possible, e.g. the user provided Dynamic
+				 * shapes in the Graph construction. If ShogunStorage already
+				 * owns data the checks are skipped.
+				 */
+				void reshape(const Shape& shape)
+				{
+					if (!shape.is_static())
+						error("Cannot set dynamic shape in storage.");
+					if (size() != get_size_from_shape(shape))
+					{
+						error(
+						    "Cannot modify the total size of shape: {} vs {}",
+						    m_shape.to_string(), shape.to_string());
+					}
+					m_shape = shape;
+				}
+
+
+			private:
+
+				[[nodiscard]] size_t get_size_from_shape(const Shape& size) const {
+					return std::accumulate(
+					    size.begin(), size.end(), size_t{1}, std::multiplies{});
+				}
+
+				void* m_data = nullptr;
+				Shape m_shape;
+				std::shared_ptr<NumberType> m_type;
+			};
+		}
+	}
+}
+
+#endif

--- a/src/shogun/mathematics/graph/ops/abstract/ShogunStorage.h
+++ b/src/shogun/mathematics/graph/ops/abstract/ShogunStorage.h
@@ -9,7 +9,6 @@
 
 #include <shogun/lib/memory.h>
 #include <shogun/mathematics/graph/Shape.h>
-#include <shogun/mathematics/graph/Tensor.h>
 #include <shogun/mathematics/graph/Types.h>
 #include <shogun/util/zip_iterator.h>
 
@@ -22,289 +21,289 @@ namespace shogun
 	{
 		namespace op
 		{
+			class ReshapeShogun;
+		}
+		/* A storage abstraction
+		 * The user should never see this. This is purely for
+		 * the backend to allocate storage. The user should use
+		 * the tensor class exclusively, in order to not mess
+		 * up shapes and so on.
+		 *
+		 */
+		class ShogunStorage
+		{
+			/* Managed storage. It's only job is to keep track of memory
+			 * and how to delete and allocate it.
+			 * It's unaware of what it actually owns. This is pretty much
+			 * a wrapper around std::shared_ptr for aligned memory.
+			 * Should this be thread safe?
+			 */
+			class InternalStorage
+			{
+			public:
+				InternalStorage(
+				    size_t size, const std::shared_ptr<NumberType>& type)
+				{
+					void* data = sg_aligned_malloc(
+					    size_in_bytes(size, type),
+					    alignment::container_alignment);
+					m_internal_data =
+					    std::shared_ptr<void>(data, [](void* ptr) {
+						    if (ptr)
+							    SG_ALIGNED_FREE(ptr);
+					    });
+				}
 
-			/* A storage abstraction
-			 * The user should never see this. This is purely for
-			 * the backend to allocate storage. The user should use
-			 * the tensor class exclusively, in order to not mess
-			 * up shapes and so on.
+				InternalStorage(void* data)
+				    : m_internal_data(data, [](void* ptr) {
+					      if (ptr)
+						      SG_ALIGNED_FREE(ptr);
+				      })
+				{
+				}
+
+				static std::shared_ptr<InternalStorage> copy_from(
+				    void* ptr, size_t size,
+				    const std::shared_ptr<NumberType>& type)
+				{
+					auto result = std::make_shared<InternalStorage>(size, type);
+					sg_memcpy(
+					    result->m_internal_data.get(), ptr,
+					    size_in_bytes(size, type));
+					return result;
+				}
+
+				void
+				realloc(size_t size, const std::shared_ptr<NumberType>& type)
+				{
+					void* new_mem = std::realloc(
+					    m_internal_data.get(), size_in_bytes(size, type));
+					if (new_mem)
+						m_internal_data.reset(new_mem, [](void* ptr) {
+							if (ptr)
+								SG_ALIGNED_FREE(ptr);
+						});
+					else
+						error("Failed to reallocate memory.");
+				}
+
+				void get_copy(
+				    void*& dst, size_t size,
+				    const std::shared_ptr<NumberType>& type) const
+				{
+					sg_memcpy(
+					    dst, m_internal_data.get(), size_in_bytes(size, type));
+				}
+
+				[[nodiscard]] void* get_copy(
+				    size_t size,
+				    const std::shared_ptr<NumberType>& type) const {
+					void* dst = sg_aligned_malloc(
+					    size_in_bytes(size, type),
+					    alignment::container_alignment);
+					sg_memcpy(
+					    dst, m_internal_data.get(), size_in_bytes(size, type));
+					return dst;
+				}
+
+				    [[nodiscard]] static size_t size_in_bytes(
+				        size_t size, const std::shared_ptr<NumberType>& type)
+				{
+					return size * type->size();
+				}
+
+				std::shared_ptr<void> m_internal_data;
+			};
+
+		public:
+			friend class op::ReshapeShogun;
+			friend std::shared_ptr<ShogunStorage>
+			device_put(void*, const Shape&, const std::shared_ptr<NumberType>&);
+			friend std::shared_ptr<Tensor>
+			from_device(const std::shared_ptr<ShogunStorage>& storage);
+			friend class NGraph;
+
+			ShogunStorage(
+			    const Shape& shape, const std::shared_ptr<NumberType>& type)
+			    : m_data(nullptr), m_shape(shape), m_type(type)
+			{
+				// shape is known at build time, let's preallocate it
+				// we could inforce immutability at this level somehow?
+				if (shape.is_static())
+					m_data = std::make_shared<InternalStorage>(
+					    get_size_from_shape(m_shape), type);
+			}
+
+			void* get_copy() const
+			{
+				return m_data->get_copy(get_size_from_shape(m_shape), m_type);
+			}
+
+			/* Allocates memory storage on the fly with a given shape.
+			 * If the exact is not static, e.g. the exact dimensions are
+			 * not known, at runtime, this will throw.
 			 *
 			 */
-			class ShogunStorage
+			void allocate_storage(const Shape& shape)
 			{
-				/* Managed storage. It's only job is to keep track of memory
-				 * and how to delete and allocate it.
-				 * It's unaware of what it actually owns. This is pretty much
-				 * a wrapper around std::shared_ptr for aligned memory.
-				 * Should this be thread safe?
-				 */
-				class InternalStorage
+				if (!shape.is_static())
+					error(
+					    "Cannot allocate tensor with shape {}, with "
+					    "unknown size requirements",
+					    shape.to_string());
+				// new allocation, call allocator_dispatch
+				if (!m_data)
 				{
-				public:
-
-					InternalStorage(
-					    size_t size, const std::shared_ptr<NumberType>& type)
-					{
-						void* data = sg_aligned_malloc(
-						    size_in_bytes(size, type),
-						    alignment::container_alignment);
-						m_internal_data =
-						    std::shared_ptr<void>(data, [](void* ptr) {
-							    if (ptr)
-								    SG_ALIGNED_FREE(ptr);
-						    });
-					}
-
-					InternalStorage(void* data)
-					    : m_internal_data(data, [](void* ptr) {
-						      if (ptr)
-							      SG_ALIGNED_FREE(ptr);
-					      })
-					{
-					}
-
-					void realloc(
-					    size_t size, const std::shared_ptr<NumberType>& type)
-					{
-						void* new_mem = std::realloc(
-						    m_internal_data.get(), size_in_bytes(size, type));
-						if (new_mem)
-							m_internal_data.reset(new_mem, [](void* ptr) {
-								if (ptr)
-									SG_ALIGNED_FREE(ptr);
-							});
-						else
-							error("Failed to reallocate memory.");
-					}
-
-					void get_copy(
-					    void*& dst, size_t size,
-					    const std::shared_ptr<NumberType>& type) const
-					{
-						sg_memcpy(
-						    dst, m_internal_data.get(),
-						    size_in_bytes(size, type));
-					}
-
-					void copy_from(
-					    void* source, size_t size,
-					    const std::shared_ptr<NumberType>& type)
-					{
-						sg_memcpy(
-						    m_internal_data.get(), source,
-						    size_in_bytes(size, type));
-					}
-
-					[[nodiscard]] static size_t size_in_bytes(
-					    size_t size, const std::shared_ptr<NumberType>& type)
-					{
-						return size * type->size();
-					}
-
-					std::shared_ptr<void> m_internal_data;
-				};
-
-			public:
-				friend class ReshapeShogun;
-
-				ShogunStorage(
-				    const Shape& shape, const std::shared_ptr<NumberType>& type)
-				    : m_data(nullptr), m_shape(shape), m_type(type)
-				{
-					// shape is known at build time, let's preallocate it
-					// we could inforce immutability at this level somehow?
-					if (shape.is_static())
-						m_data = std::make_shared<InternalStorage>(
-						    get_size_from_shape(m_shape), type);
+					set_shape(shape);
+					m_data = std::make_shared<InternalStorage>(
+					    get_size_from_shape(shape), m_type);
 				}
-
-				[[nodiscard]] std::shared_ptr<Tensor> to_tensor() const
+				else
 				{
-					auto tensor = std::make_shared<Tensor>(m_shape, m_type);
-					// transfer data to tensor
-					m_data->get_copy(
-					    tensor->data(), get_size_from_shape(m_shape), m_type);
-					tensor->m_free = true;
-					return tensor;
-				}
-
-				/* Equivalent as device_put in JAX. Transfers data to internal
-				 * storage.
-				 */
-				static std::shared_ptr<ShogunStorage>
-				from_tensor(const std::shared_ptr<Tensor>& tensor)
-				{
-					if (!tensor->get_shape().is_static())
-						error("Cannot copy a tensor of unknown shape.");
-					auto storage = std::make_shared<ShogunStorage>(
-					    tensor->get_shape(), tensor->get_type());
-					// transfer data from tensor
-					storage->m_data->copy_from(
-					    tensor->data(),
-					    get_size_from_shape(tensor->get_shape()),
-					    tensor->get_type());
-					return storage;
-				}
-
-				/* Allocates memory storage on the fly with a given shape.
-				 * If the exact is not static, e.g. the exact dimensions are
-				 * not known, at runtime, this will throw.
-				 *
-				 */
-				void allocate_storage(const Shape& shape)
-				{
-					if (!shape.is_static())
-						error(
-						    "Cannot allocate tensor with shape {}, with "
-						    "unknown size requirements",
-						    shape.to_string());
-					// new allocation, call allocator_dispatch
-					if (!m_data)
-					{
-						set_shape(shape);
-						m_data = std::make_shared<InternalStorage>(
-						    get_size_from_shape(shape), m_type);
-					}
+					// memory already allocated, and we have the right shape
+					// nothing to do
+					if (m_shape == shape)
+						return;
+					// memory has been allocated, but it isn't the same
+					// shape
 					else
 					{
-						// memory already allocated, and we have the right shape
-						// nothing to do
-						if (m_shape == shape)
-							return;
-						// memory has been allocated, but it isn't the same
-						// shape
-						else
+						auto old_shape = m_shape;
+						set_shape(shape);
+						// if the size requirement is larger, reallocate
+						// memory
+						if (get_size_from_shape(shape) > size())
 						{
-							auto old_shape = m_shape;
-							set_shape(shape);
-							// if the size requirement is larger, reallocate
-							// memory
-							if (get_size_from_shape(shape) > size())
-							{
-								m_data->realloc(
-								    get_size_from_shape(shape), m_type);
-							}
-							// otherwise nothing happens, we just own a larger
-							// memory block but only use part of it
+							m_data->realloc(get_size_from_shape(shape), m_type);
 						}
+						// otherwise nothing happens, we just own a larger
+						// memory block but only use part of it
 					}
 				}
+			}
 
-				[[nodiscard]] const Shape& get_shape() const noexcept
-				{
-					return m_shape;
-				}
+			[[nodiscard]] const Shape& get_shape() const noexcept
+			{
+				return m_shape;
+			}
 
-				[[nodiscard]] const std::shared_ptr<NumberType>&
-				get_type() const noexcept
-				{
-					return m_type;
-				}
+			[[nodiscard]] const std::shared_ptr<NumberType>& get_type() const
+			    noexcept
+			{
+				return m_type;
+			}
 
-				[[nodiscard]] void* data() {
-					return m_data->m_internal_data.get();
-				}
+			[[nodiscard]] void* data() { return m_data->m_internal_data.get(); }
 
 			    [[nodiscard]] size_t size() const
+			{
+				return get_size_from_shape(m_shape);
+			}
+
+		protected:
+			/* Sets the static Shape. There is a guarantee that
+			 * the Shape passed to this function is static.
+			 */
+			void set_static_shape(const Shape& shape)
+			{
+				if (m_shape.size() != shape.size())
 				{
-					return get_size_from_shape(m_shape);
+					error(
+					    "Mismatch in the number of dimensions, expected "
+					    "{}, "
+					    "but got {}",
+					    m_shape.size(), shape.size());
 				}
 
-			protected:
-				/* Sets the static Shape. There is a guarantee that
-				 * the Shape passed to this function is static.
-				 */
-				void set_static_shape(const Shape& shape)
+				for (const auto& [original_shape_dim_i, new_shape_dim_i] :
+				     zip_iterator(m_shape, shape))
 				{
-					if (m_shape.size() != shape.size())
+					if (original_shape_dim_i != new_shape_dim_i)
 					{
 						error(
-						    "Mismatch in the number of dimensions, expected "
-						    "{}, "
-						    "but got {}",
-						    m_shape.size(), shape.size());
+						    "Cannot set tensor shape. Shapes {} and {} are "
+						    "incompatible.",
+						    m_shape, shape);
 					}
+				}
+				m_shape = shape;
+			}
 
-					for (const auto& [original_shape_dim_i, new_shape_dim_i] :
-					     zip_iterator(m_shape, shape))
-					{
-						if (original_shape_dim_i != new_shape_dim_i)
-						{
-							error(
-							    "Cannot set tensor shape. Shapes {} and {} are "
-							    "incompatible.",
-							    m_shape, shape);
-						}
-					}
-					m_shape = shape;
+			/* Sets the runtime Shape when static Shape allocation
+			 * was not possible, e.g. the user provided Dynamic
+			 * shapes in the Graph construction. If ShogunStorage already
+			 * owns data the checks are skipped.
+			 */
+			void set_shape(const Shape& shape)
+			{
+				if (!shape.is_static())
+					error("Cannot set dynamic shape in storage.");
+				if (m_shape.size() != shape.size())
+				{
+					error(
+					    "Mismatch in the number of dimensions, expected "
+					    "{}, "
+					    "but got {}",
+					    m_shape.size(), shape.size());
 				}
 
-				/* Sets the runtime Shape when static Shape allocation
-				 * was not possible, e.g. the user provided Dynamic
-				 * shapes in the Graph construction. If ShogunStorage already
-				 * owns data the checks are skipped.
-				 */
-				void set_shape(const Shape& shape)
+				for (const auto& [original_shape_dim_i, new_shape_dim_i] :
+				     zip_iterator(m_shape, shape))
 				{
-					if (!shape.is_static())
-						error("Cannot set dynamic shape in storage.");
-					if (m_shape.size() != shape.size())
+					if (original_shape_dim_i == Shape::Dynamic)
+						continue;
+					if (original_shape_dim_i != new_shape_dim_i)
 					{
 						error(
-						    "Mismatch in the number of dimensions, expected "
-						    "{}, "
-						    "but got {}",
-						    m_shape.size(), shape.size());
+						    "Cannot set tensor shape. Shapes {} and {} are "
+						    "incompatible.",
+						    m_shape, shape);
 					}
-
-					for (const auto& [original_shape_dim_i, new_shape_dim_i] :
-					     zip_iterator(m_shape, shape))
-					{
-						if (original_shape_dim_i == Shape::Dynamic)
-							continue;
-						if (original_shape_dim_i != new_shape_dim_i)
-						{
-							error(
-							    "Cannot set tensor shape. Shapes {} and {} are "
-							    "incompatible.",
-							    m_shape, shape);
-						}
-					}
-					m_shape = shape;
 				}
+				m_shape = shape;
+			}
 
-				/* Sets the runtime Shape when static Shape allocation
-				 * was not possible, e.g. the user provided Dynamic
-				 * shapes in the Graph construction. If ShogunStorage already
-				 * owns data the checks are skipped.
-				 */
-				void reshape(const Shape& shape)
+			/* Sets the runtime Shape when static Shape allocation
+			 * was not possible, e.g. the user provided Dynamic
+			 * shapes in the Graph construction. If ShogunStorage already
+			 * owns data the checks are skipped.
+			 */
+			void reshape(const Shape& shape)
+			{
+				if (!shape.is_static())
+					error("Cannot set dynamic shape in storage.");
+				if (size() != get_size_from_shape(shape))
 				{
-					if (!shape.is_static())
-						error("Cannot set dynamic shape in storage.");
-					if (size() != get_size_from_shape(shape))
-					{
-						error(
-						    "Cannot modify the total size of shape: {} vs {}",
-						    m_shape.to_string(), shape.to_string());
-					}
-					m_shape = shape;
+					error(
+					    "Cannot modify the total size of shape: {} vs {}",
+					    m_shape.to_string(), shape.to_string());
 				}
+				m_shape = shape;
+			}
 
-			private:
-				[[nodiscard]] static size_t
-				get_size_from_shape(const Shape& size)
-				{
-					return std::accumulate(
-					    size.begin(), size.end(), size_t{1}, std::multiplies{});
-				}
+		protected:
+			ShogunStorage(
+			    void* ptr, const Shape& shape,
+			    const std::shared_ptr<NumberType>& type)
+			    : m_shape(shape), m_type(type)
+			{
+				m_data = InternalStorage::copy_from(
+				    ptr, get_size_from_shape(shape), type);
+			}
 
-				std::shared_ptr<InternalStorage> m_data;
-				Shape m_shape;
-				std::shared_ptr<NumberType> m_type;
-			};
-		} // namespace op
-	}     // namespace graph
+		private:
+			[[nodiscard]] static size_t get_size_from_shape(const Shape& size)
+			{
+				return std::accumulate(
+				    size.begin(), size.end(), size_t{1}, std::multiplies{});
+			}
+
+		protected:
+			std::shared_ptr<InternalStorage> m_data;
+			Shape m_shape;
+			std::shared_ptr<NumberType> m_type;
+		};
+	} // namespace graph
 } // namespace shogun
 
 #endif

--- a/src/shogun/mathematics/graph/ops/abstract/UnaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/UnaryOperator.h
@@ -34,37 +34,37 @@ namespace shogun
 				{
 					if (input_nodes.size() != 1)
 						error("Unary operation expected one inputs.");
-					if (m_output_tensors.size() != 1)
+					if (m_outputs.size() != 1)
 						error("Unary operation expected one output.");
 
-					const auto& input_tensor =
-					    input_nodes[0]->get_output_tensors()[0];
-					const auto& output_tensor = m_output_tensors[0];
+					const auto& input =
+					    input_nodes[0]->get_outputs()[0];
+					const auto& output = m_outputs[0];
 
-					allocate_tensor(runtime_shape_check(input_tensor));
+					allocate_storage(runtime_shape_check(input));
 
 					kernel(
-					    input_tensor->data(), output_tensor->data(),
-					    output_tensor->size(), output_tensor->get_type());
+					    input->data(), output->data(),
+					    output->size(), output->get_type());
 				}
 
 			protected:
-				void allocate_tensor(const Shape& shape)
+				void allocate_storage(const Shape& shape)
 				{
-					m_output_tensors[0]->allocate_tensor(shape);
+					m_outputs[0]->allocate_storage(shape);
 				}
 
 				const Shape&
-				runtime_shape_check(const std::shared_ptr<Tensor>& tensor)
+				runtime_shape_check(const std::shared_ptr<ShogunStorage>& input)
 				{
-					for (const auto& shape : tensor->get_shape())
+					for (const auto& shape : input->get_shape())
 					{
 						if (shape == Shape::Dynamic)
 						{
 							error("Could not infer runtime shape.");
 						}
 					}
-					return tensor->get_shape();
+					return input->get_shape();
 				}
 
 				void kernel(

--- a/src/shogun/mathematics/graph/ops/abstract/UnaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/UnaryOperator.h
@@ -37,15 +37,14 @@ namespace shogun
 					if (m_outputs.size() != 1)
 						error("Unary operation expected one output.");
 
-					const auto& input =
-					    input_nodes[0]->get_outputs()[0];
+					const auto& input = input_nodes[0]->get_outputs()[0];
 					const auto& output = m_outputs[0];
 
 					allocate_storage(runtime_shape_check(input));
 
 					kernel(
-					    input->data(), output->data(),
-					    output->size(), output->get_type());
+					    input->data(), output->data(), output->size(),
+					    output->get_type());
 				}
 
 			protected:
@@ -68,13 +67,14 @@ namespace shogun
 				}
 
 				void kernel(
-				    void* input, void* output, size_t size, const node::Node::type_info& type)
+				    void* input, void* output, size_t size,
+				    const node::Node::type_info& type)
 				{
 
-#define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)					\
-	static_cast<DerivedOperator*>(this)							\
-	    ->template kernel_implementation<NUMBER_TYPE::c_type>(	\
-	        input, output, size);       						\
+#define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)                                \
+	static_cast<DerivedOperator*>(this)                                        \
+	    ->template kernel_implementation<NUMBER_TYPE::c_type>(                 \
+	        input, output, size);                                              \
 	break;
 
 					switch (*type)

--- a/src/shogun/mathematics/graph/ops/abstract/UnaryOperator.h
+++ b/src/shogun/mathematics/graph/ops/abstract/UnaryOperator.h
@@ -54,7 +54,7 @@ namespace shogun
 				}
 
 				const Shape&
-				runtime_shape_check(const std::shared_ptr<ShogunStorage>& input)
+				runtime_shape_check(const std::shared_ptr<Storage>& input)
 				{
 					for (const auto& shape : input->get_shape())
 					{

--- a/src/shogun/mathematics/graph/ops/shogun/Cast.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Cast.h
@@ -32,8 +32,7 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
-					const auto& input =
-					    input_nodes[0]->get_outputs()[0];
+					const auto& input = input_nodes[0]->get_outputs()[0];
 
 					const auto& output = m_outputs[0];
 
@@ -58,42 +57,30 @@ namespace shogun
     INPUT_SHOGUN_TYPE, OUTPUT_SHOGUN_TYPE)                                     \
 	case OUTPUT_SHOGUN_TYPE::type_id:                                          \
 		kernel_implementation<                                                 \
-		    INPUT_SHOGUN_TYPE::c_type,                                         \
-		    OUTPUT_SHOGUN_TYPE::c_type>(                                       \
+		    INPUT_SHOGUN_TYPE::c_type, OUTPUT_SHOGUN_TYPE::c_type>(            \
 		    input->data(), output->data(), input->size());                     \
 		break;
 
 #define CALL_KERNEL_INPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE)               \
 	switch (*output->get_type())                                               \
 	{                                                                          \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, BooleanType)                          \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, Int8Type)                             \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, Int16Type)                            \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, Int32Type)                            \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, Int64Type)                            \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, UInt8Type)                            \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, UInt16Type)                           \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, UInt32Type)                           \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, UInt64Type)                           \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, Float32Type)                          \
-		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
-		    INPUT_SHOGUN_TYPE, Float64Type)                          \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, BooleanType) \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, Int8Type)    \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, Int16Type)   \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, Int32Type)   \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, Int64Type)   \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, UInt8Type)   \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, UInt16Type)  \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, UInt32Type)  \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, UInt64Type)  \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, Float32Type) \
+		CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE, Float64Type) \
 	}
 
 #define CALL_KERNEL(INPUT_SHOGUN_TYPE)                                         \
 	case INPUT_SHOGUN_TYPE::type_id:                                           \
 	{                                                                          \
-		CALL_KERNEL_INPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE)		       \
+		CALL_KERNEL_INPUT_TYPE_IMPLEMENTATION(INPUT_SHOGUN_TYPE)               \
 	}                                                                          \
 	break;
 

--- a/src/shogun/mathematics/graph/ops/shogun/Cast.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Cast.h
@@ -43,15 +43,15 @@ namespace shogun
 
 			protected:
 				void runtime_checks_and_allocation(
-				    const std::shared_ptr<ShogunStorage>& input)
+				    const std::shared_ptr<Storage>& input)
 				{
 					const auto& shape = input->get_shape();
 					m_outputs[0]->allocate_storage(shape);
 				}
 
 				void cast_implementation_type_dispatch(
-				    const std::shared_ptr<ShogunStorage>& input,
-				    const std::shared_ptr<ShogunStorage>& output)
+				    const std::shared_ptr<Storage>& input,
+				    const std::shared_ptr<Storage>& output)
 				{
 #define CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
     INPUT_SHOGUN_TYPE, OUTPUT_SHOGUN_TYPE)                                     \

--- a/src/shogun/mathematics/graph/ops/shogun/Cast.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Cast.h
@@ -32,28 +32,27 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
-					const auto& input_tensor =
-					    input_nodes[0]->get_output_tensors()[0];
+					const auto& input =
+					    input_nodes[0]->get_outputs()[0];
 
-					const auto& output_tensor = m_output_tensors[0];
+					const auto& output = m_outputs[0];
 
-					runtime_checks_and_allocation(input_tensor);
+					runtime_checks_and_allocation(input);
 
-					cast_implementation_type_dispatch(
-					    input_tensor, output_tensor);
+					cast_implementation_type_dispatch(input, output);
 				}
 
 			protected:
 				void runtime_checks_and_allocation(
-				    const std::shared_ptr<Tensor>& tensor)
+				    const std::shared_ptr<ShogunStorage>& input)
 				{
-					const auto& shape = tensor->get_shape();
-					m_output_tensors[0]->allocate_tensor(shape);
+					const auto& shape = input->get_shape();
+					m_outputs[0]->allocate_storage(shape);
 				}
 
 				void cast_implementation_type_dispatch(
-				    const std::shared_ptr<Tensor>& input,
-				    const std::shared_ptr<Tensor>& output)
+				    const std::shared_ptr<ShogunStorage>& input,
+				    const std::shared_ptr<ShogunStorage>& output)
 				{
 #define CALL_KERNEL_OUTPUT_TYPE_IMPLEMENTATION(                                \
     INPUT_SHOGUN_TYPE, OUTPUT_SHOGUN_TYPE)                                     \

--- a/src/shogun/mathematics/graph/ops/shogun/Dot.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Dot.h
@@ -52,8 +52,8 @@ namespace shogun
 
 			private:
 				void runtime_checks_and_allocation(
-				    const std::shared_ptr<ShogunStorage>& input1,
-				    const std::shared_ptr<ShogunStorage>& input2)
+				    const std::shared_ptr<Storage>& input1,
+				    const std::shared_ptr<Storage>& input2)
 				{
 					const auto& shape_a = input1->get_shape();
 					const auto& shape_b = input2->get_shape();
@@ -109,9 +109,9 @@ namespace shogun
 			protected:
 				template <typename T>
 				static void dot_product_dispatch(
-				    const std::shared_ptr<ShogunStorage>& input1,
-				    const std::shared_ptr<ShogunStorage>& input2,
-				    const std::shared_ptr<ShogunStorage>& output)
+				    const std::shared_ptr<Storage>& input1,
+				    const std::shared_ptr<Storage>& input2,
+				    const std::shared_ptr<Storage>& output)
 				{
 					if (input1->get_shape().is_scalar() &&
 					    !input2->get_shape().is_scalar())
@@ -153,9 +153,9 @@ namespace shogun
 				}
 
 				static void dot_product_type_dispatch(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out)
 				{
 #define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)                                \
 	case NUMBER_TYPE::type_id:                                                 \
@@ -181,9 +181,9 @@ namespace shogun
 
 				template <typename T>
 				static void dot_product_container_scalar_implementation(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out)
 				{
 					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> A_eig(
 					    static_cast<T*>(A->data()), A->size());
@@ -194,9 +194,9 @@ namespace shogun
 
 				template <typename T>
 				static void dot_product_vector_vector_implementation(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out)
 				{
 					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> A_eig(
 					    static_cast<T*>(A->data()), A->size());
@@ -208,9 +208,9 @@ namespace shogun
 
 				template <typename T>
 				static void dot_product_vector_matrix_implementation(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out)
 				{
 					Eigen::Map<Eigen::Matrix<T, 1, Eigen::Dynamic>> A_eig(
 					    static_cast<T*>(A->data()), A->size());
@@ -226,9 +226,9 @@ namespace shogun
 
 				template <typename T>
 				static void dot_product_matrix_vector_implementation(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out)
 				{
 					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
 					A_eig(
@@ -244,9 +244,9 @@ namespace shogun
 
 				template <typename T>
 				static void dot_product_matrix_matrix_implementation(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out)
 				{
 					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
 					A_eig(

--- a/src/shogun/mathematics/graph/ops/shogun/Dot.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Dot.h
@@ -41,10 +41,8 @@ namespace shogun
 					if (m_outputs.size() != 1)
 						error("Binary operation expected one output.");
 
-					const auto& input1 =
-					    input_nodes[0]->get_outputs()[0];
-					const auto& input2 =
-					    input_nodes[1]->get_outputs()[0];
+					const auto& input1 = input_nodes[0]->get_outputs()[0];
+					const auto& input2 = input_nodes[1]->get_outputs()[0];
 					const auto& output = m_outputs[0];
 
 					runtime_checks_and_allocation(input1, input2);
@@ -159,10 +157,9 @@ namespace shogun
 				    const std::shared_ptr<ShogunStorage>& B,
 				    const std::shared_ptr<ShogunStorage>& Out)
 				{
-#define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)              \
-	case NUMBER_TYPE::type_id:                               \
-		dot_product_dispatch<NUMBER_TYPE::c_type>(           \
-		    A, B, Out);                                      \
+#define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)                                \
+	case NUMBER_TYPE::type_id:                                                 \
+		dot_product_dispatch<NUMBER_TYPE::c_type>(A, B, Out);                  \
 		break;
 
 					switch (*A->get_type())

--- a/src/shogun/mathematics/graph/ops/shogun/Input.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Input.h
@@ -7,8 +7,8 @@
 #ifndef SHOGUNINPUTSHOGUN_H_
 #define SHOGUNINPUTSHOGUN_H_
 
-#include <shogun/mathematics/graph/nodes/Input.h>
 #include <shogun/mathematics/graph/Tensor.h>
+#include <shogun/mathematics/graph/nodes/Input.h>
 #include <shogun/mathematics/graph/ops/abstract/Operator.h>
 
 namespace shogun
@@ -17,7 +17,7 @@ namespace shogun
 	{
 		namespace op
 		{
-			/* The InputShogun operation transfers the input memory to the 
+			/* The InputShogun operation transfers the input memory to the
 			 * entry point of the DAG.
 			 * Currently only CPU-CPU mapping is implemented
 			 */
@@ -52,7 +52,8 @@ namespace shogun
 				}
 
 			protected:
-				void runtime_checks_and_allocation(const std::shared_ptr<Tensor>& input_tensor)
+				void runtime_checks_and_allocation(
+				    const std::shared_ptr<Tensor>& input_tensor)
 				{
 					runtime_type_check(input_tensor, m_outputs[0]);
 					runtime_shape_check(input_tensor, m_outputs[0]);
@@ -71,7 +72,8 @@ namespace shogun
 				    const std::shared_ptr<Tensor>& input_tensor,
 				    std::shared_ptr<ShogunStorage>& output)
 				{
-					output = ShogunStorage::from_tensor(input_tensor);
+					// get copy of shared_ptr of Storage
+					output = input_tensor->data();
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Input.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Input.h
@@ -29,7 +29,7 @@ namespace shogun
 				{
 				}
 
-				std::vector<std::shared_ptr<ShogunStorage>>
+				std::vector<std::shared_ptr<Storage>>
 				evaluate_input(const std::shared_ptr<Tensor>& tensor)
 				{
 					if (m_outputs.size() != 1)
@@ -62,7 +62,7 @@ namespace shogun
 			private:
 				void runtime_type_check(
 				    const std::shared_ptr<Tensor>& input_tensor,
-				    const std::shared_ptr<ShogunStorage>& output)
+				    const std::shared_ptr<Storage>& output)
 				{
 					if (input_tensor->get_type() != output->get_type())
 						error("Input node got wrong input type!");
@@ -70,10 +70,10 @@ namespace shogun
 
 				void runtime_shape_check(
 				    const std::shared_ptr<Tensor>& input_tensor,
-				    std::shared_ptr<ShogunStorage>& output)
+				    std::shared_ptr<Storage>& output)
 				{
 					// get copy of shared_ptr of Storage
-					output = input_tensor->data();
+					output = input_tensor->storage();
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/MatMul.h
+++ b/src/shogun/mathematics/graph/ops/shogun/MatMul.h
@@ -47,19 +47,15 @@ namespace shogun
 					    std::static_pointer_cast<node::MatMul>(m_node)
 					        ->get_transpose_b();
 
-					const auto& input1 =
-					    input_nodes[0]->get_outputs()[0];
-					const auto& input2 =
-					    input_nodes[1]->get_outputs()[0];
+					const auto& input1 = input_nodes[0]->get_outputs()[0];
+					const auto& input2 = input_nodes[1]->get_outputs()[0];
 					const auto& output = m_outputs[0];
 
 					runtime_checks_and_allocation(
-					    input1, input2, transpose_a,
-					    transpose_b);
+					    input1, input2, transpose_a, transpose_b);
 
 					matmul_type_dispatch(
-					    input1, input2, output,
-					    transpose_a, transpose_b);
+					    input1, input2, output, transpose_a, transpose_b);
 				}
 
 			private:
@@ -111,23 +107,22 @@ namespace shogun
 							output_shape_vector.push_back(el);
 					}
 
-					m_outputs[0]->allocate_storage(
-					    Shape{output_shape_vector});
+					m_outputs[0]->allocate_storage(Shape{output_shape_vector});
 				}
 
 				void matmul_type_dispatch(
 				    const std::shared_ptr<ShogunStorage>& A,
 				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out, const bool transpose_a,
-				    const bool transpose_b)
+				    const std::shared_ptr<ShogunStorage>& Out,
+				    const bool transpose_a, const bool transpose_b)
 				{
 					if (!transpose_a && !transpose_b)
 						DotShogun::dot_product_type_dispatch(A, B, Out);
 					else
 					{
 #define CALL_KERNEL_IMPLEMENTATION(NUMBER_TYPE)                                \
-	case NUMBER_TYPE::type_id:                                                   \
-		matmul_dispatch<NUMBER_TYPE::c_type>(                \
+	case NUMBER_TYPE::type_id:                                                 \
+		matmul_dispatch<NUMBER_TYPE::c_type>(                                  \
 		    A, B, Out, transpose_a, transpose_b);                              \
 		break;
 
@@ -153,8 +148,8 @@ namespace shogun
 				void matmul_dispatch(
 				    const std::shared_ptr<ShogunStorage>& A,
 				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out, const bool transpose_a,
-				    const bool transpose_b)
+				    const std::shared_ptr<ShogunStorage>& Out,
+				    const bool transpose_a, const bool transpose_b)
 				{
 					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
 					A_eig(

--- a/src/shogun/mathematics/graph/ops/shogun/MatMul.h
+++ b/src/shogun/mathematics/graph/ops/shogun/MatMul.h
@@ -60,8 +60,8 @@ namespace shogun
 
 			private:
 				void runtime_checks_and_allocation(
-				    const std::shared_ptr<ShogunStorage>& input1,
-				    const std::shared_ptr<ShogunStorage>& input2,
+				    const std::shared_ptr<Storage>& input1,
+				    const std::shared_ptr<Storage>& input2,
 				    const bool transpose_a, const bool transpose_b)
 				{
 					const auto& shape_a = input1->get_shape();
@@ -111,10 +111,10 @@ namespace shogun
 				}
 
 				void matmul_type_dispatch(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out,
-				    const bool transpose_a, const bool transpose_b)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out, const bool transpose_a,
+				    const bool transpose_b)
 				{
 					if (!transpose_a && !transpose_b)
 						DotShogun::dot_product_type_dispatch(A, B, Out);
@@ -146,10 +146,10 @@ namespace shogun
 
 				template <typename T>
 				void matmul_dispatch(
-				    const std::shared_ptr<ShogunStorage>& A,
-				    const std::shared_ptr<ShogunStorage>& B,
-				    const std::shared_ptr<ShogunStorage>& Out,
-				    const bool transpose_a, const bool transpose_b)
+				    const std::shared_ptr<Storage>& A,
+				    const std::shared_ptr<Storage>& B,
+				    const std::shared_ptr<Storage>& Out, const bool transpose_a,
+				    const bool transpose_b)
 				{
 					Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
 					A_eig(

--- a/src/shogun/mathematics/graph/ops/shogun/Reshape.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Reshape.h
@@ -32,18 +32,12 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
-					const auto& input_tensor1 =
-					    input_nodes[0]->get_output_tensors()[0];
-					const auto& output_tensor = m_output_tensors[0];
+					const auto& input =
+					    input_nodes[0]->get_outputs()[0];
+					const auto final_shape = m_outputs[0]->get_shape();
 
-					runtime_checks_and_allocation(std::vector{input_tensor1});
-				}
-
-			private:
-				void runtime_checks_and_allocation(
-				    const std::vector<std::shared_ptr<Tensor>>& tensors)
-				{
-					m_output_tensors[0]->data() = tensors[0]->data();
+					m_outputs[0] = std::move(input);
+					m_outputs[0]->reshape(final_shape);
 				}
 			};
 		} // namespace op

--- a/src/shogun/mathematics/graph/ops/shogun/Reshape.h
+++ b/src/shogun/mathematics/graph/ops/shogun/Reshape.h
@@ -32,8 +32,7 @@ namespace shogun
 				void call(const std::vector<std::shared_ptr<
 				              detail::shogun::OutputNode>>& input_nodes) final
 				{
-					const auto& input =
-					    input_nodes[0]->get_outputs()[0];
+					const auto& input = input_nodes[0]->get_outputs()[0];
 					const auto final_shape = m_outputs[0]->get_shape();
 
 					m_outputs[0] = std::move(input);

--- a/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
@@ -28,8 +28,10 @@ namespace shogun
 					BinaryRuntimeNodeNGraph()
 					    : RuntimeNodeTemplate<NodeType, ::ngraph::Node>(){}
 
-		          	[[nodiscard]] std::shared_ptr<::ngraph::Node> build_implementation(
-		                  const std::shared_ptr<node::Node>& node) const final
+					          [[nodiscard]] std::
+					              shared_ptr<::ngraph::Node> build_implementation(
+					                  const std::shared_ptr<node::Node>& node)
+					                  const final
 					{
 						if (this->m_input_nodes.size() != 2)
 							error("Expected two input nodes in "

--- a/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/BinaryRuntimeNode.h
@@ -28,14 +28,14 @@ namespace shogun
 					BinaryRuntimeNodeNGraph()
 					    : RuntimeNodeTemplate<NodeType, ::ngraph::Node>(){}
 
-					          [[nodiscard]] std::
-					              shared_ptr<::ngraph::Node> build_implementation(
-					                  const std::shared_ptr<node::Node>& node)
-					                  const final
+		          	[[nodiscard]] std::shared_ptr<::ngraph::Node> build_implementation(
+		                  const std::shared_ptr<node::Node>& node) const final
 					{
 						if (this->m_input_nodes.size() != 2)
 							error("Expected two input nodes in "
 							      "BinaryRuntimeNodeNGraph.");
+
+						std::shared_ptr<::ngraph::Node> result = nullptr;
 
 						auto binary_node =
 						    std::static_pointer_cast<NodeType>(node);
@@ -43,7 +43,7 @@ namespace shogun
 						    node::BinaryNode::BinaryShapeCompatibity::
 						        ArrayArray)
 						{
-							return std::make_shared<OperatorType>(
+							result = std::make_shared<OperatorType>(
 							    this->m_input_nodes[0], this->m_input_nodes[1]);
 						}
 						else if (
@@ -51,11 +51,12 @@ namespace shogun
 						    node::BinaryNode::BinaryShapeCompatibity::
 						        ArrayScalar)
 						{
-							return std::make_shared<OperatorType>(
+							result = std::make_shared<OperatorType>(
 							    this->m_input_nodes[0], this->m_input_nodes[1],
 							    ::ngraph::op::AutoBroadcastSpec(
 							        ::ngraph::op::AutoBroadcastType::NUMPY));
 						}
+						return result;
 					}
 				};
 			} // namespace ngraph

--- a/src/shogun/mathematics/graph/runtime/ngraph/Input.h
+++ b/src/shogun/mathematics/graph/runtime/ngraph/Input.h
@@ -26,27 +26,27 @@ namespace shogun
 					switch (type)
 					{
 					case ::ngraph::element::Type_t::f32:
-						return std::make_shared<Float32Type>();
+						return number_type(element_type::FLOAT32);
 					case ::ngraph::element::Type_t::f64:
-						return std::make_shared<Float64Type>();
+						return number_type(element_type::FLOAT64);
 					case ::ngraph::element::Type_t::boolean:
-						return std::make_shared<BooleanType>();
+						return number_type(element_type::BOOLEAN);
 					case ::ngraph::element::Type_t::i8:
-						return std::make_shared<Int8Type>();
+						return number_type(element_type::INT8);
 					case ::ngraph::element::Type_t::i16:
-						return std::make_shared<Int16Type>();
+						return number_type(element_type::INT16);
 					case ::ngraph::element::Type_t::i32:
-						return std::make_shared<Int32Type>();
+						return number_type(element_type::INT32);
 					case ::ngraph::element::Type_t::i64:
-						return std::make_shared<Int64Type>();
+						return number_type(element_type::INT64);
 					case ::ngraph::element::Type_t::u8:
-						return std::make_shared<UInt8Type>();
+						return number_type(element_type::UINT8);
 					case ::ngraph::element::Type_t::u16:
-						return std::make_shared<UInt16Type>();
+						return number_type(element_type::UINT16);
 					case ::ngraph::element::Type_t::u32:
-						return std::make_shared<UInt32Type>();
+						return number_type(element_type::UINT32);
 					case ::ngraph::element::Type_t::u64:
-						return std::make_shared<UInt64Type>();
+						return number_type(element_type::UINT64);
 					case ::ngraph::element::Type_t::undefined:
 					case ::ngraph::element::Type_t::dynamic:
 					case ::ngraph::element::Type_t::bf16:
@@ -56,8 +56,8 @@ namespace shogun
 					}
 				}
 
-				inline ::ngraph::element::Type_t
-				get_ngraph_type_from_enum(const std::shared_ptr<shogun::graph::NumberType>& type)
+				inline ::ngraph::element::Type_t get_ngraph_type_from_enum(
+				    const std::shared_ptr<shogun::graph::NumberType>& type)
 				{
 					switch (type->type())
 					{

--- a/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
+++ b/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
@@ -8,6 +8,7 @@
 #define SHOGUN_OUTPUT_NODE_H_
 
 #include <shogun/mathematics/graph/ops/abstract/Operator.h>
+#include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
 #include <shogun/mathematics/graph/ops/shogun/Input.h>
 
 namespace shogun
@@ -18,6 +19,11 @@ namespace shogun
 		{
 			namespace shogun
 			{
+				/* A OutputNode stores and passes the input nodes required 
+				 * by an operation and holds a pointer to the resulting
+				 * allocated results. These can then passed on to the 
+				 * next OutputNode in the graph.
+				 */
 				class OutputNode
 				{
 				public:
@@ -42,20 +48,23 @@ namespace shogun
 							    "Use OutputNode::evaluate_tensor(Tensor) "
 							    "instead");
 						else
-							m_output_tensors = m_op->operator()(m_input_nodes);
+							m_outputs = m_op->operator()(m_input_nodes);
 					}
 
+					/* This member functions is only called by input nodes,
+					 * and is the entry point of the execution graph.
+					 */ 
 					void evaluate_tensor(const std::shared_ptr<Tensor>& tensor)
 					{
-						m_output_tensors =
+						m_outputs =
 						    std::static_pointer_cast<op::InputShogun>(m_op)
 						        ->evaluate_input(tensor);
 					}
 
-					const std::vector<std::shared_ptr<Tensor>>&
-					get_output_tensors() const
+					const std::vector<std::shared_ptr<op::ShogunStorage>>&
+					get_outputs() const
 					{
-						return m_output_tensors;
+						return m_outputs;
 					}
 
 					const std::vector<std::shared_ptr<OutputNode>>&
@@ -65,9 +74,12 @@ namespace shogun
 					}
 
 				private:
+					/* The actual implementation of the operation */
 					std::shared_ptr<op::Operator> m_op;
+					/* Reference to inputs */
 					std::vector<std::shared_ptr<OutputNode>> m_input_nodes;
-					std::vector<std::shared_ptr<Tensor>> m_output_tensors;
+					/* Reference to Operator allocated output storage */
+					std::vector<std::shared_ptr<op::ShogunStorage>> m_outputs;
 				};
 			} // namespace shogun
 		}     // namespace detail

--- a/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
+++ b/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
@@ -7,8 +7,8 @@
 #ifndef SHOGUN_OUTPUT_NODE_H_
 #define SHOGUN_OUTPUT_NODE_H_
 
+#include <shogun/mathematics/graph/Storage.h>
 #include <shogun/mathematics/graph/ops/abstract/Operator.h>
-#include <shogun/mathematics/graph/ops/abstract/ShogunStorage.h>
 #include <shogun/mathematics/graph/ops/shogun/Input.h>
 
 namespace shogun
@@ -61,7 +61,7 @@ namespace shogun
 						        ->evaluate_input(tensor);
 					}
 
-					const std::vector<std::shared_ptr<ShogunStorage>>&
+					const std::vector<std::shared_ptr<Storage>>&
 					get_outputs() const
 					{
 						return m_outputs;
@@ -79,7 +79,7 @@ namespace shogun
 					/* Reference to inputs */
 					std::vector<std::shared_ptr<OutputNode>> m_input_nodes;
 					/* Reference to Operator allocated output storage */
-					std::vector<std::shared_ptr<ShogunStorage>> m_outputs;
+					std::vector<std::shared_ptr<Storage>> m_outputs;
 				};
 			} // namespace shogun
 		}     // namespace detail

--- a/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
+++ b/src/shogun/mathematics/graph/runtime/shogun/OutputNode.h
@@ -19,9 +19,9 @@ namespace shogun
 		{
 			namespace shogun
 			{
-				/* A OutputNode stores and passes the input nodes required 
+				/* A OutputNode stores and passes the input nodes required
 				 * by an operation and holds a pointer to the resulting
-				 * allocated results. These can then passed on to the 
+				 * allocated results. These can then passed on to the
 				 * next OutputNode in the graph.
 				 */
 				class OutputNode
@@ -53,7 +53,7 @@ namespace shogun
 
 					/* This member functions is only called by input nodes,
 					 * and is the entry point of the execution graph.
-					 */ 
+					 */
 					void evaluate_tensor(const std::shared_ptr<Tensor>& tensor)
 					{
 						m_outputs =
@@ -61,7 +61,7 @@ namespace shogun
 						        ->evaluate_input(tensor);
 					}
 
-					const std::vector<std::shared_ptr<op::ShogunStorage>>&
+					const std::vector<std::shared_ptr<ShogunStorage>>&
 					get_outputs() const
 					{
 						return m_outputs;
@@ -79,7 +79,7 @@ namespace shogun
 					/* Reference to inputs */
 					std::vector<std::shared_ptr<OutputNode>> m_input_nodes;
 					/* Reference to Operator allocated output storage */
-					std::vector<std::shared_ptr<op::ShogunStorage>> m_outputs;
+					std::vector<std::shared_ptr<ShogunStorage>> m_outputs;
 				};
 			} // namespace shogun
 		}     // namespace detail

--- a/src/shogun/mathematics/graph/test/GraphTest.h
+++ b/src/shogun/mathematics/graph/test/GraphTest.h
@@ -20,7 +20,7 @@ protected:
 	void test_binary_op_results(
 	    const std::shared_ptr<shogun::graph::Graph>& graph,
 	    const shogun::SGVector<typename T::c_type>& X1,
-		const shogun::SGVector<typename T::c_type>& X2,
+	    const shogun::SGVector<typename T::c_type>& X2,
 	    const shogun::SGVector<typename T::c_type>& expected_result1,
 	    const shogun::SGVector<typename T::c_type>& expected_result2)
 	{
@@ -33,8 +33,10 @@ protected:
 			        std::vector{std::make_shared<shogun::graph::Tensor>(X1),
 			                    std::make_shared<shogun::graph::Tensor>(X2)});
 
-			auto result1 = result[0]->template as<shogun::SGVector<typename T::c_type>>();
-			auto result2 = result[1]->template as<shogun::SGVector<typename T::c_type>>();
+			auto result1 =
+			    result[0]->template as<shogun::SGVector<typename T::c_type>>();
+			auto result2 =
+			    result[1]->template as<shogun::SGVector<typename T::c_type>>();
 
 			for (const auto& [expected_i, result_i] :
 			     shogun::zip_iterator(expected_result1, result1))
@@ -53,13 +55,12 @@ protected:
 	std::set<GRAPH_BACKEND> m_backends;
 };
 
-
 using GraphTypes = ::testing::Types<
     shogun::graph::BooleanType, shogun::graph::UInt8Type,
-	shogun::graph::Int8Type, shogun::graph::UInt16Type,
-	shogun::graph::Int16Type, shogun::graph::UInt32Type,
-	shogun::graph::Int32Type, shogun::graph::Int64Type,
-	shogun::graph::UInt64Type, shogun::graph::Float32Type,
-	shogun::graph::Float64Type>;
+    shogun::graph::Int8Type, shogun::graph::UInt16Type,
+    shogun::graph::Int16Type, shogun::graph::UInt32Type,
+    shogun::graph::Int32Type, shogun::graph::Int64Type,
+    shogun::graph::UInt64Type, shogun::graph::Float32Type,
+    shogun::graph::Float64Type>;
 
 TYPED_TEST_CASE(GraphTest, GraphTypes);

--- a/src/shogun/mathematics/linalg/LinalgBackendViennaCL.h
+++ b/src/shogun/mathematics/linalg/LinalgBackendViennaCL.h
@@ -803,7 +803,7 @@ namespace shogun
 			return SGVector<T>(result_gpu, mat.num_rows);
 		}
 
-		/** Transfer data to GPU with ViennaCL method. */
+		/** Move data to GPU with ViennaCL method. */
 		template <typename T, template <typename> class Container>
 		GPUMemoryBase<T>* to_gpu_impl(const Container<T>& a) const
 		{


### PR DESCRIPTION
Separates abstraction of data locality and Tensors.
 - Tensors should be user facing
 - ShogunStorage is internal

Adds automatic memory management of ShogunStorage with std::shared_ptr, and guarantees that the correct deleter is called