### PR TITLE
Implicit conversions for put/get

### DIFF
--- a/src/shogun/lib/any.h
+++ b/src/shogun/lib/any.h
@@ -1316,11 +1316,11 @@ namespace shogun
 		if constexpr (std::is_base_of_v<SGObject, Derived>)
 		{
 			Any::register_caster<T, SGObject*>(
-			    [](T value) { return dynamic_cast<SGObject*>(value); });
+			    [](T value) { return static_cast<SGObject*>(value); });
 			if constexpr (!std::is_same_v<std::nullptr_t, base_type<Derived>>
 					&& !std::is_same_v<Derived, base_type<Derived>>)
 				Any::register_caster<T, base_type<Derived>*>([](T value) {
-					return dynamic_cast<base_type<Derived>*>(value);
+					return static_cast<base_type<Derived>*>(value);
 				});
 		}
 		if constexpr (traits::is_shared_ptr<T>::value)
@@ -1329,11 +1329,11 @@ namespace shogun
 			if constexpr (std::is_base_of_v<SGObject, SharedType>)
 			{
 				Any::register_caster<T, std::shared_ptr<SGObject>>(
-						[](T value) { return std::dynamic_pointer_cast<SGObject>(value); });
+						[](T value) { return std::static_pointer_cast<SGObject>(value); });
 				if constexpr (!std::is_same_v<std::nullptr_t, base_type<SharedType>>
 						&& !std::is_same_v<SharedType, base_type<SharedType>>)
 					Any::register_caster<T, std::shared_ptr<base_type<SharedType>>>([](T value) {
-						return std::dynamic_pointer_cast<base_type<SharedType>>(value);
+						return std::static_pointer_cast<base_type<SharedType>>(value);
 					});
 			}
 		}

--- a/src/shogun/util/traits.h
+++ b/src/shogun/util/traits.h
@@ -175,15 +175,19 @@ namespace shogun
 		inline constexpr bool is_any_of_v = is_any_of<T, Ts...>::value;
 
 		template<uint32_t idx, typename Ts>
-		struct get_variant_type{};
-
-		template<uint32_t idx, typename ...Ts>
-		struct get_variant_type<idx, std::variant<Ts...>>{
-		    using type = typename std::tuple_element<idx, std::tuple<Ts...>>::type;
+		struct variant_type{
+			using type = Ts;
+		    static constexpr bool value = false;
 		};
 
 		template<uint32_t idx, typename ...Ts>
-		using get_variant_type_t = typename get_variant_type<idx, Ts...>::type;
+		struct variant_type<idx, std::variant<Ts...>>{
+		    using type = typename std::tuple_element<idx, std::tuple<Ts...>>::type;
+		    static constexpr bool value = true;
+		};
+
+		template<uint32_t idx, typename ...Ts>
+		using variant_type_t = typename variant_type<idx, Ts...>::type;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 	} // namespace traits
 } // namespace shogun

--- a/tests/unit/base/SGObject_unittest.cc
+++ b/tests/unit/base/SGObject_unittest.cc
@@ -483,9 +483,10 @@ TEST(SGObject, tags_set_get_int)
 
 	EXPECT_THROW(obj->get<int32_t>("foo"), ShogunException);
 	obj->put(MockObject::kInt, 10);
+	EXPECT_NO_THROW(obj->put(MockObject::kInt, 10.0));
 	EXPECT_EQ(obj->get(Tag<int32_t>(MockObject::kInt)), 10);
-	EXPECT_THROW(obj->get<float64_t>(MockObject::kInt), ShogunException);
-	EXPECT_THROW(obj->get(Tag<float64_t>(MockObject::kInt)), ShogunException);
+	EXPECT_EQ(obj->get<float64_t>(MockObject::kInt), 10.0);
+	EXPECT_EQ(obj->get(Tag<float64_t>(MockObject::kInt)), 10.0);
 	EXPECT_EQ(obj->get<int>(MockObject::kInt), 10);
 }
 


### PR DESCRIPTION
Implicit conversions as discussed in #5045. Would have to add all the primitive types, and probably come up with some better abstraction. This does the same as the Any::CastingRegistry, but by putting all this logic in SGObject we can add some very specific edge cases, like `std::variant`. I think this separates `Any` as a "type safe" type erasure abstraction from the parameters that use it.  