### PR TITLE
Fixes shogun-serialization-unit-test cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,25 @@ IF(ENABLE_TESTING AND NOT BUILD_DASHBOARD_REPORTS)
 	enable_testing()
 ENDIF()
 
+FIND_PACKAGE(Ctags)
+# TODO: the arg for -R should rather be the where libshogun's headers are residing
+ADD_CUSTOM_COMMAND(OUTPUT ${CTAGS_FILE}
+    COMMAND ${CTAGS_EXECUTABLE} -f ${CTAGS_FILE}
+    # classes, enums, functions
+    --c++-kinds=cfgp
+    --fields=+im
+    --exclude=*.cpp
+    --exclude=third_party
+    --exclude=GoogleMock
+    --exclude=rxcpp
+    --exclude=interfaces
+    --exclude=Eigen3
+    --exclude=external
+    --languages=c++
+    -R ${CMAKE_SOURCE_DIR})
+
+ADD_CUSTOM_TARGET(ctags DEPENDS ${CTAGS_FILE})
+
 IF(EXISTS ${CMAKE_SOURCE_DIR}/examples)
 	IF(ENABLE_TESTING AND NOT BUILD_EXAMPLES)
 		message(STATUS "Tests require (disabled) examples, enabling.")

--- a/examples/meta/CMakeLists.txt
+++ b/examples/meta/CMakeLists.txt
@@ -6,28 +6,10 @@ IF(NOT PLY_FOUND)
 	message(FATAL_ERROR "Python module ply required for meta examples. Install or set BUILD_META_EXAMPLES=OFF")
 ENDIF()
 
-FIND_PACKAGE(Ctags)
 IF(NOT CTAGS_FOUND)
 	message(FATAL_ERROR "Ctags required for meta examples. Install or set BUILD_META_EXAMPLES=OFF.")
 ENDIF()
 
-# TODO: the arg for -R should rather be the where libshogun's headers are residing
-ADD_CUSTOM_COMMAND(OUTPUT ${CTAGS_FILE}
-    COMMAND ${CTAGS_EXECUTABLE} -f ${CTAGS_FILE}
-    # classes, enums, functions
-    --c++-kinds=cfgp
-    --fields=+im
-    --exclude=*.cpp
-    --exclude=third_party
-    --exclude=GoogleMock
-    --exclude=rxcpp
-    --exclude=interfaces
-    --exclude=Eigen3
-    --exclude=external
-    --languages=c++
-    -R ${CMAKE_SOURCE_DIR})
-
-ADD_CUSTOM_TARGET(ctags DEPENDS ${CTAGS_FILE})
 SET_SOURCE_FILES_PROPERTIES(${CTAGS_FILE} PROPERTIES GENERATED 1)
 
 # get list of meta examples that can be built

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,4 @@
 FIND_PACKAGE(Jinja2)
-FIND_PACKAGE(Ctags)
 
 # Find GTEST and GMOCK frameworks
 include(external/GoogleTestNMock)


### PR DESCRIPTION
Right now when we don't build meta examples but build shogun-serialization-unit-test cmake target there is a cmake error (see also [here](https://buildbot.shogun.ml/#/builders/35/builds/53/steps/5/logs/stdio)):
```
ninja: error: '../tests/unit/ctags', needed by 'tests/unit/trained_model_serialization_test.h', missing and no known rule to make it
```
This is because the ctags target is created in the CMakeLists.txt inside meta (which is not included when meta examples are turned off), but ctags is declared in there. So moved the declaration to the main CMakeLists.txt, could probably be somewhere better (but now at least it should work)? 