### PR TITLE
Fixes parameter names in each SGObject class

### DIFF
--- a/src/shogun/classifier/AveragedPerceptron.cpp
+++ b/src/shogun/classifier/AveragedPerceptron.cpp
@@ -32,10 +32,10 @@ void AveragedPerceptron::init()
 	SG_ADD(
 	    &learn_rate, kLearnRate, "Learning rate.", ParameterProperties::HYPER)
 	SG_ADD(
-	    &cached_w, "cached_w", "Cached weights that contribute to the average.",
+	    &cached_w, kCachedW, "Cached weights that contribute to the average.",
 	    ParameterProperties::MODEL)
 	SG_ADD(
-	    &cached_bias, "cached_bias",
+	    &cached_bias, kCachedBias,
 	    "Cached bias that contribute to the average.",
 	    ParameterProperties::MODEL)
 }

--- a/src/shogun/classifier/AveragedPerceptron.h
+++ b/src/shogun/classifier/AveragedPerceptron.h
@@ -83,6 +83,8 @@ namespace shogun
 #ifndef SWIG
 	public:
 		static constexpr std::string_view kLearnRate = "learn_rate";
+		static constexpr std::string_view kCachedW = "cached_w";
+		static constexpr std::string_view kCachedBias = "cached_bias";
 #endif
 	};
 } // namespace shogun

--- a/src/shogun/classifier/LDA.cpp
+++ b/src/shogun/classifier/LDA.cpp
@@ -52,10 +52,10 @@ void LDA::init()
 	m_bdc_svd = true;
 
 	SG_ADD(
-	    &m_gamma, "gamma", "Regularization parameter",
+	    &m_gamma, kGamma, "Regularization parameter",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &m_bdc_svd, "bdc_svd", "Use BDC-SVD algorithm",
+	    &m_bdc_svd, kBdcSvd, "Use BDC-SVD algorithm",
 	    ParameterProperties::SETTING)
 	SG_ADD_OPTIONS(
 	    (machine_int_t*)&m_method, "method", "Method used for LDA calculation",

--- a/src/shogun/classifier/LDA.h
+++ b/src/shogun/classifier/LDA.h
@@ -183,6 +183,11 @@ class LDA : public DenseRealDispatch<LDA, LinearMachine>
 		ELDAMethod m_method;
 		/** use bdc-svd algorithm */
 		bool m_bdc_svd;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kGamma = "gamma";
+		static constexpr std::string_view kBdcSvd = "bdc_svd";	
 };
 }
 #endif//ifndef

--- a/src/shogun/classifier/Perceptron.h
+++ b/src/shogun/classifier/Perceptron.h
@@ -73,6 +73,11 @@ class Perceptron : public IterativeMachine<LinearMachine>
 		 * manually setting weights and bias before training.
 		 */
 		bool m_initialize_hyperplane;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kInitializeHyperplane = "initialize_hyperplane";
+		static constexpr std::string_view kLearnRate = "learn_rate";	
 };
 }
 #endif

--- a/src/shogun/classifier/PluginEstimate.cpp
+++ b/src/shogun/classifier/PluginEstimate.cpp
@@ -21,13 +21,13 @@ PluginEstimate::PluginEstimate(float64_t pos_pseudo, float64_t neg_pseudo)
 	pos_model(NULL), neg_model(NULL), features(NULL)
 {
 	SG_ADD(
-	    &m_pos_pseudo, "pos_pseudo", "pseudo count for positive class",
+	    &m_pos_pseudo, kPosPseudo, "pseudo count for positive class",
 	    ParameterProperties::MODEL);
 	SG_ADD(
-	    &m_neg_pseudo, "neg_pseudo", "pseudo count for negative class",
+	    &m_neg_pseudo, kNegPseudo, "pseudo count for negative class",
 	    ParameterProperties::MODEL);
 	SG_ADD(
-	    &pos_model, "pos_model", "LinearHMM modelling positive class.",
+	    &pos_model, kPosModel, "LinearHMM modelling positive class.",
 	    ParameterProperties::MODEL);
 	SG_ADD(
 	    &neg_model, "neg_model", "LinearHMM modelling negative class.",

--- a/src/shogun/classifier/PluginEstimate.h
+++ b/src/shogun/classifier/PluginEstimate.h
@@ -221,6 +221,14 @@ class PluginEstimate: public Machine
 
 		/** features */
 		std::shared_ptr<StringFeatures<uint16_t>> features;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kPosPseudo = "pos_pseudo";
+		static constexpr std::string_view kNegPseudo = "neg_pseudo";
+		static constexpr std::string_view kPosModel = "pos_model";
+		static constexpr std::string_view kNegModel = "neg_model";
+		static constexpr std::string_view kFeatures = "features";	
 };
 }
 #endif

