### PR TITLE
SigmoidKernel constructors cleanup

### DIFF
--- a/src/shogun/kernel/SigmoidKernel.cpp
+++ b/src/shogun/kernel/SigmoidKernel.cpp
@@ -13,27 +13,25 @@ using namespace shogun;
 
 SigmoidKernel::SigmoidKernel() : DotKernel()
 {
-	init();
+	SG_ADD(
+	    &gamma, "gamma", "Scaler for the dot product.",
+	    ParameterProperties::HYPER | ParameterProperties::AUTO,
+	    std::make_shared<params::GammaFeatureNumberInit>(this));
+	SG_ADD(&coef0, "coef0", "Coefficient 0.", ParameterProperties::HYPER);
 }
 
 SigmoidKernel::SigmoidKernel(int32_t size, float64_t g, float64_t c)
-    : DotKernel(size)
+    : SigmoidKernel()
 {
-	init();
-
+	set_cache_size(size);
 	gamma = g;
 	coef0 = c;
 }
 
 SigmoidKernel::SigmoidKernel(
     const std::shared_ptr<DotFeatures>& l, const std::shared_ptr<DotFeatures>& r, int32_t size, float64_t g, float64_t c)
-    : DotKernel(size)
+    : SigmoidKernel(size, g, c)
 {
-	init();
-
-	gamma = g;
-	coef0 = c;
-
 	init(l, r);
 }
 
@@ -50,16 +48,4 @@ bool SigmoidKernel::init(std::shared_ptr<Features> l, std::shared_ptr<Features> 
 {
 	DotKernel::init(l, r);
 	return init_normalizer();
-}
-
-void SigmoidKernel::init()
-{
-	gamma = 0.0;
-	coef0 = 0.0;
-
-	SG_ADD(
-	    &gamma, "gamma", "Scaler for the dot product.",
-	    ParameterProperties::HYPER | ParameterProperties::AUTO,
-	    std::make_shared<params::GammaFeatureNumberInit>(this));
-	SG_ADD(&coef0, "coef0", "Coefficient 0.", ParameterProperties::HYPER);
 }

--- a/src/shogun/kernel/SigmoidKernel.h
+++ b/src/shogun/kernel/SigmoidKernel.h
@@ -87,14 +87,11 @@ class SigmoidKernel: public DotKernel
 			return tanh(gamma*DotKernel::compute(idx_a,idx_b)+coef0);
 		}
 
-	private:
-		void init();
-
 	protected:
 		/** gamma */
-		float64_t gamma;
+		float64_t gamma = 0.0;
 		/** coefficient 0 */
-		float64_t coef0;
+		float64_t coef0 = 0.0;
 };
 }
 #endif /* _SIGMOIDKERNEL_H__ */


### PR DESCRIPTION
Example of how to refactor constructors #5030
For future reference: remember that the member initializer list is guaranteed to be executed before the body of the constructor.