### PR TITLE
zip_iterator and enumerate for lvalues and rvalues

### DIFF
--- a/src/shogun/classifier/AveragedPerceptron.cpp
+++ b/src/shogun/classifier/AveragedPerceptron.cpp
@@ -10,6 +10,7 @@
 #include <shogun/labels/Labels.h>
 #include <shogun/lib/observers/ObservedValueTemplated.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <shogun/util/zip_iterator.h>
 
 using namespace shogun;
 
@@ -71,15 +72,13 @@ void AveragedPerceptron::iteration()
 
 	SGVector<float64_t> w = get_w();
 	auto labels = binary_labels(m_labels)->get_int_labels();
-	auto iter_train_labels = labels.begin();
 
 	int32_t num_vec = features->get_num_vectors();
 	// this assumes that m_current_iteration starts at 0
 	int32_t num_prev_weights = num_vec * m_current_iteration + 1;
 
-	for (const auto& feature : DotIterator(features))
+	for (const auto& [feature, true_label] : zip_iterator(DotIterator(features), labels))
 	{
-		const auto true_label = *(iter_train_labels++);
 		auto predicted_label = feature.dot(cached_w) + cached_bias;
 
 		if (Math::sign<float64_t>(predicted_label) != true_label)

--- a/src/shogun/classifier/NearestCentroid.cpp
+++ b/src/shogun/classifier/NearestCentroid.cpp
@@ -10,6 +10,7 @@
 #include <shogun/features/FeatureTypes.h>
 #include <shogun/features/iterators/DotIterator.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <shogun/util/zip_iterator.h>
 
 
 namespace shogun{
@@ -63,13 +64,11 @@ namespace shogun{
 		SGMatrix<float64_t> centroids(num_feats, num_classes);
 		SGVector<int64_t> num_per_class(num_classes);
 
-		auto iter_labels = multiclass_labels->get_labels().begin();
-		for (const auto& current : DotIterator(dense_data))
+		for (const auto& [current, current_class] : zip_iterator(DotIterator(dense_data), multiclass_labels))
 		{
-			const auto current_class = static_cast<int32_t>(*(iter_labels++));
-			auto target = centroids.get_column(current_class);
+			auto target = centroids.get_column(static_cast<int32_t>(current_class));
 			current.add(1, target);
-			num_per_class[current_class]++;
+			num_per_class[static_cast<int32_t>(current_class)]++;
 		}
 
 		SGVector<float64_t> scale(num_classes);

--- a/src/shogun/classifier/Perceptron.cpp
+++ b/src/shogun/classifier/Perceptron.cpp
@@ -15,6 +15,7 @@
 #include <shogun/lib/observers/ObservedValueTemplated.h>
 #include <shogun/mathematics/Math.h>
 #include <shogun/mathematics/linalg/LinalgNamespace.h>
+#include <shogun/util/zip_iterator.h>
 
 using namespace shogun;
 
@@ -62,13 +63,10 @@ void Perceptron::iteration()
 	SGVector<float64_t> w = get_w();
 
 	auto labels = binary_labels(m_labels)->get_int_labels();
-	auto iter_train_labels = labels.begin();
 
-	for (const auto& v : DotIterator(features))
+	for (const auto& [v, true_label] : zip_iterator(DotIterator(features), labels))
 	{
-		const auto true_label = *(iter_train_labels++);
-
-		auto predicted_label = v.dot(w) + bias;
+		const auto predicted_label = v.dot(w) + bias;
 
 		if (Math::sign<float64_t>(predicted_label) != true_label)
 		{

--- a/src/shogun/features/iterators/DotIterator.cpp
+++ b/src/shogun/features/iterators/DotIterator.cpp
@@ -65,12 +65,12 @@ namespace shogun
 		return tmp;
 	}
 
-	bool DotIterator::iterator::operator==(const iterator& rhs)
+	bool DotIterator::iterator::operator==(const iterator& rhs) const
 	{
 		return m_feature_vector.m_idx == rhs.m_feature_vector.m_idx;
 	}
 
-	bool DotIterator::iterator::operator!=(const iterator& rhs)
+	bool DotIterator::iterator::operator!=(const iterator& rhs) const
 	{
 		return !(*this == rhs);
 	}

--- a/src/shogun/features/iterators/DotIterator.h
+++ b/src/shogun/features/iterators/DotIterator.h
@@ -118,10 +118,10 @@ namespace shogun
 			iterator operator++(int);
 
 			/** equality operator */
-			bool operator==(const iterator& rhs);
+			bool operator==(const iterator& rhs) const;
 
 			/** inequality operator */
-			bool operator!=(const iterator& rhs);
+			bool operator!=(const iterator& rhs) const;
 
 		protected:
 			value_type m_feature_vector;

--- a/src/shogun/util/enumerate.h
+++ b/src/shogun/util/enumerate.h
@@ -9,7 +9,7 @@ namespace shogun {
 	{
 	public:
 
-		enumerate(Args&... args) : m_container_tuples(args...)
+		enumerate(Args&&... args) : m_container_tuples(std::forward<Args>(args)...)
 		{
 		}
 
@@ -71,6 +71,9 @@ namespace shogun {
 		}
 
 	private:
-		std::tuple<Args&...> m_container_tuples;
+		std::tuple<Args...> m_container_tuples;
 	};
+
+	template <typename ...Args>
+	enumerate(Args&&... args) -> enumerate<Args...>;
 }

--- a/src/shogun/util/zip_iterator.h
+++ b/src/shogun/util/zip_iterator.h
@@ -131,7 +131,7 @@ namespace shogun
 	IGNORE_IN_CLASSLIST class zip_iterator
 	{
 	public:
-		zip_iterator(Args&... args) : m_container_tuples(args...)
+		zip_iterator(Args&&... args) : m_container_tuples(std::forward<Args>(args)...)
 		{
 		}
 
@@ -190,8 +190,11 @@ namespace shogun
 		}
 
 	private:
-		std::tuple<Args&...> m_container_tuples;
+		std::tuple<Args...> m_container_tuples;
 	};
+
+	template <typename ...Args>
+	zip_iterator(Args&&... args) -> zip_iterator<Args...>;
 } // namespace shogun
 
 #endif // SHOGUN_ZIP_ITERATOR_H


### PR DESCRIPTION
This fixes #5050, but we need to have a move constructor in the class iterators e.g. `DotIterator::iterator`, otherwise it will use the copy constructor.
See https://godbolt.org/z/L6P2e7. `B` does not have a move constructor, so it is constructed and copied, whereas `A` is constructed and moved.