### PR TITLE
Extend observe() to emit std::function objects

### DIFF
--- a/src/shogun/lib/observers/ObservedValue.h
+++ b/src/shogun/lib/observers/ObservedValue.h
@@ -29,6 +29,17 @@ namespace shogun
 		ObservedValue(const int64_t step, std::string_view name);
 
 		/**
+		 * Copy constructor
+		 * @param other other ObservedValue instance
+		 */
+		ObservedValue(const ObservedValue& other) : SGObject(other)
+		{
+			m_step = other.m_step;
+			m_name = other.m_name;
+			m_any_value = other.m_any_value;
+		}
+
+		/**
 		 * Destructor
 		 */
 		~ObservedValue(){};

--- a/src/shogun/lib/observers/ObservedValueTemplated.h
+++ b/src/shogun/lib/observers/ObservedValueTemplated.h
@@ -28,6 +28,23 @@ namespace shogun
 		 * @param value the observed value
 		 */
 		ObservedValueTemplated(
+		    const int64_t step, const std::string_view name, const T value)
+		    : ObservedValue(step, name), m_observed_value(value)
+		{
+			this->watch_param(
+			    name, &m_observed_value,
+			    AnyParameterProperties(
+			        "Unamed observed value", ParameterProperties::READONLY));
+			m_any_value = make_any(m_observed_value);
+		}
+
+		/**
+		 * Constructor
+		 * @param step step
+		 * @param name the observed value's name
+		 * @param value the observed value
+		 */
+		ObservedValueTemplated(
 		    const int64_t step, const std::string_view name,
 		    const std::string_view description, const T value)
 		    : ObservedValue(step, name), m_observed_value(value)
@@ -53,6 +70,12 @@ namespace shogun
 		{
 			this->watch_param(name, &m_observed_value, properties);
 			m_any_value = make_any(m_observed_value);
+		}
+
+		ObservedValueTemplated(const ObservedValueTemplated& other)
+		    : ObservedValue(other)
+		{
+			m_observed_value = other.m_observed_value;
 		}
 
 		/**

--- a/src/shogun/lib/observers/ParameterObserver.cpp
+++ b/src/shogun/lib/observers/ParameterObserver.cpp
@@ -81,4 +81,4 @@ bool ParameterObserver::observes(const AnyParameterProperties& property)
 index_t ParameterObserver::get_num_observations() const
 {
 	return utils::safe_convert<index_t>(m_observations.size());
-};
+}

--- a/src/shogun/lib/observers/ParameterObserver.h
+++ b/src/shogun/lib/observers/ParameterObserver.h
@@ -120,6 +120,13 @@ namespace shogun
 		virtual void on_complete() = 0;
 
 		/**
+		 * Check if the observed value is a lambda. If it is, execute it and
+		 * the return it as a proper observation.
+		 * @param value
+		 * @return
+		 */
+
+		/**
 		 * Get the name of this class
 		 * @return name as a string
 		 */


### PR DESCRIPTION
This addresses #5026. I still need to work around some details, but this is kind of what I had in mind to make it work. At the moment it doesn't pass the tests though. @karlnapf @gf712 