--- a/src/shogun/clustering/KMeansBase.cpp
+++ b/src/shogun/clustering/KMeansBase.cpp
@@ -301,25 +301,25 @@ void KMeansBase::init()
 	use_kmeanspp = false;
 	initial_centers = SGMatrix<float64_t>();
 	SG_ADD(
-	    &max_iter, "max_iter", "Maximum number of iterations",
+	    &max_iter, kMaxIter, "Maximum number of iterations",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &k, "k", "k, the number of clusters",
+	    &k, kK, "k, the number of clusters",
 	    ParameterProperties::HYPER | ParameterProperties::CONSTRAIN,
 	    SG_CONSTRAINT(positive<>()));
 	SG_ADD(
-	    &dimensions, "dimensions", "Dimensions of data",
+	    &dimensions, kDimensions, "Dimensions of data",
 	    ParameterProperties::READONLY);
 	SG_ADD(
-	    &fixed_centers, "fixed_centers", "Whether to use fixed centers",
+	    &fixed_centers, kFixedCenters, "Whether to use fixed centers",
 	    ParameterProperties::HYPER | ParameterProperties::SETTING);
-	SG_ADD(&R, "radiuses", "Cluster radiuses", ParameterProperties::MODEL);
+	SG_ADD(&R, kRadiuses", "Cluster radiuses", ParameterProperties::MODEL);
 	SG_ADD(
-	    &use_kmeanspp, "kmeanspp", "Whether to use kmeans++",
+	    &use_kmeanspp, kMeanspp, "Whether to use kmeans++",
 	    ParameterProperties::HYPER | ParameterProperties::SETTING);
 	watch_method("cluster_centers", &KMeansBase::get_cluster_centers);
 	SG_ADD(
-	    &initial_centers, "initial_centers", "Initial centers",
+	    &initial_centers, kInitialCenters, "Initial centers",
 	    ParameterProperties::HYPER);
 	// add this to check initial centers
 	add_callback_function(

--- a/src/shogun/clustering/KMeansBase.h
+++ b/src/shogun/clustering/KMeansBase.h
@@ -137,6 +137,16 @@ class KMeansBase : public RandomMixin<DistanceMachine>
 
 		/** Cluster centers */
 		SGMatrix<float64_t> cluster_centers;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kMaxIter = "max_iter";
+		static constexpr std::string_view kK = "k";
+		static constexpr std::string_view kDimensions = "dimensions";
+		static constexpr std::string_view kFixedCenters = "fixed_centers";
+		static constexpr std::string_view kRadiuses = "radiuses";
+		static constexpr std::string_view kMeanspp = "kmeanspp";
+		static constexpr std::string_view kInitialCenters = "initial_centers";	
 };
 }
 #endif

--- a/src/shogun/converter/DiffusionMaps.cpp
+++ b/src/shogun/converter/DiffusionMaps.cpp
@@ -25,8 +25,8 @@ DiffusionMaps::DiffusionMaps() :
 
 void DiffusionMaps::init()
 {
-	SG_ADD(&m_t, "t", "number of steps", ParameterProperties::HYPER);
-	SG_ADD(&m_width, "width", "gaussian kernel width", ParameterProperties::HYPER);
+	SG_ADD(&m_t, kT, "number of steps", ParameterProperties::HYPER);
+	SG_ADD(&m_width, kWidth, "gaussian kernel width", ParameterProperties::HYPER);
 }
 
 DiffusionMaps::~DiffusionMaps()

--- a/src/shogun/converter/DiffusionMaps.h
+++ b/src/shogun/converter/DiffusionMaps.h
@@ -88,6 +88,11 @@ protected:
 
 	/** gaussian kernel width */
 	float64_t m_width;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kT = "t";
+	static constexpr std::string_view kWidth = "width";
 
 };
 }

--- a/src/shogun/converter/EmbeddingConverter.cpp
+++ b/src/shogun/converter/EmbeddingConverter.cpp
@@ -72,12 +72,12 @@ std::shared_ptr<Kernel> EmbeddingConverter::get_kernel() const
 
 void EmbeddingConverter::init()
 {
-	SG_ADD(&m_target_dim, "target_dim",
+	SG_ADD(&m_target_dim, kTargetDim,
       "target dimensionality of preprocessor", ParameterProperties::HYPER);
 	SG_ADD(
-		&m_distance, "distance", "distance to be used for embedding",
+		&m_distance, kDistance, "distance to be used for embedding",
 		ParameterProperties::HYPER);
 	SG_ADD(
-		&m_kernel, "kernel", "kernel to be used for embedding", ParameterProperties::HYPER);
+		&m_kernel, kKernel, "kernel to be used for embedding", ParameterProperties::HYPER);
 }
 }

