### PR TITLE
Add sparse copy

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -1362,7 +1362,7 @@ std::shared_ptr<const T> make_clone(std::shared_ptr<const T> orig, ParameterProp
 }
 
 template <class T>
-std::shared_ptr<T> sparse_copy(std::shared_ptr<T> orig,
+std::shared_ptr<T> shallow_copy(std::shared_ptr<T> orig,
 							ParameterProperties pp = ParameterProperties::ALL 
 				            ^ ParameterProperties::MODEL ^ ParameterProperties::READONLY)
 {
@@ -1370,7 +1370,7 @@ std::shared_ptr<T> sparse_copy(std::shared_ptr<T> orig,
 }
 
 template <class T>
-std::shared_ptr<const T> sparse_copy(std::shared_ptr<const T> orig,
+std::shared_ptr<const T> shallow_copy(std::shared_ptr<const T> orig,
 								ParameterProperties pp = ParameterProperties::ALL 
 				              	^ ParameterProperties::MODEL ^ ParameterProperties::READONLY)
 {

--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -1361,6 +1361,22 @@ std::shared_ptr<const T> make_clone(std::shared_ptr<const T> orig, ParameterProp
 	return std::static_pointer_cast<const T>(clone);
 }
 
+template <class T>
+std::shared_ptr<T> sparse_copy(std::shared_ptr<T> orig,
+							ParameterProperties pp = ParameterProperties::ALL 
+				            ^ ParameterProperties::MODEL ^ ParameterProperties::READONLY)
+{
+	return make_clone(orig, pp);
+}
+
+template <class T>
+std::shared_ptr<const T> sparse_copy(std::shared_ptr<const T> orig,
+								ParameterProperties pp = ParameterProperties::ALL 
+				              	^ ParameterProperties::MODEL ^ ParameterProperties::READONLY)
+{
+	return make_clone(orig, pp);
+}
+
 #ifndef SWIG
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace sgo_details

--- a/src/shogun/evaluation/CrossValidation.cpp
+++ b/src/shogun/evaluation/CrossValidation.cpp
@@ -100,7 +100,7 @@ float64_t CrossValidation::evaluate_one_run(int64_t index) const
 	{
 		// only need to clone hyperparameters and settings of machine
 		// model parameters are inferred/learned during training
-		auto machine = make_clone(m_machine,
+		auto machine = shallow_copy(m_machine,
 				ParameterProperties::HYPER | ParameterProperties::SETTING);
 
 		SGVector<index_t> idx_train =
@@ -114,7 +114,7 @@ float64_t CrossValidation::evaluate_one_run(int64_t index) const
 		auto features_test = view(m_features, idx_test);
 		auto labels_test = view(m_labels, idx_test);
 
-		auto evaluation_criterion = make_clone(m_evaluation_criterion);
+		auto evaluation_criterion = shallow_copy(m_evaluation_criterion);
 
 		machine->set_labels(labels_train);
 		machine->train(features_train);

--- a/src/shogun/multiclass/tree/RelaxedTree.cpp
+++ b/src/shogun/multiclass/tree/RelaxedTree.cpp
@@ -296,7 +296,7 @@ SGVector<int32_t> RelaxedTree::train_node_with_initialization(const RelaxedTree:
 		auto feats_train = view(m_feats, subset);
 		auto labels_train = view(binary_labels, subset);
 
-		auto kernel = make_clone(m_kernel, ParameterProperties::ALL^ParameterProperties::MODEL);
+		auto kernel = sparse_copy(m_kernel, ParameterProperties::ALL ^ ParameterProperties::MODEL);
 
 		kernel->init(feats_train, feats_train);
 		svm->set_kernel(kernel);

--- a/src/shogun/multiclass/tree/RelaxedTree.cpp
+++ b/src/shogun/multiclass/tree/RelaxedTree.cpp
@@ -296,7 +296,7 @@ SGVector<int32_t> RelaxedTree::train_node_with_initialization(const RelaxedTree:
 		auto feats_train = view(m_feats, subset);
 		auto labels_train = view(binary_labels, subset);
 
-		auto kernel = sparse_copy(m_kernel, ParameterProperties::ALL ^ ParameterProperties::MODEL);
+		auto kernel = shallow_copy(m_kernel, ParameterProperties::ALL ^ ParameterProperties::MODEL);
 
 		kernel->init(feats_train, feats_train);
 		svm->set_kernel(kernel);


### PR DESCRIPTION
#5058 

A free function which has default flags as mentioned in the issue. Pretty much same as make_clone, but it "motivates" sparse copying.

SGMatrix, and Features.h seems to be potential contenders for this sparse_copy OR make_clone(for entire deep copy), we can handle them both in this PR? @gf712 

My thought process is to use make_clone for deep copy **only** and sparse_copy for if we want to copy only certain component(and therefore I've changed it in RelaxedTree).