### PR TITLE
Writing a utility function to make a shallow copy of an SGObject

### DIFF
--- a/src/shogun/base/SGObject.h
+++ b/src/shogun/base/SGObject.h
@@ -1361,6 +1361,18 @@ std::shared_ptr<const T> make_clone(std::shared_ptr<const T> orig, ParameterProp
 	return std::static_pointer_cast<const T>(clone);
 }
 
+template <class T>
+std::shared_ptr<T> shallow_copy(std::shared_ptr<T> orig, ParameterProperties pp = ParameterProperties::ALL ^ ParameterProperties::MODEL ^ ParameterProperties::READONLY)
+{
+	return make_clone(orig, pp);
+}
+
+template <class T>
+std::shared_ptr<const T> shallow_copy(std::shared_ptr<const T> orig, ParameterProperties pp = ParameterProperties::ALL ^ ParameterProperties::MODEL ^ ParameterProperties::READONLY)
+{
+	return make_clone(orig, pp);
+}
+
 #ifndef SWIG
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace sgo_details

--- a/src/shogun/multiclass/tree/RelaxedTree.cpp
+++ b/src/shogun/multiclass/tree/RelaxedTree.cpp
@@ -296,7 +296,7 @@ SGVector<int32_t> RelaxedTree::train_node_with_initialization(const RelaxedTree:
 		auto feats_train = view(m_feats, subset);
 		auto labels_train = view(binary_labels, subset);
 
-		auto kernel = make_clone(m_kernel, ParameterProperties::ALL^ParameterProperties::MODEL);
+		auto kernel = shallow_copy(m_kernel, ParameterProperties::ALL ^ ParameterProperties::MODEL);
 
 		kernel->init(feats_train, feats_train);
 		svm->set_kernel(kernel);


### PR DESCRIPTION
There is a clone method to perform deep cloning, which generally means copying features, labels, and weights, which is not always needed. This can be avoided by passing the respective [ParameterProperties](https://github.com/shogun-toolbox/shogun/blob/78cfc5f4ef6daf196819f900234be7d5455bc3a1/src/shogun/base/AnyParameter.h#L21) to the `make_clone` function, Hence this pull request is the creation of the utility function that makes a shallow copy within SGObject with parameters flagging.

Hence this Pull Request resolve this fix by committing the files within the following folders as mentioned below

* SGObject.h
* RelaxedTree.cpp

```
📁 shogun
├── 📁 src
        └──📁 shogun
               └──📁 base
               │      └──📝 SGObject.h
               └──📁 multiclass
                       └──📁 tree
                              └──📝 RelaxedTree.cpp

```

Feel free to suggest any changes required. Thanks! :smiley: 