### PR TITLE
[2] Circular

### DIFF
--- a/examples/meta/src/kernel/circular.sg.in
+++ b/examples/meta/src/kernel/circular.sg.in
@@ -7,9 +7,7 @@ Features feats_test = create_features(testdat)
 #![create_features]
 
 #![create_kernel]
-Distance d = create_distance("EuclideanDistance")
-d.init(feats_train, feats_train)
-Kernel circular_kernel = create_kernel("CircularKernel", sigma=1.0, distance=d)
+Kernel circular_kernel = create_kernel("CircularKernel", sigma=1.0)
 circular_kernel.init(feats_train, feats_train)
 #![create_kernel]
 

--- a/src/shogun/kernel/CircularKernel.cpp
+++ b/src/shogun/kernel/CircularKernel.cpp
@@ -11,29 +11,31 @@
 
 using namespace shogun;
 
-CircularKernel::CircularKernel(): Kernel(0), distance(NULL)
+CircularKernel::CircularKernel(): ShiftInvariantKernel(), distance(NULL)
 {
 	init();
+	set_cache_size(0);
 	set_sigma(1.0);
 }
 
 CircularKernel::CircularKernel(int32_t size, float64_t sig, std::shared_ptr<Distance> dist)
-: Kernel(size), distance(std::move(dist))
+: ShiftInvariantKernel(), distance(std::move(dist))
 {
 	ASSERT(distance)
 	
-
+	set_cache_size(size);
 	set_sigma(sig);
 	init();
 }
 
 CircularKernel::CircularKernel(
 	std::shared_ptr<Features >l, std::shared_ptr<Features >r, float64_t sig, std::shared_ptr<Distance> dist)
-: Kernel(10), distance(std::move(dist))
+: ShiftInvariantKernel(), distance(std::move(dist))
 {
 	ASSERT(distance)
 	
 	set_sigma(sig);
+	set_cache_size(10)
 	init();
 	init(std::move(l), std::move(r));
 }

--- a/src/shogun/kernel/CircularKernel.cpp
+++ b/src/shogun/kernel/CircularKernel.cpp
@@ -6,22 +6,23 @@
 
 #include <shogun/kernel/CircularKernel.h>
 #include <shogun/mathematics/Math.h>
+#include <shogun/distance/ManhattanMetric.h>
 
 #include <utility>
 
 using namespace shogun;
 
-CircularKernel::CircularKernel(): ShiftInvariantKernel(), distance(NULL)
+CircularKernel::CircularKernel(): ShiftInvariantKernel()
 {
 	init();
 	set_cache_size(0);
 	set_sigma(1.0);
 }
 
-CircularKernel::CircularKernel(int32_t size, float64_t sig, std::shared_ptr<Distance> dist)
-: ShiftInvariantKernel(), distance(std::move(dist))
+CircularKernel::CircularKernel(int32_t size, float64_t sig)
+: ShiftInvariantKernel()
 {
-	ASSERT(distance)
+	ASSERT(m_distance)
 	
 	set_cache_size(size);
 	set_sigma(sig);
@@ -29,13 +30,13 @@ CircularKernel::CircularKernel(int32_t size, float64_t sig, std::shared_ptr<Dist
 }
 
 CircularKernel::CircularKernel(
-	std::shared_ptr<Features >l, std::shared_ptr<Features >r, float64_t sig, std::shared_ptr<Distance> dist)
-: ShiftInvariantKernel(), distance(std::move(dist))
+	std::shared_ptr<Features >l, std::shared_ptr<Features >r, float64_t sig)
+: ShiftInvariantKernel()
 {
-	ASSERT(distance)
+	ASSERT(m_distance)
 	
 	set_sigma(sig);
-	set_cache_size(10)
+	set_cache_size(10);
 	init();
 	init(std::move(l), std::move(r));
 }
@@ -48,9 +49,9 @@ CircularKernel::~CircularKernel()
 
 bool CircularKernel::init(std::shared_ptr<Features> l, std::shared_ptr<Features> r)
 {
-	ASSERT(distance)
+	ASSERT(m_distance);
 	Kernel::init(l,r);
-	distance->init(l,r);
+	m_distance->init(l,r);
 	return init_normalizer();
 }
 