--- a/src/shogun/converter/EmbeddingConverter.h
+++ b/src/shogun/converter/EmbeddingConverter.h
@@ -90,6 +90,12 @@ protected:
 
 	/** kernel to be used */
 	std::shared_ptr<Kernel> m_kernel;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kTargetDim = "target_dim";
+	static constexpr std::string_view kDistance = "distance";
+	static constexpr std::string_view kKernel = "kernel";
 };
 }
 

--- a/src/shogun/converter/FactorAnalysis.cpp
+++ b/src/shogun/converter/FactorAnalysis.cpp
@@ -21,8 +21,8 @@ FactorAnalysis::FactorAnalysis() :
 
 void FactorAnalysis::init()
 {
-	SG_ADD(&m_max_iteration, "max_iteration", "maximum number of iterations");
-	SG_ADD(&m_epsilon, "epsilon", "convergence parameter");
+	SG_ADD(&m_max_iteration, kMaxIteration, "maximum number of iterations");
+	SG_ADD(&m_epsilon, kEpsilon, "convergence parameter");
 }
 
 FactorAnalysis::~FactorAnalysis()

--- a/src/shogun/converter/FactorAnalysis.h
+++ b/src/shogun/converter/FactorAnalysis.h
@@ -98,6 +98,11 @@ private:
 
 	/** convergence parameter */
 	float64_t m_epsilon;
+	
+		#ifndef SWIG
+public:
+	static constexpr std::string_view kMaxIteration = "max_iteration";
+	static constexpr std::string_view kEpsilon = "epsilon";
 
 }; /* class FactorAnalysis */
 

--- a/src/shogun/converter/HashedDocConverter.cpp
+++ b/src/shogun/converter/HashedDocConverter.cpp
@@ -57,11 +57,11 @@ void HashedDocConverter::init(const std::shared_ptr<Tokenizer>& tzer, int32_t ha
 	else
 		tokenizer = tzer;
 
-	SG_ADD(&num_bits, "num_bits", "Number of bits of the hash");
-	SG_ADD(&ngrams, "ngrams", "Number of consecutive tokens");
-	SG_ADD(&tokens_to_skip, "tokens_to_skip", "Number of tokens to skip");
-	SG_ADD(&should_normalize, "should_normalize", "Whether to normalize vectors or not");
-	SG_ADD(&tokenizer, "tokenizer", "Tokenizer");
+	SG_ADD(&num_bits, kNumBits, "Number of bits of the hash");
+	SG_ADD(&ngrams, kNgrams, "Number of consecutive tokens");
+	SG_ADD(&tokens_to_skip, kTokensToSkip, "Number of tokens to skip");
+	SG_ADD(&should_normalize, kShouldNormalize, "Whether to normalize vectors or not");
+	SG_ADD(&tokenizer, kTokenizer, "Tokenizer");
 }
 
 const char* HashedDocConverter::get_name() const

--- a/src/shogun/converter/HashedDocConverter.h
+++ b/src/shogun/converter/HashedDocConverter.h
@@ -152,6 +152,14 @@ protected:
 
 	/** the number of tokens to skip */
 	int32_t tokens_to_skip;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kNumBits = "num_bits";
+	static constexpr std::string_view kNgrams = "ngrams";
+	static constexpr std::string_view kTokensToSkip = "tokens_to_skip";
+	static constexpr std::string_view kShouldNormalize = "should_normalize";
+	static constexpr std::string_view kTokenizer = "tokenizer";
 };
 }
 

--- a/src/shogun/converter/Isomap.cpp
+++ b/src/shogun/converter/Isomap.cpp
@@ -21,7 +21,7 @@ Isomap::Isomap() : MultidimensionalScaling()
 
 void Isomap::init()
 {
-	SG_ADD(&m_k, "k", "number of neighbors", ParameterProperties::HYPER);
+	SG_ADD(&m_k, kK, "number of neighbors", ParameterProperties::HYPER);
 }
 
 Isomap::~Isomap()

--- a/src/shogun/converter/Isomap.h
+++ b/src/shogun/converter/Isomap.h
@@ -88,6 +88,10 @@ protected:
 
 	/** k, number of neighbors for K-Isomap */
 	int32_t m_k;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kK = "k";
 
 };
 }

--- a/src/shogun/converter/LaplacianEigenmaps.cpp
+++ b/src/shogun/converter/LaplacianEigenmaps.cpp
@@ -23,8 +23,8 @@ LaplacianEigenmaps::LaplacianEigenmaps() :
 
 void LaplacianEigenmaps::init()
 {
-	SG_ADD(&m_k, "k", "number of neighbors", ParameterProperties::HYPER);
-	SG_ADD(&m_tau, "tau", "heat distribution coefficient", ParameterProperties::HYPER);
+	SG_ADD(&m_k, kK, "number of neighbors", ParameterProperties::HYPER);
+	SG_ADD(&m_tau, kTau, "heat distribution coefficient", ParameterProperties::HYPER);
 }
 
 LaplacianEigenmaps::~LaplacianEigenmaps()

