### PR TITLE
Allow Octave interface to compile with Octave v5++ installed

### DIFF
--- a/src/interfaces/octave/swig_typemaps.i
+++ b/src/interfaces/octave/swig_typemaps.i
@@ -5,7 +5,7 @@
  */
 
 %{
-#if ((OCTAVE_MAJOR_VERSION == 4) && (OCTAVE_MINOR_VERSION >= 4))
+#if (OCTAVE_MAJOR_VERSION >= 5 || ((OCTAVE_MAJOR_VERSION == 4) && (OCTAVE_MINOR_VERSION >= 4)))
 #include <octave/octave-config.h>
 #else
 #include <octave/config.h>


### PR DESCRIPTION
This PR is for users who want the Octave interface and have Octave version 5.x.x installed.

Synopsis:
Compiled Shogun with the Octave interface (only that one) in Ubuntu 20.04 LTS. I followed the build steps from the Install page in the Home website, but it failed when it didn't find the header file "**octave/config.h**"
My local Octave installation is version 5.2.0 and I found that the make templates didn't cater for any version higher than 4.x.x.

After adding the check for Octave version 5.x,x and pointing the compiler to the right header file (**octave/octave-config.h**) the compilation and installation went through with no issues.
I also tested several of the examples within my Octave installation and they all run fine.