@@ -61,13 +62,15 @@ void CircularKernel::load_serializable_post() noexcept(false)
 
 void CircularKernel::init()
 {
-	SG_ADD(&distance, "distance", "Distance to be used.", ParameterProperties::HYPER);
+	auto dist = std::make_shared<ManhattanMetric>();
+	m_distance = dist;
+
 	SG_ADD(&sigma, "sigma", "Sigma kernel parameter.", ParameterProperties::HYPER);
 }
 
 float64_t CircularKernel::compute(int32_t idx_a, int32_t idx_b)
 {
-	float64_t dist=distance->distance(idx_a, idx_b);
+	float64_t dist=m_distance->distance(idx_a, idx_b);
 	float64_t ds_ratio=dist/sigma;
 
 	if (dist < sigma)

--- a/src/shogun/kernel/CircularKernel.h
+++ b/src/shogun/kernel/CircularKernel.h
@@ -37,7 +37,7 @@ class CircularKernel: public ShiftInvariantKernel
 	 * @param sigma kernel parameter sigma
 	 * @param dist distance
 	 */
-	CircularKernel(int32_t size, float64_t sigma, std::shared_ptr<Distance> dist);
+	CircularKernel(int32_t size, float64_t sigma);
 
 	/** constructor
 	 *
@@ -46,7 +46,7 @@ class CircularKernel: public ShiftInvariantKernel
 	 * @param sigma kernel parameter sigma
 	 * @param dist distance
 	 */
-	CircularKernel(std::shared_ptr<Features >l, std::shared_ptr<Features >r, float64_t sigma, std::shared_ptr<Distance> dist);
+	CircularKernel(std::shared_ptr<Features >l, std::shared_ptr<Features >r, float64_t sigma);
 
 	/** initialize kernel with features
 	 *
@@ -64,12 +64,12 @@ class CircularKernel: public ShiftInvariantKernel
 	/**
 	 * @return type of features
 	 */
-	EFeatureType get_feature_type() override { return distance->get_feature_type(); }
+	EFeatureType get_feature_type() override { return m_distance->get_feature_type(); }
 
 	/**
 	 * @return class of features
 	 */
-	EFeatureClass get_feature_class() override { return distance->get_feature_class(); }
+	EFeatureClass get_feature_class() override { return m_distance->get_feature_class(); }
 
 	/**
 	 * @return name of kernel
@@ -121,9 +121,6 @@ private:
 	void init();
 
 protected:
-
-	/** distance */
-	std::shared_ptr<Distance> distance;
 
 	/** width */
 	float64_t sigma;

--- a/src/shogun/kernel/CircularKernel.h
+++ b/src/shogun/kernel/CircularKernel.h
@@ -4,19 +4,14 @@
  * Authors: Soeren Sonnenburg, Bjoern Esser, Sergey Lisitsyn
  */
 
-#include <shogun/lib/config.h>
 
 #ifndef _CIRCULARKERNEL_H__
 #define _CIRCULARKERNEL_H__
 
-#include <shogun/lib/common.h>
-#include <shogun/kernel/Kernel.h>
-#include <shogun/distance/Distance.h>
+#include <shogun/kernel/ShiftInvariantKernel.h>
 
 namespace shogun
 {
-
-class Distance;
 
 /** @brief Circular kernel
  *
@@ -30,7 +25,7 @@ class Distance;
  *
  */
 
-class CircularKernel: public Kernel
+class CircularKernel: public ShiftInvariantKernel
 {
 	public:
 	/** default constructor */


### PR DESCRIPTION
@gf712  I was pondering on why do we allow the users to specify the Distance Class? The formula is very clear with the distance metric to use. Besides, the distance metric being shift invariant is the very foundation on which I'm moving these classes inside SIV. I've taken the liberty to initialize the appropriate distance class by default inside the ctor. If you have differing opinion, lemme know :) #5151  