--- a/src/shogun/converter/LaplacianEigenmaps.h
+++ b/src/shogun/converter/LaplacianEigenmaps.h
@@ -88,6 +88,11 @@ protected:
 
 	/** tau parameter of heat distribution */
 	float64_t m_tau;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kK = "k";
+	static constexpr std::string_view kTau = "tau";
 
 };
 }

--- a/src/shogun/converter/LocallyLinearEmbedding.cpp
+++ b/src/shogun/converter/LocallyLinearEmbedding.cpp
@@ -26,7 +26,7 @@ LocallyLinearEmbedding::LocallyLinearEmbedding() :
 
 void LocallyLinearEmbedding::init()
 {
-	SG_ADD(&m_k, "k", "number of neighbors", ParameterProperties::HYPER);
+	SG_ADD(&m_k, kK, "number of neighbors", ParameterProperties::HYPER);
 	SG_ADD(&m_nullspace_shift, "nullspace_shift",
       "nullspace finding regularization shift");
 	SG_ADD(&m_reconstruction_shift, "reconstruction_shift",

--- a/src/shogun/converter/LocallyLinearEmbedding.h
+++ b/src/shogun/converter/LocallyLinearEmbedding.h
@@ -104,6 +104,11 @@ protected:
 
 	/** regularization shift of nullspace finding step */
 	float64_t m_nullspace_shift;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kK = "k";
+	static constexpr std::string_view kReconstructionShift = "reconstruction_shift";
 
 };
 }

--- a/src/shogun/converter/ManifoldSculpting.cpp
+++ b/src/shogun/converter/ManifoldSculpting.cpp
@@ -24,9 +24,9 @@ ManifoldSculpting::ManifoldSculpting() :
 void ManifoldSculpting::init()
 {
 	SG_ADD(&m_k, "k", "number of neighbors");
-	SG_ADD(&m_squishing_rate, "quishing_rate",
+	SG_ADD(&m_squishing_rate, kQuishingRate",
       "squishing rate");
-	SG_ADD(&m_max_iteration, "max_iteration",
+	SG_ADD(&m_max_iteration, kMaxIteration,
       "maximum number of algorithm's iterations");
 }
 

--- a/src/shogun/converter/ManifoldSculpting.h
+++ b/src/shogun/converter/ManifoldSculpting.h
@@ -92,6 +92,12 @@ private:
 	 * iterations
 	 */
 	float64_t m_max_iteration;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kK = "k";
+	static constexpr std::string_view kQuishingRate = "quishing_rate";
+	static constexpr std::string_view kMaxIteration = "max_iteration";
 
 }; /* class ManifoldSculpting */
 

--- a/src/shogun/converter/MultidimensionalScaling.cpp
+++ b/src/shogun/converter/MultidimensionalScaling.cpp
@@ -29,10 +29,10 @@ MultidimensionalScaling::MultidimensionalScaling() : EmbeddingConverter()
 
 void MultidimensionalScaling::init()
 {
-	SG_ADD(&m_eigenvalues, "eigenvalues", "eigenvalues of last embedding");
-	SG_ADD(&m_landmark, "landmark",
+	SG_ADD(&m_eigenvalues, kEigenvalues, "eigenvalues of last embedding");
+	SG_ADD(&m_landmark, kLandmark,
 	    "indicates if landmark approximation should be used");
-	SG_ADD(&m_landmark_number, "landmark_number",
+	SG_ADD(&m_landmark_number, kLandmarkNumber",
 	    "the number of landmarks for approximation", ParameterProperties::HYPER);
 }
 

--- a/src/shogun/converter/MultidimensionalScaling.h
+++ b/src/shogun/converter/MultidimensionalScaling.h
@@ -124,6 +124,12 @@ protected:
 
 	/** number of landmarks */
 	int32_t m_landmark_number;
+	
+	#ifndef SWIG
+public:
+	static constexpr std::string_view kEigenvalues = "eigenvalues";
+	static constexpr std::string_view kLandmark = "landmark";
+	static constexpr std::string_view kLandmarkNumber = "landmark_number";
 
 };
 

--- a/src/shogun/machine/BaseMulticlassMachine.cpp
+++ b/src/shogun/machine/BaseMulticlassMachine.cpp
@@ -10,7 +10,7 @@ using namespace shogun;
 
 BaseMulticlassMachine::BaseMulticlassMachine()
 {
-	SG_ADD(&m_machines, "machines", "Machines that jointly make up the multi-class machine.");
+	SG_ADD(&m_machines, kMachines, "Machines that jointly make up the multi-class machine.");
 }
 
 BaseMulticlassMachine::~BaseMulticlassMachine()

--- a/src/shogun/machine/BaseMulticlassMachine.h
+++ b/src/shogun/machine/BaseMulticlassMachine.h
@@ -50,7 +50,10 @@ protected:
 
 	/** machines */
 	std::vector<std::shared_ptr<Machine>> m_machines;
-};
+
+#ifndef SWIG
+public:
+     static constexpr std::string_view kMachines = "machines";
 
 } /* shogun */
 

