### PR TITLE
Graph hash

### DIFF
--- a/src/shogun/mathematics/graph/Graph.h
+++ b/src/shogun/mathematics/graph/Graph.h
@@ -43,6 +43,18 @@ namespace shogun
 			void build();
 			void build(GRAPH_BACKEND backend);
 
+			size_t hash() const;
+
+			bool operator==(const Graph& other) const
+			{
+				return hash() == other.hash();
+			}
+
+			bool operator!=(const Graph& other) const
+			{
+				return !(*this == other);
+			}
+
 		private:
 			std::unordered_map<std::shared_ptr<node::Node>, STATUS>
 			check_fully_connected(
@@ -55,12 +67,13 @@ namespace shogun
 			    const std::shared_ptr<node::Node>& node,
 			    std::unordered_map<std::shared_ptr<node::Node>, Graph::STATUS>&
 			        all_nodes,
-			    std::deque<std::shared_ptr<node::Node>>& result);
+			    std::vector<std::shared_ptr<node::Node>>& result);
 
 			std::vector<std::shared_ptr<node::Input>> m_inputs;
 			std::vector<std::shared_ptr<node::Node>> m_outputs;
 
-			std::deque<std::shared_ptr<node::Node>> m_cached_nodes;
+			std::vector<std::shared_ptr<node::Node>> m_cached_nodes;
+			GRAPH_BACKEND m_current_backend;
 
 			std::shared_ptr<GraphExecutor> m_executor;
 		};

--- a/src/shogun/mathematics/graph/Graph_test.cc
+++ b/src/shogun/mathematics/graph/Graph_test.cc
@@ -19,6 +19,44 @@ using namespace shogun;
 using namespace shogun::graph;
 using namespace std;
 
+TYPED_TEST(GraphTest, abtract_graph_hash)
+{
+	using NumericType = typename TypeParam::c_type;
+
+	if constexpr (std::is_same_v<NumericType, bool>)
+		return;
+	
+	auto input =
+	    make_shared<node::Input>(Shape{Shape::Dynamic}, TypeParam::type_id);
+	auto input1 = make_shared<node::Input>(Shape{10}, TypeParam::type_id);
+
+	auto intermediate = input + input;
+
+	auto output = intermediate + input1;
+
+	auto graph1 = make_shared<Graph>(
+	    vector{input, input1},
+	    vector<shared_ptr<node::Node>>{intermediate, output});
+
+	auto graph2 = make_shared<Graph>(
+	    vector{input, input1},
+	    vector<shared_ptr<node::Node>>{intermediate, output});
+
+	auto graph3 = make_shared<Graph>(
+	    vector{input, input1},
+	    vector<shared_ptr<node::Node>>{output});
+
+	for (auto&& backend : this->m_backends)
+	{
+		graph1->build(backend);
+		graph2->build(backend);
+		graph3->build(backend);
+
+		EXPECT_EQ(*graph1, *graph2);
+		EXPECT_NE(*graph1, *graph3);
+	}
+}
+
 TYPED_TEST(GraphTest, perceptron_stochastic_gradient_descent)
 {
 #if 0

--- a/src/shogun/mathematics/graph/Shape.h
+++ b/src/shogun/mathematics/graph/Shape.h
@@ -16,6 +16,7 @@
 
 #include <shogun/io/SGIO.h>
 #include <shogun/util/zip_iterator.h>
+#include <shogun/mathematics/graph/utils.h>
 
 namespace shogun
 {
@@ -139,6 +140,11 @@ namespace shogun
 			operator<<(std::ostream& os, const Shape& shape)
 			{
 				return os << shape.to_string();
+			}
+
+			[[nodiscard]] size_t hash() const 
+			{
+				return shogun::graph::hash(m_shape);
 			}
 
 		private:

--- a/src/shogun/mathematics/graph/Types.h
+++ b/src/shogun/mathematics/graph/Types.h
@@ -61,6 +61,11 @@ namespace shogun
 				return m_et;
 			}
 
+			[[nodiscard]] size_t hash() const 
+			{
+				return std::hash<element_type>{}(m_et);
+			}
+
 		private:
 			const element_type m_et;
 		};

