### PR TITLE
Fix macOS CI

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -136,7 +136,7 @@ jobs:
       -DOpenMP_omp_LIBRARY="/usr/local/opt/libomp/lib/libomp.dylib"'
 
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
 
   steps:
   - template: ./macos-steps.yml

--- a/.ci/macos-steps.yml
+++ b/.ci/macos-steps.yml
@@ -16,8 +16,8 @@ steps:
     downloadPath: $(build.binariesDirectory)
 
 - bash: |
-    sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
-  displayName: Select XCode10 env
+    sudo xcode-select --switch /Applications/Xcode_11.app/Contents/Developer
+  displayName: Select XCode11 env
 
 - bash: |
     brew update

--- a/cmake/ShogunFindLAPACK.cmake
+++ b/cmake/ShogunFindLAPACK.cmake
@@ -6,7 +6,9 @@ IF (LAPACK_FOUND)
   SET(HAVE_LAPACK 1)
 
   # find out the type of Lapack/BLAS implementation we are dealing with
-  IF("${LAPACK_LIBRARIES}" MATCHES ".*/Accelerate.framework$")
+  # it seems like findLAPACK includes in LAPACK_LIBRARIES all the libraries 
+  # that need to be linked: "Accelerate.framework;-lm;-ldl"
+  IF("${LAPACK_LIBRARIES}" MATCHES ".*/Accelerate.framework(;-l[a-z]+)*$")
     # Accelerate.framework we found for LaPack/BLAS
     SET(HAVE_MVEC 1)
     SET(HAVE_CATLAS 1)


### PR DESCRIPTION
- Upgraded image to 10.15 and use Xcode 11 (seems like there was some distribution bug in Xcode 10)
- Fixed LAPACK_LIBRARIES regex to match arbitrary number of libraries now included in this cmake variable (which comes from CMake's FindLapack.cmake) 