--- a/src/shogun/machine/DistanceMachine.cpp
+++ b/src/shogun/machine/DistanceMachine.cpp
@@ -30,7 +30,7 @@ DistanceMachine::~DistanceMachine()
 void DistanceMachine::init()
 {
 	distance=NULL;
-	SG_ADD(&distance, "distance", "Distance to use", ParameterProperties::HYPER);
+	SG_ADD(&distance, kDistance, "Distance to use", ParameterProperties::HYPER);
 }
 
 void DistanceMachine::distances_lhs(SGVector<float64_t>& result, index_t idx_a1, index_t idx_a2, index_t idx_b)

--- a/src/shogun/machine/DistanceMachine.h
+++ b/src/shogun/machine/DistanceMachine.h
@@ -98,6 +98,10 @@ class DistanceMachine : public Machine
 	protected:
 		/** the distance */
 		std::shared_ptr<Distance> distance;
+		
+#ifndef SWIG
+        public:
+               static constexpr std::string_view kDistance = "distance";
 };
 }
 #endif

--- a/src/shogun/machine/GLM.cpp
+++ b/src/shogun/machine/GLM.cpp
@@ -25,25 +25,25 @@ using namespace shogun;
 GLM::GLM()
 {
 	SG_ADD_OPTIONS(
-	    (machine_int_t*)&distribution, "distribution_type",
+	    (machine_int_t*)&distribution, kDistributionType,
 	    "variable to store name of distribution type",
 	    ParameterProperties::HYPER, SG_OPTIONS(POISSON));
 	SG_ADD(
-	    &m_eta, "eta",
+	    &m_eta, kEta,
 	    "threshold parameter that linearizes the exp() function above eta",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &m_lambda, "lambda", "regularization parameter of penalty term",
+	    &m_lambda, kLambda, "regularization parameter of penalty term",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &m_alpha, "alpha",
+	    &m_alpha, kAlpha,
 	    "weighting between L1 penalty and L2 penalty term of the loss function",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &m_tolerance, "tolerance", "convergence threshold or stopping criteria",
+	    &m_tolerance, kTolerance, "convergence threshold or stopping criteria",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &m_learning_rate, "learning_rate", "learning rate for gradient descent",
+	    &m_learning_rate, kLearningRate, "learning rate for gradient descent",
 	    ParameterProperties::HYPER);
 
 	m_gradient_updater = std::make_shared<GradientDescendUpdater>();

--- a/src/shogun/machine/GLM.h
+++ b/src/shogun/machine/GLM.h
@@ -281,6 +281,16 @@ namespace shogun
 
 			return result;
 		}
+		
+				#ifndef SWIG
+       public:
+             static constexpr std::string_view kDistributionType = "distribution_type";
+             static constexpr std::string_view kEta = "eta";
+             static constexpr std::string_view kLambda = "lambda";
+             static constexpr std::string_view kAlpha = "alpha";
+             static constexpr std::string_view kTolerance = "tolerance";
+             static constexpr std::string_view kLearningRate = "learning_rate";
+             static constexpr std::string_view kInterfaceMethod = "distribution_type";
 	};
 } // namespace shogun
 // #endif