--- a/src/shogun/mathematics/graph/nodes/BinaryNode.h
+++ b/src/shogun/mathematics/graph/nodes/BinaryNode.h
@@ -8,6 +8,7 @@
 #define SHOGUN_NODES_BINARY_NODE_H_
 
 #include <shogun/mathematics/graph/nodes/Node.h>
+#include <shogun/mathematics/graph/utils.h>
 #include <shogun/util/enumerate.h>
 
 #define IGNORE_IN_CLASSLIST

--- a/src/shogun/mathematics/graph/nodes/MatMul.h
+++ b/src/shogun/mathematics/graph/nodes/MatMul.h
@@ -103,6 +103,14 @@ namespace shogun
 					return true;
 				}
 
+				[[nodiscard]] size_t hash() const final
+				{
+					size_t seed = Node::hash();
+					seed = hash_combine(seed, m_transpose_a);
+					seed = hash_combine(seed, m_transpose_b);
+					return seed;
+				}
+
 			protected:
 				element_type check_type_compatible(
 				    const std::shared_ptr<Node>& A,

--- a/src/shogun/mathematics/graph/nodes/Node.h
+++ b/src/shogun/mathematics/graph/nodes/Node.h
@@ -91,6 +91,15 @@ namespace shogun
 
 				virtual bool requires_column_major_conversion() const = 0;
 
+				[[nodiscard]] virtual size_t hash() const
+				{
+					size_t seed = 0;
+					hash_combine(seed, m_types);
+					hash_combine(seed, m_shapes);
+					hash_combine(seed, m_input_nodes);
+					return seed;
+				}
+
 			protected:
 				std::vector<std::shared_ptr<Node>> m_input_nodes;
 				std::vector<Shape> m_shapes;

--- a/src/shogun/mathematics/graph/utils.h
+++ b/src/shogun/mathematics/graph/utils.h
@@ -1,0 +1,59 @@
+/*
+ * This software is distributed under BSD 3-clause license (see LICENSE file).
+ *
+ * Authors: Gil Hoben
+ */
+
+#ifndef SHOGUN_GRAPH_UTILS_H_
+#define SHOGUN_GRAPH_UTILS_H_
+
+namespace shogun
+{
+	namespace graph {
+
+		template <typename T>
+		size_t hash(const std::vector<T>& vec);
+
+		template <typename T>
+		inline auto hash_combine(std::size_t seed, const T& v) -> decltype(std::hash<T>{}(v))
+		{
+			std::hash<T> hasher;
+		    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+		    return seed;
+		}
+
+		template <typename T>
+		inline auto hash_combine(std::size_t seed, const T& v) -> decltype(hash(v))
+		{
+		    seed ^= hash(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+		    return seed;
+		}
+
+		// template <typename T>
+		// inline auto hash_combine(std::size_t seed, const T& v) -> decltype(v->hash())
+		// {
+		//     seed ^= v->hash() + 0x9e3779b9 + (seed<<6) + (seed>>2);
+		//     return seed;
+		// }
+
+		template <typename T>
+		inline auto hash_combine(std::size_t seed, const T& v) -> decltype(v.hash())
+		{
+		    seed ^= v.hash() + 0x9e3779b9 + (seed<<6) + (seed>>2);
+		    return seed;
+		}
+
+		template <typename T>
+		size_t hash(const std::vector<T>& vec)
+		{
+			size_t seed = 0;
+			for (const auto& el: vec)
+			{
+				seed = hash_combine(seed, el);
+			}
+			return seed;
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
Hashes required:
- [x] Abstract node -> may contain runtime values
- [ ] Runtime node -> knows static shape and input. The graph can use this to find out if it requires recomputation of the graph
- [ ] Tensor hash with fingerprint (might be handled in PR by @vigsterkr)

The hash of the nodes is a combination of all hashes of all previous nodes. This might be too expensive for very simple graphs?