--- a/src/shogun/machine/GaussianProcess.cpp
+++ b/src/shogun/machine/GaussianProcess.cpp
@@ -38,13 +38,13 @@ void GaussianProcess::init()
 {
 	m_compute_variance = false;
 	SG_ADD(
-	    &m_method, "inference_method", "Inference method",
+	    &m_method, kInterfaceMethod, "Inference method",
 	    ParameterProperties::HYPER);
 	SG_ADD(
-	    &m_compute_variance, "compute_variance",
+	    &m_compute_variance, kComputeVariance,
 	    "Whether predictive variance is computed in predictions");
 	SG_ADD(
-	    &m_inducing_features, "inducing_features",
+	    &m_inducing_features, kInducingFeatures,
 	    "inducing features for approximation", ParameterProperties::MODEL);
 	add_callback_function("seed", [&]() {
 		if (m_method)

--- a/src/shogun/machine/GaussianProcess.h
+++ b/src/shogun/machine/GaussianProcess.h
@@ -144,6 +144,12 @@ namespace shogun
 		bool m_compute_variance;
 		/**use in inference method*/
 		std::shared_ptr<Features> m_inducing_features;
+		
+		#ifndef SWIG
+       public:
+             static constexpr std::string_view kInterfaceMethod = "inference_method";
+             static constexpr std::string_view kComputeVariance = "compute_variance";
+             static constexpr std::string_view kInducingFeatures = "inducing_features";
 	};
 } // namespace shogun
 #endif /* _GAUSSIANPROCESSMACHINE_H_ */

--- a/src/shogun/machine/KernelMachine.cpp
+++ b/src/shogun/machine/KernelMachine.cpp
@@ -435,14 +435,14 @@ void KernelMachine::init()
 	use_linadd=true;
 	use_bias=true;
 
-	SG_ADD(&kernel, "kernel", "", ParameterProperties::HYPER);
-	SG_ADD(&use_batch_computation, "use_batch_computation",
+	SG_ADD(&kernel, kKernel, "", ParameterProperties::HYPER);
+	SG_ADD(&use_batch_computation, kUseBatchComputation,
 			"Batch computation is enabled.", ParameterProperties::SETTING);
-	SG_ADD(&use_linadd, "use_linadd", "Linadd is enabled.", ParameterProperties::SETTING);
-	SG_ADD(&use_bias, "use_bias", "Bias shall be used.", ParameterProperties::SETTING);
-	SG_ADD(&m_bias, "m_bias", "Bias term.", ParameterProperties::MODEL);
-	SG_ADD(&m_alpha, "m_alpha", "Array of coefficients alpha.", ParameterProperties::MODEL);
-	SG_ADD(&m_svs, "m_svs", "Number of ``support vectors''.", ParameterProperties::MODEL);
+	SG_ADD(&use_linadd, kUselinadd, "Linadd is enabled.", ParameterProperties::SETTING);
+	SG_ADD(&use_bias, kUseBias, "Bias shall be used.", ParameterProperties::SETTING);
+	SG_ADD(&m_bias, kMBias, "Bias term.", ParameterProperties::MODEL);
+	SG_ADD(&m_alpha, kMAlpha, "Array of coefficients alpha.", ParameterProperties::MODEL);
+	SG_ADD(&m_svs, kMSVS, "Number of ``support vectors''.", ParameterProperties::MODEL);
 	watch_method("store_model_features", &KernelMachine::store_model_features);
 }
 

--- a/src/shogun/machine/KernelMachine.h
+++ b/src/shogun/machine/KernelMachine.h
@@ -264,6 +264,16 @@ class KernelMachine : public Machine
 
 		/** array of ``support vectors'' (indices of feature objects) */
 		SGVector<int32_t> m_svs;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kKernel = "kernel";
+		static constexpr std::string_view kUseBatchComputation = "use_batch_computation";
+		static constexpr std::string_view kUselinadd = "use_linadd";
+		static constexpr std::string_view kMBias = "m_bias";
+		static constexpr std::string_view kMAlpha = "m_alpha";
+		static constexpr std::string_view kMSVS = "m_svs";
+		static constexpr std::string_view kFeatures = "features";
 };
 }
 #endif /* _KERNEL_MACHINE_H__ */

--- a/src/shogun/machine/KernelMulticlassMachine.cpp
+++ b/src/shogun/machine/KernelMulticlassMachine.cpp
@@ -75,7 +75,7 @@ void KernelMulticlassMachine::store_model_features()
 
 KernelMulticlassMachine::KernelMulticlassMachine() : MulticlassMachine(), m_kernel(NULL)
 {
-	SG_ADD(&m_kernel,"kernel", "The kernel to be used", ParameterProperties::HYPER);
+	SG_ADD(&m_kernel, kKernel, "The kernel to be used", ParameterProperties::HYPER);
 }
 
 /** standard constructor
@@ -88,7 +88,7 @@ KernelMulticlassMachine::KernelMulticlassMachine(std::shared_ptr<MulticlassStrat
 	MulticlassMachine(std::move(strategy),std::move(machine),std::move(labs)), m_kernel(NULL)
 {
 	set_kernel(std::move(kernel));
-	SG_ADD(&m_kernel,"kernel", "The kernel to be used", ParameterProperties::HYPER);
+	SG_ADD(&m_kernel, kKernel, "The kernel to be used", ParameterProperties::HYPER);
 }
 
 /** destructor */

--- a/src/shogun/machine/KernelMulticlassMachine.h
+++ b/src/shogun/machine/KernelMulticlassMachine.h
@@ -93,6 +93,10 @@ class KernelMulticlassMachine : public MulticlassMachine
 
 		/** kernel */
 		std::shared_ptr<Kernel> m_kernel;
+		
+	#ifndef SWIG
+	public:
+		static constexpr std::string_view kKernel = "kernel";
 
 };
 }

--- a/src/shogun/machine/KernelStructuredOutputMachine.cpp
+++ b/src/shogun/machine/KernelStructuredOutputMachine.cpp
@@ -47,5 +47,5 @@ std::shared_ptr<Kernel> KernelStructuredOutputMachine::get_kernel() const
 
 void KernelStructuredOutputMachine::register_parameters()
 {
-	SG_ADD((std::shared_ptr<SGObject>*)&m_kernel, "m_kernel", "The kernel", ParameterProperties::HYPER);
+	SG_ADD((std::shared_ptr<SGObject>*)&m_kernel, kMKernel, "The kernel", ParameterProperties::HYPER);
 }

--- a/src/shogun/machine/KernelStructuredOutputMachine.h
+++ b/src/shogun/machine/KernelStructuredOutputMachine.h
@@ -60,6 +60,10 @@ class KernelStructuredOutputMachine : public StructuredOutputMachine
 	protected:
 		/** kernel */
 		std::shared_ptr<Kernel> m_kernel;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kMKernel = "m_kernel";
 
 }; /* class KernelStructuredOutputMachine */
 

--- a/src/shogun/machine/LinearLatentMachine.cpp
+++ b/src/shogun/machine/LinearLatentMachine.cpp
@@ -120,9 +120,9 @@ void LinearLatentMachine::init()
 	m_max_iter = 400;
 	m_model = NULL;
 
-	SG_ADD(&m_C, "C", "Cost constant.");
-	SG_ADD(&m_epsilon, "epsilon", "Convergence precision.");
-	SG_ADD(&m_max_iter, "max_iter", "Maximum iterations.");
-	SG_ADD(&m_model, "latent_model", "Latent Model.");
+	SG_ADD(&m_C, kC, "Cost constant.");
+	SG_ADD(&m_epsilon, kEpsilon, "Convergence precision.");
+	SG_ADD(&m_max_iter, kMaxIter, "Maximum iterations.");
+	SG_ADD(&m_model, kLatentModel, "Latent Model.");
 }
 

--- a/src/shogun/machine/LinearLatentMachine.h
+++ b/src/shogun/machine/LinearLatentMachine.h
@@ -137,6 +137,13 @@ namespace shogun
 		private:
 			/** initalize the values to default values */
 			void init();
+			
+	#ifndef SWIG
+	       public:
+		static constexpr std::string_view kC = "C";
+		static constexpr std::string_view kEpsilon = "epsilon";
+		static constexpr std::string_view kMaxIter = "max_iter";
+		static constexpr std::string_view kLatentModel = "latent_model";
 	};
 }
 

--- a/src/shogun/machine/LinearStructuredOutputMachine.cpp
+++ b/src/shogun/machine/LinearStructuredOutputMachine.cpp
@@ -71,6 +71,6 @@ std::shared_ptr<StructuredLabels> LinearStructuredOutputMachine::apply_structure
 
 void LinearStructuredOutputMachine::register_parameters()
 {
-	SG_ADD(&m_w, "w", "Weight vector", ParameterProperties::MODEL);
+	SG_ADD(&m_w, kW, "Weight vector", ParameterProperties::MODEL);
 }
 

--- a/src/shogun/machine/LinearStructuredOutputMachine.h
+++ b/src/shogun/machine/LinearStructuredOutputMachine.h
@@ -70,6 +70,10 @@ class LinearStructuredOutputMachine : public StructuredOutputMachine
 	protected:
 		/** weight vector */
 		SGVector< float64_t > m_w;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kW = "w";
 
 }; /* class LinearStructuredOutputMachine */
 

--- a/src/shogun/machine/Machine.cpp
+++ b/src/shogun/machine/Machine.cpp
@@ -16,8 +16,8 @@ Machine::Machine()
     : StoppableSGObject(), m_max_train_time(0), m_labels(NULL),
       m_solver_type(ST_AUTO)
 {
-	SG_ADD(&m_max_train_time, "max_train_time", "Maximum training time.");
-	SG_ADD(&m_labels, "labels", "Labels to be used.");
+	SG_ADD(&m_max_train_time, kMaxTrainTime", "Maximum training time.");
+	SG_ADD(&m_labels, kLabels, "Labels to be used.");
 	SG_ADD_OPTIONS(
 	    (machine_int_t*)&m_solver_type, "solver_type", "Type of solver.",
 	    ParameterProperties::NONE,

--- a/src/shogun/machine/Machine.h
+++ b/src/shogun/machine/Machine.h
@@ -317,6 +317,12 @@ class Machine : public StoppableSGObject
 
 		/** solver type */
 		ESolverType m_solver_type;
+		
+				#ifndef SWIG
+	public:
+		static constexpr std::string_view kMaxTrainTime = "max_train_time";
+		static constexpr std::string_view kLabels = "labels";
+
 };
 }
 #endif // _MACHINE_H__

--- a/src/shogun/machine/MulticlassMachine.cpp
+++ b/src/shogun/machine/MulticlassMachine.cpp
@@ -47,8 +47,8 @@ void MulticlassMachine::set_labels(std::shared_ptr<Labels> lab)
 
 void MulticlassMachine::register_parameters()
 {
-	SG_ADD(&m_multiclass_strategy,"multiclass_strategy", "Multiclass strategy");
-	SG_ADD(&m_machine, "machine", "The base machine");
+	SG_ADD(&m_multiclass_strategy,kMulticlassStrategy, "Multiclass strategy");
+	SG_ADD(&m_machine, kMachine, "The base machine");
 }
 
 void MulticlassMachine::init_strategy()

--- a/src/shogun/machine/MulticlassMachine.h
+++ b/src/shogun/machine/MulticlassMachine.h
@@ -203,6 +203,10 @@ class MulticlassMachine : public BaseMulticlassMachine
 
 		/** machine */
 		std::shared_ptr<Machine> m_machine;
-};
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kMulticlassStrategy = "multiclass_strategy";
+		static constexpr std::string_view kMachine = "kmachine";
 }
 #endif

--- a/src/shogun/machine/OnlineLinearMachine.cpp
+++ b/src/shogun/machine/OnlineLinearMachine.cpp
@@ -18,9 +18,9 @@ using namespace shogun;
 OnlineLinearMachine::OnlineLinearMachine()
 : Machine(), bias(0), features(NULL)
 {
-	SG_ADD(&m_w, "m_w", "Parameter vector w.", ParameterProperties::MODEL);
-	SG_ADD(&bias, "bias", "Bias b.", ParameterProperties::MODEL);
-	SG_ADD((std::shared_ptr<SGObject>*) &features, "features",
+	SG_ADD(&m_w, kMw, "Parameter vector w.", ParameterProperties::MODEL);
+	SG_ADD(&bias, kBias, "Bias b.", ParameterProperties::MODEL);
+	SG_ADD((std::shared_ptr<SGObject>*) &features, kFeatures,
 	    "Feature object.");
 }
 

--- a/src/shogun/machine/OnlineLinearMachine.h
+++ b/src/shogun/machine/OnlineLinearMachine.h
@@ -236,6 +236,12 @@ class OnlineLinearMachine : public Machine
 		float32_t bias;
 		/** features */
 		std::shared_ptr<StreamingDotFeatures> features;
+		
+	#ifndef SWIG
+	public:
+		static constexpr std::string_view kMw = "m_w";
+		static constexpr std::string_view kBias = "bias";
+		static constexpr std::string_view kFeatures = "features";
 };
 }
 #endif

--- a/src/shogun/machine/StructuredOutputMachine.cpp
+++ b/src/shogun/machine/StructuredOutputMachine.cpp
@@ -47,10 +47,10 @@ std::shared_ptr<StructuredModel> StructuredOutputMachine::get_model() const
 
 void StructuredOutputMachine::register_parameters()
 {
-	SG_ADD(&m_model, "model", "Structured model");
-	SG_ADD(&m_surrogate_loss, "surrogate_loss", "Surrogate loss");
-	SG_ADD(&m_verbose, "verbose", "Verbosity flag");
-	SG_ADD((std::shared_ptr<SGObject>*)&m_helper, "helper", "Training helper");
+	SG_ADD(&m_model, kModel, "Structured model");
+	SG_ADD(&m_surrogate_loss, kSurrogateLoss, "Surrogate loss");
+	SG_ADD(&m_verbose, kVerbose, "Verbosity flag");
+	SG_ADD((std::shared_ptr<SGObject>*)&m_helper, kHelper, "Training helper");
 
 	m_verbose = false;
 	m_helper = NULL;

--- a/src/shogun/machine/StructuredOutputMachine.h
+++ b/src/shogun/machine/StructuredOutputMachine.h
@@ -220,6 +220,13 @@ class StructuredOutputMachine : public Machine
 
 		/** verbose outputs and statistics */
 		bool m_verbose;
+		
+		#ifndef SWIG
+	public:
+		static constexpr std::string_view kModel = "model";
+		static constexpr std::string_view kSurrogateLoss = "surrogate_loss";
+		static constexpr std::string_view kVerbose = "verbose";
+		static constexpr std::string_view kHelper = "helper";
 
 }; /* class StructuredOutputMachine */
 


### PR DESCRIPTION
Before this commit the parameter names within the SGObject Class were using `SG_ADD(&class_member, "name", "parameter description").` and with this the problem was that when changing the registered name (in this case "name") results in issues everytime there was refactoring of the parameters name. Hence to address this issue the class should register a `static constexpr std::string_view kParam = "name"` that should be used to register the class name which resolve this problem.

Hence this Pull Request resolve this fix by committing the files within following folders as mentioned below

* machine
* clustering
* converter

```
📁 shogun
├── 📁 src
        └──📁 shogun
               ├── 📁 machine
               ├── 📁 clustering
               └── 📁 converter
```

Feel free to suggest any changes required. Thanks! :smiley: 